### PR TITLE
Add some nouns that are being misused as names to the filter

### DIFF
--- a/filter.json
+++ b/filter.json
@@ -77,6 +77,14 @@
         "Peluqueria",
         "Bäckerei",
         "Panificio",
-        "Eiscafe"
+        "Eiscafe",
+	"Tankstelle",
+	"Freie Tankstelle",
+	"Bank",
+	"Döner",
+	"Döner Kebab",
+	"Kebab",
+	"Asia Imbiss",
+	"Fast Food"
     ]
 }


### PR DESCRIPTION
The additions to the list have been checked against their geographic use to avoid mistakenly removing foriegn language nouns that are being used as chain names.