### PR TITLE
Speedups

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "osm",
     "names"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "osmium":"0.1.x"
+  },
   "author": "Aaron Lidman",
   "license": "BSD"
 }


### PR DESCRIPTION
Use packaged osmium 0.1.x series and touches up `getRaw.js` to behave like `getRaw.py`.

I ma testing with `node-osmium` v0.1.2 which will be released shortly with more speedups.

My benchmark on OS X 10.8 (8 core, 8 GB memory) was to download latest germany extract:

```
time python getRaw.py germany-latest.osm.pbf 
real    6m7.909s
user    25m11.010s
sys 1m25.193s
```

```
time node getRaw.js  germany-latest.osm.pbf 
real    5m13.427s
user    17m27.235s
sys 3m51.121s
```
