### PR TITLE
Filter some further nouns that are improperly being used as names

### DIFF
--- a/filter.json
+++ b/filter.json
@@ -90,12 +90,12 @@
         "Imbiss",
         "Eisdiele",
         "Bäcker",
-	"Döner",
-	"Döner Kebab",
-	"Asia Imbiss",
-	"Fast Food",
-	"Friterie",
-	"Apotheke",
-	"Bank"
+        "Döner",
+        "Döner Kebab",
+        "Asia Imbiss",
+        "Fast Food",
+        "Friterie",
+        "Apotheke",
+        "Bank"
     ]
 }

--- a/filter.json
+++ b/filter.json
@@ -89,6 +89,13 @@
         "Kebab",
         "Imbiss",
         "Eisdiele",
-        "Bäcker"
+        "Bäcker",
+	"Döner",
+	"Döner Kebab",
+	"Asia Imbiss",
+	"Fast Food",
+	"Friterie",
+	"Apotheke",
+	"Bank"
     ]
 }


### PR DESCRIPTION
The values have been checked (as far as possible) against their geographic usage to ensure that we are not removing foreign language nouns that are being used as names.