### PR TITLE
Add some German nouns which are not names

### DIFF
--- a/filter.json
+++ b/filter.json
@@ -79,6 +79,10 @@
         "Peluqueria",
         "Bäckerei",
         "Panificio",
-        "Eiscafe"
+        "Eiscafe",
+        "Kebab",
+        "Imbiss",
+        "Eisdiele",
+        "Bäcker"
     ]
 }


### PR DESCRIPTION
Eisdiele is like Eiscafe a type of POI not a name. Imbiss is a German noun for a type of fast-food POI. Bäcker is another noun for Bäckerei (bakery) and no name.