### PR TITLE
Add listing for Save-A-Lot

### DIFF
--- a/canonical.json
+++ b/canonical.json
@@ -353,6 +353,16 @@
             "cuisine": "sandwich"
         }
     },
+    "Save-A-Lot": {
+        "matches": [
+            "Save A Lot",
+            "Save-a-Lot",
+            "Save a Lot"
+        ],
+        "tags": {
+            "shop": "supermarket"
+        }
+    },
     "Sonic": {
         "matches": [
             "Sonic Drive In",


### PR DESCRIPTION
Added a listing for Save-A-Lot, grocery store chain in the US. although there's only 30 or 40 mapped in the US, there's >1300 locations according to their website.  
