### PR TITLE
Corrected some brands to match ad copy

### DIFF
--- a/canonical.json
+++ b/canonical.json
@@ -150,9 +150,9 @@
             "Costa Coffee"
         ]
     },
-    "Dunkin Donuts": {
+    "Dunkin' Donuts": {
         "matches": [
-            "Dunkin' Donuts"
+            "Dunkin Donuts"
         ],
         "nix_value": [
             "fast_food"
@@ -892,9 +892,9 @@
             "ローソン (LAWSON)"
         ]
     },
-    "Lowes": {
+    "Lowe's": {
         "matches": [
-            "Lowe's"
+            "Lowes"
         ]
     },
     "OBI": {

--- a/canonical.json
+++ b/canonical.json
@@ -1277,5 +1277,51 @@
         "matches": [
             "Timpsons"
         ]
+    },
+    "Whole Foods Market": {
+        "matches": [
+            "Whole Foods"
+        ]
+    },
+    "Baskin-Robbins": {
+        "matches": [
+            "Baskin Robbins"
+            "Baskin Robins"
+        ],
+        "tags": {
+            "amenity": "ice_cream"
+    },
+    "Jimmy John's": {
+        "matches": [
+            "Jimmy Johns"
+            "Jimmy John's Gourmet Sandwiches"
+        ],
+        "tags": {
+            "cuisine": "sandwich"
+    },
+    "Little Caesars": {
+        "matches": [
+            "Little Caesars Pizza"
+        ],
+        "tags": {
+            "cuisine": "pizza"
+    },
+    "LongHorn Steakhouse": {
+        "matches": [
+            "Longhorn Steakhouse"
+        ]
+    },
+    "McCafé": {
+        "matches": [
+            "McCafe"
+        ],
+        "tags": {
+            "amenity": "cafe",
+            "cuisine": "coffee_shop"
+    },
+    "ShopRite": {
+        "matches": [
+            "Shoprite"
+        ]
     }
 }

--- a/name-suggestions.json
+++ b/name-suggestions.json
@@ -115,9 +115,6 @@
             "Shell Express": {
                 "count": 131
             },
-            "Hess": {
-                "count": 127
-            },
             "Flying V": {
                 "count": 129
             },
@@ -897,7 +894,7 @@
             "Робин Сдобин": {
                 "count": 82
             },
-            "Baskin Robbins": {
+            "Baskin-Robbins": {
                 "count": 74
             },
             "ケンタッキーフライドチキン": {
@@ -2447,7 +2444,7 @@
             "Second Cup": {
                 "count": 193
             },
-            "Dunkin Donuts": {
+            "Dunkin' Donuts": {
                 "count": 428,
                 "tags": {
                     "cuisine": "donut"
@@ -3870,7 +3867,7 @@
             "OBI": {
                 "count": 422
             },
-            "Lowes": {
+            "Lowe's": {
                 "count": 1152
             },
             "Wickes": {


### PR DESCRIPTION
Removed Hess gas station
The Hess brand is no longer used in retail fuel sales. Signs may still exist, but are being converted to Speedway brand.
http://www.usatoday.com/story/money/business/2014/05/25/hess-stations-name-change/9445589/

Dunkin' Donuts
http://news.dunkindonuts.com/

Lowe's
http://media.lowes.com/about-lowes/

Baskin-Robbins
http://news.baskinrobbins.com/about