### PR TITLE
Modified existing entries add added new ones

### DIFF
--- a/canonical.json
+++ b/canonical.json
@@ -150,12 +150,9 @@
             "Costa Coffee"
         ]
     },
-    "Dunkin Donuts": {
+    "Dunkin' Donuts": {
         "matches": [
-            "Dunkin' Donuts"
-        ],
-        "nix_value": [
-            "fast_food"
+            "Dunkin Donuts"
         ],
         "tags": {
             "cuisine": "donut"
@@ -178,9 +175,6 @@
     "Tim Hortons": {
         "matches": [
             "Tim Horton's"
-        ],
-        "nix_value": [
-            "cafe"
         ]
     },
     "スターバックス": {
@@ -432,9 +426,9 @@
             "Wal Mart"
         ]
     },
-    "Whole Foods": {
+    "Whole Foods Market": {
         "matches": [
-            "Whole Foods Market"
+            "Whole Foods"
         ],
         "tags": {
             "shop": "supermarket"
@@ -486,6 +480,7 @@
         "matches": [
             "7 Eleven",
             "7-11",
+            "7/11",
             "7-ELEVEN",
             "7-eleven",
             "Seven Eleven"
@@ -892,11 +887,6 @@
             "ローソン (LAWSON)"
         ]
     },
-    "Lowes": {
-        "matches": [
-            "Lowe's"
-        ]
-    },
     "OBI": {
         "matches": [
             "Obi"
@@ -1093,7 +1083,6 @@
     "Panera Bread": {
         "nix_value": [
             "cafe",
-            "fast_food"
         ]
     },
     "Dairy Queen": {
@@ -1125,9 +1114,6 @@
         ]
     },
     "Pizza Hut": {
-        "nix_value": [
-            "fast_food"
-        ],
         "tags": {
             "cuisine": "pizza"
         }
@@ -1277,5 +1263,41 @@
         "matches": [
             "Timpsons"
         ]
+    },
+    "Baskin-Robbins": {
+        "matches": [
+            "Baskin Robbins"
+            "Baskin Robins"
+        ],
+        "tags": {
+            "amenity": "ice_cream"
+    },
+    "Jimmy John's": {
+        "matches": [
+            "Jimmy Johns"
+            "Jimmy John's Gourmet Sandwiches"
+        ],
+        "tags": {
+            "cuisine": "sandwich"
+    },
+    "Little Caesars": {
+        "matches": [
+            "Little Caesars Pizza"
+        ],
+        "tags": {
+            "cuisine": "pizza"
+    },
+    "LongHorn Steakhouse": {
+        "matches": [
+            "Longhorn Steakhouse"
+        ]
+    },
+    "McCafé": {
+        "matches": [
+            "McCafe"
+        ],
+        "tags": {
+            "amenity": "cafe",
+            "cuisine": "coffee_shop"
     }
 }


### PR DESCRIPTION
Dunkin' Donuts is the correct spelling. Removed nix value fast food.

Tim Hortons: Removed nix value cafe

AFAIK there is no consenus between cafe and fast_food for many chain coffee shops. Especially since many have drive-through service and serve sandwiches. Until there is a consensus I don't think it makes sense to set them arbitrarily.

Whole Foods Market: swapped values to correct

7-Eleven: added match 7/11, a default that shows up before 7-Eleven in iD. Or is there another convenience store chain called 7/11?

Lowes: The correct name for the DIY store is Lowe's, but there are other stores such as Lowes Foods and Lowe's Market so canonicalization is troublesome.

Panera Bread: remove nix value fast_food. Paying for the food first is the major distinction between fast_food and restaurant.

Pizza Hut: remove nix value fast_food. See above.

Baskin-Robbins: correct spelling includes a "-"