### PR TITLE
First pass at generating JOSM presets.

### DIFF
--- a/buildJosm.js
+++ b/buildJosm.js
@@ -5,7 +5,7 @@ var fs = require("fs"),
 var presets=xmlbuilder.create('presets', {version: '1.0', encoding: 'UTF-8'})
   .att('xmlns', 'http://josm.openstreetmap.de/tagging-preset-1.0')
   .att('author', 'Name Suggestion Index');
-var topgroup=presets.ele('group').att('name','Name Sugg. Index');
+var topgroup=presets.ele('group').att('name','Name Suggestion Index');
 
 // for each name in name-suggestions.json, create a one-click
 // JOSM preset using the key and value structure from the json
@@ -13,16 +13,18 @@ var topgroup=presets.ele('group').att('name','Name Sugg. Index');
 for (key in suggest){
     var keygroup=topgroup.ele('group').att('name',key);
     for (value in suggest[key]){
-	var valuegroup=keygroup.ele('group').att('name',value);
-        for (name in suggest[key][value]){
-            var item=valuegroup.ele('item')
-              .att('name', name);
-              item.ele('key').att('key',key).att('value',value);
-              item.ele('key').att('key','name').att('value',name);
-	    var thisname=suggest[key][value][name];
-            if ('tags' in thisname){
-                for (k in thisname['tags']){
-                    item.ele('key').att('key',k).att('value',thisname['tags'][k]);
+        if(Object.keys(suggest[key][value]).length > 0){
+            var valuegroup=keygroup.ele('group').att('name',value);
+            for (name in suggest[key][value]){
+                var item=valuegroup.ele('item')
+                  .att('name', name);
+                item.ele('key').att('key',key).att('value',value);
+                item.ele('key').att('key','name').att('value',name);
+                var thisname=suggest[key][value][name];
+                if ('tags' in thisname){
+                    for (k in thisname['tags']){
+                        item.ele('key').att('key',k).att('value',thisname['tags'][k]);
+                    }
                 }
             }
         }

--- a/buildJosm.js
+++ b/buildJosm.js
@@ -7,12 +7,15 @@ var presets=xmlbuilder.create('presets', {version: '1.0', encoding: 'UTF-8'})
   .att('author', 'Name Suggestion Index');
 var topgroup=presets.ele('group').att('name','Name Sugg. Index');
 
+// for each name in name-suggestions.json, create a one-click
+// JOSM preset using the key and value structure from the json
+// to organize the presets into JOSM preset groups.
 for (key in suggest){
-    var group=topgroup.ele('group').att('name',key);
+    var keygroup=topgroup.ele('group').att('name',key);
     for (value in suggest[key]){
-	var subgroup=group.ele('group').att('name',value);
+	var valuegroup=keygroup.ele('group').att('name',value);
         for (name in suggest[key][value]){
-            var item=subgroup.ele('item')
+            var item=valuegroup.ele('item')
               .att('name', name);
               item.ele('key').att('key',key).att('value',value);
               item.ele('key').att('key','name').att('value',name);

--- a/buildJosm.js
+++ b/buildJosm.js
@@ -1,0 +1,30 @@
+var fs = require("fs"),
+    xmlbuilder = require('xmlbuilder')
+    suggest = require('./name-suggestions.json');
+
+var presets=xmlbuilder.create('presets', {version: '1.0', encoding: 'UTF-8'})
+  .att('xmlns', 'http://josm.openstreetmap.de/tagging-preset-1.0')
+  .att('author', 'Name Suggestion Index');
+var topgroup=presets.ele('group').att('name','Name Sugg. Index');
+
+for (key in suggest){
+    var group=topgroup.ele('group').att('name',key);
+    for (value in suggest[key]){
+	var subgroup=group.ele('group').att('name',value);
+        for (name in suggest[key][value]){
+            var item=subgroup.ele('item')
+              .att('name', name);
+              item.ele('key').att('key',key).att('value',value);
+              item.ele('key').att('key','name').att('value',name);
+	    var thisname=suggest[key][value][name];
+            if ('tags' in thisname){
+                for (k in thisname['tags']){
+                    item.ele('key').att('key',k).att('value',thisname['tags'][k]);
+                }
+            }
+        }
+    }
+}
+
+var xmlstring=presets.end({ pretty: true })
+fs.writeFileSync('name-suggestions.presets.xml', xmlstring);

--- a/name-suggestions.presets.xml
+++ b/name-suggestions.presets.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <presets xmlns="http://josm.openstreetmap.de/tagging-preset-1.0" author="Name Suggestion Index">
-  <group name="Name Sugg. Index">
+  <group name="Name Suggestion Index">
     <group name="amenity">
       <group name="arts_centre">
         <item name="Świetlica wiejska">
@@ -9607,7 +9607,6 @@
           <key key="name" value="Kind Hörgeräte"/>
         </item>
       </group>
-      <group name="hifi"/>
       <group name="houseware">
         <item name="Blokker">
           <key key="shop" value="houseware"/>

--- a/name-suggestions.presets.xml
+++ b/name-suggestions.presets.xml
@@ -1,0 +1,12262 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<presets xmlns="http://josm.openstreetmap.de/tagging-preset-1.0" author="Name Suggestion Index">
+  <group name="Name Sugg. Index">
+    <group name="amenity">
+      <group name="arts_centre">
+        <item name="Świetlica wiejska">
+          <key key="amenity" value="arts_centre"/>
+          <key key="name" value="Świetlica wiejska"/>
+        </item>
+        <item name="Дом культуры">
+          <key key="amenity" value="arts_centre"/>
+          <key key="name" value="Дом культуры"/>
+        </item>
+      </group>
+      <group name="bank">
+        <item name="ABANCA">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ABANCA"/>
+        </item>
+        <item name="ABN AMRO">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ABN AMRO"/>
+        </item>
+        <item name="ABSA">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ABSA"/>
+        </item>
+        <item name="AIB">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="AIB"/>
+        </item>
+        <item name="ANZ">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ANZ"/>
+        </item>
+        <item name="ASB Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ASB Bank"/>
+        </item>
+        <item name="ATB Financial">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ATB Financial"/>
+        </item>
+        <item name="AXA">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="AXA"/>
+        </item>
+        <item name="Akbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Akbank"/>
+        </item>
+        <item name="Alior Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Alior Bank"/>
+        </item>
+        <item name="Alpha Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Alpha Bank"/>
+        </item>
+        <item name="Andhra Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Andhra Bank"/>
+        </item>
+        <item name="Argenta">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Argenta"/>
+        </item>
+        <item name="Axis Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Axis Bank"/>
+        </item>
+        <item name="BAC">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BAC"/>
+        </item>
+        <item name="BAWAG PSK">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BAWAG PSK"/>
+        </item>
+        <item name="BB&amp;T">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BB&amp;T"/>
+        </item>
+        <item name="BBBank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BBBank"/>
+        </item>
+        <item name="BBK">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BBK"/>
+        </item>
+        <item name="BBVA">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BBVA"/>
+        </item>
+        <item name="BBVA Bancomer">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BBVA Bancomer"/>
+        </item>
+        <item name="BBVA Compass">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BBVA Compass"/>
+        </item>
+        <item name="BBVA Francés">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BBVA Francés"/>
+        </item>
+        <item name="BCA">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BCA"/>
+        </item>
+        <item name="BCI">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BCI"/>
+        </item>
+        <item name="BCP">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BCP"/>
+        </item>
+        <item name="BCR">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BCR"/>
+        </item>
+        <item name="BDO">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BDO"/>
+        </item>
+        <item name="BES">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BES"/>
+        </item>
+        <item name="BMO">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BMO"/>
+        </item>
+        <item name="BNA">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BNA"/>
+        </item>
+        <item name="BNL">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BNL"/>
+        </item>
+        <item name="BNP Paribas">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BNP Paribas"/>
+        </item>
+        <item name="BNP Paribas Fortis">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BNP Paribas Fortis"/>
+        </item>
+        <item name="BOC">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BOC"/>
+        </item>
+        <item name="BPH">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BPH"/>
+        </item>
+        <item name="BPI">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BPI"/>
+        </item>
+        <item name="BRD">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BRD"/>
+        </item>
+        <item name="BRED">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BRED"/>
+        </item>
+        <item name="BRI">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BRI"/>
+        </item>
+        <item name="BW-Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BW-Bank"/>
+        </item>
+        <item name="BZ WBK">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BZ WBK"/>
+        </item>
+        <item name="Banamex">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banamex"/>
+        </item>
+        <item name="Banc Sabadell">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banc Sabadell"/>
+        </item>
+        <item name="Banca Intesa">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banca Intesa"/>
+        </item>
+        <item name="Banca March">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banca March"/>
+        </item>
+        <item name="Banca Popolare di Milano">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banca Popolare di Milano"/>
+        </item>
+        <item name="Banca Popolare di Novara">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banca Popolare di Novara"/>
+        </item>
+        <item name="Banca Popolare di Sondrio">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banca Popolare di Sondrio"/>
+        </item>
+        <item name="Banca Popolare di Verona">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banca Popolare di Verona"/>
+        </item>
+        <item name="Banca Popolare di Vicenza">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banca Popolare di Vicenza"/>
+        </item>
+        <item name="Banca Românească">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banca Românească"/>
+        </item>
+        <item name="Banca Transilvania">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banca Transilvania"/>
+        </item>
+        <item name="Banco Azteca">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco Azteca"/>
+        </item>
+        <item name="Banco BCI">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco BCI"/>
+        </item>
+        <item name="Banco Bradesco">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco Bradesco"/>
+        </item>
+        <item name="Banco Estado">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco Estado"/>
+        </item>
+        <item name="Banco G&amp;T Continental">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco G&amp;T Continental"/>
+        </item>
+        <item name="Banco Galicia">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco Galicia"/>
+        </item>
+        <item name="Banco Industrial">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco Industrial"/>
+        </item>
+        <item name="Banco Itaú">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco Itaú"/>
+        </item>
+        <item name="Banco Macro">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco Macro"/>
+        </item>
+        <item name="Banco Nacional">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco Nacional"/>
+        </item>
+        <item name="Banco Nación">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco Nación"/>
+        </item>
+        <item name="Banco Pastor">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco Pastor"/>
+        </item>
+        <item name="Banco Patagonia">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco Patagonia"/>
+        </item>
+        <item name="Banco Pichincha">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco Pichincha"/>
+        </item>
+        <item name="Banco Popular">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco Popular"/>
+        </item>
+        <item name="Banco Provincia">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco Provincia"/>
+        </item>
+        <item name="Banco Sabadell">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco Sabadell"/>
+        </item>
+        <item name="Banco de Bogotá">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco de Bogotá"/>
+        </item>
+        <item name="Banco de Chile">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco de Chile"/>
+        </item>
+        <item name="Banco de Costa Rica">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco de Costa Rica"/>
+        </item>
+        <item name="Banco de Desarrollo Banrural">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco de Desarrollo Banrural"/>
+        </item>
+        <item name="Banco de Occidente">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco de Occidente"/>
+        </item>
+        <item name="Banco de Venezuela">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco de Venezuela"/>
+        </item>
+        <item name="Banco de la Nación">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco de la Nación"/>
+        </item>
+        <item name="Banco de la Nación Argentina">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco de la Nación Argentina"/>
+        </item>
+        <item name="Banco di Napoli">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco di Napoli"/>
+        </item>
+        <item name="Banco di Sardegna">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco di Sardegna"/>
+        </item>
+        <item name="Banco do Brasil">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banco do Brasil"/>
+        </item>
+        <item name="BancoEstado">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="BancoEstado"/>
+        </item>
+        <item name="Bancolombia">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bancolombia"/>
+        </item>
+        <item name="Bancomer">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bancomer"/>
+        </item>
+        <item name="Bancpost">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bancpost"/>
+        </item>
+        <item name="Banesco">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banesco"/>
+        </item>
+        <item name="Bangkok Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bangkok Bank"/>
+        </item>
+        <item name="Bank Austria">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank Austria"/>
+        </item>
+        <item name="Bank BPH">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank BPH"/>
+        </item>
+        <item name="Bank BRI">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank BRI"/>
+        </item>
+        <item name="Bank Mandiri">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank Mandiri"/>
+        </item>
+        <item name="Bank Spółdzielczy">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank Spółdzielczy"/>
+        </item>
+        <item name="Bank Zachodni WBK">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank Zachodni WBK"/>
+        </item>
+        <item name="Bank of Africa">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank of Africa"/>
+        </item>
+        <item name="Bank of America">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank of America"/>
+        </item>
+        <item name="Bank of Baroda">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank of Baroda"/>
+        </item>
+        <item name="Bank of China">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank of China"/>
+        </item>
+        <item name="Bank of Commerce">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank of Commerce"/>
+        </item>
+        <item name="Bank of India">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank of India"/>
+        </item>
+        <item name="Bank of Ireland">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank of Ireland"/>
+        </item>
+        <item name="Bank of Montreal">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank of Montreal"/>
+        </item>
+        <item name="Bank of New Zealand">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank of New Zealand"/>
+        </item>
+        <item name="Bank of Scotland">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank of Scotland"/>
+        </item>
+        <item name="Bank of the West">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bank of the West"/>
+        </item>
+        <item name="Bankia">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bankia"/>
+        </item>
+        <item name="Bankinter">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bankinter"/>
+        </item>
+        <item name="Banorte">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banorte"/>
+        </item>
+        <item name="Banque Nationale">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banque Nationale"/>
+        </item>
+        <item name="Banque Populaire">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banque Populaire"/>
+        </item>
+        <item name="Banrisul">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banrisul"/>
+        </item>
+        <item name="Banrural">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Banrural"/>
+        </item>
+        <item name="Barclays">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Barclays"/>
+        </item>
+        <item name="Belfius">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Belfius"/>
+        </item>
+        <item name="Bendigo Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bendigo Bank"/>
+        </item>
+        <item name="Berliner Sparkasse">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Berliner Sparkasse"/>
+        </item>
+        <item name="Berliner Volksbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Berliner Volksbank"/>
+        </item>
+        <item name="Bicentenario">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bicentenario"/>
+        </item>
+        <item name="Bradesco">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Bradesco"/>
+        </item>
+        <item name="Budapest Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Budapest Bank"/>
+        </item>
+        <item name="CEC Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="CEC Bank"/>
+        </item>
+        <item name="CGD">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="CGD"/>
+        </item>
+        <item name="CIB Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="CIB Bank"/>
+        </item>
+        <item name="CIBC">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="CIBC"/>
+        </item>
+        <item name="CIC">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="CIC"/>
+        </item>
+        <item name="Caisse d'Épargne">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Caisse d'Épargne"/>
+        </item>
+        <item name="Caixa">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Caixa"/>
+        </item>
+        <item name="Caixa Econômica Federal">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Caixa Econômica Federal"/>
+        </item>
+        <item name="Caixa Geral de Depósitos">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Caixa Geral de Depósitos"/>
+        </item>
+        <item name="CaixaBank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="CaixaBank"/>
+        </item>
+        <item name="Caja Círculo">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Caja Círculo"/>
+        </item>
+        <item name="Caja Duero">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Caja Duero"/>
+        </item>
+        <item name="Caja España">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Caja España"/>
+        </item>
+        <item name="Caja Rural">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Caja Rural"/>
+        </item>
+        <item name="Caja Rural de Jaén">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Caja Rural de Jaén"/>
+        </item>
+        <item name="CajaSur">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="CajaSur"/>
+        </item>
+        <item name="Cajamar">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Cajamar"/>
+        </item>
+        <item name="Cajero Automatico Bancared">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Cajero Automatico Bancared"/>
+        </item>
+        <item name="Canara Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Canara Bank"/>
+        </item>
+        <item name="Capital One">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Capital One"/>
+        </item>
+        <item name="Cariparma">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Cariparma"/>
+        </item>
+        <item name="Cassa di Risparmio del Veneto">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Cassa di Risparmio del Veneto"/>
+        </item>
+        <item name="CatalunyaCaixa">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="CatalunyaCaixa"/>
+        </item>
+        <item name="Chase">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Chase"/>
+        </item>
+        <item name="China Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="China Bank"/>
+        </item>
+        <item name="Citibank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Citibank"/>
+        </item>
+        <item name="Citizens Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Citizens Bank"/>
+        </item>
+        <item name="CityCommerce Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="CityCommerce Bank"/>
+        </item>
+        <item name="Clydesdale Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Clydesdale Bank"/>
+        </item>
+        <item name="Comerica Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Comerica Bank"/>
+        </item>
+        <item name="Commercial Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Commercial Bank"/>
+        </item>
+        <item name="Commercial Bank of Ceylon PLC">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Commercial Bank of Ceylon PLC"/>
+        </item>
+        <item name="Commerzbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Commerzbank"/>
+        </item>
+        <item name="Commonwealth Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Commonwealth Bank"/>
+        </item>
+        <item name="Corporation Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Corporation Bank"/>
+        </item>
+        <item name="Credem">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Credem"/>
+        </item>
+        <item name="Credit Suisse">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Credit Suisse"/>
+        </item>
+        <item name="Crédit Agricole">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Crédit Agricole"/>
+        </item>
+        <item name="Crédit Mutuel">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Crédit Mutuel"/>
+        </item>
+        <item name="Crédit Mutuel de Bretagne">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Crédit Mutuel de Bretagne"/>
+        </item>
+        <item name="Crédit du Nord">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Crédit du Nord"/>
+        </item>
+        <item name="Crédito Agrícola">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Crédito Agrícola"/>
+        </item>
+        <item name="Cбербанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Cбербанк"/>
+        </item>
+        <item name="Danske Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Danske Bank"/>
+        </item>
+        <item name="Davivienda">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Davivienda"/>
+        </item>
+        <item name="De Venezuela">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="De Venezuela"/>
+        </item>
+        <item name="Deutsche Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Deutsche Bank"/>
+        </item>
+        <item name="EastWest Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="EastWest Bank"/>
+        </item>
+        <item name="Ecobank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Ecobank"/>
+        </item>
+        <item name="Erste Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Erste Bank"/>
+        </item>
+        <item name="Eurobank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Eurobank"/>
+        </item>
+        <item name="FNB">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="FNB"/>
+        </item>
+        <item name="Fifth Third Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Fifth Third Bank"/>
+        </item>
+        <item name="First Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="First Bank"/>
+        </item>
+        <item name="First Citizens Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="First Citizens Bank"/>
+        </item>
+        <item name="First National Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="First National Bank"/>
+        </item>
+        <item name="GE Money Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="GE Money Bank"/>
+        </item>
+        <item name="Galicia">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Galicia"/>
+        </item>
+        <item name="Garanti Bankası">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Garanti Bankası"/>
+        </item>
+        <item name="Getin Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Getin Bank"/>
+        </item>
+        <item name="HDFC Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="HDFC Bank"/>
+        </item>
+        <item name="HNB">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="HNB"/>
+        </item>
+        <item name="HSBC">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="HSBC"/>
+        </item>
+        <item name="Halifax">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Halifax"/>
+        </item>
+        <item name="Hamburger Sparkasse">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Hamburger Sparkasse"/>
+        </item>
+        <item name="Handelsbanken">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Handelsbanken"/>
+        </item>
+        <item name="Hrvatska poštanska banka">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Hrvatska poštanska banka"/>
+        </item>
+        <item name="Huntington Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Huntington Bank"/>
+        </item>
+        <item name="HypoVereinsbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="HypoVereinsbank"/>
+        </item>
+        <item name="ICBC">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ICBC"/>
+        </item>
+        <item name="ICICI Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ICICI Bank"/>
+        </item>
+        <item name="ING">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ING"/>
+        </item>
+        <item name="ING Bank Śląski">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ING Bank Śląski"/>
+        </item>
+        <item name="IberCaja">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="IberCaja"/>
+        </item>
+        <item name="Indian Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Indian Bank"/>
+        </item>
+        <item name="Indian Overseas Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Indian Overseas Bank"/>
+        </item>
+        <item name="Interbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Interbank"/>
+        </item>
+        <item name="Intesa San Paolo">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Intesa San Paolo"/>
+        </item>
+        <item name="Itaú">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Itaú"/>
+        </item>
+        <item name="K&amp;H Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="K&amp;H Bank"/>
+        </item>
+        <item name="KBC">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="KBC"/>
+        </item>
+        <item name="Kasa Stefczyka">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Kasa Stefczyka"/>
+        </item>
+        <item name="Key Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Key Bank"/>
+        </item>
+        <item name="Komerční banka">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Komerční banka"/>
+        </item>
+        <item name="Kreissparkasse">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Kreissparkasse"/>
+        </item>
+        <item name="Kreissparkasse Köln">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Kreissparkasse Köln"/>
+        </item>
+        <item name="LCL">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="LCL"/>
+        </item>
+        <item name="La Banque Postale">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="La Banque Postale"/>
+        </item>
+        <item name="La Caixa">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="La Caixa"/>
+        </item>
+        <item name="Landbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Landbank"/>
+        </item>
+        <item name="Liberbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Liberbank"/>
+        </item>
+        <item name="Lloyds Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Lloyds Bank"/>
+        </item>
+        <item name="M&amp;T Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="M&amp;T Bank"/>
+        </item>
+        <item name="Macro">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Macro"/>
+        </item>
+        <item name="Maybank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Maybank"/>
+        </item>
+        <item name="Mercantil">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Mercantil"/>
+        </item>
+        <item name="Metrobank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Metrobank"/>
+        </item>
+        <item name="Millenium">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Millenium"/>
+        </item>
+        <item name="Millenium BCP">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Millenium BCP"/>
+        </item>
+        <item name="Millennium Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Millennium Bank"/>
+        </item>
+        <item name="Monte dei Paschi di Siena">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Monte dei Paschi di Siena"/>
+        </item>
+        <item name="Montepio">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Montepio"/>
+        </item>
+        <item name="NAB">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="NAB"/>
+        </item>
+        <item name="NatWest">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="NatWest"/>
+        </item>
+        <item name="National Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="National Bank"/>
+        </item>
+        <item name="Nationwide">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Nationwide"/>
+        </item>
+        <item name="Nedbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Nedbank"/>
+        </item>
+        <item name="Nordea">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Nordea"/>
+        </item>
+        <item name="Novo Banco">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Novo Banco"/>
+        </item>
+        <item name="OLB">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="OLB"/>
+        </item>
+        <item name="OTP">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="OTP"/>
+        </item>
+        <item name="Oberbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Oberbank"/>
+        </item>
+        <item name="Occidental de Descuento">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Occidental de Descuento"/>
+        </item>
+        <item name="Oldenburgische Landesbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Oldenburgische Landesbank"/>
+        </item>
+        <item name="One Network Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="One Network Bank"/>
+        </item>
+        <item name="Osuuspankki">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Osuuspankki"/>
+        </item>
+        <item name="PBZ">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="PBZ"/>
+        </item>
+        <item name="PKO">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="PKO"/>
+        </item>
+        <item name="PKO BP">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="PKO BP"/>
+        </item>
+        <item name="PNB">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="PNB"/>
+        </item>
+        <item name="PNC Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="PNC Bank"/>
+        </item>
+        <item name="PSBank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="PSBank"/>
+        </item>
+        <item name="Pekao SA">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Pekao SA"/>
+        </item>
+        <item name="Peoples Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Peoples Bank"/>
+        </item>
+        <item name="Philippine National Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Philippine National Bank"/>
+        </item>
+        <item name="Piraeus Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Piraeus Bank"/>
+        </item>
+        <item name="Popular">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Popular"/>
+        </item>
+        <item name="Postbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Postbank"/>
+        </item>
+        <item name="Postbank Finanzcenter">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Postbank Finanzcenter"/>
+        </item>
+        <item name="ProCredit Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ProCredit Bank"/>
+        </item>
+        <item name="Provincial">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Provincial"/>
+        </item>
+        <item name="Public Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Public Bank"/>
+        </item>
+        <item name="Punjab National Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Punjab National Bank"/>
+        </item>
+        <item name="RBC">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="RBC"/>
+        </item>
+        <item name="RBC Financial Group">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="RBC Financial Group"/>
+        </item>
+        <item name="RBS">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="RBS"/>
+        </item>
+        <item name="RCBC">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="RCBC"/>
+        </item>
+        <item name="RCBC Savings Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="RCBC Savings Bank"/>
+        </item>
+        <item name="Rabobank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Rabobank"/>
+        </item>
+        <item name="Raiffeisen Polbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Raiffeisen Polbank"/>
+        </item>
+        <item name="Raiffeisenbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Raiffeisenbank"/>
+        </item>
+        <item name="Regions Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Regions Bank"/>
+        </item>
+        <item name="Republic Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Republic Bank"/>
+        </item>
+        <item name="Royal Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Royal Bank"/>
+        </item>
+        <item name="Royal Bank of Scotland">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Royal Bank of Scotland"/>
+        </item>
+        <item name="SBI">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="SBI"/>
+        </item>
+        <item name="SEB">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="SEB"/>
+        </item>
+        <item name="Sampath Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Sampath Bank"/>
+        </item>
+        <item name="Santander">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Santander"/>
+        </item>
+        <item name="Santander Consumer Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Santander Consumer Bank"/>
+        </item>
+        <item name="Santander Río">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Santander Río"/>
+        </item>
+        <item name="Santander Totta">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Santander Totta"/>
+        </item>
+        <item name="Sberbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Sberbank"/>
+        </item>
+        <item name="Scotiabank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Scotiabank"/>
+        </item>
+        <item name="Security Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Security Bank"/>
+        </item>
+        <item name="Sicredi">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Sicredi"/>
+        </item>
+        <item name="Slovenská sporiteľňa">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Slovenská sporiteľňa"/>
+        </item>
+        <item name="Société Générale">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Société Générale"/>
+        </item>
+        <item name="Sparda-Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Sparda-Bank"/>
+        </item>
+        <item name="Sparkasse">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Sparkasse"/>
+        </item>
+        <item name="Sparkasse Aachen">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Sparkasse Aachen"/>
+        </item>
+        <item name="Sparkasse KölnBonn">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Sparkasse KölnBonn"/>
+        </item>
+        <item name="Stadtsparkasse">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Stadtsparkasse"/>
+        </item>
+        <item name="Standard Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Standard Bank"/>
+        </item>
+        <item name="Standard Chartered">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Standard Chartered"/>
+        </item>
+        <item name="State Bank of India">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="State Bank of India"/>
+        </item>
+        <item name="State Bank of Mysore">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="State Bank of Mysore"/>
+        </item>
+        <item name="SunTrust">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="SunTrust"/>
+        </item>
+        <item name="Swedbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Swedbank"/>
+        </item>
+        <item name="Syndicate Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Syndicate Bank"/>
+        </item>
+        <item name="TCF Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="TCF Bank"/>
+        </item>
+        <item name="TD Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="TD Bank"/>
+        </item>
+        <item name="TD Canada Trust">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="TD Canada Trust"/>
+        </item>
+        <item name="TSB">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="TSB"/>
+        </item>
+        <item name="Takarékszövetkezet">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Takarékszövetkezet"/>
+        </item>
+        <item name="Targobank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Targobank"/>
+        </item>
+        <item name="Tatra banka">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Tatra banka"/>
+        </item>
+        <item name="UBS">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="UBS"/>
+        </item>
+        <item name="UCPB">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="UCPB"/>
+        </item>
+        <item name="US Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="US Bank"/>
+        </item>
+        <item name="Ulster Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Ulster Bank"/>
+        </item>
+        <item name="Umpqua Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Umpqua Bank"/>
+        </item>
+        <item name="UniCredit Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="UniCredit Bank"/>
+        </item>
+        <item name="Unicaja Banco">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Unicaja Banco"/>
+        </item>
+        <item name="Unicredit Banca">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Unicredit Banca"/>
+        </item>
+        <item name="Union Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Union Bank"/>
+        </item>
+        <item name="VR-Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="VR-Bank"/>
+        </item>
+        <item name="Veneto Banca">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Veneto Banca"/>
+        </item>
+        <item name="Volksbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Volksbank"/>
+        </item>
+        <item name="Volksbank Raiffeisenbank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Volksbank Raiffeisenbank"/>
+        </item>
+        <item name="VÚB">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="VÚB"/>
+        </item>
+        <item name="Wachovia">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Wachovia"/>
+        </item>
+        <item name="Wells Fargo">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Wells Fargo"/>
+        </item>
+        <item name="Western Union">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Western Union"/>
+        </item>
+        <item name="Westpac">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Westpac"/>
+        </item>
+        <item name="Yorkshire Bank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Yorkshire Bank"/>
+        </item>
+        <item name="Yorkshire Building Society">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Yorkshire Building Society"/>
+        </item>
+        <item name="Ziraat Bankası">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Ziraat Bankası"/>
+        </item>
+        <item name="mBank">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="mBank"/>
+        </item>
+        <item name="ČSOB">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ČSOB"/>
+        </item>
+        <item name="Česká spořitelna">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Česká spořitelna"/>
+        </item>
+        <item name="İş Bankası">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="İş Bankası"/>
+        </item>
+        <item name="Εθνική Τράπεζα">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Εθνική Τράπεζα"/>
+        </item>
+        <item name="Πειραιώς">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Πειραιώς"/>
+        </item>
+        <item name="Τράπεζα Πειραιώς">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Τράπεζα Πειραιώς"/>
+        </item>
+        <item name="Авангард">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Авангард"/>
+        </item>
+        <item name="Альфа-Банк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Альфа-Банк"/>
+        </item>
+        <item name="БПС-Сбербанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="БПС-Сбербанк"/>
+        </item>
+        <item name="Банк Москвы">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Банк Москвы"/>
+        </item>
+        <item name="Банка ДСК">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Банка ДСК"/>
+        </item>
+        <item name="Белагропромбанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Белагропромбанк"/>
+        </item>
+        <item name="Беларусбанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Беларусбанк"/>
+        </item>
+        <item name="Белинвестбанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Белинвестбанк"/>
+        </item>
+        <item name="Бинбанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Бинбанк"/>
+        </item>
+        <item name="ВТБ">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ВТБ"/>
+        </item>
+        <item name="ВТБ24">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ВТБ24"/>
+        </item>
+        <item name="Возрождение">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Возрождение"/>
+        </item>
+        <item name="Газпромбанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Газпромбанк"/>
+        </item>
+        <item name="Генбанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Генбанк"/>
+        </item>
+        <item name="Казкоммерцбанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Казкоммерцбанк"/>
+        </item>
+        <item name="МДМ Банк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="МДМ Банк"/>
+        </item>
+        <item name="Мособлбанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Мособлбанк"/>
+        </item>
+        <item name="Народный банк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Народный банк"/>
+        </item>
+        <item name="Открытие">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Открытие"/>
+        </item>
+        <item name="Ощадбанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Ощадбанк"/>
+        </item>
+        <item name="ПУМБ">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ПУМБ"/>
+        </item>
+        <item name="ПриватБанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ПриватБанк"/>
+        </item>
+        <item name="Приорбанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Приорбанк"/>
+        </item>
+        <item name="Промсвязьбанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Промсвязьбанк"/>
+        </item>
+        <item name="РНКБ">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="РНКБ"/>
+        </item>
+        <item name="Райффайзен Банк Аваль">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Райффайзен Банк Аваль"/>
+        </item>
+        <item name="Райффайзенбанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Райффайзенбанк"/>
+        </item>
+        <item name="Росбанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Росбанк"/>
+        </item>
+        <item name="Россельхозбанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Россельхозбанк"/>
+        </item>
+        <item name="Русский стандарт">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Русский стандарт"/>
+        </item>
+        <item name="Сбербанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Сбербанк"/>
+        </item>
+        <item name="Совкомбанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Совкомбанк"/>
+        </item>
+        <item name="УкрСиббанк">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="УкрСиббанк"/>
+        </item>
+        <item name="Уралсиб">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="Уралсиб"/>
+        </item>
+        <item name="بانک تجارت">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="بانک تجارت"/>
+        </item>
+        <item name="بانک سپه">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="بانک سپه"/>
+        </item>
+        <item name="بانک صادرات">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="بانک صادرات"/>
+        </item>
+        <item name="بانک مسکن">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="بانک مسکن"/>
+        </item>
+        <item name="بانک ملت">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="بانک ملت"/>
+        </item>
+        <item name="بانک ملی">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="بانک ملی"/>
+        </item>
+        <item name="بانک کشاورزی">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="بانک کشاورزی"/>
+        </item>
+        <item name="صادرات">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="صادرات"/>
+        </item>
+        <item name="ملی">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ملی"/>
+        </item>
+        <item name="ธนาคารกรุงเทพ">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ธนาคารกรุงเทพ"/>
+        </item>
+        <item name="ธนาคารกรุงไทย">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ธนาคารกรุงไทย"/>
+        </item>
+        <item name="ธนาคารกสิกรไทย">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ธนาคารกสิกรไทย"/>
+        </item>
+        <item name="ธนาคารไทยพาณิชย์">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ธนาคารไทยพาณิชย์"/>
+        </item>
+        <item name="ლიბერთი ბანკი">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="ლიბერთი ბანკი"/>
+          <key key="name:en" value="Liberty Bank"/>
+        </item>
+        <item name="みずほ銀行">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="みずほ銀行"/>
+        </item>
+        <item name="りそな銀行">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="りそな銀行"/>
+        </item>
+        <item name="三井住友銀行">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="三井住友銀行"/>
+        </item>
+        <item name="三菱東京UFJ銀行">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="三菱東京UFJ銀行"/>
+        </item>
+        <item name="中国农业银行">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="中国农业银行"/>
+        </item>
+        <item name="中国工商银行">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="中国工商银行"/>
+        </item>
+        <item name="中国建设银行">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="中国建设银行"/>
+        </item>
+        <item name="中国银行">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="中国银行"/>
+        </item>
+        <item name="京都銀行">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="京都銀行"/>
+        </item>
+        <item name="农业银行">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="农业银行"/>
+        </item>
+        <item name="工商银行">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="工商银行"/>
+        </item>
+        <item name="建设银行">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="建设银行"/>
+        </item>
+        <item name="招商银行">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="招商银行"/>
+        </item>
+        <item name="横浜銀行">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="横浜銀行"/>
+        </item>
+        <item name="第一銀行">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="第一銀行"/>
+        </item>
+        <item name="국민은행">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="국민은행"/>
+          <key key="name:en" value="Gungmin Bank"/>
+        </item>
+        <item name="농협">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="농협"/>
+        </item>
+        <item name="신한은행">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="신한은행"/>
+          <key key="name:en" value="Sinhan Bank"/>
+        </item>
+        <item name="우리은행">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="우리은행"/>
+          <key key="name:en" value="Uri Bank"/>
+        </item>
+        <item name="하나은행">
+          <key key="amenity" value="bank"/>
+          <key key="name" value="하나은행"/>
+        </item>
+      </group>
+      <group name="bar">
+        <item name="Bar Centrale">
+          <key key="amenity" value="bar"/>
+          <key key="name" value="Bar Centrale"/>
+        </item>
+        <item name="Bar Sport">
+          <key key="amenity" value="bar"/>
+          <key key="name" value="Bar Sport"/>
+        </item>
+        <item name="Beach Bar">
+          <key key="amenity" value="bar"/>
+          <key key="name" value="Beach Bar"/>
+        </item>
+      </group>
+      <group name="bicycle_rental">
+        <item name="Bicing">
+          <key key="amenity" value="bicycle_rental"/>
+          <key key="name" value="Bicing"/>
+        </item>
+        <item name="metropolradruhr">
+          <key key="amenity" value="bicycle_rental"/>
+          <key key="name" value="metropolradruhr"/>
+        </item>
+      </group>
+      <group name="bureau_de_change">
+        <item name="Western Union">
+          <key key="amenity" value="bureau_de_change"/>
+          <key key="name" value="Western Union"/>
+        </item>
+      </group>
+      <group name="cafe">
+        <item name="85度C">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="85度C"/>
+        </item>
+        <item name="Bar Centrale">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Bar Centrale"/>
+        </item>
+        <item name="Bar Kafe">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Bar Kafe"/>
+        </item>
+        <item name="Barista">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Barista"/>
+        </item>
+        <item name="Bistro">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Bistro"/>
+        </item>
+        <item name="Cafe Coffee Day">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Cafe Coffee Day"/>
+        </item>
+        <item name="Cafeteria">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Cafeteria"/>
+        </item>
+        <item name="Caffè Nero">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Caffè Nero"/>
+        </item>
+        <item name="Café Amazon">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Café Amazon"/>
+        </item>
+        <item name="Café Central">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Café Central"/>
+        </item>
+        <item name="Café des Sports">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Café des Sports"/>
+        </item>
+        <item name="Caribou Coffee">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Caribou Coffee"/>
+        </item>
+        <item name="Coffee Fellows">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Coffee Fellows"/>
+        </item>
+        <item name="Coffee House">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Coffee House"/>
+        </item>
+        <item name="Coffee Shop">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Coffee Shop"/>
+        </item>
+        <item name="Coffee Time">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Coffee Time"/>
+        </item>
+        <item name="Costa">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Costa"/>
+        </item>
+        <item name="Country Style">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Country Style"/>
+        </item>
+        <item name="Dolce Vita">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Dolce Vita"/>
+        </item>
+        <item name="Dunkin' Donuts">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Dunkin' Donuts"/>
+          <key key="cuisine" value="donut"/>
+        </item>
+        <item name="Eiscafe Dolomiti">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Eiscafe Dolomiti"/>
+        </item>
+        <item name="Eiscafe Venezia">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Eiscafe Venezia"/>
+        </item>
+        <item name="Espresso House">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Espresso House"/>
+        </item>
+        <item name="Havanna">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Havanna"/>
+        </item>
+        <item name="Internet Cafe">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Internet Cafe"/>
+        </item>
+        <item name="Jamba Juice">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Jamba Juice"/>
+        </item>
+        <item name="Peet's Coffee &amp; Tea">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Peet's Coffee &amp; Tea"/>
+        </item>
+        <item name="Pret A Manger">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Pret A Manger"/>
+        </item>
+        <item name="Second Cup">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Second Cup"/>
+        </item>
+        <item name="Segafredo">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Segafredo"/>
+        </item>
+        <item name="Starbucks">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Starbucks"/>
+          <key key="cuisine" value="coffee_shop"/>
+        </item>
+        <item name="Subway">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Subway"/>
+        </item>
+        <item name="Tchibo">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Tchibo"/>
+        </item>
+        <item name="The Coffee Bean &amp; Tea Leaf">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="The Coffee Bean &amp; Tea Leaf"/>
+        </item>
+        <item name="The Coffee Club">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="The Coffee Club"/>
+        </item>
+        <item name="Tim Hortons">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Tim Hortons"/>
+        </item>
+        <item name="Traveler's Coffee">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Traveler's Coffee"/>
+        </item>
+        <item name="Venezia">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Venezia"/>
+        </item>
+        <item name="Wayne's Coffee">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Wayne's Coffee"/>
+        </item>
+        <item name="Бистро">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Бистро"/>
+        </item>
+        <item name="Встреча">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Встреча"/>
+        </item>
+        <item name="Закусочная">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Закусочная"/>
+        </item>
+        <item name="Кофе Хауз">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Кофе Хауз"/>
+        </item>
+        <item name="Кофейня">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Кофейня"/>
+        </item>
+        <item name="Сказка">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Сказка"/>
+        </item>
+        <item name="Столовая">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Столовая"/>
+        </item>
+        <item name="Теремок">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Теремок"/>
+        </item>
+        <item name="Уют">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Уют"/>
+        </item>
+        <item name="Шашлычная">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Шашлычная"/>
+        </item>
+        <item name="Шоколадница">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="Шоколадница"/>
+        </item>
+        <item name="ארומה">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="ארומה"/>
+        </item>
+        <item name="คาเฟ่ อเมซอน">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="คาเฟ่ อเมซอน"/>
+        </item>
+        <item name="エクセルシオール カフェ">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="エクセルシオール カフェ"/>
+        </item>
+        <item name="カフェ・ド・クリエ">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="カフェ・ド・クリエ"/>
+          <key key="name:en" value="Cafe de CRIE"/>
+        </item>
+        <item name="カフェ・ベローチェ">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="カフェ・ベローチェ"/>
+        </item>
+        <item name="コメダ珈琲店">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="コメダ珈琲店"/>
+        </item>
+        <item name="サンマルクカフェ">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="サンマルクカフェ"/>
+        </item>
+        <item name="スターバックス">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="スターバックス"/>
+          <key key="name:en" value="Starbucks"/>
+        </item>
+        <item name="タリーズコーヒー">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="タリーズコーヒー"/>
+        </item>
+        <item name="ドトールコーヒーショップ">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="ドトールコーヒーショップ"/>
+        </item>
+        <item name="星巴克">
+          <key key="amenity" value="cafe"/>
+          <key key="name" value="星巴克"/>
+        </item>
+      </group>
+      <group name="car_rental">
+        <item name="Avis">
+          <key key="amenity" value="car_rental"/>
+          <key key="name" value="Avis"/>
+        </item>
+        <item name="Budget">
+          <key key="amenity" value="car_rental"/>
+          <key key="name" value="Budget"/>
+        </item>
+        <item name="Enterprise">
+          <key key="amenity" value="car_rental"/>
+          <key key="name" value="Enterprise"/>
+        </item>
+        <item name="Europcar">
+          <key key="amenity" value="car_rental"/>
+          <key key="name" value="Europcar"/>
+        </item>
+        <item name="Hertz">
+          <key key="amenity" value="car_rental"/>
+          <key key="name" value="Hertz"/>
+        </item>
+        <item name="Sixt">
+          <key key="amenity" value="car_rental"/>
+          <key key="name" value="Sixt"/>
+        </item>
+        <item name="Thrifty">
+          <key key="amenity" value="car_rental"/>
+          <key key="name" value="Thrifty"/>
+        </item>
+        <item name="U-Haul">
+          <key key="amenity" value="car_rental"/>
+          <key key="name" value="U-Haul"/>
+        </item>
+        <item name="ニッポンレンタカー">
+          <key key="amenity" value="car_rental"/>
+          <key key="name" value="ニッポンレンタカー"/>
+        </item>
+      </group>
+      <group name="car_wash">
+        <item name="Aral">
+          <key key="amenity" value="car_wash"/>
+          <key key="name" value="Aral"/>
+        </item>
+        <item name="BP">
+          <key key="amenity" value="car_wash"/>
+          <key key="name" value="BP"/>
+        </item>
+        <item name="H-E-B Car Wash">
+          <key key="amenity" value="car_wash"/>
+          <key key="name" value="H-E-B Car Wash"/>
+        </item>
+        <item name="Intermarché">
+          <key key="amenity" value="car_wash"/>
+          <key key="name" value="Intermarché"/>
+        </item>
+        <item name="Myjnia bezdotykowa">
+          <key key="amenity" value="car_wash"/>
+          <key key="name" value="Myjnia bezdotykowa"/>
+        </item>
+        <item name="Myjnia samochodowa">
+          <key key="amenity" value="car_wash"/>
+          <key key="name" value="Myjnia samochodowa"/>
+        </item>
+        <item name="Shell">
+          <key key="amenity" value="car_wash"/>
+          <key key="name" value="Shell"/>
+        </item>
+        <item name="Spălătorie Auto">
+          <key key="amenity" value="car_wash"/>
+          <key key="name" value="Spălătorie Auto"/>
+        </item>
+        <item name="Statoil">
+          <key key="amenity" value="car_wash"/>
+          <key key="name" value="Statoil"/>
+        </item>
+        <item name="Waschanlage">
+          <key key="amenity" value="car_wash"/>
+          <key key="name" value="Waschanlage"/>
+        </item>
+      </group>
+      <group name="cinema">
+        <item name="Cinemark">
+          <key key="amenity" value="cinema"/>
+          <key key="name" value="Cinemark"/>
+        </item>
+        <item name="Cineworld">
+          <key key="amenity" value="cinema"/>
+          <key key="name" value="Cineworld"/>
+        </item>
+        <item name="Odeon">
+          <key key="amenity" value="cinema"/>
+          <key key="name" value="Odeon"/>
+        </item>
+      </group>
+      <group name="clinic">
+        <item name="ФАП">
+          <key key="amenity" value="clinic"/>
+          <key key="name" value="ФАП"/>
+        </item>
+      </group>
+      <group name="dentist">
+        <item name="Aspen Dental">
+          <key key="amenity" value="dentist"/>
+          <key key="name" value="Aspen Dental"/>
+        </item>
+      </group>
+      <group name="doctors">
+        <item name="Инвитро">
+          <key key="amenity" value="doctors"/>
+          <key key="name" value="Инвитро"/>
+        </item>
+        <item name="ФАП">
+          <key key="amenity" value="doctors"/>
+          <key key="name" value="ФАП"/>
+        </item>
+      </group>
+      <group name="fast_food">
+        <item name="A&amp;W">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="A&amp;W"/>
+        </item>
+        <item name="Ali Baba">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Ali Baba"/>
+        </item>
+        <item name="Arby's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Arby's"/>
+        </item>
+        <item name="Asia Wok">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Asia Wok"/>
+        </item>
+        <item name="Baskin-Robbins">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Baskin-Robbins"/>
+          <key key="amenity" value="ice_cream"/>
+        </item>
+        <item name="Bistro">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Bistro"/>
+        </item>
+        <item name="Bob's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Bob's"/>
+        </item>
+        <item name="Bojangles">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Bojangles"/>
+        </item>
+        <item name="Booster Juice">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Booster Juice"/>
+        </item>
+        <item name="Boston Market">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Boston Market"/>
+        </item>
+        <item name="Burger King">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Burger King"/>
+          <key key="cuisine" value="burger"/>
+        </item>
+        <item name="Burger Machine">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Burger Machine"/>
+        </item>
+        <item name="Carl's Jr.">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Carl's Jr."/>
+          <key key="cuisine" value="burger"/>
+        </item>
+        <item name="Checkers">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Checkers"/>
+        </item>
+        <item name="Chick-fil-A">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Chick-fil-A"/>
+          <key key="cuisine" value="chicken"/>
+        </item>
+        <item name="Chipotle">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Chipotle"/>
+          <key key="cuisine" value="mexican"/>
+        </item>
+        <item name="Chowking">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Chowking"/>
+        </item>
+        <item name="Church's Chicken">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Church's Chicken"/>
+        </item>
+        <item name="CoCo壱番屋">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="CoCo壱番屋"/>
+        </item>
+        <item name="Cold Stone Creamery">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Cold Stone Creamery"/>
+        </item>
+        <item name="Culver's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Culver's"/>
+        </item>
+        <item name="DQ">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="DQ"/>
+        </item>
+        <item name="Dairy Queen">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Dairy Queen"/>
+        </item>
+        <item name="Del Taco">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Del Taco"/>
+        </item>
+        <item name="Domino's Pizza">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Domino's Pizza"/>
+          <key key="cuisine" value="pizza"/>
+        </item>
+        <item name="Dunkin' Donuts">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Dunkin' Donuts"/>
+          <key key="cuisine" value="donut"/>
+        </item>
+        <item name="El Pollo Loco">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="El Pollo Loco"/>
+        </item>
+        <item name="Firehouse Subs">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Firehouse Subs"/>
+        </item>
+        <item name="Fish &amp; Chips">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Fish &amp; Chips"/>
+        </item>
+        <item name="Five Guys">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Five Guys"/>
+        </item>
+        <item name="Food Court">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Food Court"/>
+        </item>
+        <item name="Greenwich">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Greenwich"/>
+        </item>
+        <item name="Habib's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Habib's"/>
+        </item>
+        <item name="Hallo Pizza">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Hallo Pizza"/>
+        </item>
+        <item name="Hardee's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Hardee's"/>
+          <key key="cuisine" value="burger"/>
+        </item>
+        <item name="Harvey's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Harvey's"/>
+        </item>
+        <item name="Hesburger">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Hesburger"/>
+        </item>
+        <item name="Hungry Jacks">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Hungry Jacks"/>
+          <key key="cuisine" value="burger"/>
+        </item>
+        <item name="In-N-Out Burger">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="In-N-Out Burger"/>
+        </item>
+        <item name="Istanbul">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Istanbul"/>
+        </item>
+        <item name="Istanbul Kebab">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Istanbul Kebab"/>
+        </item>
+        <item name="Jack in the Box">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Jack in the Box"/>
+          <key key="cuisine" value="burger"/>
+        </item>
+        <item name="Jamba Juice">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Jamba Juice"/>
+        </item>
+        <item name="Jersey Mike's Subs">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Jersey Mike's Subs"/>
+        </item>
+        <item name="Jimmy John's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Jimmy John's"/>
+          <key key="cuisine" value="sandwich"/>
+        </item>
+        <item name="Jollibee">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Jollibee"/>
+        </item>
+        <item name="KFC">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="KFC"/>
+          <key key="cuisine" value="chicken"/>
+        </item>
+        <item name="KFC/Taco Bell">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="KFC/Taco Bell"/>
+        </item>
+        <item name="Kebabai">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Kebabai"/>
+        </item>
+        <item name="Kiosk">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Kiosk"/>
+        </item>
+        <item name="Kochlöffel">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Kochlöffel"/>
+        </item>
+        <item name="Kotipizza">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Kotipizza"/>
+        </item>
+        <item name="Krispy Kreme">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Krispy Kreme"/>
+        </item>
+        <item name="Little Caesars">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Little Caesars"/>
+        </item>
+        <item name="Little Caesars Pizza">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Little Caesars Pizza"/>
+        </item>
+        <item name="Long John Silver's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Long John Silver's"/>
+        </item>
+        <item name="Lotteria">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Lotteria"/>
+        </item>
+        <item name="Max">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Max"/>
+        </item>
+        <item name="McDonald's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="McDonald's"/>
+          <key key="cuisine" value="burger"/>
+        </item>
+        <item name="Mr. Sub">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Mr. Sub"/>
+        </item>
+        <item name="New York Pizza">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="New York Pizza"/>
+        </item>
+        <item name="Nordsee">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Nordsee"/>
+        </item>
+        <item name="Panda Express">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Panda Express"/>
+          <key key="cuisine" value="chinese"/>
+        </item>
+        <item name="Panera Bread">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Panera Bread"/>
+        </item>
+        <item name="Papa John's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Papa John's"/>
+          <key key="cuisine" value="pizza"/>
+        </item>
+        <item name="Papa Murphy's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Papa Murphy's"/>
+        </item>
+        <item name="Pinulito">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Pinulito"/>
+        </item>
+        <item name="Pita Pit">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Pita Pit"/>
+        </item>
+        <item name="Pizza Hut">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Pizza Hut"/>
+          <key key="cuisine" value="pizza"/>
+        </item>
+        <item name="Pizza Hut Delivery">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Pizza Hut Delivery"/>
+        </item>
+        <item name="Pizza Nova">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Pizza Nova"/>
+        </item>
+        <item name="Pizza Pizza">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Pizza Pizza"/>
+        </item>
+        <item name="Pollo Campero">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Pollo Campero"/>
+        </item>
+        <item name="Pollo Granjero">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Pollo Granjero"/>
+        </item>
+        <item name="Popeye's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Popeye's"/>
+          <key key="cuisine" value="chicken"/>
+        </item>
+        <item name="Qdoba">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Qdoba"/>
+        </item>
+        <item name="Quick">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Quick"/>
+        </item>
+        <item name="Quizno's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Quizno's"/>
+        </item>
+        <item name="Quiznos">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Quiznos"/>
+        </item>
+        <item name="Rally's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Rally's"/>
+        </item>
+        <item name="Red Rooster">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Red Rooster"/>
+        </item>
+        <item name="Schlotzsky's Deli">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Schlotzsky's Deli"/>
+        </item>
+        <item name="Sibylla">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Sibylla"/>
+        </item>
+        <item name="Sonic">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Sonic"/>
+          <key key="cuisine" value="burger"/>
+        </item>
+        <item name="Steers">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Steers"/>
+        </item>
+        <item name="Subway">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Subway"/>
+        </item>
+        <item name="Subway Sandwiches">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Subway Sandwiches"/>
+        </item>
+        <item name="Taco Bell">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Taco Bell"/>
+          <key key="cuisine" value="mexican"/>
+        </item>
+        <item name="Taco Cabana">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Taco Cabana"/>
+        </item>
+        <item name="Taco John's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Taco John's"/>
+        </item>
+        <item name="Taco Time">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Taco Time"/>
+        </item>
+        <item name="Telepizza">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Telepizza"/>
+        </item>
+        <item name="The Pizza Company">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="The Pizza Company"/>
+        </item>
+        <item name="Tim Hortons">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Tim Hortons"/>
+        </item>
+        <item name="Waffle House">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Waffle House"/>
+        </item>
+        <item name="Wendy's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Wendy's"/>
+          <key key="cuisine" value="burger"/>
+        </item>
+        <item name="Whataburger">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Whataburger"/>
+        </item>
+        <item name="White Castle">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="White Castle"/>
+        </item>
+        <item name="Wienerschnitzel">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Wienerschnitzel"/>
+        </item>
+        <item name="Wimpy">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Wimpy"/>
+        </item>
+        <item name="Zaxby's">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Zaxby's"/>
+        </item>
+        <item name="Бистро">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Бистро"/>
+        </item>
+        <item name="Бургер Кинг">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Бургер Кинг"/>
+        </item>
+        <item name="Макдоналдс">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Макдоналдс"/>
+          <key key="name:en" value="McDonald's"/>
+        </item>
+        <item name="Робин Сдобин">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Робин Сдобин"/>
+        </item>
+        <item name="Русский Аппетит">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Русский Аппетит"/>
+        </item>
+        <item name="СтарДогс">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="СтарДогс"/>
+        </item>
+        <item name="Теремок">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Теремок"/>
+        </item>
+        <item name="Шаверма">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Шаверма"/>
+        </item>
+        <item name="Шаурма">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="Шаурма"/>
+        </item>
+        <item name="かっぱ寿司">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="かっぱ寿司"/>
+        </item>
+        <item name="くら寿司">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="くら寿司"/>
+        </item>
+        <item name="すき家">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="すき家"/>
+          <key key="name:en" value="SUKIYA"/>
+        </item>
+        <item name="なか卯">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="なか卯"/>
+        </item>
+        <item name="ほっともっと">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="ほっともっと"/>
+        </item>
+        <item name="オリジン弁当">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="オリジン弁当"/>
+        </item>
+        <item name="ケンタッキーフライドチキン">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="ケンタッキーフライドチキン"/>
+          <key key="cuisine" value="chicken"/>
+          <key key="name:en" value="KFC"/>
+        </item>
+        <item name="サブウェイ">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="サブウェイ"/>
+        </item>
+        <item name="スシロー">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="スシロー"/>
+        </item>
+        <item name="マクドナルド">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="マクドナルド"/>
+          <key key="cuisine" value="burger"/>
+          <key key="name:en" value="McDonald's"/>
+        </item>
+        <item name="ミスタードーナツ">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="ミスタードーナツ"/>
+        </item>
+        <item name="モスバーガー">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="モスバーガー"/>
+          <key key="name:en" value="MOS BURGER"/>
+        </item>
+        <item name="ロッテリア">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="ロッテリア"/>
+        </item>
+        <item name="吉野家">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="吉野家"/>
+        </item>
+        <item name="幸楽苑">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="幸楽苑"/>
+        </item>
+        <item name="摩斯漢堡">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="摩斯漢堡"/>
+        </item>
+        <item name="松屋">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="松屋"/>
+          <key key="name:en" value="Matsuya"/>
+        </item>
+        <item name="肯德基">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="肯德基"/>
+        </item>
+        <item name="麥當勞">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="麥當勞"/>
+        </item>
+        <item name="麦当劳">
+          <key key="amenity" value="fast_food"/>
+          <key key="name" value="麦当劳"/>
+        </item>
+      </group>
+      <group name="fuel">
+        <item name="76">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="76"/>
+        </item>
+        <item name="1-2-3">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="1-2-3"/>
+        </item>
+        <item name="7-Eleven">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="7-Eleven"/>
+        </item>
+        <item name="ABC">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="ABC"/>
+        </item>
+        <item name="ANP">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="ANP"/>
+        </item>
+        <item name="ARAL">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="ARAL"/>
+        </item>
+        <item name="Afriquia">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Afriquia"/>
+        </item>
+        <item name="Agip">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Agip"/>
+        </item>
+        <item name="Agrola">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Agrola"/>
+        </item>
+        <item name="Api">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Api"/>
+        </item>
+        <item name="Aral">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Aral"/>
+        </item>
+        <item name="Arco">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Arco"/>
+        </item>
+        <item name="Auchan">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Auchan"/>
+        </item>
+        <item name="Avanti">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Avanti"/>
+        </item>
+        <item name="Avia">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Avia"/>
+        </item>
+        <item name="BEBECO">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="BEBECO"/>
+        </item>
+        <item name="BFT">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="BFT"/>
+        </item>
+        <item name="BP">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="BP"/>
+        </item>
+        <item name="BR">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="BR"/>
+        </item>
+        <item name="Bangchak">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Bangchak"/>
+        </item>
+        <item name="Benzina">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Benzina"/>
+        </item>
+        <item name="Bharat Petroleum">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Bharat Petroleum"/>
+        </item>
+        <item name="Bliska">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Bliska"/>
+        </item>
+        <item name="CAMPSA">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="CAMPSA"/>
+        </item>
+        <item name="CARREFOUR">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="CARREFOUR"/>
+        </item>
+        <item name="CEPSA">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="CEPSA"/>
+        </item>
+        <item name="CNG">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="CNG"/>
+        </item>
+        <item name="Caltex">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Caltex"/>
+        </item>
+        <item name="Canadian Tire">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Canadian Tire"/>
+        </item>
+        <item name="Carrefour">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Carrefour"/>
+        </item>
+        <item name="Casey's General Store">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Casey's General Store"/>
+        </item>
+        <item name="Cenex">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Cenex"/>
+        </item>
+        <item name="Cepsa">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Cepsa"/>
+        </item>
+        <item name="Ceypetco">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Ceypetco"/>
+        </item>
+        <item name="Chevron">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Chevron"/>
+        </item>
+        <item name="Circle K">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Circle K"/>
+        </item>
+        <item name="Citgo">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Citgo"/>
+        </item>
+        <item name="Coles Express">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Coles Express"/>
+        </item>
+        <item name="Conoco">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Conoco"/>
+        </item>
+        <item name="Coop">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Coop"/>
+        </item>
+        <item name="Copec">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Copec"/>
+        </item>
+        <item name="Cosmo">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Cosmo"/>
+        </item>
+        <item name="Costco">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Costco"/>
+        </item>
+        <item name="Costco Gas">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Costco Gas"/>
+        </item>
+        <item name="Cumberland Farms">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Cumberland Farms"/>
+        </item>
+        <item name="Delta">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Delta"/>
+        </item>
+        <item name="Drummed Fuel">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Drummed Fuel"/>
+        </item>
+        <item name="EKO">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="EKO"/>
+        </item>
+        <item name="ENEOS">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="ENEOS"/>
+        </item>
+        <item name="ENI">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="ENI"/>
+        </item>
+        <item name="ERG">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="ERG"/>
+        </item>
+        <item name="Elan">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Elan"/>
+        </item>
+        <item name="Eneos">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Eneos"/>
+        </item>
+        <item name="Engen">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Engen"/>
+        </item>
+        <item name="Eni">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Eni"/>
+        </item>
+        <item name="Erg">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Erg"/>
+        </item>
+        <item name="Esso">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Esso"/>
+        </item>
+        <item name="Esso Express">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Esso Express"/>
+        </item>
+        <item name="Exxon">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Exxon"/>
+        </item>
+        <item name="F24">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="F24"/>
+        </item>
+        <item name="Flying V">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Flying V"/>
+        </item>
+        <item name="GALP">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="GALP"/>
+        </item>
+        <item name="GNV">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="GNV"/>
+        </item>
+        <item name="Gazprom">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Gazprom"/>
+        </item>
+        <item name="Gulf">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Gulf"/>
+        </item>
+        <item name="H-E-B Gas">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="H-E-B Gas"/>
+        </item>
+        <item name="HEM">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="HEM"/>
+        </item>
+        <item name="HP">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="HP"/>
+        </item>
+        <item name="Helios">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Helios"/>
+        </item>
+        <item name="Hess">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Hess"/>
+        </item>
+        <item name="Hindustan Petroleum">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Hindustan Petroleum"/>
+        </item>
+        <item name="Holiday">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Holiday"/>
+        </item>
+        <item name="Husky">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Husky"/>
+        </item>
+        <item name="IES">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="IES"/>
+        </item>
+        <item name="IP">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="IP"/>
+        </item>
+        <item name="Independent Fuel Station">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Independent Fuel Station"/>
+        </item>
+        <item name="Indian Oil">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Indian Oil"/>
+        </item>
+        <item name="Indipend.">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Indipend."/>
+        </item>
+        <item name="Intermarché">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Intermarché"/>
+        </item>
+        <item name="Intermarché Super">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Intermarché Super"/>
+        </item>
+        <item name="Ipiranga">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Ipiranga"/>
+        </item>
+        <item name="Irving">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Irving"/>
+        </item>
+        <item name="JA-SS">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="JA-SS"/>
+        </item>
+        <item name="JOMO">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="JOMO"/>
+        </item>
+        <item name="Jet">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Jet"/>
+        </item>
+        <item name="Jetti">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Jetti"/>
+        </item>
+        <item name="Kangaroo">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Kangaroo"/>
+        </item>
+        <item name="Kobil">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Kobil"/>
+        </item>
+        <item name="Kroger Fuel">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Kroger Fuel"/>
+        </item>
+        <item name="Kum &amp; Go">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Kum &amp; Go"/>
+        </item>
+        <item name="Kwik Trip">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Kwik Trip"/>
+        </item>
+        <item name="LPG">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="LPG"/>
+        </item>
+        <item name="LUKOIL">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="LUKOIL"/>
+        </item>
+        <item name="Liberty">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Liberty"/>
+        </item>
+        <item name="Lotos">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Lotos"/>
+        </item>
+        <item name="Lotos Optima">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Lotos Optima"/>
+        </item>
+        <item name="Lukoil">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Lukoil"/>
+        </item>
+        <item name="MEROIL">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="MEROIL"/>
+        </item>
+        <item name="MOL">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="MOL"/>
+        </item>
+        <item name="Marathon">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Marathon"/>
+        </item>
+        <item name="Metano">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Metano"/>
+        </item>
+        <item name="Migrol">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Migrol"/>
+        </item>
+        <item name="Minipump">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Minipump"/>
+        </item>
+        <item name="Mobil">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Mobil"/>
+        </item>
+        <item name="Mobile">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Mobile"/>
+        </item>
+        <item name="Mol">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Mol"/>
+        </item>
+        <item name="Morrisons">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Morrisons"/>
+        </item>
+        <item name="Moya">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Moya"/>
+        </item>
+        <item name="Murphy USA">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Murphy USA"/>
+        </item>
+        <item name="NP">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="NP"/>
+        </item>
+        <item name="Neste">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Neste"/>
+        </item>
+        <item name="Neste A24">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Neste A24"/>
+        </item>
+        <item name="OIL!">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="OIL!"/>
+        </item>
+        <item name="OK">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="OK"/>
+        </item>
+        <item name="OKQ8">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="OKQ8"/>
+        </item>
+        <item name="OMV">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="OMV"/>
+        </item>
+        <item name="Oilibya">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Oilibya"/>
+        </item>
+        <item name="Opet">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Opet"/>
+        </item>
+        <item name="Orlen">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Orlen"/>
+        </item>
+        <item name="PETRONOR">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="PETRONOR"/>
+        </item>
+        <item name="PSO">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="PSO"/>
+        </item>
+        <item name="PT">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="PT"/>
+        </item>
+        <item name="PTT">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="PTT"/>
+        </item>
+        <item name="Pecsa">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Pecsa"/>
+        </item>
+        <item name="Pemex">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Pemex"/>
+        </item>
+        <item name="Pertamina">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Pertamina"/>
+        </item>
+        <item name="Petro-Canada">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Petro-Canada"/>
+        </item>
+        <item name="Petrobras">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Petrobras"/>
+        </item>
+        <item name="Petrochina">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Petrochina"/>
+        </item>
+        <item name="Petrol Ofisi">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Petrol Ofisi"/>
+        </item>
+        <item name="Petrolimex">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Petrolimex"/>
+        </item>
+        <item name="Petrom">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Petrom"/>
+        </item>
+        <item name="Petron">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Petron"/>
+        </item>
+        <item name="Petronas">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Petronas"/>
+        </item>
+        <item name="Petroperu">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Petroperu"/>
+        </item>
+        <item name="Phillips 66">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Phillips 66"/>
+        </item>
+        <item name="Phoenix">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Phoenix"/>
+        </item>
+        <item name="Pilot">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Pilot"/>
+        </item>
+        <item name="Pioneer">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Pioneer"/>
+        </item>
+        <item name="Posto">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Posto"/>
+        </item>
+        <item name="Posto Atem">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Posto Atem"/>
+        </item>
+        <item name="Posto BR">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Posto BR"/>
+        </item>
+        <item name="Posto Ipiranga">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Posto Ipiranga"/>
+        </item>
+        <item name="Posto Shell">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Posto Shell"/>
+        </item>
+        <item name="Primax">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Primax"/>
+        </item>
+        <item name="Puma">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Puma"/>
+        </item>
+        <item name="Q1">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Q1"/>
+        </item>
+        <item name="Q8">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Q8"/>
+        </item>
+        <item name="QuikTrip">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="QuikTrip"/>
+        </item>
+        <item name="REPSOL">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="REPSOL"/>
+        </item>
+        <item name="RaceTrac">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="RaceTrac"/>
+        </item>
+        <item name="Raiffeisenbank">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Raiffeisenbank"/>
+        </item>
+        <item name="Repsol">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Repsol"/>
+        </item>
+        <item name="Rompetrol">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Rompetrol"/>
+        </item>
+        <item name="Royal Farms">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Royal Farms"/>
+        </item>
+        <item name="Rubis">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Rubis"/>
+        </item>
+        <item name="SB Tank">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="SB Tank"/>
+        </item>
+        <item name="SPBU">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="SPBU"/>
+        </item>
+        <item name="Safeway">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Safeway"/>
+        </item>
+        <item name="Sainsbury's">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Sainsbury's"/>
+        </item>
+        <item name="Sam's Club">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Sam's Club"/>
+        </item>
+        <item name="Sasol">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Sasol"/>
+        </item>
+        <item name="Sea Oil">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Sea Oil"/>
+        </item>
+        <item name="Sheetz">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Sheetz"/>
+        </item>
+        <item name="Shell">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Shell"/>
+        </item>
+        <item name="Shell Express">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Shell Express"/>
+        </item>
+        <item name="Sinclair">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Sinclair"/>
+        </item>
+        <item name="Sinopec Fuel">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Sinopec Fuel"/>
+        </item>
+        <item name="Slovnaft">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Slovnaft"/>
+        </item>
+        <item name="Socar">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Socar"/>
+        </item>
+        <item name="Sokimex">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Sokimex"/>
+        </item>
+        <item name="Speedway">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Speedway"/>
+        </item>
+        <item name="St1">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="St1"/>
+        </item>
+        <item name="Star">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Star"/>
+        </item>
+        <item name="Star Oil">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Star Oil"/>
+        </item>
+        <item name="Station Service E. Leclerc">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Station Service E. Leclerc"/>
+        </item>
+        <item name="Statoil">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Statoil"/>
+        </item>
+        <item name="Stewart's">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Stewart's"/>
+        </item>
+        <item name="Sunoco">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Sunoco"/>
+        </item>
+        <item name="Super U">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Super U"/>
+        </item>
+        <item name="Tamoil">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Tamoil"/>
+        </item>
+        <item name="Tango">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Tango"/>
+        </item>
+        <item name="Teboil">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Teboil"/>
+        </item>
+        <item name="Tela">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Tela"/>
+        </item>
+        <item name="Terpel">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Terpel"/>
+        </item>
+        <item name="Tesco">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Tesco"/>
+        </item>
+        <item name="Texaco">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Texaco"/>
+        </item>
+        <item name="Tinq">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Tinq"/>
+        </item>
+        <item name="Topaz">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Topaz"/>
+        </item>
+        <item name="Total">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Total"/>
+        </item>
+        <item name="Total Access">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Total Access"/>
+        </item>
+        <item name="TotalErg">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="TotalErg"/>
+        </item>
+        <item name="Turkey Hill">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Turkey Hill"/>
+        </item>
+        <item name="Turmöl">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Turmöl"/>
+        </item>
+        <item name="Ultramar">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Ultramar"/>
+        </item>
+        <item name="United">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="United"/>
+        </item>
+        <item name="Uno">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Uno"/>
+        </item>
+        <item name="Uno-X">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Uno-X"/>
+        </item>
+        <item name="Valero">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Valero"/>
+        </item>
+        <item name="Vito">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Vito"/>
+        </item>
+        <item name="WOG">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="WOG"/>
+        </item>
+        <item name="Wawa">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Wawa"/>
+        </item>
+        <item name="Westfalen">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Westfalen"/>
+        </item>
+        <item name="Woolworths Petrol">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Woolworths Petrol"/>
+        </item>
+        <item name="Z">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Z"/>
+        </item>
+        <item name="bft">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="bft"/>
+        </item>
+        <item name="eni">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="eni"/>
+        </item>
+        <item name="АГЗС">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="АГЗС"/>
+        </item>
+        <item name="АГНКС">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="АГНКС"/>
+        </item>
+        <item name="АЗС">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="АЗС"/>
+        </item>
+        <item name="Авіас">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Авіас"/>
+        </item>
+        <item name="БРСМ-Нафта">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="БРСМ-Нафта"/>
+        </item>
+        <item name="Башнефть">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Башнефть"/>
+        </item>
+        <item name="Белоруснефть">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Белоруснефть"/>
+        </item>
+        <item name="Газпромнефть">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Газпромнефть"/>
+        </item>
+        <item name="КазМунайГаз">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="КазМунайГаз"/>
+        </item>
+        <item name="Лукойл">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Лукойл"/>
+        </item>
+        <item name="Макпетрол">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Макпетрол"/>
+        </item>
+        <item name="НК Альянс">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="НК Альянс"/>
+        </item>
+        <item name="Нефтьмагистраль">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Нефтьмагистраль"/>
+        </item>
+        <item name="ОККО">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="ОККО"/>
+        </item>
+        <item name="ОМВ">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="ОМВ"/>
+        </item>
+        <item name="ПТК">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="ПТК"/>
+        </item>
+        <item name="Петрол">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Петрол"/>
+        </item>
+        <item name="Пропан">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Пропан"/>
+        </item>
+        <item name="Роснефть">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Роснефть"/>
+        </item>
+        <item name="Сургутнефтегаз">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Сургутнефтегаз"/>
+        </item>
+        <item name="ТНК">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="ТНК"/>
+        </item>
+        <item name="Татнефтепродукт">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Татнефтепродукт"/>
+        </item>
+        <item name="Татнефть">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Татнефть"/>
+        </item>
+        <item name="Укрнафта">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="Укрнафта"/>
+        </item>
+        <item name="محطه وقود">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="محطه وقود"/>
+        </item>
+        <item name="پمپ بنزین">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="پمپ بنزین"/>
+        </item>
+        <item name="پمپ گاز">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="پمپ گاز"/>
+        </item>
+        <item name="คาลเท็กซ์">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="คาลเท็กซ์"/>
+        </item>
+        <item name="บางจาก">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="บางจาก"/>
+        </item>
+        <item name="ป.ต.ท.">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="ป.ต.ท."/>
+        </item>
+        <item name="เชลล์">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="เชลล์"/>
+        </item>
+        <item name="เอสโซ่">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="เอสโซ่"/>
+        </item>
+        <item name="エネオス">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="エネオス"/>
+        </item>
+        <item name="コスモ石油">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="コスモ石油"/>
+        </item>
+        <item name="ゼネラル">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="ゼネラル"/>
+        </item>
+        <item name="出光">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="出光"/>
+          <key key="name:en" value="IDEMITSU"/>
+        </item>
+        <item name="台灣中油">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="台灣中油"/>
+        </item>
+        <item name="昭和シェル">
+          <key key="amenity" value="fuel"/>
+          <key key="name" value="昭和シェル"/>
+        </item>
+      </group>
+      <group name="hospital">
+        <item name="Cruz Roja">
+          <key key="amenity" value="hospital"/>
+          <key key="name" value="Cruz Roja"/>
+        </item>
+        <item name="Hospital Municipal">
+          <key key="amenity" value="hospital"/>
+          <key key="name" value="Hospital Municipal"/>
+        </item>
+        <item name="IMSS">
+          <key key="amenity" value="hospital"/>
+          <key key="name" value="IMSS"/>
+        </item>
+        <item name="Инфекционное отделение">
+          <key key="amenity" value="hospital"/>
+          <key key="name" value="Инфекционное отделение"/>
+        </item>
+        <item name="Кожно-венерологический диспансер">
+          <key key="amenity" value="hospital"/>
+          <key key="name" value="Кожно-венерологический диспансер"/>
+        </item>
+        <item name="Районная больница">
+          <key key="amenity" value="hospital"/>
+          <key key="name" value="Районная больница"/>
+        </item>
+        <item name="Роддом">
+          <key key="amenity" value="hospital"/>
+          <key key="name" value="Роддом"/>
+        </item>
+        <item name="Родильный дом">
+          <key key="amenity" value="hospital"/>
+          <key key="name" value="Родильный дом"/>
+        </item>
+        <item name="Скорая помощь">
+          <key key="amenity" value="hospital"/>
+          <key key="name" value="Скорая помощь"/>
+        </item>
+        <item name="ФАП">
+          <key key="amenity" value="hospital"/>
+          <key key="name" value="ФАП"/>
+        </item>
+        <item name="ЦРБ">
+          <key key="amenity" value="hospital"/>
+          <key key="name" value="ЦРБ"/>
+        </item>
+        <item name="Центральная районная больница">
+          <key key="amenity" value="hospital"/>
+          <key key="name" value="Центральная районная больница"/>
+        </item>
+        <item name="โรงพยาบาลส่งเสริมสุขภาพตำบล">
+          <key key="amenity" value="hospital"/>
+          <key key="name" value="โรงพยาบาลส่งเสริมสุขภาพตำบล"/>
+        </item>
+        <item name="경희한의원 (Gyeonghui Oriental Medicine Clinic)">
+          <key key="amenity" value="hospital"/>
+          <key key="name" value="경희한의원 (Gyeonghui Oriental Medicine Clinic)"/>
+        </item>
+      </group>
+      <group name="ice_cream">
+        <item name="Grido">
+          <key key="amenity" value="ice_cream"/>
+          <key key="name" value="Grido"/>
+        </item>
+      </group>
+      <group name="kindergarten">
+        <item name="Amado Nervo">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Amado Nervo"/>
+        </item>
+        <item name="Anganwadi">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Anganwadi"/>
+        </item>
+        <item name="Arche Noah">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Arche Noah"/>
+        </item>
+        <item name="Benito Juarez">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Benito Juarez"/>
+        </item>
+        <item name="CONAFE Preescolar">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="CONAFE Preescolar"/>
+        </item>
+        <item name="Cuauhtemoc">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Cuauhtemoc"/>
+        </item>
+        <item name="Cursos Comunitarios">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Cursos Comunitarios"/>
+        </item>
+        <item name="Educacion Inicial de CONAFE No Escolarizado">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Educacion Inicial de CONAFE No Escolarizado"/>
+        </item>
+        <item name="Emiliano Zapata">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Emiliano Zapata"/>
+        </item>
+        <item name="Estefania Casta�eda">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Estefania Casta�eda"/>
+        </item>
+        <item name="Ev. Kindergarten">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Ev. Kindergarten"/>
+        </item>
+        <item name="Evangelischer Kindergarten">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Evangelischer Kindergarten"/>
+        </item>
+        <item name="Federico Froebel">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Federico Froebel"/>
+        </item>
+        <item name="Gabriela Mistral">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Gabriela Mistral"/>
+        </item>
+        <item name="Jardin Infantil">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Jardin Infantil"/>
+        </item>
+        <item name="Jean Piaget">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Jean Piaget"/>
+        </item>
+        <item name="Jose Vasconcelos">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Jose Vasconcelos"/>
+        </item>
+        <item name="Juan Escutia">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Juan Escutia"/>
+        </item>
+        <item name="Katholischer Kindergarten">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Katholischer Kindergarten"/>
+        </item>
+        <item name="Kindergarten Regenbogen">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Kindergarten Regenbogen"/>
+        </item>
+        <item name="Kindergarten St. Josef">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Kindergarten St. Josef"/>
+        </item>
+        <item name="Maria Montessori">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Maria Montessori"/>
+        </item>
+        <item name="Miguel Hidalgo Y Costilla">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Miguel Hidalgo Y Costilla"/>
+        </item>
+        <item name="Ni�os Heroes">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Ni�os Heroes"/>
+        </item>
+        <item name="PAUD">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="PAUD"/>
+        </item>
+        <item name="Pusteblume">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Pusteblume"/>
+        </item>
+        <item name="Rosaura Zapata">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Rosaura Zapata"/>
+        </item>
+        <item name="Sor Juana Ines De La Cruz">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Sor Juana Ines De La Cruz"/>
+        </item>
+        <item name="Städtischer Kindergarten">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Städtischer Kindergarten"/>
+        </item>
+        <item name="Villa Kunterbunt">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Villa Kunterbunt"/>
+        </item>
+        <item name="Waldkindergarten">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Waldkindergarten"/>
+        </item>
+        <item name="Waldorfkindergarten">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Waldorfkindergarten"/>
+        </item>
+        <item name="Óvoda">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Óvoda"/>
+        </item>
+        <item name="Детский сад &quot;Солнышко&quot;">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад &quot;Солнышко&quot;"/>
+        </item>
+        <item name="Детский сад №1">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №1"/>
+        </item>
+        <item name="Детский сад №10">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №10"/>
+        </item>
+        <item name="Детский сад №11">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №11"/>
+        </item>
+        <item name="Детский сад №12">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №12"/>
+        </item>
+        <item name="Детский сад №14">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №14"/>
+        </item>
+        <item name="Детский сад №15">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №15"/>
+        </item>
+        <item name="Детский сад №17">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №17"/>
+        </item>
+        <item name="Детский сад №18">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №18"/>
+        </item>
+        <item name="Детский сад №19">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №19"/>
+        </item>
+        <item name="Детский сад №2">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №2"/>
+        </item>
+        <item name="Детский сад №22">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №22"/>
+        </item>
+        <item name="Детский сад №25">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №25"/>
+        </item>
+        <item name="Детский сад №29">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №29"/>
+        </item>
+        <item name="Детский сад №3">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №3"/>
+        </item>
+        <item name="Детский сад №4">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №4"/>
+        </item>
+        <item name="Детский сад №5">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №5"/>
+        </item>
+        <item name="Детский сад №6">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №6"/>
+        </item>
+        <item name="Детский сад №7">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №7"/>
+        </item>
+        <item name="Детский сад №8">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №8"/>
+        </item>
+        <item name="Детский сад №9">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Детский сад №9"/>
+        </item>
+        <item name="Солнышко">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="Солнышко"/>
+        </item>
+        <item name="中央保育所">
+          <key key="amenity" value="kindergarten"/>
+          <key key="name" value="中央保育所"/>
+        </item>
+      </group>
+      <group name="library">
+        <item name="Biblioteca Comunale">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Biblioteca Comunale"/>
+        </item>
+        <item name="Biblioteca Municipal">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Biblioteca Municipal"/>
+        </item>
+        <item name="Biblioteca Pública">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Biblioteca Pública"/>
+        </item>
+        <item name="Biblioteca Pública Municipal">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Biblioteca Pública Municipal"/>
+        </item>
+        <item name="Biblioteca comunale">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Biblioteca comunale"/>
+        </item>
+        <item name="Biblioteka Publiczna">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Biblioteka Publiczna"/>
+        </item>
+        <item name="Bibliothèque Municipale">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Bibliothèque Municipale"/>
+        </item>
+        <item name="Bibliothèque municipale">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Bibliothèque municipale"/>
+        </item>
+        <item name="Bücherei">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Bücherei"/>
+        </item>
+        <item name="Central Library">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Central Library"/>
+        </item>
+        <item name="Gemeindebücherei">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Gemeindebücherei"/>
+        </item>
+        <item name="Gminna Biblioteka Publiczna">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Gminna Biblioteka Publiczna"/>
+        </item>
+        <item name="Miejska Biblioteka Publiczna">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Miejska Biblioteka Publiczna"/>
+        </item>
+        <item name="Médiathèque">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Médiathèque"/>
+        </item>
+        <item name="Městská knihovna">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Městská knihovna"/>
+        </item>
+        <item name="Public Library">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Public Library"/>
+        </item>
+        <item name="Stadtbibliothek">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Stadtbibliothek"/>
+        </item>
+        <item name="Stadtbücherei">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Stadtbücherei"/>
+        </item>
+        <item name="Городская библиотека">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Городская библиотека"/>
+        </item>
+        <item name="Детская библиотека">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Детская библиотека"/>
+        </item>
+        <item name="Центральная библиотека">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Центральная библиотека"/>
+        </item>
+        <item name="Центральная городская библиотека">
+          <key key="amenity" value="library"/>
+          <key key="name" value="Центральная городская библиотека"/>
+        </item>
+        <item name="图书馆">
+          <key key="amenity" value="library"/>
+          <key key="name" value="图书馆"/>
+        </item>
+      </group>
+      <group name="pharmacy">
+        <item name="36.6">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="36.6"/>
+        </item>
+        <item name="Adler Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Adler Apotheke"/>
+        </item>
+        <item name="Alte Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Alte Apotheke"/>
+        </item>
+        <item name="Apollo Pharmacy">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Apollo Pharmacy"/>
+        </item>
+        <item name="Apotheke am Markt">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Apotheke am Markt"/>
+        </item>
+        <item name="Bahnhof Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Bahnhof Apotheke"/>
+        </item>
+        <item name="Bahnhof-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Bahnhof-Apotheke"/>
+        </item>
+        <item name="Benavides">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Benavides"/>
+        </item>
+        <item name="Boots">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Boots"/>
+        </item>
+        <item name="Brunnen-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Brunnen-Apotheke"/>
+        </item>
+        <item name="Burg-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Burg-Apotheke"/>
+        </item>
+        <item name="Bären-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Bären-Apotheke"/>
+        </item>
+        <item name="CVS">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="CVS"/>
+        </item>
+        <item name="Catena">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Catena"/>
+        </item>
+        <item name="Chemist Warehouse">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Chemist Warehouse"/>
+        </item>
+        <item name="Clicks">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Clicks"/>
+        </item>
+        <item name="Cruz Verde">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Cruz Verde"/>
+        </item>
+        <item name="Dbam o Zdrowie">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Dbam o Zdrowie"/>
+        </item>
+        <item name="Dr. Max">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Dr. Max"/>
+        </item>
+        <item name="Droga Raia">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Droga Raia"/>
+        </item>
+        <item name="Drogaria São Paulo">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Drogaria São Paulo"/>
+        </item>
+        <item name="Drogasil">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Drogasil"/>
+        </item>
+        <item name="Duane Reade">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Duane Reade"/>
+        </item>
+        <item name="Eczane">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Eczane"/>
+        </item>
+        <item name="Engel-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Engel-Apotheke"/>
+        </item>
+        <item name="Eurovaistinė">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Eurovaistinė"/>
+        </item>
+        <item name="Farmacia Comunale">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Farmacia Comunale"/>
+        </item>
+        <item name="Farmacia Guadalajara">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Farmacia Guadalajara"/>
+        </item>
+        <item name="Farmacias Ahumada">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Farmacias Ahumada"/>
+        </item>
+        <item name="Farmacias Cruz Verde">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Farmacias Cruz Verde"/>
+        </item>
+        <item name="Farmacias Guadalajara">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Farmacias Guadalajara"/>
+        </item>
+        <item name="Farmacias SalcoBrand">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Farmacias SalcoBrand"/>
+        </item>
+        <item name="Farmacias Similares">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Farmacias Similares"/>
+        </item>
+        <item name="Farmacias del Ahorro">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Farmacias del Ahorro"/>
+        </item>
+        <item name="Farmacity">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Farmacity"/>
+        </item>
+        <item name="Farmahorro">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Farmahorro"/>
+        </item>
+        <item name="Farmatodo">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Farmatodo"/>
+        </item>
+        <item name="Gintarinė vaistinė">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Gintarinė vaistinė"/>
+        </item>
+        <item name="Guardian">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Guardian"/>
+        </item>
+        <item name="Gyógyszertár">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Gyógyszertár"/>
+        </item>
+        <item name="H-E-B Pharmacy">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="H-E-B Pharmacy"/>
+        </item>
+        <item name="Hirsch-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Hirsch-Apotheke"/>
+        </item>
+        <item name="Hubertus Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Hubertus Apotheke"/>
+        </item>
+        <item name="Inkafarma">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Inkafarma"/>
+        </item>
+        <item name="Jean Coutu">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Jean Coutu"/>
+        </item>
+        <item name="Kinney Drugs">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Kinney Drugs"/>
+        </item>
+        <item name="Linden-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Linden-Apotheke"/>
+        </item>
+        <item name="Ljekarna">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Ljekarna"/>
+        </item>
+        <item name="Lloyds Pharmacy">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Lloyds Pharmacy"/>
+        </item>
+        <item name="Löwen-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Löwen-Apotheke"/>
+        </item>
+        <item name="Marien-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Marien-Apotheke"/>
+        </item>
+        <item name="Markt-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Markt-Apotheke"/>
+        </item>
+        <item name="Mercury Drug">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Mercury Drug"/>
+        </item>
+        <item name="Mēness aptieka">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Mēness aptieka"/>
+        </item>
+        <item name="Neue Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Neue Apotheke"/>
+        </item>
+        <item name="Pague Menos">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Pague Menos"/>
+        </item>
+        <item name="Panvel">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Panvel"/>
+        </item>
+        <item name="Park-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Park-Apotheke"/>
+        </item>
+        <item name="Pharmacie Centrale">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Pharmacie Centrale"/>
+        </item>
+        <item name="Pharmacie Principale">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Pharmacie Principale"/>
+        </item>
+        <item name="Pharmacie de la Gare">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Pharmacie de la Gare"/>
+        </item>
+        <item name="Pharmacie de la Mairie">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Pharmacie de la Mairie"/>
+        </item>
+        <item name="Pharmacie du Centre">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Pharmacie du Centre"/>
+        </item>
+        <item name="Pharmacie du Marché">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Pharmacie du Marché"/>
+        </item>
+        <item name="Pharmaprix">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Pharmaprix"/>
+        </item>
+        <item name="Pharmasave">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Pharmasave"/>
+        </item>
+        <item name="Rathaus-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Rathaus-Apotheke"/>
+        </item>
+        <item name="Rats-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Rats-Apotheke"/>
+        </item>
+        <item name="Rexall">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Rexall"/>
+        </item>
+        <item name="Rite Aid">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Rite Aid"/>
+        </item>
+        <item name="Rose Pharmacy">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Rose Pharmacy"/>
+        </item>
+        <item name="Rosen-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Rosen-Apotheke"/>
+        </item>
+        <item name="Rowlands Pharmacy">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Rowlands Pharmacy"/>
+        </item>
+        <item name="SalcoBrand">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="SalcoBrand"/>
+        </item>
+        <item name="Schloss-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Schloss-Apotheke"/>
+        </item>
+        <item name="Sensiblu">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Sensiblu"/>
+        </item>
+        <item name="Shoppers Drug Mart">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Shoppers Drug Mart"/>
+        </item>
+        <item name="Sonnen-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Sonnen-Apotheke"/>
+        </item>
+        <item name="South Star Drug">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="South Star Drug"/>
+        </item>
+        <item name="Stadt-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Stadt-Apotheke"/>
+        </item>
+        <item name="Stern-Apotheke">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Stern-Apotheke"/>
+        </item>
+        <item name="Superdrug">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Superdrug"/>
+        </item>
+        <item name="The Generics Pharmacy">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="The Generics Pharmacy"/>
+        </item>
+        <item name="Walgreens">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Walgreens"/>
+        </item>
+        <item name="Walgreens Pharmacy">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Walgreens Pharmacy"/>
+        </item>
+        <item name="Walmart Pharmacy">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Walmart Pharmacy"/>
+        </item>
+        <item name="Watsons">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Watsons"/>
+        </item>
+        <item name="А5">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="А5"/>
+        </item>
+        <item name="Айболит">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Айболит"/>
+        </item>
+        <item name="Аптека 36,6">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Аптека 36,6"/>
+        </item>
+        <item name="Аптека низьких цін">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Аптека низьких цін"/>
+        </item>
+        <item name="Аптека от склада">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Аптека от склада"/>
+        </item>
+        <item name="Аптека №1">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Аптека №1"/>
+        </item>
+        <item name="Аптечный пункт">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Аптечный пункт"/>
+        </item>
+        <item name="Арніка">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Арніка"/>
+        </item>
+        <item name="Бережная аптека">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Бережная аптека"/>
+        </item>
+        <item name="Вита">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Вита"/>
+        </item>
+        <item name="Горздрав">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Горздрав"/>
+        </item>
+        <item name="Живика">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Живика"/>
+        </item>
+        <item name="Здоровье">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Здоровье"/>
+        </item>
+        <item name="Имплозия">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Имплозия"/>
+        </item>
+        <item name="Классика">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Классика"/>
+        </item>
+        <item name="Невис">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Невис"/>
+        </item>
+        <item name="Норма">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Норма"/>
+        </item>
+        <item name="Панацея">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Панацея"/>
+        </item>
+        <item name="Первая помощь">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Первая помощь"/>
+        </item>
+        <item name="Планета здоровья">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Планета здоровья"/>
+        </item>
+        <item name="Радуга">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Радуга"/>
+        </item>
+        <item name="Ригла">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Ригла"/>
+        </item>
+        <item name="Фармакопейка">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Фармакопейка"/>
+        </item>
+        <item name="Фармакор">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Фармакор"/>
+        </item>
+        <item name="Фармация">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Фармация"/>
+        </item>
+        <item name="Фармленд">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="Фармленд"/>
+        </item>
+        <item name="داروخانه">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="داروخانه"/>
+        </item>
+        <item name="ავერსი (Aversi)">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="ავერსი (Aversi)"/>
+        </item>
+        <item name="ウエルシア">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="ウエルシア"/>
+        </item>
+        <item name="クリエイト">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="クリエイト"/>
+        </item>
+        <item name="サンドラッグ">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="サンドラッグ"/>
+        </item>
+        <item name="スギ薬局">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="スギ薬局"/>
+        </item>
+        <item name="セイジョー">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="セイジョー"/>
+        </item>
+        <item name="ツルハドラッグ">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="ツルハドラッグ"/>
+        </item>
+        <item name="ドラッグてらしま (Drug Terashima)">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="ドラッグてらしま (Drug Terashima)"/>
+        </item>
+        <item name="マツモトキヨシ">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="マツモトキヨシ"/>
+        </item>
+        <item name="丁丁藥局">
+          <key key="amenity" value="pharmacy"/>
+          <key key="name" value="丁丁藥局"/>
+        </item>
+      </group>
+      <group name="pub">
+        <item name="Black Bull">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="Black Bull"/>
+        </item>
+        <item name="Black Horse">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="Black Horse"/>
+        </item>
+        <item name="Commercial Hotel">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="Commercial Hotel"/>
+        </item>
+        <item name="Cross Keys">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="Cross Keys"/>
+        </item>
+        <item name="Irish Pub">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="Irish Pub"/>
+        </item>
+        <item name="Kings Arms">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="Kings Arms"/>
+        </item>
+        <item name="Kings Head">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="Kings Head"/>
+        </item>
+        <item name="New Inn">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="New Inn"/>
+        </item>
+        <item name="Prince of Wales">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="Prince of Wales"/>
+        </item>
+        <item name="Queens Head">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="Queens Head"/>
+        </item>
+        <item name="Red Lion">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="Red Lion"/>
+        </item>
+        <item name="Rose &amp; Crown">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="Rose &amp; Crown"/>
+        </item>
+        <item name="Rose and Crown">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="Rose and Crown"/>
+        </item>
+        <item name="Royal Hotel">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="Royal Hotel"/>
+        </item>
+        <item name="Royal Oak">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="Royal Oak"/>
+        </item>
+        <item name="The Albion">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Albion"/>
+        </item>
+        <item name="The Anchor">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Anchor"/>
+        </item>
+        <item name="The Angel">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Angel"/>
+        </item>
+        <item name="The Bell">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Bell"/>
+        </item>
+        <item name="The Bell Inn">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Bell Inn"/>
+        </item>
+        <item name="The Black Horse">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Black Horse"/>
+        </item>
+        <item name="The Bull">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Bull"/>
+        </item>
+        <item name="The Castle">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Castle"/>
+        </item>
+        <item name="The Chequers">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Chequers"/>
+        </item>
+        <item name="The Cricketers">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Cricketers"/>
+        </item>
+        <item name="The Cross Keys">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Cross Keys"/>
+        </item>
+        <item name="The Crown">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Crown"/>
+        </item>
+        <item name="The Crown Inn">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Crown Inn"/>
+        </item>
+        <item name="The Fox">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Fox"/>
+        </item>
+        <item name="The George">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The George"/>
+        </item>
+        <item name="The Green Man">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Green Man"/>
+        </item>
+        <item name="The Greyhound">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Greyhound"/>
+        </item>
+        <item name="The Kings Arms">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Kings Arms"/>
+        </item>
+        <item name="The Kings Head">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Kings Head"/>
+        </item>
+        <item name="The New Inn">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The New Inn"/>
+        </item>
+        <item name="The Plough">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Plough"/>
+        </item>
+        <item name="The Queens Head">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Queens Head"/>
+        </item>
+        <item name="The Railway">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Railway"/>
+        </item>
+        <item name="The Red Lion">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Red Lion"/>
+        </item>
+        <item name="The Rising Sun">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Rising Sun"/>
+        </item>
+        <item name="The Royal Oak">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Royal Oak"/>
+        </item>
+        <item name="The Ship">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Ship"/>
+        </item>
+        <item name="The Ship Inn">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Ship Inn"/>
+        </item>
+        <item name="The Star">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Star"/>
+        </item>
+        <item name="The Star Inn">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Star Inn"/>
+        </item>
+        <item name="The Swan">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Swan"/>
+        </item>
+        <item name="The Swan Inn">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Swan Inn"/>
+        </item>
+        <item name="The Victoria">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Victoria"/>
+        </item>
+        <item name="The Wheatsheaf">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The Wheatsheaf"/>
+        </item>
+        <item name="The White Hart">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The White Hart"/>
+        </item>
+        <item name="The White Horse">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The White Horse"/>
+        </item>
+        <item name="The White Lion">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The White Lion"/>
+        </item>
+        <item name="The White Swan">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="The White Swan"/>
+        </item>
+        <item name="魚民">
+          <key key="amenity" value="pub"/>
+          <key key="name" value="魚民"/>
+        </item>
+      </group>
+      <group name="restaurant">
+        <item name="Adler">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Adler"/>
+        </item>
+        <item name="Adria">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Adria"/>
+        </item>
+        <item name="Akropolis">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Akropolis"/>
+        </item>
+        <item name="Ali Baba">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Ali Baba"/>
+        </item>
+        <item name="Alte Post">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Alte Post"/>
+        </item>
+        <item name="Applebee's">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Applebee's"/>
+        </item>
+        <item name="Asia">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Asia"/>
+        </item>
+        <item name="Athen">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Athen"/>
+        </item>
+        <item name="Athos">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Athos"/>
+        </item>
+        <item name="Bahnhof">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Bahnhof"/>
+        </item>
+        <item name="Bella Italia">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Bella Italia"/>
+        </item>
+        <item name="Bella Napoli">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Bella Napoli"/>
+        </item>
+        <item name="Belvedere">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Belvedere"/>
+        </item>
+        <item name="Bistro">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Bistro"/>
+        </item>
+        <item name="Bob Evans">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Bob Evans"/>
+        </item>
+        <item name="Bonefish Grill">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Bonefish Grill"/>
+        </item>
+        <item name="Boston Market">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Boston Market"/>
+        </item>
+        <item name="Boston Pizza">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Boston Pizza"/>
+        </item>
+        <item name="Buffalo Grill">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Buffalo Grill"/>
+        </item>
+        <item name="Buffalo Wild Wings">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Buffalo Wild Wings"/>
+        </item>
+        <item name="Bären">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Bären"/>
+        </item>
+        <item name="California Pizza Kitchen">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="California Pizza Kitchen"/>
+        </item>
+        <item name="Campanile">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Campanile"/>
+        </item>
+        <item name="Canteen">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Canteen"/>
+        </item>
+        <item name="Carpe Diem">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Carpe Diem"/>
+        </item>
+        <item name="Carrabba's Italian Grill">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Carrabba's Italian Grill"/>
+        </item>
+        <item name="Casa Mia">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Casa Mia"/>
+        </item>
+        <item name="Casablanca">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Casablanca"/>
+        </item>
+        <item name="Chili's">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Chili's"/>
+        </item>
+        <item name="China Garden">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="China Garden"/>
+        </item>
+        <item name="China House">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="China House"/>
+        </item>
+        <item name="China Town">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="China Town"/>
+        </item>
+        <item name="China Wok">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="China Wok"/>
+        </item>
+        <item name="Cold Stone Creamery">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Cold Stone Creamery"/>
+        </item>
+        <item name="Courtepaille">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Courtepaille"/>
+        </item>
+        <item name="Cracker Barrel">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Cracker Barrel"/>
+        </item>
+        <item name="Da Grasso">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Da Grasso"/>
+        </item>
+        <item name="Da Vinci">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Da Vinci"/>
+        </item>
+        <item name="Delphi">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Delphi"/>
+        </item>
+        <item name="Denny's">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Denny's"/>
+        </item>
+        <item name="Deutsches Haus">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Deutsches Haus"/>
+        </item>
+        <item name="Dionysos">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Dionysos"/>
+        </item>
+        <item name="Dolce Vita">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Dolce Vita"/>
+        </item>
+        <item name="Dorfkrug">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Dorfkrug"/>
+        </item>
+        <item name="Dunkin' Donuts">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Dunkin' Donuts"/>
+          <key key="cuisine" value="donut"/>
+        </item>
+        <item name="El Greco">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="El Greco"/>
+        </item>
+        <item name="El Paso">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="El Paso"/>
+        </item>
+        <item name="El Rancho">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="El Rancho"/>
+        </item>
+        <item name="Engel">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Engel"/>
+        </item>
+        <item name="Europa">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Europa"/>
+        </item>
+        <item name="Famous Dave's">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Famous Dave's"/>
+        </item>
+        <item name="Firehouse Subs">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Firehouse Subs"/>
+        </item>
+        <item name="Five Guys">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Five Guys"/>
+        </item>
+        <item name="Flunch">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Flunch"/>
+        </item>
+        <item name="Frankie &amp; Benny's">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Frankie &amp; Benny's"/>
+        </item>
+        <item name="Friendly's">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Friendly's"/>
+        </item>
+        <item name="Frohsinn">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Frohsinn"/>
+        </item>
+        <item name="Gasthaus Krone">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Gasthaus Krone"/>
+        </item>
+        <item name="Gasthaus zur Linde">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Gasthaus zur Linde"/>
+        </item>
+        <item name="Gasthof zur Post">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Gasthof zur Post"/>
+        </item>
+        <item name="Golden Corral">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Golden Corral"/>
+        </item>
+        <item name="Golden Dragon">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Golden Dragon"/>
+        </item>
+        <item name="Grüner Baum">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Grüner Baum"/>
+        </item>
+        <item name="Gusto">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Gusto"/>
+        </item>
+        <item name="Hard Rock Cafe">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Hard Rock Cafe"/>
+        </item>
+        <item name="Hardee's">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Hardee's"/>
+          <key key="cuisine" value="burger"/>
+        </item>
+        <item name="Harvester">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Harvester"/>
+        </item>
+        <item name="Hellas">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Hellas"/>
+        </item>
+        <item name="Hippopotamus">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Hippopotamus"/>
+        </item>
+        <item name="Hirsch">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Hirsch"/>
+        </item>
+        <item name="Hirschen">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Hirschen"/>
+        </item>
+        <item name="Hong Kong">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Hong Kong"/>
+        </item>
+        <item name="Hooters">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Hooters"/>
+        </item>
+        <item name="IHOP">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="IHOP"/>
+        </item>
+        <item name="Jason's Deli">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Jason's Deli"/>
+        </item>
+        <item name="Jimmy John's">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Jimmy John's"/>
+          <key key="cuisine" value="sandwich"/>
+        </item>
+        <item name="Joe's Crab Shack">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Joe's Crab Shack"/>
+        </item>
+        <item name="Jägerhof">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Jägerhof"/>
+        </item>
+        <item name="Kantine">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Kantine"/>
+        </item>
+        <item name="Kelsey's">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Kelsey's"/>
+        </item>
+        <item name="Kirchenwirt">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Kirchenwirt"/>
+        </item>
+        <item name="Kreta">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Kreta"/>
+        </item>
+        <item name="Kreuz">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Kreuz"/>
+        </item>
+        <item name="Krone">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Krone"/>
+        </item>
+        <item name="Kudu">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Kudu"/>
+        </item>
+        <item name="L'Escale">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="L'Escale"/>
+        </item>
+        <item name="L'Osteria">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="L'Osteria"/>
+        </item>
+        <item name="La Bodega">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Bodega"/>
+        </item>
+        <item name="La Boucherie">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Boucherie"/>
+        </item>
+        <item name="La Cantina">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Cantina"/>
+        </item>
+        <item name="La Casa">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Casa"/>
+        </item>
+        <item name="La Dolce Vita">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Dolce Vita"/>
+        </item>
+        <item name="La Fontana">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Fontana"/>
+        </item>
+        <item name="La Gondola">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Gondola"/>
+        </item>
+        <item name="La Pataterie">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Pataterie"/>
+        </item>
+        <item name="La Pergola">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Pergola"/>
+        </item>
+        <item name="La Perla">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Perla"/>
+        </item>
+        <item name="La Piazza">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Piazza"/>
+        </item>
+        <item name="La Piazzetta">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Piazzetta"/>
+        </item>
+        <item name="La Scala">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Scala"/>
+        </item>
+        <item name="La Strada">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Strada"/>
+        </item>
+        <item name="La Tasca">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Tasca"/>
+        </item>
+        <item name="La Taverna">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Taverna"/>
+        </item>
+        <item name="La Terrasse">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Terrasse"/>
+        </item>
+        <item name="La Terrazza">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Terrazza"/>
+        </item>
+        <item name="La Trattoria">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="La Trattoria"/>
+        </item>
+        <item name="Lamm">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Lamm"/>
+        </item>
+        <item name="Linde">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Linde"/>
+        </item>
+        <item name="Lindenhof">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Lindenhof"/>
+        </item>
+        <item name="Little Caesars">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Little Caesars"/>
+        </item>
+        <item name="Little Chef">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Little Chef"/>
+        </item>
+        <item name="Little Italy">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Little Italy"/>
+        </item>
+        <item name="Logan's Roadhouse">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Logan's Roadhouse"/>
+        </item>
+        <item name="LongHorn Steakhouse">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="LongHorn Steakhouse"/>
+        </item>
+        <item name="Lotus">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Lotus"/>
+        </item>
+        <item name="Léon de Bruxelles">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Léon de Bruxelles"/>
+        </item>
+        <item name="Löwen">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Löwen"/>
+        </item>
+        <item name="MK Restaurants">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="MK Restaurants"/>
+        </item>
+        <item name="Mamma Mia">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Mamma Mia"/>
+        </item>
+        <item name="Mandarin">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Mandarin"/>
+        </item>
+        <item name="Mang Inasal">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Mang Inasal"/>
+        </item>
+        <item name="Marco Polo">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Marco Polo"/>
+        </item>
+        <item name="Mellow Mushroom">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Mellow Mushroom"/>
+        </item>
+        <item name="Mensa">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Mensa"/>
+        </item>
+        <item name="Milano">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Milano"/>
+        </item>
+        <item name="Mimi's Cafe">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Mimi's Cafe"/>
+        </item>
+        <item name="Moe's Southwest Grill">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Moe's Southwest Grill"/>
+        </item>
+        <item name="Mykonos">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Mykonos"/>
+        </item>
+        <item name="Nando's">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Nando's"/>
+        </item>
+        <item name="Noodles &amp; Company">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Noodles &amp; Company"/>
+        </item>
+        <item name="O'Charley's">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="O'Charley's"/>
+        </item>
+        <item name="Oasis">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Oasis"/>
+        </item>
+        <item name="Ocean Basket">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Ocean Basket"/>
+        </item>
+        <item name="Ochsen">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Ochsen"/>
+        </item>
+        <item name="Old Chicago">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Old Chicago"/>
+        </item>
+        <item name="Olive Garden">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Olive Garden"/>
+        </item>
+        <item name="Olympia">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Olympia"/>
+        </item>
+        <item name="Outback Steakhouse">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Outback Steakhouse"/>
+        </item>
+        <item name="Pancake House">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Pancake House"/>
+        </item>
+        <item name="Panera Bread">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Panera Bread"/>
+        </item>
+        <item name="Panorama">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Panorama"/>
+        </item>
+        <item name="Peking">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Peking"/>
+        </item>
+        <item name="Perkins">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Perkins"/>
+        </item>
+        <item name="Pinocchio">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Pinocchio"/>
+        </item>
+        <item name="Pizza Express">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Pizza Express"/>
+        </item>
+        <item name="Pizza Hut">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Pizza Hut"/>
+          <key key="cuisine" value="pizza"/>
+        </item>
+        <item name="Pizza Ranch">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Pizza Ranch"/>
+        </item>
+        <item name="Pizzeria Italia">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Pizzeria Italia"/>
+        </item>
+        <item name="Pizzeria Roma">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Pizzeria Roma"/>
+        </item>
+        <item name="Pomodoro">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Pomodoro"/>
+        </item>
+        <item name="Portofino">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Portofino"/>
+        </item>
+        <item name="Poseidon">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Poseidon"/>
+        </item>
+        <item name="Prezzo">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Prezzo"/>
+        </item>
+        <item name="Qdoba">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Qdoba"/>
+        </item>
+        <item name="Ratskeller">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Ratskeller"/>
+        </item>
+        <item name="Red Lobster">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Red Lobster"/>
+        </item>
+        <item name="Red Robin">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Red Robin"/>
+        </item>
+        <item name="Rhodos">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Rhodos"/>
+        </item>
+        <item name="Ristorante Del Arte">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Ristorante Del Arte"/>
+        </item>
+        <item name="Roma">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Roma"/>
+        </item>
+        <item name="Round Table Pizza">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Round Table Pizza"/>
+        </item>
+        <item name="Ruby Tuesday">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Ruby Tuesday"/>
+        </item>
+        <item name="Rössli">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Rössli"/>
+        </item>
+        <item name="Sakura">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Sakura"/>
+        </item>
+        <item name="San Marco">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="San Marco"/>
+        </item>
+        <item name="Santorini">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Santorini"/>
+        </item>
+        <item name="Schwarzer Adler">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Schwarzer Adler"/>
+        </item>
+        <item name="Schützenhaus">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Schützenhaus"/>
+        </item>
+        <item name="Shakey's">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Shakey's"/>
+        </item>
+        <item name="Shanghai">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Shanghai"/>
+        </item>
+        <item name="Shari's">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Shari's"/>
+        </item>
+        <item name="Sizzler">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Sizzler"/>
+        </item>
+        <item name="Sonic">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Sonic"/>
+          <key key="cuisine" value="burger"/>
+        </item>
+        <item name="Sonne">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Sonne"/>
+        </item>
+        <item name="Sphinx">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Sphinx"/>
+        </item>
+        <item name="Sportheim">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Sportheim"/>
+        </item>
+        <item name="Spur">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Spur"/>
+        </item>
+        <item name="Steak 'n Shake">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Steak 'n Shake"/>
+          <key key="cuisine" value="burger"/>
+        </item>
+        <item name="Sternen">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Sternen"/>
+        </item>
+        <item name="Subway">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Subway"/>
+        </item>
+        <item name="Sushi">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Sushi"/>
+        </item>
+        <item name="Sushi Bar">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Sushi Bar"/>
+        </item>
+        <item name="Swiss Chalet">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Swiss Chalet"/>
+        </item>
+        <item name="Syrtaki">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Syrtaki"/>
+        </item>
+        <item name="TGI Friday's">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="TGI Friday's"/>
+        </item>
+        <item name="Taj Mahal">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Taj Mahal"/>
+        </item>
+        <item name="Taste of India">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Taste of India"/>
+        </item>
+        <item name="Taverna">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Taverna"/>
+        </item>
+        <item name="Telepizza">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Telepizza"/>
+        </item>
+        <item name="Texas Roadhouse">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Texas Roadhouse"/>
+        </item>
+        <item name="Tim Hortons">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Tim Hortons"/>
+        </item>
+        <item name="Tony Roma's">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Tony Roma's"/>
+        </item>
+        <item name="Toscana">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Toscana"/>
+        </item>
+        <item name="Trattoria">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Trattoria"/>
+        </item>
+        <item name="Traube">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Traube"/>
+        </item>
+        <item name="Vapiano">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Vapiano"/>
+        </item>
+        <item name="Venezia">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Venezia"/>
+        </item>
+        <item name="Village Inn">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Village Inn"/>
+        </item>
+        <item name="Vips">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Vips"/>
+        </item>
+        <item name="Waffle House">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Waffle House"/>
+        </item>
+        <item name="Wagamama">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Wagamama"/>
+        </item>
+        <item name="Waldschänke">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Waldschänke"/>
+        </item>
+        <item name="Wasabi">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Wasabi"/>
+        </item>
+        <item name="Wimpy">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Wimpy"/>
+        </item>
+        <item name="Zizzi">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Zizzi"/>
+        </item>
+        <item name="Zorbas">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Zorbas"/>
+        </item>
+        <item name="Zum Hirschen">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Zum Hirschen"/>
+        </item>
+        <item name="Zum Löwen">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Zum Löwen"/>
+        </item>
+        <item name="Zur Krone">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Zur Krone"/>
+        </item>
+        <item name="Zur Linde">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Zur Linde"/>
+        </item>
+        <item name="Zur Post">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Zur Post"/>
+        </item>
+        <item name="Zur Sonne">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Zur Sonne"/>
+        </item>
+        <item name="Евразия">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Евразия"/>
+        </item>
+        <item name="Тануки">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Тануки"/>
+        </item>
+        <item name="Якитория">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="Якитория"/>
+        </item>
+        <item name="びっくりドンキー">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="びっくりドンキー"/>
+        </item>
+        <item name="やよい軒">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="やよい軒"/>
+        </item>
+        <item name="ガスト">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="ガスト"/>
+          <key key="name:en" value="Gusto"/>
+        </item>
+        <item name="ココス">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="ココス"/>
+        </item>
+        <item name="サイゼリヤ">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="サイゼリヤ"/>
+        </item>
+        <item name="ジョイフル">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="ジョイフル"/>
+        </item>
+        <item name="ジョナサン">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="ジョナサン"/>
+        </item>
+        <item name="ジョリーパスタ">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="ジョリーパスタ"/>
+        </item>
+        <item name="デニーズ">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="デニーズ"/>
+        </item>
+        <item name="バーミヤン">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="バーミヤン"/>
+        </item>
+        <item name="ロイヤルホスト">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="ロイヤルホスト"/>
+        </item>
+        <item name="丸亀製麺">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="丸亀製麺"/>
+        </item>
+        <item name="八方雲集">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="八方雲集"/>
+        </item>
+        <item name="夢庵">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="夢庵"/>
+        </item>
+        <item name="大戸屋">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="大戸屋"/>
+        </item>
+        <item name="天下一品">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="天下一品"/>
+        </item>
+        <item name="安楽亭">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="安楽亭"/>
+        </item>
+        <item name="牛角">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="牛角"/>
+        </item>
+        <item name="餃子の王将">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="餃子の王将"/>
+        </item>
+        <item name="바다횟집 (Bada Fish Restaurant)">
+          <key key="amenity" value="restaurant"/>
+          <key key="name" value="바다횟집 (Bada Fish Restaurant)"/>
+        </item>
+      </group>
+      <group name="school">
+        <item name="Adolfo Lopez Mateos">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Adolfo Lopez Mateos"/>
+        </item>
+        <item name="Agustin Ya�ez">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Agustin Ya�ez"/>
+        </item>
+        <item name="Albert-Schweitzer-Schule">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Albert-Schweitzer-Schule"/>
+        </item>
+        <item name="Amado Nervo">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Amado Nervo"/>
+        </item>
+        <item name="Antioch School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Antioch School (historical)"/>
+        </item>
+        <item name="Astrid-Lindgren-Schule">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Astrid-Lindgren-Schule"/>
+        </item>
+        <item name="Benito Juarez">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Benito Juarez"/>
+        </item>
+        <item name="Bethel School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Bethel School (historical)"/>
+        </item>
+        <item name="Brown School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Brown School"/>
+        </item>
+        <item name="CEM">
+          <key key="amenity" value="school"/>
+          <key key="name" value="CEM"/>
+        </item>
+        <item name="Cedar Grove School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Cedar Grove School (historical)"/>
+        </item>
+        <item name="Center School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Center School"/>
+        </item>
+        <item name="Center School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Center School (historical)"/>
+        </item>
+        <item name="Central Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Central Elementary School"/>
+        </item>
+        <item name="Central High School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Central High School"/>
+        </item>
+        <item name="Central School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Central School"/>
+        </item>
+        <item name="Central School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Central School (historical)"/>
+        </item>
+        <item name="Colegio San José">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Colegio San José"/>
+        </item>
+        <item name="Collège Jean Moulin">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Collège Jean Moulin"/>
+        </item>
+        <item name="Collège privé Saint-Joseph">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Collège privé Saint-Joseph"/>
+        </item>
+        <item name="Cuauhtemoc">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Cuauhtemoc"/>
+        </item>
+        <item name="Curso Comunitario">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Curso Comunitario"/>
+        </item>
+        <item name="Cursos Comunitarios">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Cursos Comunitarios"/>
+        </item>
+        <item name="EPP">
+          <key key="amenity" value="school"/>
+          <key key="name" value="EPP"/>
+        </item>
+        <item name="Emiliano Zapata">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Emiliano Zapata"/>
+        </item>
+        <item name="Erich-Kästner-Schule">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Erich-Kästner-Schule"/>
+        </item>
+        <item name="Escola Estadual">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Escola Estadual"/>
+        </item>
+        <item name="Escola Municipal">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Escola Municipal"/>
+        </item>
+        <item name="Fairview Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Fairview Elementary School"/>
+        </item>
+        <item name="Fairview School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Fairview School"/>
+        </item>
+        <item name="Fairview School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Fairview School (historical)"/>
+        </item>
+        <item name="Francisco I Madero">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Francisco I Madero"/>
+        </item>
+        <item name="Francisco I. Madero">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Francisco I. Madero"/>
+        </item>
+        <item name="Francisco Villa">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Francisco Villa"/>
+        </item>
+        <item name="Franklin Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Franklin Elementary School"/>
+        </item>
+        <item name="Franklin School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Franklin School"/>
+        </item>
+        <item name="Friendship School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Friendship School (historical)"/>
+        </item>
+        <item name="Garfield Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Garfield Elementary School"/>
+        </item>
+        <item name="Garfield School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Garfield School"/>
+        </item>
+        <item name="Gimnazjum nr 1">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Gimnazjum nr 1"/>
+        </item>
+        <item name="Gregorio Torres Quintero">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Gregorio Torres Quintero"/>
+        </item>
+        <item name="Groupe Scolaire">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Groupe Scolaire"/>
+        </item>
+        <item name="Guadalupe Victoria">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Guadalupe Victoria"/>
+        </item>
+        <item name="Hickory Grove School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Hickory Grove School (historical)"/>
+        </item>
+        <item name="Highland Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Highland Elementary School"/>
+        </item>
+        <item name="Highland School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Highland School"/>
+        </item>
+        <item name="Hillcrest Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Hillcrest Elementary School"/>
+        </item>
+        <item name="Holy Cross School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Holy Cross School"/>
+        </item>
+        <item name="Holy Family School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Holy Family School"/>
+        </item>
+        <item name="Holy Trinity School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Holy Trinity School"/>
+        </item>
+        <item name="Hopewell School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Hopewell School (historical)"/>
+        </item>
+        <item name="Ignacio Allende">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Ignacio Allende"/>
+        </item>
+        <item name="Ignacio Zaragoza">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Ignacio Zaragoza"/>
+        </item>
+        <item name="Immaculate Conception School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Immaculate Conception School"/>
+        </item>
+        <item name="Jackson Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Jackson Elementary School"/>
+        </item>
+        <item name="Jackson School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Jackson School"/>
+        </item>
+        <item name="Jefferson Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Jefferson Elementary School"/>
+        </item>
+        <item name="Jefferson School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Jefferson School"/>
+        </item>
+        <item name="Jose Clemente Orozco">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Jose Clemente Orozco"/>
+        </item>
+        <item name="Jose Ma Morelos Y Pavon">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Jose Ma Morelos Y Pavon"/>
+        </item>
+        <item name="Jose Vasconcelos">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Jose Vasconcelos"/>
+        </item>
+        <item name="Josefa Ortiz De Dominguez">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Josefa Ortiz De Dominguez"/>
+        </item>
+        <item name="Juan Escutia">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Juan Escutia"/>
+        </item>
+        <item name="Justo Sierra">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Justo Sierra"/>
+        </item>
+        <item name="Lazaro Cardenas">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Lazaro Cardenas"/>
+        </item>
+        <item name="Lazaro Cardenas Del Rio">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Lazaro Cardenas Del Rio"/>
+        </item>
+        <item name="Leona Vicario">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Leona Vicario"/>
+        </item>
+        <item name="Liberty Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Liberty Elementary School"/>
+        </item>
+        <item name="Liberty School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Liberty School"/>
+        </item>
+        <item name="Liberty School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Liberty School (historical)"/>
+        </item>
+        <item name="Lincoln Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Lincoln Elementary School"/>
+        </item>
+        <item name="Lincoln School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Lincoln School"/>
+        </item>
+        <item name="Longfellow Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Longfellow Elementary School"/>
+        </item>
+        <item name="Longfellow School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Longfellow School"/>
+        </item>
+        <item name="Manuel Lopez Cotilla">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Manuel Lopez Cotilla"/>
+        </item>
+        <item name="Maple Grove School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Maple Grove School"/>
+        </item>
+        <item name="Maple Grove School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Maple Grove School (historical)"/>
+        </item>
+        <item name="McKinley Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="McKinley Elementary School"/>
+        </item>
+        <item name="McKinley School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="McKinley School"/>
+        </item>
+        <item name="Midway School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Midway School (historical)"/>
+        </item>
+        <item name="Miguel Hidalgo">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Miguel Hidalgo"/>
+        </item>
+        <item name="Miguel Hidalgo Y Costilla">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Miguel Hidalgo Y Costilla"/>
+        </item>
+        <item name="Miller School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Miller School"/>
+        </item>
+        <item name="Mount Olive School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Mount Olive School (historical)"/>
+        </item>
+        <item name="Mount Pleasant School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Mount Pleasant School"/>
+        </item>
+        <item name="Mount Pleasant School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Mount Pleasant School (historical)"/>
+        </item>
+        <item name="Mount Zion School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Mount Zion School"/>
+        </item>
+        <item name="Mount Zion School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Mount Zion School (historical)"/>
+        </item>
+        <item name="New Hope School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="New Hope School (historical)"/>
+        </item>
+        <item name="Nicolas Bravo">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Nicolas Bravo"/>
+        </item>
+        <item name="Ni�os Heroes">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Ni�os Heroes"/>
+        </item>
+        <item name="Nombre En Tramite">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Nombre En Tramite"/>
+        </item>
+        <item name="North Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="North Elementary School"/>
+        </item>
+        <item name="Oak Grove School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Oak Grove School"/>
+        </item>
+        <item name="Oak Grove School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Oak Grove School (historical)"/>
+        </item>
+        <item name="Oak Hill School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Oak Hill School (historical)"/>
+        </item>
+        <item name="Pedro Moreno">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Pedro Moreno"/>
+        </item>
+        <item name="Pestalozzischule">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Pestalozzischule"/>
+        </item>
+        <item name="Pine Grove School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Pine Grove School"/>
+        </item>
+        <item name="Pine Grove School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Pine Grove School (historical)"/>
+        </item>
+        <item name="Pleasant Grove School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Pleasant Grove School (historical)"/>
+        </item>
+        <item name="Pleasant Hill School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Pleasant Hill School"/>
+        </item>
+        <item name="Pleasant Hill School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Pleasant Hill School (historical)"/>
+        </item>
+        <item name="Pleasant Valley School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Pleasant Valley School"/>
+        </item>
+        <item name="Pleasant Valley School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Pleasant Valley School (historical)"/>
+        </item>
+        <item name="Pleasant View School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Pleasant View School"/>
+        </item>
+        <item name="Primaria Comunitaria">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Primaria Comunitaria"/>
+        </item>
+        <item name="Ramon Corona">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Ramon Corona"/>
+        </item>
+        <item name="Ricardo Flores Magon">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Ricardo Flores Magon"/>
+        </item>
+        <item name="Riverside School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Riverside School"/>
+        </item>
+        <item name="Roosevelt Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Roosevelt Elementary School"/>
+        </item>
+        <item name="Roosevelt School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Roosevelt School"/>
+        </item>
+        <item name="SD">
+          <key key="amenity" value="school"/>
+          <key key="name" value="SD"/>
+        </item>
+        <item name="SDN">
+          <key key="amenity" value="school"/>
+          <key key="name" value="SDN"/>
+        </item>
+        <item name="Sacred Heart School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Sacred Heart School"/>
+        </item>
+        <item name="Saint Francis School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Saint Francis School"/>
+        </item>
+        <item name="Saint James School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Saint James School"/>
+        </item>
+        <item name="Saint Johns School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Saint Johns School"/>
+        </item>
+        <item name="Saint Joseph School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Saint Joseph School"/>
+        </item>
+        <item name="Saint Josephs School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Saint Josephs School"/>
+        </item>
+        <item name="Saint Kizito Primary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Saint Kizito Primary School"/>
+        </item>
+        <item name="Saint Mary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Saint Mary School"/>
+        </item>
+        <item name="Saint Marys School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Saint Marys School"/>
+        </item>
+        <item name="Saint Patricks School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Saint Patricks School"/>
+        </item>
+        <item name="Saint Paul School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Saint Paul School"/>
+        </item>
+        <item name="Saint Pauls School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Saint Pauls School"/>
+        </item>
+        <item name="Saint Peters School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Saint Peters School"/>
+        </item>
+        <item name="Salem School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Salem School (historical)"/>
+        </item>
+        <item name="Schillerschule">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Schillerschule"/>
+        </item>
+        <item name="School Number 1">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 1"/>
+        </item>
+        <item name="School Number 1 (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 1 (historical)"/>
+        </item>
+        <item name="School Number 10 (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 10 (historical)"/>
+        </item>
+        <item name="School Number 11 (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 11 (historical)"/>
+        </item>
+        <item name="School Number 12 (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 12 (historical)"/>
+        </item>
+        <item name="School Number 13 (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 13 (historical)"/>
+        </item>
+        <item name="School Number 14 (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 14 (historical)"/>
+        </item>
+        <item name="School Number 15 (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 15 (historical)"/>
+        </item>
+        <item name="School Number 2">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 2"/>
+        </item>
+        <item name="School Number 2 (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 2 (historical)"/>
+        </item>
+        <item name="School Number 3">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 3"/>
+        </item>
+        <item name="School Number 3 (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 3 (historical)"/>
+        </item>
+        <item name="School Number 4">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 4"/>
+        </item>
+        <item name="School Number 4 (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 4 (historical)"/>
+        </item>
+        <item name="School Number 5 (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 5 (historical)"/>
+        </item>
+        <item name="School Number 6 (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 6 (historical)"/>
+        </item>
+        <item name="School Number 7 (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 7 (historical)"/>
+        </item>
+        <item name="School Number 8 (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 8 (historical)"/>
+        </item>
+        <item name="School Number 9 (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="School Number 9 (historical)"/>
+        </item>
+        <item name="Shady Grove School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Shady Grove School (historical)"/>
+        </item>
+        <item name="Shiloh School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Shiloh School (historical)"/>
+        </item>
+        <item name="Smith School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Smith School"/>
+        </item>
+        <item name="Sor Juana Ines De La Cruz">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Sor Juana Ines De La Cruz"/>
+        </item>
+        <item name="Sunnyside School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Sunnyside School"/>
+        </item>
+        <item name="Szkoła Podstawowa nr 1">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Szkoła Podstawowa nr 1"/>
+        </item>
+        <item name="Szkoła Podstawowa nr 2">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Szkoła Podstawowa nr 2"/>
+        </item>
+        <item name="Szkoła Podstawowa nr 3">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Szkoła Podstawowa nr 3"/>
+        </item>
+        <item name="Trinity Lutheran School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Trinity Lutheran School"/>
+        </item>
+        <item name="Trinity School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Trinity School"/>
+        </item>
+        <item name="UNIDAD EDUCATIVA">
+          <key key="amenity" value="school"/>
+          <key key="name" value="UNIDAD EDUCATIVA"/>
+        </item>
+        <item name="Union School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Union School"/>
+        </item>
+        <item name="Union School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Union School (historical)"/>
+        </item>
+        <item name="Valentin Gomez Farias">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Valentin Gomez Farias"/>
+        </item>
+        <item name="Venustiano Carranza">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Venustiano Carranza"/>
+        </item>
+        <item name="Vicente Guerrero">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Vicente Guerrero"/>
+        </item>
+        <item name="Volkshochschule">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Volkshochschule"/>
+        </item>
+        <item name="Volksschule">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Volksschule"/>
+        </item>
+        <item name="Walnut Grove School (historical)">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Walnut Grove School (historical)"/>
+        </item>
+        <item name="Washington Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Washington Elementary School"/>
+        </item>
+        <item name="Washington School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Washington School"/>
+        </item>
+        <item name="West Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="West Elementary School"/>
+        </item>
+        <item name="White School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="White School"/>
+        </item>
+        <item name="Wilson Elementary School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Wilson Elementary School"/>
+        </item>
+        <item name="Wilson School">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Wilson School"/>
+        </item>
+        <item name="Általános iskola">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Általános iskola"/>
+        </item>
+        <item name="École Saint-Joseph">
+          <key key="amenity" value="school"/>
+          <key key="name" value="École Saint-Joseph"/>
+        </item>
+        <item name="École primaire Jean Jaurès">
+          <key key="amenity" value="school"/>
+          <key key="name" value="École primaire Jean Jaurès"/>
+        </item>
+        <item name="École primaire Jules Ferry">
+          <key key="amenity" value="school"/>
+          <key key="name" value="École primaire Jules Ferry"/>
+        </item>
+        <item name="École primaire privée Notre-Dame">
+          <key key="amenity" value="school"/>
+          <key key="name" value="École primaire privée Notre-Dame"/>
+        </item>
+        <item name="École primaire privée Saint-Joseph">
+          <key key="amenity" value="school"/>
+          <key key="name" value="École primaire privée Saint-Joseph"/>
+        </item>
+        <item name="École primaire privée Sainte-Marie">
+          <key key="amenity" value="school"/>
+          <key key="name" value="École primaire privée Sainte-Marie"/>
+        </item>
+        <item name="Гимназия №1">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Гимназия №1"/>
+        </item>
+        <item name="Средняя школа №1">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Средняя школа №1"/>
+        </item>
+        <item name="Средняя школа №2">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Средняя школа №2"/>
+        </item>
+        <item name="Школа № 1">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа № 1"/>
+        </item>
+        <item name="Школа № 2">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа № 2"/>
+        </item>
+        <item name="Школа № 3">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа № 3"/>
+        </item>
+        <item name="Школа № 4">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа № 4"/>
+        </item>
+        <item name="Школа № 6">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа № 6"/>
+        </item>
+        <item name="Школа №1">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №1"/>
+        </item>
+        <item name="Школа №10">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №10"/>
+        </item>
+        <item name="Школа №11">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №11"/>
+        </item>
+        <item name="Школа №12">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №12"/>
+        </item>
+        <item name="Школа №13">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №13"/>
+        </item>
+        <item name="Школа №14">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №14"/>
+        </item>
+        <item name="Школа №15">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №15"/>
+        </item>
+        <item name="Школа №16">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №16"/>
+        </item>
+        <item name="Школа №17">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №17"/>
+        </item>
+        <item name="Школа №18">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №18"/>
+        </item>
+        <item name="Школа №19">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №19"/>
+        </item>
+        <item name="Школа №2">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №2"/>
+        </item>
+        <item name="Школа №20">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №20"/>
+        </item>
+        <item name="Школа №21">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №21"/>
+        </item>
+        <item name="Школа №22">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №22"/>
+        </item>
+        <item name="Школа №23">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №23"/>
+        </item>
+        <item name="Школа №24">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №24"/>
+        </item>
+        <item name="Школа №25">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №25"/>
+        </item>
+        <item name="Школа №26">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №26"/>
+        </item>
+        <item name="Школа №27">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №27"/>
+        </item>
+        <item name="Школа №3">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №3"/>
+        </item>
+        <item name="Школа №31">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №31"/>
+        </item>
+        <item name="Школа №4">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №4"/>
+        </item>
+        <item name="Школа №5">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №5"/>
+        </item>
+        <item name="Школа №6">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №6"/>
+        </item>
+        <item name="Школа №7">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №7"/>
+        </item>
+        <item name="Школа №8">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №8"/>
+        </item>
+        <item name="Школа №9">
+          <key key="amenity" value="school"/>
+          <key key="name" value="Школа №9"/>
+        </item>
+        <item name="مدرسه">
+          <key key="amenity" value="school"/>
+          <key key="name" value="مدرسه"/>
+        </item>
+        <item name="市立南中学校">
+          <key key="amenity" value="school"/>
+          <key key="name" value="市立南中学校"/>
+        </item>
+        <item name="市立南小学校">
+          <key key="amenity" value="school"/>
+          <key key="name" value="市立南小学校"/>
+        </item>
+        <item name="市立東中学校">
+          <key key="amenity" value="school"/>
+          <key key="name" value="市立東中学校"/>
+        </item>
+        <item name="市立西中学校">
+          <key key="amenity" value="school"/>
+          <key key="name" value="市立西中学校"/>
+        </item>
+      </group>
+      <group name="social_facility">
+        <item name="Safe Haven">
+          <key key="amenity" value="social_facility"/>
+          <key key="name" value="Safe Haven"/>
+        </item>
+        <item name="Социальный участковый">
+          <key key="amenity" value="social_facility"/>
+          <key key="name" value="Социальный участковый"/>
+        </item>
+      </group>
+      <group name="theatre">
+        <item name="Amfiteatr">
+          <key key="amenity" value="theatre"/>
+          <key key="name" value="Amfiteatr"/>
+        </item>
+        <item name="Amphitheater">
+          <key key="amenity" value="theatre"/>
+          <key key="name" value="Amphitheater"/>
+        </item>
+        <item name="Amphitheatre">
+          <key key="amenity" value="theatre"/>
+          <key key="name" value="Amphitheatre"/>
+        </item>
+        <item name="Anfiteatro">
+          <key key="amenity" value="theatre"/>
+          <key key="name" value="Anfiteatro"/>
+        </item>
+        <item name="Freilichtbühne">
+          <key key="amenity" value="theatre"/>
+          <key key="name" value="Freilichtbühne"/>
+        </item>
+        <item name="Teatro Municipal">
+          <key key="amenity" value="theatre"/>
+          <key key="name" value="Teatro Municipal"/>
+        </item>
+        <item name="Дом культуры">
+          <key key="amenity" value="theatre"/>
+          <key key="name" value="Дом культуры"/>
+        </item>
+      </group>
+    </group>
+    <group name="leisure">
+      <group name="sports_centre">
+        <item name="24 Hour Fitness">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="24 Hour Fitness"/>
+        </item>
+        <item name="Anytime Fitness">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="Anytime Fitness"/>
+        </item>
+        <item name="Curves">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="Curves"/>
+        </item>
+        <item name="Fitness First">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="Fitness First"/>
+        </item>
+        <item name="Gold's Gym">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="Gold's Gym"/>
+        </item>
+        <item name="Kieser Training">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="Kieser Training"/>
+        </item>
+        <item name="LA Fitness">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="LA Fitness"/>
+        </item>
+        <item name="Life Time Fitness">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="Life Time Fitness"/>
+        </item>
+        <item name="McFit">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="McFit"/>
+        </item>
+        <item name="Mrs. Sporty">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="Mrs. Sporty"/>
+        </item>
+        <item name="Orlik">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="Orlik"/>
+        </item>
+        <item name="Pabellón Municipal de Deportes">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="Pabellón Municipal de Deportes"/>
+        </item>
+        <item name="Palestra Comunale">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="Palestra Comunale"/>
+        </item>
+        <item name="Planet Fitness">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="Planet Fitness"/>
+        </item>
+        <item name="Polideportivo">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="Polideportivo"/>
+        </item>
+        <item name="Schützenhaus">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="Schützenhaus"/>
+        </item>
+        <item name="Virgin Active">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="Virgin Active"/>
+        </item>
+        <item name="YMCA">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="YMCA"/>
+        </item>
+        <item name="ДЮСШ">
+          <key key="leisure" value="sports_centre"/>
+          <key key="name" value="ДЮСШ"/>
+        </item>
+      </group>
+    </group>
+    <group name="man_made">
+      <group name="windmill">
+        <item name="De Hoop">
+          <key key="man_made" value="windmill"/>
+          <key key="name" value="De Hoop"/>
+        </item>
+      </group>
+    </group>
+    <group name="shop">
+      <group name="alcohol">
+        <item name="Alko">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Alko"/>
+        </item>
+        <item name="BC Liquor Store">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="BC Liquor Store"/>
+        </item>
+        <item name="BWS">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="BWS"/>
+        </item>
+        <item name="Bargain Booze">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Bargain Booze"/>
+        </item>
+        <item name="Beer Store">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Beer Store"/>
+        </item>
+        <item name="Botilleria">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Botilleria"/>
+        </item>
+        <item name="Dan Murphy's">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Dan Murphy's"/>
+        </item>
+        <item name="Gall &amp; Gall">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Gall &amp; Gall"/>
+        </item>
+        <item name="LCBO">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="LCBO"/>
+        </item>
+        <item name="Liquor Store">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Liquor Store"/>
+        </item>
+        <item name="Liquorland">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Liquorland"/>
+        </item>
+        <item name="Mitra">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Mitra"/>
+        </item>
+        <item name="Nicolas">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Nicolas"/>
+        </item>
+        <item name="SAQ">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="SAQ"/>
+        </item>
+        <item name="Systembolaget">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Systembolaget"/>
+        </item>
+        <item name="The Beer Store">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="The Beer Store"/>
+        </item>
+        <item name="Vinmonopolet">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Vinmonopolet"/>
+        </item>
+        <item name="Ароматный мир">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Ароматный мир"/>
+        </item>
+        <item name="Бристоль">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Бристоль"/>
+        </item>
+        <item name="Живое пиво">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Живое пиво"/>
+        </item>
+        <item name="Красное &amp; Белое">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Красное &amp; Белое"/>
+        </item>
+        <item name="Норман">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Норман"/>
+        </item>
+        <item name="Пиво">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Пиво"/>
+        </item>
+        <item name="Разливное пиво">
+          <key key="shop" value="alcohol"/>
+          <key key="name" value="Разливное пиво"/>
+        </item>
+      </group>
+      <group name="baby_goods">
+        <item name="Babies R Us">
+          <key key="shop" value="baby_goods"/>
+          <key key="name" value="Babies R Us"/>
+        </item>
+      </group>
+      <group name="bakery">
+        <item name="Anker">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Anker"/>
+        </item>
+        <item name="Backshop">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Backshop"/>
+        </item>
+        <item name="Backwerk">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Backwerk"/>
+        </item>
+        <item name="Bakers Delight">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Bakers Delight"/>
+        </item>
+        <item name="Bakker Bart">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Bakker Bart"/>
+        </item>
+        <item name="Banette">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Banette"/>
+        </item>
+        <item name="Boulangerie">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Boulangerie"/>
+        </item>
+        <item name="Bäckerei Fuchs">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Bäckerei Fuchs"/>
+        </item>
+        <item name="Bäckerei Grimminger">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Bäckerei Grimminger"/>
+        </item>
+        <item name="Bäckerei Müller">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Bäckerei Müller"/>
+        </item>
+        <item name="Bäckerei Schmidt">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Bäckerei Schmidt"/>
+        </item>
+        <item name="Cooplands">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Cooplands"/>
+        </item>
+        <item name="Dat Backhus">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Dat Backhus"/>
+        </item>
+        <item name="Der Beck">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Der Beck"/>
+        </item>
+        <item name="Ditsch">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Ditsch"/>
+        </item>
+        <item name="Fornetti">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Fornetti"/>
+        </item>
+        <item name="Goeken backen">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Goeken backen"/>
+        </item>
+        <item name="Goldilocks">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Goldilocks"/>
+        </item>
+        <item name="Greggs">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Greggs"/>
+        </item>
+        <item name="Hofpfisterei">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Hofpfisterei"/>
+        </item>
+        <item name="Ihle">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Ihle"/>
+        </item>
+        <item name="K&amp;U">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="K&amp;U"/>
+        </item>
+        <item name="Kamps">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Kamps"/>
+        </item>
+        <item name="Le Fournil">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Le Fournil"/>
+        </item>
+        <item name="Lila Bäcker">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Lila Bäcker"/>
+        </item>
+        <item name="Marie Blachère">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Marie Blachère"/>
+        </item>
+        <item name="Mlinar">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Mlinar"/>
+        </item>
+        <item name="Musmanni">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Musmanni"/>
+        </item>
+        <item name="Oebel">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Oebel"/>
+        </item>
+        <item name="Panaderia">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Panaderia"/>
+        </item>
+        <item name="Paul">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Paul"/>
+        </item>
+        <item name="Red Ribbon">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Red Ribbon"/>
+        </item>
+        <item name="Schäfer's">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Schäfer's"/>
+        </item>
+        <item name="Sehne">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Sehne"/>
+        </item>
+        <item name="Stadtbäckerei">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Stadtbäckerei"/>
+        </item>
+        <item name="Steinecke">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Steinecke"/>
+        </item>
+        <item name="Sternenbäck">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Sternenbäck"/>
+        </item>
+        <item name="Ströck">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Ströck"/>
+        </item>
+        <item name="Wiener Feinbäcker">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Wiener Feinbäcker"/>
+        </item>
+        <item name="von Allwörden">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="von Allwörden"/>
+        </item>
+        <item name="Булочная">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Булочная"/>
+        </item>
+        <item name="Кулиничи">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Кулиничи"/>
+        </item>
+        <item name="Свежий хлеб">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Свежий хлеб"/>
+        </item>
+        <item name="Хлеб">
+          <key key="shop" value="bakery"/>
+          <key key="name" value="Хлеб"/>
+        </item>
+      </group>
+      <group name="beauty">
+        <item name="Nails">
+          <key key="shop" value="beauty"/>
+          <key key="name" value="Nails"/>
+        </item>
+        <item name="Sally Beauty Supply">
+          <key key="shop" value="beauty"/>
+          <key key="name" value="Sally Beauty Supply"/>
+        </item>
+        <item name="Yves Rocher">
+          <key key="shop" value="beauty"/>
+          <key key="name" value="Yves Rocher"/>
+        </item>
+      </group>
+      <group name="bed">
+        <item name="Dänisches Bettenlager">
+          <key key="shop" value="bed"/>
+          <key key="name" value="Dänisches Bettenlager"/>
+        </item>
+        <item name="Matratzen Concord">
+          <key key="shop" value="bed"/>
+          <key key="name" value="Matratzen Concord"/>
+        </item>
+        <item name="Mattress Firm">
+          <key key="shop" value="bed"/>
+          <key key="name" value="Mattress Firm"/>
+        </item>
+      </group>
+      <group name="beverages">
+        <item name="Dursty">
+          <key key="shop" value="beverages"/>
+          <key key="name" value="Dursty"/>
+        </item>
+        <item name="Edeka Getränkemarkt">
+          <key key="shop" value="beverages"/>
+          <key key="name" value="Edeka Getränkemarkt"/>
+        </item>
+        <item name="Fristo">
+          <key key="shop" value="beverages"/>
+          <key key="name" value="Fristo"/>
+        </item>
+        <item name="Getränke Hoffmann">
+          <key key="shop" value="beverages"/>
+          <key key="name" value="Getränke Hoffmann"/>
+        </item>
+        <item name="Getränkeland">
+          <key key="shop" value="beverages"/>
+          <key key="name" value="Getränkeland"/>
+        </item>
+        <item name="Getränkemarkt">
+          <key key="shop" value="beverages"/>
+          <key key="name" value="Getränkemarkt"/>
+        </item>
+        <item name="Orterer Getränkemarkt">
+          <key key="shop" value="beverages"/>
+          <key key="name" value="Orterer Getränkemarkt"/>
+        </item>
+        <item name="REWE Getränkemarkt">
+          <key key="shop" value="beverages"/>
+          <key key="name" value="REWE Getränkemarkt"/>
+        </item>
+        <item name="Trinkgut">
+          <key key="shop" value="beverages"/>
+          <key key="name" value="Trinkgut"/>
+        </item>
+      </group>
+      <group name="bicycle">
+        <item name="Halfords">
+          <key key="shop" value="bicycle"/>
+          <key key="name" value="Halfords"/>
+        </item>
+        <item name="Веломарка">
+          <key key="shop" value="bicycle"/>
+          <key key="name" value="Веломарка"/>
+        </item>
+        <item name="サイクルベースあさひ">
+          <key key="shop" value="bicycle"/>
+          <key key="name" value="サイクルベースあさひ"/>
+        </item>
+      </group>
+      <group name="bookmaker">
+        <item name="Betfred">
+          <key key="shop" value="bookmaker"/>
+          <key key="name" value="Betfred"/>
+        </item>
+        <item name="Coral">
+          <key key="shop" value="bookmaker"/>
+          <key key="name" value="Coral"/>
+        </item>
+        <item name="Ladbrokes">
+          <key key="shop" value="bookmaker"/>
+          <key key="name" value="Ladbrokes"/>
+        </item>
+        <item name="Paddy Power">
+          <key key="shop" value="bookmaker"/>
+          <key key="name" value="Paddy Power"/>
+        </item>
+        <item name="William Hill">
+          <key key="shop" value="bookmaker"/>
+          <key key="name" value="William Hill"/>
+        </item>
+      </group>
+      <group name="butcher">
+        <item name="Macelleria">
+          <key key="shop" value="butcher"/>
+          <key key="name" value="Macelleria"/>
+        </item>
+        <item name="Ариант">
+          <key key="shop" value="butcher"/>
+          <key key="name" value="Ариант"/>
+        </item>
+        <item name="Великолукский мясокомбинат">
+          <key key="shop" value="butcher"/>
+          <key key="name" value="Великолукский мясокомбинат"/>
+        </item>
+        <item name="Мясная лавка">
+          <key key="shop" value="butcher"/>
+          <key key="name" value="Мясная лавка"/>
+        </item>
+        <item name="Мясо">
+          <key key="shop" value="butcher"/>
+          <key key="name" value="Мясо"/>
+        </item>
+        <item name="Свежее мясо">
+          <key key="shop" value="butcher"/>
+          <key key="name" value="Свежее мясо"/>
+        </item>
+      </group>
+      <group name="car">
+        <item name="Audi">
+          <key key="shop" value="car"/>
+          <key key="name" value="Audi"/>
+        </item>
+        <item name="BMW">
+          <key key="shop" value="car"/>
+          <key key="name" value="BMW"/>
+        </item>
+        <item name="Chevrolet">
+          <key key="shop" value="car"/>
+          <key key="name" value="Chevrolet"/>
+        </item>
+        <item name="Citroen">
+          <key key="shop" value="car"/>
+          <key key="name" value="Citroen"/>
+        </item>
+        <item name="Fiat">
+          <key key="shop" value="car"/>
+          <key key="name" value="Fiat"/>
+        </item>
+        <item name="Ford">
+          <key key="shop" value="car"/>
+          <key key="name" value="Ford"/>
+        </item>
+        <item name="Honda">
+          <key key="shop" value="car"/>
+          <key key="name" value="Honda"/>
+        </item>
+        <item name="Hyundai">
+          <key key="shop" value="car"/>
+          <key key="name" value="Hyundai"/>
+        </item>
+        <item name="Kia">
+          <key key="shop" value="car"/>
+          <key key="name" value="Kia"/>
+        </item>
+        <item name="Lexus">
+          <key key="shop" value="car"/>
+          <key key="name" value="Lexus"/>
+        </item>
+        <item name="Mazda">
+          <key key="shop" value="car"/>
+          <key key="name" value="Mazda"/>
+        </item>
+        <item name="Mercedes-Benz">
+          <key key="shop" value="car"/>
+          <key key="name" value="Mercedes-Benz"/>
+        </item>
+        <item name="Mitsubishi">
+          <key key="shop" value="car"/>
+          <key key="name" value="Mitsubishi"/>
+        </item>
+        <item name="Nissan">
+          <key key="shop" value="car"/>
+          <key key="name" value="Nissan"/>
+        </item>
+        <item name="Opel">
+          <key key="shop" value="car"/>
+          <key key="name" value="Opel"/>
+        </item>
+        <item name="Peugeot">
+          <key key="shop" value="car"/>
+          <key key="name" value="Peugeot"/>
+        </item>
+        <item name="Porsche">
+          <key key="shop" value="car"/>
+          <key key="name" value="Porsche"/>
+        </item>
+        <item name="Renault">
+          <key key="shop" value="car"/>
+          <key key="name" value="Renault"/>
+        </item>
+        <item name="Seat">
+          <key key="shop" value="car"/>
+          <key key="name" value="Seat"/>
+        </item>
+        <item name="Skoda">
+          <key key="shop" value="car"/>
+          <key key="name" value="Skoda"/>
+        </item>
+        <item name="Subaru">
+          <key key="shop" value="car"/>
+          <key key="name" value="Subaru"/>
+        </item>
+        <item name="Suzuki">
+          <key key="shop" value="car"/>
+          <key key="name" value="Suzuki"/>
+        </item>
+        <item name="Toyota">
+          <key key="shop" value="car"/>
+          <key key="name" value="Toyota"/>
+        </item>
+        <item name="Volkswagen">
+          <key key="shop" value="car"/>
+          <key key="name" value="Volkswagen"/>
+        </item>
+        <item name="Volvo">
+          <key key="shop" value="car"/>
+          <key key="name" value="Volvo"/>
+        </item>
+      </group>
+      <group name="car_parts">
+        <item name="Advance Auto Parts">
+          <key key="shop" value="car_parts"/>
+          <key key="name" value="Advance Auto Parts"/>
+        </item>
+        <item name="AutoZone">
+          <key key="shop" value="car_parts"/>
+          <key key="name" value="AutoZone"/>
+        </item>
+        <item name="Halfords">
+          <key key="shop" value="car_parts"/>
+          <key key="name" value="Halfords"/>
+        </item>
+        <item name="NAPA Auto Parts">
+          <key key="shop" value="car_parts"/>
+          <key key="name" value="NAPA Auto Parts"/>
+        </item>
+        <item name="O'Reilly Auto Parts">
+          <key key="shop" value="car_parts"/>
+          <key key="name" value="O'Reilly Auto Parts"/>
+        </item>
+        <item name="Repco">
+          <key key="shop" value="car_parts"/>
+          <key key="name" value="Repco"/>
+        </item>
+        <item name="Tokić">
+          <key key="shop" value="car_parts"/>
+          <key key="name" value="Tokić"/>
+        </item>
+        <item name="repuestos automotrices">
+          <key key="shop" value="car_parts"/>
+          <key key="name" value="repuestos automotrices"/>
+        </item>
+        <item name="イエローハット">
+          <key key="shop" value="car_parts"/>
+          <key key="name" value="イエローハット"/>
+        </item>
+        <item name="オートバックス">
+          <key key="shop" value="car_parts"/>
+          <key key="name" value="オートバックス"/>
+        </item>
+        <item name="タイヤ館">
+          <key key="shop" value="car_parts"/>
+          <key key="name" value="タイヤ館"/>
+        </item>
+      </group>
+      <group name="car_repair">
+        <item name="A.T.U">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="A.T.U"/>
+        </item>
+        <item name="Advance Auto Parts">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Advance Auto Parts"/>
+        </item>
+        <item name="Carglass">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Carglass"/>
+        </item>
+        <item name="Citroen">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Citroen"/>
+        </item>
+        <item name="Euromaster">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Euromaster"/>
+        </item>
+        <item name="Feu Vert">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Feu Vert"/>
+        </item>
+        <item name="Firestone">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Firestone"/>
+        </item>
+        <item name="Firestone Complete Auto Care">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Firestone Complete Auto Care"/>
+        </item>
+        <item name="Garage Renault">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Garage Renault"/>
+        </item>
+        <item name="Gomeria">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Gomeria"/>
+        </item>
+        <item name="Gomería">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Gomería"/>
+        </item>
+        <item name="Goodyear">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Goodyear"/>
+        </item>
+        <item name="Jiffy Lube">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Jiffy Lube"/>
+        </item>
+        <item name="Kwik Fit">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Kwik Fit"/>
+        </item>
+        <item name="Mekonomen">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Mekonomen"/>
+        </item>
+        <item name="Midas">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Midas"/>
+        </item>
+        <item name="Mr. Lube">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Mr. Lube"/>
+        </item>
+        <item name="NAPA Auto Parts">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="NAPA Auto Parts"/>
+        </item>
+        <item name="Norauto">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Norauto"/>
+        </item>
+        <item name="O'Reilly Auto Parts">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="O'Reilly Auto Parts"/>
+        </item>
+        <item name="Pep Boys">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Pep Boys"/>
+        </item>
+        <item name="Peugeot">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Peugeot"/>
+        </item>
+        <item name="Pit Stop">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Pit Stop"/>
+        </item>
+        <item name="Renault">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Renault"/>
+        </item>
+        <item name="Roady">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Roady"/>
+        </item>
+        <item name="Speedy">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Speedy"/>
+        </item>
+        <item name="Valvoline Instant Oil Change">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Valvoline Instant Oil Change"/>
+        </item>
+        <item name="Wulkanizacja">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Wulkanizacja"/>
+        </item>
+        <item name="ÖAMTC">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="ÖAMTC"/>
+        </item>
+        <item name="Автомастерская">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Автомастерская"/>
+        </item>
+        <item name="Автосервис">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Автосервис"/>
+        </item>
+        <item name="Автосервис+шиномонтаж">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Автосервис+шиномонтаж"/>
+        </item>
+        <item name="Замена масла">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Замена масла"/>
+        </item>
+        <item name="СТО">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="СТО"/>
+        </item>
+        <item name="Шиномонтаж">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="Шиномонтаж"/>
+        </item>
+        <item name="шиномонтаж">
+          <key key="shop" value="car_repair"/>
+          <key key="name" value="шиномонтаж"/>
+        </item>
+      </group>
+      <group name="carpet">
+        <item name="Carpet Right">
+          <key key="shop" value="carpet"/>
+          <key key="name" value="Carpet Right"/>
+        </item>
+      </group>
+      <group name="charity">
+        <item name="Age UK">
+          <key key="shop" value="charity"/>
+          <key key="name" value="Age UK"/>
+        </item>
+        <item name="British Heart Foundation">
+          <key key="shop" value="charity"/>
+          <key key="name" value="British Heart Foundation"/>
+        </item>
+        <item name="Cancer Research UK">
+          <key key="shop" value="charity"/>
+          <key key="name" value="Cancer Research UK"/>
+        </item>
+        <item name="Goodwill">
+          <key key="shop" value="charity"/>
+          <key key="name" value="Goodwill"/>
+        </item>
+        <item name="Oxfam">
+          <key key="shop" value="charity"/>
+          <key key="name" value="Oxfam"/>
+        </item>
+        <item name="Scope">
+          <key key="shop" value="charity"/>
+          <key key="name" value="Scope"/>
+        </item>
+        <item name="Sue Ryder">
+          <key key="shop" value="charity"/>
+          <key key="name" value="Sue Ryder"/>
+        </item>
+      </group>
+      <group name="chemist">
+        <item name="7 Дней">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="7 Дней"/>
+        </item>
+        <item name="Bipa">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="Bipa"/>
+        </item>
+        <item name="Budnikowsky">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="Budnikowsky"/>
+        </item>
+        <item name="Etos">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="Etos"/>
+        </item>
+        <item name="Kruidvat">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="Kruidvat"/>
+        </item>
+        <item name="Müller">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="Müller"/>
+        </item>
+        <item name="Rossmann">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="Rossmann"/>
+        </item>
+        <item name="Schlecker">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="Schlecker"/>
+        </item>
+        <item name="Teta">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="Teta"/>
+        </item>
+        <item name="Walgreens">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="Walgreens"/>
+        </item>
+        <item name="Watsons">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="Watsons"/>
+        </item>
+        <item name="dm">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="dm"/>
+        </item>
+        <item name="Бытовая химия">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="Бытовая химия"/>
+        </item>
+        <item name="Магнит Косметик">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="Магнит Косметик"/>
+        </item>
+        <item name="Рубль Бум">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="Рубль Бум"/>
+        </item>
+        <item name="Улыбка радуги">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="Улыбка радуги"/>
+        </item>
+        <item name="丁丁藥局">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="丁丁藥局"/>
+        </item>
+        <item name="屈臣氏">
+          <key key="shop" value="chemist"/>
+          <key key="name" value="屈臣氏"/>
+        </item>
+      </group>
+      <group name="clothes">
+        <item name="AOKI">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="AOKI"/>
+        </item>
+        <item name="AWG">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="AWG"/>
+        </item>
+        <item name="Ackermans">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Ackermans"/>
+        </item>
+        <item name="Adidas">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Adidas"/>
+        </item>
+        <item name="Adler">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Adler"/>
+        </item>
+        <item name="American Apparel">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="American Apparel"/>
+        </item>
+        <item name="American Eagle Outfitters">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="American Eagle Outfitters"/>
+        </item>
+        <item name="Banana Republic">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Banana Republic"/>
+        </item>
+        <item name="Benetton">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Benetton"/>
+        </item>
+        <item name="Bershka">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Bershka"/>
+        </item>
+        <item name="Bonita">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Bonita"/>
+        </item>
+        <item name="Burlington Coat Factory">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Burlington Coat Factory"/>
+        </item>
+        <item name="Burton">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Burton"/>
+        </item>
+        <item name="C&amp;A">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="C&amp;A"/>
+        </item>
+        <item name="Cache Cache">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Cache Cache"/>
+        </item>
+        <item name="Calvin Klein">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Calvin Klein"/>
+        </item>
+        <item name="Calzedonia">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Calzedonia"/>
+        </item>
+        <item name="Camaïeu">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Camaïeu"/>
+        </item>
+        <item name="Caroll">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Caroll"/>
+        </item>
+        <item name="Cecil">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Cecil"/>
+        </item>
+        <item name="Celio">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Celio"/>
+        </item>
+        <item name="Charles Vögele">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Charles Vögele"/>
+        </item>
+        <item name="Chico's">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Chico's"/>
+        </item>
+        <item name="Cropp">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Cropp"/>
+        </item>
+        <item name="Cubus">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Cubus"/>
+        </item>
+        <item name="Desigual">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Desigual"/>
+        </item>
+        <item name="Diesel">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Diesel"/>
+        </item>
+        <item name="Dorothy Perkins">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Dorothy Perkins"/>
+        </item>
+        <item name="Dress Barn">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Dress Barn"/>
+        </item>
+        <item name="Dressmann">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Dressmann"/>
+        </item>
+        <item name="Edgars">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Edgars"/>
+        </item>
+        <item name="Engbers">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Engbers"/>
+        </item>
+        <item name="Ernsting's family">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Ernsting's family"/>
+        </item>
+        <item name="Esprit">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Esprit"/>
+        </item>
+        <item name="Etam">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Etam"/>
+        </item>
+        <item name="Fat Face">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Fat Face"/>
+        </item>
+        <item name="Forever 21">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Forever 21"/>
+        </item>
+        <item name="Gant">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Gant"/>
+        </item>
+        <item name="Gap">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Gap"/>
+        </item>
+        <item name="Gerry Weber">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Gerry Weber"/>
+        </item>
+        <item name="Gina Laura">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Gina Laura"/>
+        </item>
+        <item name="Goodwill">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Goodwill"/>
+        </item>
+        <item name="Guess">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Guess"/>
+        </item>
+        <item name="Gémo">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Gémo"/>
+        </item>
+        <item name="H&amp;M">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="H&amp;M"/>
+        </item>
+        <item name="House">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="House"/>
+        </item>
+        <item name="Hugo Boss">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Hugo Boss"/>
+        </item>
+        <item name="Hunkemöller">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Hunkemöller"/>
+        </item>
+        <item name="Intimissimi">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Intimissimi"/>
+        </item>
+        <item name="Jack &amp; Jones">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Jack &amp; Jones"/>
+        </item>
+        <item name="Jack Wolfskin">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Jack Wolfskin"/>
+        </item>
+        <item name="Jeans Fritz">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Jeans Fritz"/>
+        </item>
+        <item name="Jennyfer">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Jennyfer"/>
+        </item>
+        <item name="Jet">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Jet"/>
+        </item>
+        <item name="Jules">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Jules"/>
+        </item>
+        <item name="Justice">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Justice"/>
+        </item>
+        <item name="KappAhl">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="KappAhl"/>
+        </item>
+        <item name="KiK">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="KiK"/>
+        </item>
+        <item name="Kiabi">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Kiabi"/>
+        </item>
+        <item name="La Halle">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="La Halle"/>
+        </item>
+        <item name="Lacoste">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Lacoste"/>
+        </item>
+        <item name="Lane Bryant">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Lane Bryant"/>
+        </item>
+        <item name="Levi's">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Levi's"/>
+        </item>
+        <item name="Lindex">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Lindex"/>
+        </item>
+        <item name="Mango">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Mango"/>
+        </item>
+        <item name="Marc O'Polo">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Marc O'Polo"/>
+        </item>
+        <item name="Mark's">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Mark's"/>
+        </item>
+        <item name="Marshalls">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Marshalls"/>
+        </item>
+        <item name="Massimo Dutti">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Massimo Dutti"/>
+        </item>
+        <item name="Matalan">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Matalan"/>
+        </item>
+        <item name="Men's Wearhouse">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Men's Wearhouse"/>
+        </item>
+        <item name="Mexx">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Mexx"/>
+        </item>
+        <item name="Mim">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Mim"/>
+        </item>
+        <item name="Monsoon">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Monsoon"/>
+        </item>
+        <item name="Mr Price">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Mr Price"/>
+        </item>
+        <item name="NKD">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="NKD"/>
+        </item>
+        <item name="New Look">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="New Look"/>
+        </item>
+        <item name="New Yorker">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="New Yorker"/>
+        </item>
+        <item name="Next">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Next"/>
+        </item>
+        <item name="Nike">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Nike"/>
+        </item>
+        <item name="OVS">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="OVS"/>
+        </item>
+        <item name="Old Navy">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Old Navy"/>
+        </item>
+        <item name="Only">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Only"/>
+        </item>
+        <item name="Orchestra">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Orchestra"/>
+        </item>
+        <item name="Orsay">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Orsay"/>
+        </item>
+        <item name="Palmers">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Palmers"/>
+        </item>
+        <item name="Peacocks">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Peacocks"/>
+        </item>
+        <item name="Peek &amp; Cloppenburg">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Peek &amp; Cloppenburg"/>
+        </item>
+        <item name="Pep">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Pep"/>
+        </item>
+        <item name="Pepco">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Pepco"/>
+        </item>
+        <item name="Petit Bateau">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Petit Bateau"/>
+        </item>
+        <item name="Pimkie">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Pimkie"/>
+        </item>
+        <item name="Primark">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Primark"/>
+        </item>
+        <item name="Promod">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Promod"/>
+        </item>
+        <item name="Puma">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Puma"/>
+        </item>
+        <item name="Reitmans">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Reitmans"/>
+        </item>
+        <item name="Reserved">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Reserved"/>
+        </item>
+        <item name="River Island">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="River Island"/>
+        </item>
+        <item name="Ross">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Ross"/>
+        </item>
+        <item name="Sergent Major">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Sergent Major"/>
+        </item>
+        <item name="Sisley">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Sisley"/>
+        </item>
+        <item name="Springfield">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Springfield"/>
+        </item>
+        <item name="Stefanel">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Stefanel"/>
+        </item>
+        <item name="Stradivarius">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Stradivarius"/>
+        </item>
+        <item name="Street One">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Street One"/>
+        </item>
+        <item name="Superdry">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Superdry"/>
+        </item>
+        <item name="TJ Maxx">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="TJ Maxx"/>
+        </item>
+        <item name="TK Maxx">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="TK Maxx"/>
+        </item>
+        <item name="Takko">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Takko"/>
+        </item>
+        <item name="Tally Weijl">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Tally Weijl"/>
+        </item>
+        <item name="Tezenis">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Tezenis"/>
+        </item>
+        <item name="Timberland">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Timberland"/>
+        </item>
+        <item name="Toko Pakaian">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Toko Pakaian"/>
+        </item>
+        <item name="Tom Tailor">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Tom Tailor"/>
+        </item>
+        <item name="Tommy Hilfiger">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Tommy Hilfiger"/>
+        </item>
+        <item name="Topshop">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Topshop"/>
+        </item>
+        <item name="Triumph">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Triumph"/>
+        </item>
+        <item name="Truworths">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Truworths"/>
+        </item>
+        <item name="Ulla Popken">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Ulla Popken"/>
+        </item>
+        <item name="United Colors of Benetton">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="United Colors of Benetton"/>
+        </item>
+        <item name="Urban Outfitters">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Urban Outfitters"/>
+        </item>
+        <item name="Vero Moda">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Vero Moda"/>
+        </item>
+        <item name="Victoria's Secret">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Victoria's Secret"/>
+        </item>
+        <item name="Vögele">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Vögele"/>
+        </item>
+        <item name="WE">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="WE"/>
+        </item>
+        <item name="Wibra">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Wibra"/>
+        </item>
+        <item name="Winners">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Winners"/>
+        </item>
+        <item name="Woolworths">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Woolworths"/>
+        </item>
+        <item name="Zara">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Zara"/>
+        </item>
+        <item name="Zeeman">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Zeeman"/>
+        </item>
+        <item name="s.Oliver">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="s.Oliver"/>
+        </item>
+        <item name="Женская одежда">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Женская одежда"/>
+        </item>
+        <item name="Одежда">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Одежда"/>
+        </item>
+        <item name="Спецодежда">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="Спецодежда"/>
+        </item>
+        <item name="しまむら">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="しまむら"/>
+        </item>
+        <item name="ユニクロ">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="ユニクロ"/>
+        </item>
+        <item name="ワークマン">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="ワークマン"/>
+        </item>
+        <item name="洋服の青山">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="洋服の青山"/>
+        </item>
+        <item name="西松屋">
+          <key key="shop" value="clothes"/>
+          <key key="name" value="西松屋"/>
+        </item>
+      </group>
+      <group name="coffee">
+        <item name="Café Amazon">
+          <key key="shop" value="coffee"/>
+          <key key="name" value="Café Amazon"/>
+        </item>
+        <item name="Starbucks">
+          <key key="shop" value="coffee"/>
+          <key key="name" value="Starbucks"/>
+          <key key="cuisine" value="coffee_shop"/>
+        </item>
+        <item name="Tchibo">
+          <key key="shop" value="coffee"/>
+          <key key="name" value="Tchibo"/>
+        </item>
+      </group>
+      <group name="computer">
+        <item name="Apple Store">
+          <key key="shop" value="computer"/>
+          <key key="name" value="Apple Store"/>
+        </item>
+        <item name="DNS">
+          <key key="shop" value="computer"/>
+          <key key="name" value="DNS"/>
+        </item>
+        <item name="PC World">
+          <key key="shop" value="computer"/>
+          <key key="name" value="PC World"/>
+        </item>
+        <item name="ДНС">
+          <key key="shop" value="computer"/>
+          <key key="name" value="ДНС"/>
+        </item>
+      </group>
+      <group name="confectionery">
+        <item name="Fagyizó">
+          <key key="shop" value="confectionery"/>
+          <key key="name" value="Fagyizó"/>
+        </item>
+        <item name="Hussel">
+          <key key="shop" value="confectionery"/>
+          <key key="name" value="Hussel"/>
+        </item>
+        <item name="Leonidas">
+          <key key="shop" value="confectionery"/>
+          <key key="name" value="Leonidas"/>
+        </item>
+        <item name="Thorntons">
+          <key key="shop" value="confectionery"/>
+          <key key="name" value="Thorntons"/>
+        </item>
+      </group>
+      <group name="convenience">
+        <item name="24 часа">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="24 часа"/>
+        </item>
+        <item name="7-Eleven">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="7-Eleven"/>
+        </item>
+        <item name="8 à Huit">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="8 à Huit"/>
+        </item>
+        <item name="ABC">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="ABC"/>
+        </item>
+        <item name="AMPM">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="AMPM"/>
+        </item>
+        <item name="Aibė">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Aibė"/>
+        </item>
+        <item name="Alepa">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Alepa"/>
+        </item>
+        <item name="Alfamart">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Alfamart"/>
+        </item>
+        <item name="Almacen">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Almacen"/>
+        </item>
+        <item name="Almacén">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Almacén"/>
+        </item>
+        <item name="Aral">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Aral"/>
+        </item>
+        <item name="BP">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="BP"/>
+        </item>
+        <item name="BP Shop">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="BP Shop"/>
+        </item>
+        <item name="Baqala">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Baqala"/>
+        </item>
+        <item name="Biedronka">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Biedronka"/>
+        </item>
+        <item name="Bodega">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Bodega"/>
+        </item>
+        <item name="Boutique">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Boutique"/>
+        </item>
+        <item name="CBA">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="CBA"/>
+        </item>
+        <item name="COOP">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="COOP"/>
+        </item>
+        <item name="COOP Jednota">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="COOP Jednota"/>
+        </item>
+        <item name="CU">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="CU"/>
+        </item>
+        <item name="Carrefour City">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Carrefour City"/>
+        </item>
+        <item name="Carrefour Express">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Carrefour Express"/>
+        </item>
+        <item name="Casey's General Store">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Casey's General Store"/>
+        </item>
+        <item name="Centra">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Centra"/>
+        </item>
+        <item name="Central Convenience Store">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Central Convenience Store"/>
+        </item>
+        <item name="Chevron">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Chevron"/>
+        </item>
+        <item name="Circle K">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Circle K"/>
+        </item>
+        <item name="Citgo">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Citgo"/>
+        </item>
+        <item name="Co-Op">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Co-Op"/>
+        </item>
+        <item name="Co-op">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Co-op"/>
+        </item>
+        <item name="Coles Express">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Coles Express"/>
+        </item>
+        <item name="Coop">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Coop"/>
+        </item>
+        <item name="Coop Jednota">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Coop Jednota"/>
+        </item>
+        <item name="Coop Pronto">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Coop Pronto"/>
+        </item>
+        <item name="Corner Store">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Corner Store"/>
+        </item>
+        <item name="Costcutter">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Costcutter"/>
+        </item>
+        <item name="Couche-Tard">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Couche-Tard"/>
+        </item>
+        <item name="Cumberland Farms">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Cumberland Farms"/>
+        </item>
+        <item name="Delikatesy">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Delikatesy"/>
+        </item>
+        <item name="Delikatesy Centrum">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Delikatesy Centrum"/>
+        </item>
+        <item name="Dollar General">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Dollar General"/>
+        </item>
+        <item name="Esso">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Esso"/>
+        </item>
+        <item name="Extra">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Extra"/>
+        </item>
+        <item name="Family Dollar">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Family Dollar"/>
+        </item>
+        <item name="FamilyMart">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="FamilyMart"/>
+        </item>
+        <item name="Food Mart">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Food Mart"/>
+        </item>
+        <item name="Four Square">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Four Square"/>
+        </item>
+        <item name="Franprix">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Franprix"/>
+        </item>
+        <item name="Fresh">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Fresh"/>
+        </item>
+        <item name="Freshmarket">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Freshmarket"/>
+        </item>
+        <item name="GS25">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="GS25"/>
+        </item>
+        <item name="Groszek">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Groszek"/>
+        </item>
+        <item name="Hasty Market">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Hasty Market"/>
+        </item>
+        <item name="Holiday">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Holiday"/>
+        </item>
+        <item name="Hruška">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Hruška"/>
+        </item>
+        <item name="Indomaret">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Indomaret"/>
+        </item>
+        <item name="Jednota">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Jednota"/>
+        </item>
+        <item name="K-Market">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="K-Market"/>
+        </item>
+        <item name="Kiosk">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Kiosk"/>
+        </item>
+        <item name="Kisbolt">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Kisbolt"/>
+        </item>
+        <item name="Konzum">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Konzum"/>
+        </item>
+        <item name="Kum &amp; Go">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Kum &amp; Go"/>
+        </item>
+        <item name="Kwik Trip">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Kwik Trip"/>
+        </item>
+        <item name="LAWSON">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="LAWSON"/>
+        </item>
+        <item name="Lewiatan">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Lewiatan"/>
+        </item>
+        <item name="Lifestyle Express">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Lifestyle Express"/>
+        </item>
+        <item name="Londis">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Londis"/>
+        </item>
+        <item name="M&amp;S Simply Food">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="M&amp;S Simply Food"/>
+        </item>
+        <item name="Mac's">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Mac's"/>
+        </item>
+        <item name="Mace">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Mace"/>
+        </item>
+        <item name="Magazin">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Magazin"/>
+        </item>
+        <item name="Magazin Alimentar">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Magazin Alimentar"/>
+        </item>
+        <item name="Magazin Mixt">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Magazin Mixt"/>
+        </item>
+        <item name="Magazin Non-Stop">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Magazin Non-Stop"/>
+        </item>
+        <item name="Martin's">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Martin's"/>
+        </item>
+        <item name="Małpka Express">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Małpka Express"/>
+        </item>
+        <item name="McColl's">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="McColl's"/>
+        </item>
+        <item name="Mercator">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Mercator"/>
+        </item>
+        <item name="Migrolino">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Migrolino"/>
+        </item>
+        <item name="Mini ABC">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Mini ABC"/>
+        </item>
+        <item name="Mini Market">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Mini Market"/>
+        </item>
+        <item name="Mini Market Non-Stop">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Mini Market Non-Stop"/>
+        </item>
+        <item name="Mini Mart">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Mini Mart"/>
+        </item>
+        <item name="Mini Stop">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Mini Stop"/>
+        </item>
+        <item name="Minimarket">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Minimarket"/>
+        </item>
+        <item name="Mlin i pekare">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Mlin i pekare"/>
+        </item>
+        <item name="Mobil">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Mobil"/>
+        </item>
+        <item name="Nasz Sklep">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Nasz Sklep"/>
+        </item>
+        <item name="Nisa">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Nisa"/>
+        </item>
+        <item name="Nisa Local">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Nisa Local"/>
+        </item>
+        <item name="OK">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="OK"/>
+        </item>
+        <item name="OK便利商店">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="OK便利商店"/>
+        </item>
+        <item name="Odido">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Odido"/>
+        </item>
+        <item name="On the Run">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="On the Run"/>
+        </item>
+        <item name="One Stop">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="One Stop"/>
+        </item>
+        <item name="Oxxo">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Oxxo"/>
+        </item>
+        <item name="Parduotuvė">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Parduotuvė"/>
+        </item>
+        <item name="Petit Casino">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Petit Casino"/>
+        </item>
+        <item name="Picard">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Picard"/>
+        </item>
+        <item name="Plaid Pantry">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Plaid Pantry"/>
+        </item>
+        <item name="Potraviny">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Potraviny"/>
+        </item>
+        <item name="Prehrana">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Prehrana"/>
+        </item>
+        <item name="Premier">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Premier"/>
+        </item>
+        <item name="Proxi">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Proxi"/>
+        </item>
+        <item name="QuikTrip">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="QuikTrip"/>
+        </item>
+        <item name="Reál">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Reál"/>
+        </item>
+        <item name="Rite Aid">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Rite Aid"/>
+        </item>
+        <item name="Royal Farms">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Royal Farms"/>
+        </item>
+        <item name="Sainsbury's Local">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Sainsbury's Local"/>
+        </item>
+        <item name="Sale">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Sale"/>
+        </item>
+        <item name="Sari-sari Store">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Sari-sari Store"/>
+        </item>
+        <item name="Select">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Select"/>
+        </item>
+        <item name="Sheetz">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Sheetz"/>
+        </item>
+        <item name="Shell">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Shell"/>
+        </item>
+        <item name="Shop &amp; Go">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Shop &amp; Go"/>
+        </item>
+        <item name="Siwa">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Siwa"/>
+        </item>
+        <item name="Sklep spożywczy">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Sklep spożywczy"/>
+        </item>
+        <item name="Spar">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Spar"/>
+        </item>
+        <item name="Speedway">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Speedway"/>
+        </item>
+        <item name="Społem">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Społem"/>
+        </item>
+        <item name="Statoil">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Statoil"/>
+        </item>
+        <item name="Stewart's">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Stewart's"/>
+        </item>
+        <item name="Stores">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Stores"/>
+        </item>
+        <item name="Studenac">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Studenac"/>
+        </item>
+        <item name="Sunkus">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Sunkus"/>
+        </item>
+        <item name="Sunoco">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Sunoco"/>
+        </item>
+        <item name="Tchibo">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Tchibo"/>
+        </item>
+        <item name="Tesco">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Tesco"/>
+        </item>
+        <item name="Tesco Express">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Tesco Express"/>
+        </item>
+        <item name="Tesco Lotus Express">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Tesco Lotus Express"/>
+        </item>
+        <item name="The Co-operative Food">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="The Co-operative Food"/>
+        </item>
+        <item name="Total">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Total"/>
+        </item>
+        <item name="United Dairy Farmers">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="United Dairy Farmers"/>
+        </item>
+        <item name="Valintatalo">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Valintatalo"/>
+        </item>
+        <item name="Vegyesbolt">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Vegyesbolt"/>
+        </item>
+        <item name="Večerka">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Večerka"/>
+        </item>
+        <item name="Vival">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Vival"/>
+        </item>
+        <item name="Volg">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Volg"/>
+        </item>
+        <item name="Wawa">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Wawa"/>
+        </item>
+        <item name="Woolworths Petrol">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Woolworths Petrol"/>
+        </item>
+        <item name="abc">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="abc"/>
+        </item>
+        <item name="ampm">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="ampm"/>
+        </item>
+        <item name="odido">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="odido"/>
+        </item>
+        <item name="Żabka">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Żabka"/>
+        </item>
+        <item name="Авоська">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Авоська"/>
+        </item>
+        <item name="Агрокомплекс">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Агрокомплекс"/>
+        </item>
+        <item name="Апельсин">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Апельсин"/>
+        </item>
+        <item name="Ассорти">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Ассорти"/>
+        </item>
+        <item name="Берёзка">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Берёзка"/>
+        </item>
+        <item name="Верный">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Верный"/>
+        </item>
+        <item name="Весна">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Весна"/>
+        </item>
+        <item name="Визит">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Визит"/>
+        </item>
+        <item name="Виктория">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Виктория"/>
+        </item>
+        <item name="Гастроном">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Гастроном"/>
+        </item>
+        <item name="Гурман">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Гурман"/>
+        </item>
+        <item name="Дикси">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Дикси"/>
+        </item>
+        <item name="Евроопт">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Евроопт"/>
+        </item>
+        <item name="Елена">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Елена"/>
+        </item>
+        <item name="КазМунайГаз">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="КазМунайГаз"/>
+        </item>
+        <item name="Кировский">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Кировский"/>
+        </item>
+        <item name="Копеечка">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Копеечка"/>
+        </item>
+        <item name="Копейка">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Копейка"/>
+        </item>
+        <item name="Кулинария">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Кулинария"/>
+        </item>
+        <item name="Любимый">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Любимый"/>
+        </item>
+        <item name="Магнит">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Магнит"/>
+        </item>
+        <item name="Магнолия">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Магнолия"/>
+        </item>
+        <item name="Мария-Ра">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Мария-Ра"/>
+        </item>
+        <item name="Маяк">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Маяк"/>
+        </item>
+        <item name="Меркурий">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Меркурий"/>
+        </item>
+        <item name="Мечта">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Мечта"/>
+        </item>
+        <item name="Минимаркет">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Минимаркет"/>
+        </item>
+        <item name="Мираж">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Мираж"/>
+        </item>
+        <item name="Монетка">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Монетка"/>
+        </item>
+        <item name="Надежда">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Надежда"/>
+        </item>
+        <item name="Перекресток">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Перекресток"/>
+        </item>
+        <item name="Продукти">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Продукти"/>
+        </item>
+        <item name="Продуктовый">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Продуктовый"/>
+        </item>
+        <item name="Продуктовый магазин">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Продуктовый магазин"/>
+        </item>
+        <item name="Продукты">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Продукты"/>
+        </item>
+        <item name="Продукты 24">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Продукты 24"/>
+        </item>
+        <item name="Пятёрочка">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Пятёрочка"/>
+        </item>
+        <item name="Радуга">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Радуга"/>
+        </item>
+        <item name="Ромашка">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Ромашка"/>
+        </item>
+        <item name="Русь">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Русь"/>
+        </item>
+        <item name="Светлана">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Светлана"/>
+        </item>
+        <item name="Смак">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Смак"/>
+        </item>
+        <item name="Татьяна">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Татьяна"/>
+        </item>
+        <item name="Теремок">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Теремок"/>
+        </item>
+        <item name="Тройка">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Тройка"/>
+        </item>
+        <item name="Универсам">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Универсам"/>
+        </item>
+        <item name="Фортуна">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Фортуна"/>
+        </item>
+        <item name="Центральный">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Центральный"/>
+        </item>
+        <item name="Эконом">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="Эконом"/>
+        </item>
+        <item name="магазин">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="магазин"/>
+        </item>
+        <item name="продукты">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="продукты"/>
+        </item>
+        <item name="მარკეტი (Market)">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="მარკეტი (Market)"/>
+        </item>
+        <item name="ココストア">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="ココストア"/>
+        </item>
+        <item name="サンクス">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="サンクス"/>
+          <key key="name:en" value="sunkus"/>
+        </item>
+        <item name="サークルK">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="サークルK"/>
+          <key key="name:en" value="Circle K"/>
+        </item>
+        <item name="スリーエフ">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="スリーエフ"/>
+        </item>
+        <item name="セイコーマート">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="セイコーマート"/>
+        </item>
+        <item name="セブンイレブン">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="セブンイレブン"/>
+          <key key="name:en" value="7-Eleven"/>
+        </item>
+        <item name="セブンイレブン(Seven-Eleven)">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="セブンイレブン(Seven-Eleven)"/>
+        </item>
+        <item name="デイリーヤマザキ">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="デイリーヤマザキ"/>
+        </item>
+        <item name="ファミリーマート">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="ファミリーマート"/>
+          <key key="name:en" value="FamilyMart"/>
+        </item>
+        <item name="ポプラ">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="ポプラ"/>
+        </item>
+        <item name="ミニストップ">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="ミニストップ"/>
+          <key key="name:en" value="MINISTOP"/>
+        </item>
+        <item name="ヤマザキショップ">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="ヤマザキショップ"/>
+        </item>
+        <item name="ローソン">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="ローソン"/>
+          <key key="name:en" value="LAWSON"/>
+        </item>
+        <item name="ローソンストア100">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="ローソンストア100"/>
+        </item>
+        <item name="全家">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="全家"/>
+        </item>
+        <item name="全家便利商店">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="全家便利商店"/>
+        </item>
+        <item name="萊爾富">
+          <key key="shop" value="convenience"/>
+          <key key="name" value="萊爾富"/>
+        </item>
+      </group>
+      <group name="copyshop">
+        <item name="FedEx Office Print and Ship Center">
+          <key key="shop" value="copyshop"/>
+          <key key="name" value="FedEx Office Print and Ship Center"/>
+        </item>
+      </group>
+      <group name="cosmetics">
+        <item name="Sephora">
+          <key key="shop" value="cosmetics"/>
+          <key key="name" value="Sephora"/>
+        </item>
+        <item name="The Body Shop">
+          <key key="shop" value="cosmetics"/>
+          <key key="name" value="The Body Shop"/>
+        </item>
+        <item name="Yves Rocher">
+          <key key="shop" value="cosmetics"/>
+          <key key="name" value="Yves Rocher"/>
+        </item>
+        <item name="Л'Этуаль">
+          <key key="shop" value="cosmetics"/>
+          <key key="name" value="Л'Этуаль"/>
+        </item>
+      </group>
+      <group name="craft">
+        <item name="Hobby Lobby">
+          <key key="shop" value="craft"/>
+          <key key="name" value="Hobby Lobby"/>
+        </item>
+        <item name="Michaels">
+          <key key="shop" value="craft"/>
+          <key key="name" value="Michaels"/>
+        </item>
+      </group>
+      <group name="department_store">
+        <item name="Argos">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Argos"/>
+        </item>
+        <item name="BHS">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="BHS"/>
+        </item>
+        <item name="Bed Bath &amp; Beyond">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Bed Bath &amp; Beyond"/>
+        </item>
+        <item name="Big Lots">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Big Lots"/>
+        </item>
+        <item name="Big W">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Big W"/>
+        </item>
+        <item name="Canadian Tire">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Canadian Tire"/>
+        </item>
+        <item name="Debenhams">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Debenhams"/>
+        </item>
+        <item name="Dillard's">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Dillard's"/>
+        </item>
+        <item name="Dollar General">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Dollar General"/>
+        </item>
+        <item name="Dollar Tree">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Dollar Tree"/>
+        </item>
+        <item name="El Corte Inglés">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="El Corte Inglés"/>
+        </item>
+        <item name="Family Dollar">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Family Dollar"/>
+        </item>
+        <item name="Galeria Kaufhof">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Galeria Kaufhof"/>
+        </item>
+        <item name="HEMA">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="HEMA"/>
+        </item>
+        <item name="JCPenney">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="JCPenney"/>
+        </item>
+        <item name="Karstadt">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Karstadt"/>
+        </item>
+        <item name="Kmart">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Kmart"/>
+        </item>
+        <item name="Kohl's">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Kohl's"/>
+        </item>
+        <item name="Macy's">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Macy's"/>
+        </item>
+        <item name="Marks &amp; Spencer">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Marks &amp; Spencer"/>
+        </item>
+        <item name="Sam's Club">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Sam's Club"/>
+        </item>
+        <item name="Sears">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Sears"/>
+        </item>
+        <item name="Target">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Target"/>
+        </item>
+        <item name="The Warehouse">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="The Warehouse"/>
+        </item>
+        <item name="Walmart">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Walmart"/>
+        </item>
+        <item name="Walmart Supercenter">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Walmart Supercenter"/>
+        </item>
+        <item name="Woolworth">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Woolworth"/>
+        </item>
+        <item name="Магнит">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Магнит"/>
+        </item>
+        <item name="Универмаг">
+          <key key="shop" value="department_store"/>
+          <key key="name" value="Универмаг"/>
+        </item>
+      </group>
+      <group name="doityourself">
+        <item name="Ace Hardware">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Ace Hardware"/>
+        </item>
+        <item name="B&amp;Q">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="B&amp;Q"/>
+        </item>
+        <item name="Bauhaus">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Bauhaus"/>
+        </item>
+        <item name="BayWa">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="BayWa"/>
+        </item>
+        <item name="Biltema">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Biltema"/>
+        </item>
+        <item name="Brico">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Brico"/>
+        </item>
+        <item name="Bricomarché">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Bricomarché"/>
+        </item>
+        <item name="Bricorama">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Bricorama"/>
+        </item>
+        <item name="Bunnings Warehouse">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Bunnings Warehouse"/>
+        </item>
+        <item name="Canadian Tire">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Canadian Tire"/>
+        </item>
+        <item name="Castorama">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Castorama"/>
+        </item>
+        <item name="Easy">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Easy"/>
+        </item>
+        <item name="Gamma">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Gamma"/>
+        </item>
+        <item name="Hagebaumarkt">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Hagebaumarkt"/>
+        </item>
+        <item name="Hellweg">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Hellweg"/>
+        </item>
+        <item name="Home Depot">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Home Depot"/>
+        </item>
+        <item name="Home Hardware">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Home Hardware"/>
+        </item>
+        <item name="Homebase">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Homebase"/>
+        </item>
+        <item name="Hornbach">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Hornbach"/>
+        </item>
+        <item name="Hubo">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Hubo"/>
+        </item>
+        <item name="Karwei">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Karwei"/>
+        </item>
+        <item name="Lagerhaus">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Lagerhaus"/>
+        </item>
+        <item name="Leroy Merlin">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Leroy Merlin"/>
+        </item>
+        <item name="Lowe's">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Lowe's"/>
+        </item>
+        <item name="Menards">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Menards"/>
+        </item>
+        <item name="Mr Bricolage">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Mr Bricolage"/>
+        </item>
+        <item name="OBI">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="OBI"/>
+        </item>
+        <item name="Point P">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Point P"/>
+        </item>
+        <item name="Praktiker">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Praktiker"/>
+        </item>
+        <item name="Rona">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Rona"/>
+        </item>
+        <item name="Screwfix">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Screwfix"/>
+        </item>
+        <item name="Sonderpreis Baumarkt">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Sonderpreis Baumarkt"/>
+        </item>
+        <item name="Toom Baumarkt">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Toom Baumarkt"/>
+        </item>
+        <item name="Weldom">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Weldom"/>
+        </item>
+        <item name="Wickes">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Wickes"/>
+        </item>
+        <item name="Мастер">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Мастер"/>
+        </item>
+        <item name="Строитель">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Строитель"/>
+        </item>
+        <item name="Стройматериалы">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Стройматериалы"/>
+        </item>
+        <item name="Хозтовары">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="Хозтовары"/>
+        </item>
+        <item name="コメリ">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="コメリ"/>
+        </item>
+        <item name="コーナン">
+          <key key="shop" value="doityourself"/>
+          <key key="name" value="コーナン"/>
+        </item>
+      </group>
+      <group name="dry_cleaning">
+        <item name="Cleaners">
+          <key key="shop" value="dry_cleaning"/>
+          <key key="name" value="Cleaners"/>
+        </item>
+        <item name="Диана">
+          <key key="shop" value="dry_cleaning"/>
+          <key key="name" value="Диана"/>
+        </item>
+        <item name="Химчистка">
+          <key key="shop" value="dry_cleaning"/>
+          <key key="name" value="Химчистка"/>
+        </item>
+        <item name="ホワイト急便">
+          <key key="shop" value="dry_cleaning"/>
+          <key key="name" value="ホワイト急便"/>
+        </item>
+      </group>
+      <group name="electronics">
+        <item name="Apple Store">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Apple Store"/>
+        </item>
+        <item name="Batteries Plus Bulbs">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Batteries Plus Bulbs"/>
+        </item>
+        <item name="Bell">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Bell"/>
+        </item>
+        <item name="Best Buy">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Best Buy"/>
+        </item>
+        <item name="Boulanger">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Boulanger"/>
+        </item>
+        <item name="Currys">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Currys"/>
+        </item>
+        <item name="DNS">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="DNS"/>
+        </item>
+        <item name="Darty">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Darty"/>
+        </item>
+        <item name="Elgiganten">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Elgiganten"/>
+        </item>
+        <item name="Euronics">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Euronics"/>
+        </item>
+        <item name="Expert">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Expert"/>
+        </item>
+        <item name="Hartlauer">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Hartlauer"/>
+        </item>
+        <item name="Interdiscount">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Interdiscount"/>
+        </item>
+        <item name="La Curacao">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="La Curacao"/>
+        </item>
+        <item name="Maplin">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Maplin"/>
+        </item>
+        <item name="Media Expert">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Media Expert"/>
+        </item>
+        <item name="Media Markt">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Media Markt"/>
+        </item>
+        <item name="Neonet">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Neonet"/>
+        </item>
+        <item name="Radio Shack">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Radio Shack"/>
+        </item>
+        <item name="Rogers">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Rogers"/>
+        </item>
+        <item name="Samsung">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Samsung"/>
+        </item>
+        <item name="Saturn">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Saturn"/>
+        </item>
+        <item name="The Source">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="The Source"/>
+        </item>
+        <item name="М.Видео">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="М.Видео"/>
+        </item>
+        <item name="Фокстрот">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Фокстрот"/>
+        </item>
+        <item name="Эксперт">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Эксперт"/>
+        </item>
+        <item name="Эльдорадо">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="Эльдорадо"/>
+        </item>
+        <item name="エディオン">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="エディオン"/>
+        </item>
+        <item name="ケーズデンキ">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="ケーズデンキ"/>
+        </item>
+        <item name="ヤマダ電機">
+          <key key="shop" value="electronics"/>
+          <key key="name" value="ヤマダ電機"/>
+        </item>
+      </group>
+      <group name="energy">
+        <item name="Punto Enel">
+          <key key="shop" value="energy"/>
+          <key key="name" value="Punto Enel"/>
+        </item>
+      </group>
+      <group name="erotic">
+        <item name="Orion">
+          <key key="shop" value="erotic"/>
+          <key key="name" value="Orion"/>
+        </item>
+      </group>
+      <group name="fabric">
+        <item name="Ткани">
+          <key key="shop" value="fabric"/>
+          <key key="name" value="Ткани"/>
+        </item>
+      </group>
+      <group name="farm">
+        <item name="Hofladen">
+          <key key="shop" value="farm"/>
+          <key key="name" value="Hofladen"/>
+        </item>
+      </group>
+      <group name="florist">
+        <item name="Blume 2000">
+          <key key="shop" value="florist"/>
+          <key key="name" value="Blume 2000"/>
+        </item>
+        <item name="Blumen Risse">
+          <key key="shop" value="florist"/>
+          <key key="name" value="Blumen Risse"/>
+        </item>
+        <item name="Interflora">
+          <key key="shop" value="florist"/>
+          <key key="name" value="Interflora"/>
+        </item>
+        <item name="Monceau Fleurs">
+          <key key="shop" value="florist"/>
+          <key key="name" value="Monceau Fleurs"/>
+        </item>
+        <item name="Virágbolt">
+          <key key="shop" value="florist"/>
+          <key key="name" value="Virágbolt"/>
+        </item>
+        <item name="Цветы">
+          <key key="shop" value="florist"/>
+          <key key="name" value="Цветы"/>
+        </item>
+        <item name="상록식물원 (Sangnok Florist)">
+          <key key="shop" value="florist"/>
+          <key key="name" value="상록식물원 (Sangnok Florist)"/>
+        </item>
+      </group>
+      <group name="frame">
+        <item name="rumah penduduk">
+          <key key="shop" value="frame"/>
+          <key key="name" value="rumah penduduk"/>
+        </item>
+      </group>
+      <group name="funeral_directors">
+        <item name="The Co-operative Funeralcare">
+          <key key="shop" value="funeral_directors"/>
+          <key key="name" value="The Co-operative Funeralcare"/>
+        </item>
+        <item name="Ритуальные услуги">
+          <key key="shop" value="funeral_directors"/>
+          <key key="name" value="Ритуальные услуги"/>
+        </item>
+      </group>
+      <group name="furniture">
+        <item name="Black Red White">
+          <key key="shop" value="furniture"/>
+          <key key="name" value="Black Red White"/>
+        </item>
+        <item name="But">
+          <key key="shop" value="furniture"/>
+          <key key="name" value="But"/>
+        </item>
+        <item name="Casa">
+          <key key="shop" value="furniture"/>
+          <key key="name" value="Casa"/>
+        </item>
+        <item name="Conforama">
+          <key key="shop" value="furniture"/>
+          <key key="name" value="Conforama"/>
+        </item>
+        <item name="Dänisches Bettenlager">
+          <key key="shop" value="furniture"/>
+          <key key="name" value="Dänisches Bettenlager"/>
+        </item>
+        <item name="IKEA">
+          <key key="shop" value="furniture"/>
+          <key key="name" value="IKEA"/>
+        </item>
+        <item name="JYSK">
+          <key key="shop" value="furniture"/>
+          <key key="name" value="JYSK"/>
+        </item>
+        <item name="Pier 1 Imports">
+          <key key="shop" value="furniture"/>
+          <key key="name" value="Pier 1 Imports"/>
+        </item>
+        <item name="Roller">
+          <key key="shop" value="furniture"/>
+          <key key="name" value="Roller"/>
+        </item>
+        <item name="The Brick">
+          <key key="shop" value="furniture"/>
+          <key key="name" value="The Brick"/>
+        </item>
+        <item name="ニトリ">
+          <key key="shop" value="furniture"/>
+          <key key="name" value="ニトリ"/>
+        </item>
+      </group>
+      <group name="garden_centre">
+        <item name="Dehner">
+          <key key="shop" value="garden_centre"/>
+          <key key="name" value="Dehner"/>
+        </item>
+        <item name="Gamm Vert">
+          <key key="shop" value="garden_centre"/>
+          <key key="name" value="Gamm Vert"/>
+        </item>
+        <item name="Jardiland">
+          <key key="shop" value="garden_centre"/>
+          <key key="name" value="Jardiland"/>
+        </item>
+        <item name="Point Vert">
+          <key key="shop" value="garden_centre"/>
+          <key key="name" value="Point Vert"/>
+        </item>
+      </group>
+      <group name="gift">
+        <item name="Card Factory">
+          <key key="shop" value="gift"/>
+          <key key="name" value="Card Factory"/>
+        </item>
+        <item name="Hallmark">
+          <key key="shop" value="gift"/>
+          <key key="name" value="Hallmark"/>
+        </item>
+      </group>
+      <group name="hairdresser">
+        <item name="Cost Cutters">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Cost Cutters"/>
+        </item>
+        <item name="Figaro">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Figaro"/>
+        </item>
+        <item name="Franck Provost">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Franck Provost"/>
+        </item>
+        <item name="Great Clips">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Great Clips"/>
+        </item>
+        <item name="Haarmonie">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Haarmonie"/>
+        </item>
+        <item name="Haarscharf">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Haarscharf"/>
+        </item>
+        <item name="Hair Cuttery">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Hair Cuttery"/>
+        </item>
+        <item name="Hairkiller">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Hairkiller"/>
+        </item>
+        <item name="Jean Louis David">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Jean Louis David"/>
+        </item>
+        <item name="Klier">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Klier"/>
+        </item>
+        <item name="Klipp">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Klipp"/>
+        </item>
+        <item name="Peluquería">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Peluquería"/>
+        </item>
+        <item name="Sport Clips">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Sport Clips"/>
+        </item>
+        <item name="Supercuts">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Supercuts"/>
+        </item>
+        <item name="Tchip">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Tchip"/>
+        </item>
+        <item name="The Barber Shop">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="The Barber Shop"/>
+        </item>
+        <item name="Toni &amp; Guy">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Toni &amp; Guy"/>
+        </item>
+        <item name="Top Hair">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Top Hair"/>
+        </item>
+        <item name="Парикмахерская">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Парикмахерская"/>
+        </item>
+        <item name="Перукарня">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Перукарня"/>
+        </item>
+        <item name="Салон красоты">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Салон красоты"/>
+        </item>
+        <item name="Стиль">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Стиль"/>
+        </item>
+        <item name="Шарм">
+          <key key="shop" value="hairdresser"/>
+          <key key="name" value="Шарм"/>
+        </item>
+      </group>
+      <group name="hardware">
+        <item name="1000 мелочей">
+          <key key="shop" value="hardware"/>
+          <key key="name" value="1000 мелочей"/>
+        </item>
+        <item name="Ferretería">
+          <key key="shop" value="hardware"/>
+          <key key="name" value="Ferretería"/>
+        </item>
+        <item name="Home Hardware">
+          <key key="shop" value="hardware"/>
+          <key key="name" value="Home Hardware"/>
+        </item>
+        <item name="Lowe's">
+          <key key="shop" value="hardware"/>
+          <key key="name" value="Lowe's"/>
+        </item>
+        <item name="Quincaillerie">
+          <key key="shop" value="hardware"/>
+          <key key="name" value="Quincaillerie"/>
+        </item>
+        <item name="Сантехника">
+          <key key="shop" value="hardware"/>
+          <key key="name" value="Сантехника"/>
+        </item>
+        <item name="Стройматериалы">
+          <key key="shop" value="hardware"/>
+          <key key="name" value="Стройматериалы"/>
+        </item>
+        <item name="Хозтовары">
+          <key key="shop" value="hardware"/>
+          <key key="name" value="Хозтовары"/>
+        </item>
+      </group>
+      <group name="hearing_aids">
+        <item name="Amplifon">
+          <key key="shop" value="hearing_aids"/>
+          <key key="name" value="Amplifon"/>
+        </item>
+        <item name="Kind Hörgeräte">
+          <key key="shop" value="hearing_aids"/>
+          <key key="name" value="Kind Hörgeräte"/>
+        </item>
+      </group>
+      <group name="hifi"/>
+      <group name="houseware">
+        <item name="Blokker">
+          <key key="shop" value="houseware"/>
+          <key key="name" value="Blokker"/>
+        </item>
+        <item name="Marskramer">
+          <key key="shop" value="houseware"/>
+          <key key="name" value="Marskramer"/>
+        </item>
+        <item name="Xenos">
+          <key key="shop" value="houseware"/>
+          <key key="name" value="Xenos"/>
+        </item>
+      </group>
+      <group name="ice_cream">
+        <item name="Мороженое">
+          <key key="shop" value="ice_cream"/>
+          <key key="name" value="Мороженое"/>
+        </item>
+      </group>
+      <group name="interior_decoration">
+        <item name="Depot">
+          <key key="shop" value="interior_decoration"/>
+          <key key="name" value="Depot"/>
+        </item>
+      </group>
+      <group name="jewelry">
+        <item name="585">
+          <key key="shop" value="jewelry"/>
+          <key key="name" value="585"/>
+        </item>
+        <item name="Bijou Brigitte">
+          <key key="shop" value="jewelry"/>
+          <key key="name" value="Bijou Brigitte"/>
+        </item>
+        <item name="Christ">
+          <key key="shop" value="jewelry"/>
+          <key key="name" value="Christ"/>
+        </item>
+        <item name="Claire's">
+          <key key="shop" value="jewelry"/>
+          <key key="name" value="Claire's"/>
+        </item>
+        <item name="Kay Jewelers">
+          <key key="shop" value="jewelry"/>
+          <key key="name" value="Kay Jewelers"/>
+        </item>
+        <item name="Pandora">
+          <key key="shop" value="jewelry"/>
+          <key key="name" value="Pandora"/>
+        </item>
+        <item name="Swarovski">
+          <key key="shop" value="jewelry"/>
+          <key key="name" value="Swarovski"/>
+        </item>
+        <item name="Адамас">
+          <key key="shop" value="jewelry"/>
+          <key key="name" value="Адамас"/>
+        </item>
+      </group>
+      <group name="kiosk">
+        <item name="Aral">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Aral"/>
+        </item>
+        <item name="Edicola">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Edicola"/>
+        </item>
+        <item name="KIOS">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="KIOS"/>
+        </item>
+        <item name="Kiosco">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Kiosco"/>
+        </item>
+        <item name="Kiosk">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Kiosk"/>
+        </item>
+        <item name="Kiosko">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Kiosko"/>
+        </item>
+        <item name="Kolporter">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Kolporter"/>
+        </item>
+        <item name="Lietuvos spauda">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Lietuvos spauda"/>
+        </item>
+        <item name="Narvesen">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Narvesen"/>
+        </item>
+        <item name="Pressbyrån">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Pressbyrån"/>
+        </item>
+        <item name="Pulpería">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Pulpería"/>
+        </item>
+        <item name="R-Kioski">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="R-Kioski"/>
+        </item>
+        <item name="Relay">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Relay"/>
+        </item>
+        <item name="Ruch">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Ruch"/>
+        </item>
+        <item name="Shell">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Shell"/>
+        </item>
+        <item name="Tabak Trafik">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Tabak Trafik"/>
+        </item>
+        <item name="Tisak">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Tisak"/>
+        </item>
+        <item name="Trafik">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Trafik"/>
+        </item>
+        <item name="Trafika">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Trafika"/>
+        </item>
+        <item name="Trinkhalle">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Trinkhalle"/>
+        </item>
+        <item name="Warung">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Warung"/>
+        </item>
+        <item name="Киоск">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Киоск"/>
+        </item>
+        <item name="Мороженое">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Мороженое"/>
+        </item>
+        <item name="Продукты">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Продукты"/>
+        </item>
+        <item name="Роспечать">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Роспечать"/>
+        </item>
+        <item name="Союзпечать">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="Союзпечать"/>
+        </item>
+        <item name="მარკეტი (Market)">
+          <key key="shop" value="kiosk"/>
+          <key key="name" value="მარკეტი (Market)"/>
+        </item>
+      </group>
+      <group name="kitchen">
+        <item name="Home Utensils">
+          <key key="shop" value="kitchen"/>
+          <key key="name" value="Home Utensils"/>
+        </item>
+      </group>
+      <group name="lottery">
+        <item name="Lotto">
+          <key key="shop" value="lottery"/>
+          <key key="name" value="Lotto"/>
+        </item>
+        <item name="Lottózó">
+          <key key="shop" value="lottery"/>
+          <key key="name" value="Lottózó"/>
+        </item>
+        <item name="ONCE">
+          <key key="shop" value="lottery"/>
+          <key key="name" value="ONCE"/>
+        </item>
+      </group>
+      <group name="mobile_phone">
+        <item name="3 Store">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="3 Store"/>
+        </item>
+        <item name="AT&amp;T">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="AT&amp;T"/>
+        </item>
+        <item name="Bell">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Bell"/>
+        </item>
+        <item name="Bitė">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Bitė"/>
+        </item>
+        <item name="Boost Mobile">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Boost Mobile"/>
+        </item>
+        <item name="Carphone Warehouse">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Carphone Warehouse"/>
+        </item>
+        <item name="Claro">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Claro"/>
+        </item>
+        <item name="Cricket">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Cricket"/>
+        </item>
+        <item name="Digicel">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Digicel"/>
+        </item>
+        <item name="EE">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="EE"/>
+        </item>
+        <item name="MetroPCS">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="MetroPCS"/>
+        </item>
+        <item name="Movistar">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Movistar"/>
+        </item>
+        <item name="O2">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="O2"/>
+        </item>
+        <item name="Orange">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Orange"/>
+        </item>
+        <item name="Play">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Play"/>
+        </item>
+        <item name="Plus">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Plus"/>
+        </item>
+        <item name="SFR">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="SFR"/>
+        </item>
+        <item name="Sprint">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Sprint"/>
+        </item>
+        <item name="T-Mobile">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="T-Mobile"/>
+        </item>
+        <item name="T-Punkt">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="T-Punkt"/>
+        </item>
+        <item name="Tele2">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Tele2"/>
+        </item>
+        <item name="Telekom">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Telekom"/>
+        </item>
+        <item name="Telekom Shop">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Telekom Shop"/>
+        </item>
+        <item name="Telenor">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Telenor"/>
+        </item>
+        <item name="Telus">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Telus"/>
+        </item>
+        <item name="The Phone House">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="The Phone House"/>
+        </item>
+        <item name="Verizon">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Verizon"/>
+        </item>
+        <item name="Verizon Wireless">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Verizon Wireless"/>
+        </item>
+        <item name="Vodafone">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Vodafone"/>
+        </item>
+        <item name="Wind">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Wind"/>
+        </item>
+        <item name="au">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="au"/>
+        </item>
+        <item name="auショップ">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="auショップ"/>
+        </item>
+        <item name="mobilcom debitel">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="mobilcom debitel"/>
+        </item>
+        <item name="Алло">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Алло"/>
+        </item>
+        <item name="Билайн">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Билайн"/>
+        </item>
+        <item name="Евросеть">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Евросеть"/>
+        </item>
+        <item name="МТС">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="МТС"/>
+        </item>
+        <item name="Мегафон">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Мегафон"/>
+        </item>
+        <item name="Связной">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Связной"/>
+        </item>
+        <item name="Теле2">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="Теле2"/>
+        </item>
+        <item name="ソフトバンクショップ">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="ソフトバンクショップ"/>
+        </item>
+        <item name="ドコモショップ">
+          <key key="shop" value="mobile_phone"/>
+          <key key="name" value="ドコモショップ"/>
+        </item>
+      </group>
+      <group name="money_lender">
+        <item name="Money Mart">
+          <key key="shop" value="money_lender"/>
+          <key key="name" value="Money Mart"/>
+        </item>
+      </group>
+      <group name="motorcycle">
+        <item name="Harley Davidson">
+          <key key="shop" value="motorcycle"/>
+          <key key="name" value="Harley Davidson"/>
+        </item>
+        <item name="Honda">
+          <key key="shop" value="motorcycle"/>
+          <key key="name" value="Honda"/>
+        </item>
+        <item name="Suzuki">
+          <key key="shop" value="motorcycle"/>
+          <key key="name" value="Suzuki"/>
+        </item>
+        <item name="Yamaha">
+          <key key="shop" value="motorcycle"/>
+          <key key="name" value="Yamaha"/>
+        </item>
+      </group>
+      <group name="music">
+        <item name="HMV">
+          <key key="shop" value="music"/>
+          <key key="name" value="HMV"/>
+        </item>
+      </group>
+      <group name="newsagent">
+        <item name="Edicola">
+          <key key="shop" value="newsagent"/>
+          <key key="name" value="Edicola"/>
+        </item>
+        <item name="Maison de la Presse">
+          <key key="shop" value="newsagent"/>
+          <key key="name" value="Maison de la Presse"/>
+        </item>
+        <item name="Relay">
+          <key key="shop" value="newsagent"/>
+          <key key="name" value="Relay"/>
+        </item>
+        <item name="Tabac Presse">
+          <key key="shop" value="newsagent"/>
+          <key key="name" value="Tabac Presse"/>
+        </item>
+        <item name="WHSmith">
+          <key key="shop" value="newsagent"/>
+          <key key="name" value="WHSmith"/>
+        </item>
+        <item name="Витебскоблсоюзпечать">
+          <key key="shop" value="newsagent"/>
+          <key key="name" value="Витебскоблсоюзпечать"/>
+        </item>
+        <item name="Печать">
+          <key key="shop" value="newsagent"/>
+          <key key="name" value="Печать"/>
+        </item>
+        <item name="Роспечать">
+          <key key="shop" value="newsagent"/>
+          <key key="name" value="Роспечать"/>
+        </item>
+        <item name="Союзпечать">
+          <key key="shop" value="newsagent"/>
+          <key key="name" value="Союзпечать"/>
+        </item>
+      </group>
+      <group name="optician">
+        <item name="Alain Afflelou">
+          <key key="shop" value="optician"/>
+          <key key="name" value="Alain Afflelou"/>
+        </item>
+        <item name="Apollo">
+          <key key="shop" value="optician"/>
+          <key key="name" value="Apollo"/>
+        </item>
+        <item name="Atol">
+          <key key="shop" value="optician"/>
+          <key key="name" value="Atol"/>
+        </item>
+        <item name="Boots Opticians">
+          <key key="shop" value="optician"/>
+          <key key="name" value="Boots Opticians"/>
+        </item>
+        <item name="Fielmann">
+          <key key="shop" value="optician"/>
+          <key key="name" value="Fielmann"/>
+        </item>
+        <item name="Générale d'Optique">
+          <key key="shop" value="optician"/>
+          <key key="name" value="Générale d'Optique"/>
+        </item>
+        <item name="Hakim Optical">
+          <key key="shop" value="optician"/>
+          <key key="name" value="Hakim Optical"/>
+        </item>
+        <item name="Hans Anders">
+          <key key="shop" value="optician"/>
+          <key key="name" value="Hans Anders"/>
+        </item>
+        <item name="Krys">
+          <key key="shop" value="optician"/>
+          <key key="name" value="Krys"/>
+        </item>
+        <item name="Les Opticiens Mutualistes">
+          <key key="shop" value="optician"/>
+          <key key="name" value="Les Opticiens Mutualistes"/>
+        </item>
+        <item name="Optic 2000">
+          <key key="shop" value="optician"/>
+          <key key="name" value="Optic 2000"/>
+        </item>
+        <item name="Optical Center">
+          <key key="shop" value="optician"/>
+          <key key="name" value="Optical Center"/>
+        </item>
+        <item name="Pearle">
+          <key key="shop" value="optician"/>
+          <key key="name" value="Pearle"/>
+        </item>
+        <item name="Specsavers">
+          <key key="shop" value="optician"/>
+          <key key="name" value="Specsavers"/>
+        </item>
+        <item name="Vision Express">
+          <key key="shop" value="optician"/>
+          <key key="name" value="Vision Express"/>
+        </item>
+        <item name="แว่นท็อปเจริญ">
+          <key key="shop" value="optician"/>
+          <key key="name" value="แว่นท็อปเจริญ"/>
+        </item>
+        <item name="メガネスーパー">
+          <key key="shop" value="optician"/>
+          <key key="name" value="メガネスーパー"/>
+        </item>
+        <item name="眼鏡市場">
+          <key key="shop" value="optician"/>
+          <key key="name" value="眼鏡市場"/>
+        </item>
+      </group>
+      <group name="outdoor">
+        <item name="Mountain Warehouse">
+          <key key="shop" value="outdoor"/>
+          <key key="name" value="Mountain Warehouse"/>
+        </item>
+        <item name="REI">
+          <key key="shop" value="outdoor"/>
+          <key key="name" value="REI"/>
+        </item>
+        <item name="Рыболов">
+          <key key="shop" value="outdoor"/>
+          <key key="name" value="Рыболов"/>
+        </item>
+      </group>
+      <group name="paint">
+        <item name="Comex">
+          <key key="shop" value="paint"/>
+          <key key="name" value="Comex"/>
+        </item>
+        <item name="Sherwin Williams">
+          <key key="shop" value="paint"/>
+          <key key="name" value="Sherwin Williams"/>
+        </item>
+      </group>
+      <group name="pawnbroker">
+        <item name="Cash Converters">
+          <key key="shop" value="pawnbroker"/>
+          <key key="name" value="Cash Converters"/>
+        </item>
+      </group>
+      <group name="pet">
+        <item name="Das Futterhaus">
+          <key key="shop" value="pet"/>
+          <key key="name" value="Das Futterhaus"/>
+        </item>
+        <item name="Fressnapf">
+          <key key="shop" value="pet"/>
+          <key key="name" value="Fressnapf"/>
+        </item>
+        <item name="Pet Valu">
+          <key key="shop" value="pet"/>
+          <key key="name" value="Pet Valu"/>
+        </item>
+        <item name="PetSmart">
+          <key key="shop" value="pet"/>
+          <key key="name" value="PetSmart"/>
+        </item>
+        <item name="Petco">
+          <key key="shop" value="pet"/>
+          <key key="name" value="Petco"/>
+        </item>
+        <item name="Pets at Home">
+          <key key="shop" value="pet"/>
+          <key key="name" value="Pets at Home"/>
+        </item>
+        <item name="Зоотовары">
+          <key key="shop" value="pet"/>
+          <key key="name" value="Зоотовары"/>
+        </item>
+      </group>
+      <group name="second_hand">
+        <item name="Goodwill">
+          <key key="shop" value="second_hand"/>
+          <key key="name" value="Goodwill"/>
+        </item>
+      </group>
+      <group name="shoes">
+        <item name="Aldo">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Aldo"/>
+        </item>
+        <item name="Bata">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Bata"/>
+        </item>
+        <item name="Brantano">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Brantano"/>
+        </item>
+        <item name="CCC">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="CCC"/>
+        </item>
+        <item name="Chaussea">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Chaussea"/>
+        </item>
+        <item name="Clarks">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Clarks"/>
+        </item>
+        <item name="Deichmann">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Deichmann"/>
+        </item>
+        <item name="Ecco">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Ecco"/>
+        </item>
+        <item name="Eram">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Eram"/>
+        </item>
+        <item name="Famous Footwear">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Famous Footwear"/>
+        </item>
+        <item name="Foot Locker">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Foot Locker"/>
+        </item>
+        <item name="Geox">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Geox"/>
+        </item>
+        <item name="La Halle aux Chaussures">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="La Halle aux Chaussures"/>
+        </item>
+        <item name="Payless Shoe Source">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Payless Shoe Source"/>
+        </item>
+        <item name="Payless ShoeSource">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Payless ShoeSource"/>
+        </item>
+        <item name="Quick Schuh">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Quick Schuh"/>
+        </item>
+        <item name="Reno">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Reno"/>
+        </item>
+        <item name="Rieker">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Rieker"/>
+        </item>
+        <item name="Salamander">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Salamander"/>
+        </item>
+        <item name="Scapino">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Scapino"/>
+        </item>
+        <item name="Shoe Zone">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Shoe Zone"/>
+        </item>
+        <item name="Siemes Schuhcenter">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Siemes Schuhcenter"/>
+        </item>
+        <item name="Tamaris">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Tamaris"/>
+        </item>
+        <item name="Ремонт обуви">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Ремонт обуви"/>
+        </item>
+        <item name="ЦентрОбувь">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="ЦентрОбувь"/>
+        </item>
+        <item name="Юничел">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="Юничел"/>
+        </item>
+        <item name="東京靴流通センター">
+          <key key="shop" value="shoes"/>
+          <key key="name" value="東京靴流通センター"/>
+        </item>
+      </group>
+      <group name="sports">
+        <item name="Adidas">
+          <key key="shop" value="sports"/>
+          <key key="name" value="Adidas"/>
+        </item>
+        <item name="Big 5 Sporting Goods">
+          <key key="shop" value="sports"/>
+          <key key="name" value="Big 5 Sporting Goods"/>
+        </item>
+        <item name="Decathlon">
+          <key key="shop" value="sports"/>
+          <key key="name" value="Decathlon"/>
+        </item>
+        <item name="Dick's Sporting Goods">
+          <key key="shop" value="sports"/>
+          <key key="name" value="Dick's Sporting Goods"/>
+        </item>
+        <item name="Hervis">
+          <key key="shop" value="sports"/>
+          <key key="name" value="Hervis"/>
+        </item>
+        <item name="Intersport">
+          <key key="shop" value="sports"/>
+          <key key="name" value="Intersport"/>
+        </item>
+        <item name="Nike">
+          <key key="shop" value="sports"/>
+          <key key="name" value="Nike"/>
+        </item>
+        <item name="Sport 2000">
+          <key key="shop" value="sports"/>
+          <key key="name" value="Sport 2000"/>
+        </item>
+        <item name="Sports Authority">
+          <key key="shop" value="sports"/>
+          <key key="name" value="Sports Authority"/>
+        </item>
+        <item name="Sports Direct">
+          <key key="shop" value="sports"/>
+          <key key="name" value="Sports Direct"/>
+        </item>
+        <item name="Спортмастер">
+          <key key="shop" value="sports"/>
+          <key key="name" value="Спортмастер"/>
+        </item>
+        <item name="Спорттовары">
+          <key key="shop" value="sports"/>
+          <key key="name" value="Спорттовары"/>
+        </item>
+      </group>
+      <group name="stationery">
+        <item name="Libro">
+          <key key="shop" value="stationery"/>
+          <key key="name" value="Libro"/>
+        </item>
+        <item name="McPaper">
+          <key key="shop" value="stationery"/>
+          <key key="name" value="McPaper"/>
+        </item>
+        <item name="Office Depot">
+          <key key="shop" value="stationery"/>
+          <key key="name" value="Office Depot"/>
+        </item>
+        <item name="Office Max">
+          <key key="shop" value="stationery"/>
+          <key key="name" value="Office Max"/>
+        </item>
+        <item name="Officeworks">
+          <key key="shop" value="stationery"/>
+          <key key="name" value="Officeworks"/>
+        </item>
+        <item name="Pagro">
+          <key key="shop" value="stationery"/>
+          <key key="name" value="Pagro"/>
+        </item>
+        <item name="Ryman">
+          <key key="shop" value="stationery"/>
+          <key key="name" value="Ryman"/>
+        </item>
+        <item name="Staples">
+          <key key="shop" value="stationery"/>
+          <key key="name" value="Staples"/>
+        </item>
+        <item name="Канцтовары">
+          <key key="shop" value="stationery"/>
+          <key key="name" value="Канцтовары"/>
+        </item>
+      </group>
+      <group name="supermarket">
+        <item name="A&amp;O">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="A&amp;O"/>
+        </item>
+        <item name="A101">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="A101"/>
+        </item>
+        <item name="AD Delhaize">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="AD Delhaize"/>
+        </item>
+        <item name="ADEG">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="ADEG"/>
+        </item>
+        <item name="ALDI">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="ALDI"/>
+        </item>
+        <item name="ALDI Süd">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="ALDI Süd"/>
+        </item>
+        <item name="Ahorramás">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Ahorramás"/>
+        </item>
+        <item name="Albert">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Albert"/>
+        </item>
+        <item name="Albert Heijn">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Albert Heijn"/>
+        </item>
+        <item name="Albertsons">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Albertsons"/>
+        </item>
+        <item name="Aldi Nord">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Aldi Nord"/>
+        </item>
+        <item name="Aldi Süd">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Aldi Süd"/>
+        </item>
+        <item name="Alfamart">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Alfamart"/>
+        </item>
+        <item name="Alimerka">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Alimerka"/>
+        </item>
+        <item name="Alnatura">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Alnatura"/>
+        </item>
+        <item name="Asda">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Asda"/>
+        </item>
+        <item name="Atacadão">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Atacadão"/>
+        </item>
+        <item name="Auchan">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Auchan"/>
+        </item>
+        <item name="Biedronka">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Biedronka"/>
+        </item>
+        <item name="Big C">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Big C"/>
+        </item>
+        <item name="Billa">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Billa"/>
+        </item>
+        <item name="Bim">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Bim"/>
+        </item>
+        <item name="Biocoop">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Biocoop"/>
+        </item>
+        <item name="Bodega Aurrera">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Bodega Aurrera"/>
+        </item>
+        <item name="Budgens">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Budgens"/>
+        </item>
+        <item name="Bunnpris">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Bunnpris"/>
+        </item>
+        <item name="CBA">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="CBA"/>
+        </item>
+        <item name="CONAD">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="CONAD"/>
+        </item>
+        <item name="COOP">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="COOP"/>
+        </item>
+        <item name="COOP Jednota">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="COOP Jednota"/>
+        </item>
+        <item name="CRAI">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="CRAI"/>
+        </item>
+        <item name="Caprabo">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Caprabo"/>
+        </item>
+        <item name="Cargills Food City">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Cargills Food City"/>
+        </item>
+        <item name="Carrefour">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Carrefour"/>
+        </item>
+        <item name="Carrefour City">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Carrefour City"/>
+        </item>
+        <item name="Carrefour Contact">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Carrefour Contact"/>
+        </item>
+        <item name="Carrefour Express">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Carrefour Express"/>
+        </item>
+        <item name="Centra">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Centra"/>
+        </item>
+        <item name="Centre Commercial E. Leclerc">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Centre Commercial E. Leclerc"/>
+        </item>
+        <item name="Checkers">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Checkers"/>
+        </item>
+        <item name="Chedraui">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Chedraui"/>
+        </item>
+        <item name="Co-Op">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Co-Op"/>
+        </item>
+        <item name="Co-op">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Co-op"/>
+        </item>
+        <item name="Co-operative">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Co-operative"/>
+        </item>
+        <item name="Coles">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Coles"/>
+        </item>
+        <item name="Colruyt">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Colruyt"/>
+        </item>
+        <item name="Combi">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Combi"/>
+        </item>
+        <item name="Comercial Mexicana">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Comercial Mexicana"/>
+        </item>
+        <item name="Conad">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Conad"/>
+        </item>
+        <item name="Conad City">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Conad City"/>
+        </item>
+        <item name="Condis">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Condis"/>
+        </item>
+        <item name="Consum">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Consum"/>
+        </item>
+        <item name="Continente">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Continente"/>
+        </item>
+        <item name="Coop">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Coop"/>
+        </item>
+        <item name="Coop Extra">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Coop Extra"/>
+        </item>
+        <item name="Coop Jednota">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Coop Jednota"/>
+        </item>
+        <item name="Coop Konsum">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Coop Konsum"/>
+        </item>
+        <item name="Costco">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Costco"/>
+        </item>
+        <item name="Costcutter">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Costcutter"/>
+        </item>
+        <item name="Countdown">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Countdown"/>
+        </item>
+        <item name="Coviran">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Coviran"/>
+        </item>
+        <item name="Crai">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Crai"/>
+        </item>
+        <item name="Cub Foods">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Cub Foods"/>
+        </item>
+        <item name="Delhaize">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Delhaize"/>
+        </item>
+        <item name="Delikatesy Centrum">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Delikatesy Centrum"/>
+        </item>
+        <item name="Denner">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Denner"/>
+        </item>
+        <item name="Despar">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Despar"/>
+        </item>
+        <item name="Despensa Familiar">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Despensa Familiar"/>
+        </item>
+        <item name="Dia">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Dia"/>
+        </item>
+        <item name="Dia %">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Dia %"/>
+        </item>
+        <item name="Dino">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Dino"/>
+        </item>
+        <item name="Dirk van den Broek">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Dirk van den Broek"/>
+        </item>
+        <item name="Disco">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Disco"/>
+        </item>
+        <item name="Diska">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Diska"/>
+        </item>
+        <item name="Dollar General">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Dollar General"/>
+        </item>
+        <item name="Dunnes Stores">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Dunnes Stores"/>
+        </item>
+        <item name="E-Center">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="E-Center"/>
+        </item>
+        <item name="E. Leclerc">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="E. Leclerc"/>
+        </item>
+        <item name="E. Leclerc Drive">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="E. Leclerc Drive"/>
+        </item>
+        <item name="EKO">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="EKO"/>
+        </item>
+        <item name="EMTÉ">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="EMTÉ"/>
+        </item>
+        <item name="Edeka">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Edeka"/>
+        </item>
+        <item name="Ekom">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Ekom"/>
+        </item>
+        <item name="Ekono">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Ekono"/>
+        </item>
+        <item name="El Árbol">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="El Árbol"/>
+        </item>
+        <item name="Eroski">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Eroski"/>
+        </item>
+        <item name="Esselunga">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Esselunga"/>
+        </item>
+        <item name="Eurospar">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Eurospar"/>
+        </item>
+        <item name="Eurospin">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Eurospin"/>
+        </item>
+        <item name="Extra">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Extra"/>
+        </item>
+        <item name="Fakta">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Fakta"/>
+        </item>
+        <item name="Famiglia Cooperativa">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Famiglia Cooperativa"/>
+        </item>
+        <item name="Famila">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Famila"/>
+        </item>
+        <item name="Family Dollar">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Family Dollar"/>
+        </item>
+        <item name="Farmfoods">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Farmfoods"/>
+        </item>
+        <item name="Feneberg">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Feneberg"/>
+        </item>
+        <item name="Food Basics">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Food Basics"/>
+        </item>
+        <item name="Food Lion">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Food Lion"/>
+        </item>
+        <item name="Foodland">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Foodland"/>
+        </item>
+        <item name="Foodworks">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Foodworks"/>
+        </item>
+        <item name="Franprix">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Franprix"/>
+        </item>
+        <item name="Fred Meyer">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Fred Meyer"/>
+        </item>
+        <item name="Freshmarket">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Freshmarket"/>
+        </item>
+        <item name="Froiz">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Froiz"/>
+        </item>
+        <item name="Føtex">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Føtex"/>
+        </item>
+        <item name="G20">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="G20"/>
+        </item>
+        <item name="Gadis">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Gadis"/>
+        </item>
+        <item name="Game">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Game"/>
+        </item>
+        <item name="Giant">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Giant"/>
+        </item>
+        <item name="Giant Eagle">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Giant Eagle"/>
+        </item>
+        <item name="Grand Frais">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Grand Frais"/>
+        </item>
+        <item name="Grocery Outlet">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Grocery Outlet"/>
+        </item>
+        <item name="Géant Casino">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Géant Casino"/>
+        </item>
+        <item name="H-E-B">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="H-E-B"/>
+        </item>
+        <item name="HIT">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="HIT"/>
+        </item>
+        <item name="Hannaford">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Hannaford"/>
+        </item>
+        <item name="Harris Teeter">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Harris Teeter"/>
+        </item>
+        <item name="Hemköp">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Hemköp"/>
+        </item>
+        <item name="Hofer">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Hofer"/>
+        </item>
+        <item name="Hoogvliet">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Hoogvliet"/>
+        </item>
+        <item name="Hy-Vee">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Hy-Vee"/>
+        </item>
+        <item name="ICA">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="ICA"/>
+        </item>
+        <item name="IGA">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="IGA"/>
+        </item>
+        <item name="Iceland">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Iceland"/>
+        </item>
+        <item name="Indomaret">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Indomaret"/>
+        </item>
+        <item name="Intermarché">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Intermarché"/>
+        </item>
+        <item name="Intermarché Contact">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Intermarché Contact"/>
+        </item>
+        <item name="Intermarché Super">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Intermarché Super"/>
+        </item>
+        <item name="Interspar">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Interspar"/>
+        </item>
+        <item name="Irma">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Irma"/>
+        </item>
+        <item name="Jewel-Osco">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Jewel-Osco"/>
+        </item>
+        <item name="Jumbo">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Jumbo"/>
+        </item>
+        <item name="K+K">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="K+K"/>
+        </item>
+        <item name="Kaiser's">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Kaiser's"/>
+        </item>
+        <item name="Kaufland">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Kaufland"/>
+        </item>
+        <item name="King Soopers">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="King Soopers"/>
+        </item>
+        <item name="Kiwi">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Kiwi"/>
+        </item>
+        <item name="Konsum">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Konsum"/>
+        </item>
+        <item name="Konzum">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Konzum"/>
+        </item>
+        <item name="Kroger">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Kroger"/>
+        </item>
+        <item name="Kvickly">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Kvickly"/>
+        </item>
+        <item name="Landi">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Landi"/>
+        </item>
+        <item name="Leader Price">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Leader Price"/>
+        </item>
+        <item name="Leclerc Drive">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Leclerc Drive"/>
+        </item>
+        <item name="Lewiatan">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Lewiatan"/>
+        </item>
+        <item name="Lider">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Lider"/>
+        </item>
+        <item name="Lidl">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Lidl"/>
+        </item>
+        <item name="Londis">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Londis"/>
+        </item>
+        <item name="Lupa">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Lupa"/>
+        </item>
+        <item name="M-Preis">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="M-Preis"/>
+        </item>
+        <item name="Makro">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Makro"/>
+        </item>
+        <item name="Markant">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Markant"/>
+        </item>
+        <item name="Marktkauf">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Marktkauf"/>
+        </item>
+        <item name="Match">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Match"/>
+        </item>
+        <item name="Maxi">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Maxi"/>
+        </item>
+        <item name="Maxi Dia">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Maxi Dia"/>
+        </item>
+        <item name="Maxima">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Maxima"/>
+        </item>
+        <item name="Maxima X">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Maxima X"/>
+        </item>
+        <item name="Maxima XX">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Maxima XX"/>
+        </item>
+        <item name="Mega Image">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Mega Image"/>
+        </item>
+        <item name="Meijer">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Meijer"/>
+        </item>
+        <item name="Meny">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Meny"/>
+        </item>
+        <item name="Mercado de Abastos">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Mercado de Abastos"/>
+        </item>
+        <item name="Mercadona">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Mercadona"/>
+        </item>
+        <item name="Mercator">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Mercator"/>
+        </item>
+        <item name="Merkur">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Merkur"/>
+        </item>
+        <item name="Metro">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Metro"/>
+        </item>
+        <item name="Migros">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Migros"/>
+        </item>
+        <item name="Mila">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Mila"/>
+        </item>
+        <item name="Mini Market">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Mini Market"/>
+        </item>
+        <item name="Minimarket">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Minimarket"/>
+        </item>
+        <item name="Minipreço">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Minipreço"/>
+        </item>
+        <item name="Monoprix">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Monoprix"/>
+        </item>
+        <item name="Morrisons">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Morrisons"/>
+        </item>
+        <item name="NETTO">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="NETTO"/>
+        </item>
+        <item name="NORMA">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="NORMA"/>
+        </item>
+        <item name="NP">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="NP"/>
+        </item>
+        <item name="Nah &amp; Frisch">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Nah &amp; Frisch"/>
+        </item>
+        <item name="Nahkauf">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Nahkauf"/>
+        </item>
+        <item name="Netto Marken-Discount">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Netto Marken-Discount"/>
+        </item>
+        <item name="New World">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="New World"/>
+        </item>
+        <item name="No Frills">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="No Frills"/>
+        </item>
+        <item name="Norfa XL">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Norfa XL"/>
+        </item>
+        <item name="Norma">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Norma"/>
+        </item>
+        <item name="Oxxo">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Oxxo"/>
+        </item>
+        <item name="PENNY">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="PENNY"/>
+        </item>
+        <item name="PLUS">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="PLUS"/>
+        </item>
+        <item name="POLOmarket">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="POLOmarket"/>
+        </item>
+        <item name="Palí">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Palí"/>
+        </item>
+        <item name="Pam">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Pam"/>
+        </item>
+        <item name="Penny">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Penny"/>
+        </item>
+        <item name="Penny Markt">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Penny Markt"/>
+        </item>
+        <item name="Petit Casino">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Petit Casino"/>
+        </item>
+        <item name="Picard">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Picard"/>
+        </item>
+        <item name="Pick n Pay">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Pick n Pay"/>
+        </item>
+        <item name="Piggly Wiggly">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Piggly Wiggly"/>
+        </item>
+        <item name="Pingo Doce">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Pingo Doce"/>
+        </item>
+        <item name="Piotr i Paweł">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Piotr i Paweł"/>
+        </item>
+        <item name="Plaza Vea">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Plaza Vea"/>
+        </item>
+        <item name="Plodine">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Plodine"/>
+        </item>
+        <item name="Price Chopper">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Price Chopper"/>
+        </item>
+        <item name="Prix">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Prix"/>
+        </item>
+        <item name="Profi">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Profi"/>
+        </item>
+        <item name="Proxi">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Proxi"/>
+        </item>
+        <item name="Publix">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Publix"/>
+        </item>
+        <item name="Puregold">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Puregold"/>
+        </item>
+        <item name="Pão de Açúcar">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Pão de Açúcar"/>
+        </item>
+        <item name="QFC">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="QFC"/>
+        </item>
+        <item name="REWE City">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="REWE City"/>
+        </item>
+        <item name="Ralphs">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Ralphs"/>
+        </item>
+        <item name="Real">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Real"/>
+        </item>
+        <item name="Real Canadian Superstore">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Real Canadian Superstore"/>
+        </item>
+        <item name="Reliance Fresh">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Reliance Fresh"/>
+        </item>
+        <item name="Rema 1000">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Rema 1000"/>
+        </item>
+        <item name="Rewe">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Rewe"/>
+        </item>
+        <item name="Rimi">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Rimi"/>
+        </item>
+        <item name="S-Market">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="S-Market"/>
+        </item>
+        <item name="Safeway">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Safeway"/>
+        </item>
+        <item name="Sainsbury's">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Sainsbury's"/>
+        </item>
+        <item name="Sainsbury's Local">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Sainsbury's Local"/>
+        </item>
+        <item name="Sam's Club">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Sam's Club"/>
+        </item>
+        <item name="Santa Isabel">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Santa Isabel"/>
+        </item>
+        <item name="Save-A-Lot">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Save-A-Lot"/>
+          <key key="shop" value="supermarket"/>
+        </item>
+        <item name="Shoprite">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Shoprite"/>
+        </item>
+        <item name="Sigma">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Sigma"/>
+        </item>
+        <item name="Simply Market">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Simply Market"/>
+        </item>
+        <item name="Sisa">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Sisa"/>
+        </item>
+        <item name="Sky">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Sky"/>
+        </item>
+        <item name="Smith's">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Smith's"/>
+        </item>
+        <item name="Sobeys">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Sobeys"/>
+        </item>
+        <item name="Soriana">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Soriana"/>
+        </item>
+        <item name="Spar">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Spar"/>
+        </item>
+        <item name="Społem">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Społem"/>
+        </item>
+        <item name="Sprouts Farmers Market">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Sprouts Farmers Market"/>
+        </item>
+        <item name="Stokrotka">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Stokrotka"/>
+        </item>
+        <item name="Stop &amp; Shop">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Stop &amp; Shop"/>
+        </item>
+        <item name="Super Brugsen">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Super Brugsen"/>
+        </item>
+        <item name="Super U">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Super U"/>
+        </item>
+        <item name="SuperBrugsen">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="SuperBrugsen"/>
+        </item>
+        <item name="SuperValu">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="SuperValu"/>
+        </item>
+        <item name="Tegut">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Tegut"/>
+        </item>
+        <item name="Tengelmann">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Tengelmann"/>
+        </item>
+        <item name="Tesco">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Tesco"/>
+        </item>
+        <item name="Tesco Express">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Tesco Express"/>
+        </item>
+        <item name="Tesco Extra">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Tesco Extra"/>
+        </item>
+        <item name="Tesco Lotus">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Tesco Lotus"/>
+        </item>
+        <item name="Tesco Metro">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Tesco Metro"/>
+        </item>
+        <item name="The Co-operative">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="The Co-operative"/>
+        </item>
+        <item name="The Co-operative Food">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="The Co-operative Food"/>
+        </item>
+        <item name="Tottus">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Tottus"/>
+        </item>
+        <item name="Trader Joe's">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Trader Joe's"/>
+        </item>
+        <item name="Treff 3000">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Treff 3000"/>
+        </item>
+        <item name="U Express">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="U Express"/>
+        </item>
+        <item name="Unimarc">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Unimarc"/>
+        </item>
+        <item name="Unimarkt">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Unimarkt"/>
+        </item>
+        <item name="Utile">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Utile"/>
+        </item>
+        <item name="Vea">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Vea"/>
+        </item>
+        <item name="Vival">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Vival"/>
+        </item>
+        <item name="Volg">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Volg"/>
+        </item>
+        <item name="Waitrose">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Waitrose"/>
+        </item>
+        <item name="Walmart">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Walmart"/>
+        </item>
+        <item name="Walmart Neighborhood Market">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Walmart Neighborhood Market"/>
+        </item>
+        <item name="Walmart Supercenter">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Walmart Supercenter"/>
+        </item>
+        <item name="Wasgau">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Wasgau"/>
+        </item>
+        <item name="Wegmans">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Wegmans"/>
+        </item>
+        <item name="Whole Foods Market">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Whole Foods Market"/>
+          <key key="shop" value="supermarket"/>
+        </item>
+        <item name="Willys">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Willys"/>
+        </item>
+        <item name="Winn Dixie">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Winn Dixie"/>
+        </item>
+        <item name="Woolworths">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Woolworths"/>
+        </item>
+        <item name="Zielpunkt">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Zielpunkt"/>
+        </item>
+        <item name="denn's Biomarkt">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="denn's Biomarkt"/>
+        </item>
+        <item name="real">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="real"/>
+        </item>
+        <item name="tegut">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="tegut"/>
+        </item>
+        <item name="Şok">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Şok"/>
+        </item>
+        <item name="Żabka">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Żabka"/>
+        </item>
+        <item name="ΑΒ Βασιλόπουλος">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="ΑΒ Βασιλόπουλος"/>
+        </item>
+        <item name="Μασούτης">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Μασούτης"/>
+        </item>
+        <item name="АТБ">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="АТБ"/>
+        </item>
+        <item name="Авоська">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Авоська"/>
+        </item>
+        <item name="Азбука Вкуса">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Азбука Вкуса"/>
+        </item>
+        <item name="Атак">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Атак"/>
+        </item>
+        <item name="Ашан">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Ашан"/>
+        </item>
+        <item name="Верный">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Верный"/>
+        </item>
+        <item name="Виват">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Виват"/>
+        </item>
+        <item name="Виктория">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Виктория"/>
+        </item>
+        <item name="Гроздь">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Гроздь"/>
+        </item>
+        <item name="Дикси">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Дикси"/>
+        </item>
+        <item name="Евроопт">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Евроопт"/>
+        </item>
+        <item name="Карусель">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Карусель"/>
+        </item>
+        <item name="Квартал">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Квартал"/>
+        </item>
+        <item name="Командор">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Командор"/>
+        </item>
+        <item name="Копейка">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Копейка"/>
+        </item>
+        <item name="Красный Яр">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Красный Яр"/>
+        </item>
+        <item name="Лента">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Лента"/>
+        </item>
+        <item name="Магнит">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Магнит"/>
+        </item>
+        <item name="Магнолия">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Магнолия"/>
+        </item>
+        <item name="Мария-Ра">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Мария-Ра"/>
+        </item>
+        <item name="Монетка">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Монетка"/>
+        </item>
+        <item name="Народная 7Я семьЯ">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Народная 7Я семьЯ"/>
+        </item>
+        <item name="Перекресток">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Перекресток"/>
+        </item>
+        <item name="Покупочка">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Покупочка"/>
+        </item>
+        <item name="Полушка">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Полушка"/>
+        </item>
+        <item name="Пятёрочка">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Пятёрочка"/>
+        </item>
+        <item name="Радеж">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Радеж"/>
+        </item>
+        <item name="Седьмой континент">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Седьмой континент"/>
+        </item>
+        <item name="Семья">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Семья"/>
+        </item>
+        <item name="Супермаркет">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Супермаркет"/>
+        </item>
+        <item name="Сільпо">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Сільпо"/>
+        </item>
+        <item name="Таврія-В">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Таврія-В"/>
+        </item>
+        <item name="Универсам">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Универсам"/>
+        </item>
+        <item name="Фора">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Фора"/>
+        </item>
+        <item name="Фуршет">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Фуршет"/>
+        </item>
+        <item name="Хүнсний дэлгүүр">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="Хүнсний дэлгүүр"/>
+        </item>
+        <item name="いなげや">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="いなげや"/>
+        </item>
+        <item name="まいばすけっと">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="まいばすけっと"/>
+        </item>
+        <item name="イオン">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="イオン"/>
+        </item>
+        <item name="イトーヨーカドー">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="イトーヨーカドー"/>
+        </item>
+        <item name="マックスバリュ">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="マックスバリュ"/>
+        </item>
+        <item name="マルエツ">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="マルエツ"/>
+        </item>
+        <item name="ライフ">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="ライフ"/>
+        </item>
+        <item name="全聯">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="全聯"/>
+        </item>
+        <item name="全聯福利中心">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="全聯福利中心"/>
+        </item>
+        <item name="業務スーパー">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="業務スーパー"/>
+        </item>
+        <item name="西友">
+          <key key="shop" value="supermarket"/>
+          <key key="name" value="西友"/>
+        </item>
+      </group>
+      <group name="ticket">
+        <item name="Boutique Grandes Lignes">
+          <key key="shop" value="ticket"/>
+          <key key="name" value="Boutique Grandes Lignes"/>
+        </item>
+        <item name="Guichet Transilien">
+          <key key="shop" value="ticket"/>
+          <key key="name" value="Guichet Transilien"/>
+        </item>
+        <item name="Проездные билеты">
+          <key key="shop" value="ticket"/>
+          <key key="name" value="Проездные билеты"/>
+        </item>
+      </group>
+      <group name="tobacco">
+        <item name="Estanco">
+          <key key="shop" value="tobacco"/>
+          <key key="name" value="Estanco"/>
+        </item>
+        <item name="Nemzeti Dohánybolt">
+          <key key="shop" value="tobacco"/>
+          <key key="name" value="Nemzeti Dohánybolt"/>
+        </item>
+      </group>
+      <group name="toys">
+        <item name="Bart Smit">
+          <key key="shop" value="toys"/>
+          <key key="name" value="Bart Smit"/>
+        </item>
+        <item name="Dráčik">
+          <key key="shop" value="toys"/>
+          <key key="name" value="Dráčik"/>
+        </item>
+        <item name="Intertoys">
+          <key key="shop" value="toys"/>
+          <key key="name" value="Intertoys"/>
+        </item>
+        <item name="King Jouet">
+          <key key="shop" value="toys"/>
+          <key key="name" value="King Jouet"/>
+        </item>
+        <item name="La Grande Récré">
+          <key key="shop" value="toys"/>
+          <key key="name" value="La Grande Récré"/>
+        </item>
+        <item name="Maxi Toys">
+          <key key="shop" value="toys"/>
+          <key key="name" value="Maxi Toys"/>
+        </item>
+        <item name="Toys R Us">
+          <key key="shop" value="toys"/>
+          <key key="name" value="Toys R Us"/>
+          <key key="shop" value="toys"/>
+        </item>
+        <item name="Детский мир">
+          <key key="shop" value="toys"/>
+          <key key="name" value="Детский мир"/>
+        </item>
+        <item name="Игрушки">
+          <key key="shop" value="toys"/>
+          <key key="name" value="Игрушки"/>
+        </item>
+      </group>
+      <group name="travel_agency">
+        <item name="First Reisebüro">
+          <key key="shop" value="travel_agency"/>
+          <key key="name" value="First Reisebüro"/>
+        </item>
+        <item name="Flight Centre">
+          <key key="shop" value="travel_agency"/>
+          <key key="name" value="Flight Centre"/>
+        </item>
+        <item name="TUI">
+          <key key="shop" value="travel_agency"/>
+          <key key="name" value="TUI"/>
+        </item>
+        <item name="The Co-operative Travel">
+          <key key="shop" value="travel_agency"/>
+          <key key="name" value="The Co-operative Travel"/>
+        </item>
+        <item name="Thomas Cook">
+          <key key="shop" value="travel_agency"/>
+          <key key="name" value="Thomas Cook"/>
+        </item>
+        <item name="Thomson">
+          <key key="shop" value="travel_agency"/>
+          <key key="name" value="Thomson"/>
+        </item>
+      </group>
+      <group name="tyres">
+        <item name="Borracharia">
+          <key key="shop" value="tyres"/>
+          <key key="name" value="Borracharia"/>
+        </item>
+        <item name="Discount Tire">
+          <key key="shop" value="tyres"/>
+          <key key="name" value="Discount Tire"/>
+        </item>
+        <item name="Euromaster">
+          <key key="shop" value="tyres"/>
+          <key key="name" value="Euromaster"/>
+        </item>
+        <item name="Вулканизация">
+          <key key="shop" value="tyres"/>
+          <key key="name" value="Вулканизация"/>
+        </item>
+        <item name="Шиномонтаж">
+          <key key="shop" value="tyres"/>
+          <key key="name" value="Шиномонтаж"/>
+        </item>
+      </group>
+      <group name="variety_store">
+        <item name="Action">
+          <key key="shop" value="variety_store"/>
+          <key key="name" value="Action"/>
+        </item>
+        <item name="Big Lots">
+          <key key="shop" value="variety_store"/>
+          <key key="name" value="Big Lots"/>
+        </item>
+        <item name="Dollar General">
+          <key key="shop" value="variety_store"/>
+          <key key="name" value="Dollar General"/>
+        </item>
+        <item name="Dollar Tree">
+          <key key="shop" value="variety_store"/>
+          <key key="name" value="Dollar Tree"/>
+        </item>
+        <item name="Dollarama">
+          <key key="shop" value="variety_store"/>
+          <key key="name" value="Dollarama"/>
+        </item>
+        <item name="Family Dollar">
+          <key key="shop" value="variety_store"/>
+          <key key="name" value="Family Dollar"/>
+        </item>
+        <item name="Fix Price">
+          <key key="shop" value="variety_store"/>
+          <key key="name" value="Fix Price"/>
+        </item>
+        <item name="GiFi">
+          <key key="shop" value="variety_store"/>
+          <key key="name" value="GiFi"/>
+        </item>
+        <item name="Poundland">
+          <key key="shop" value="variety_store"/>
+          <key key="name" value="Poundland"/>
+        </item>
+        <item name="Tedi">
+          <key key="shop" value="variety_store"/>
+          <key key="name" value="Tedi"/>
+        </item>
+        <item name="ダイソー">
+          <key key="shop" value="variety_store"/>
+          <key key="name" value="ダイソー"/>
+        </item>
+      </group>
+      <group name="video">
+        <item name="Blockbuster">
+          <key key="shop" value="video"/>
+          <key key="name" value="Blockbuster"/>
+        </item>
+        <item name="Family Video">
+          <key key="shop" value="video"/>
+          <key key="name" value="Family Video"/>
+        </item>
+        <item name="TSUTAYA">
+          <key key="shop" value="video"/>
+          <key key="name" value="TSUTAYA"/>
+        </item>
+        <item name="World of Video">
+          <key key="shop" value="video"/>
+          <key key="name" value="World of Video"/>
+        </item>
+        <item name="ゲオ">
+          <key key="shop" value="video"/>
+          <key key="name" value="ゲオ"/>
+        </item>
+      </group>
+      <group name="video_games">
+        <item name="EB Games">
+          <key key="shop" value="video_games"/>
+          <key key="name" value="EB Games"/>
+        </item>
+        <item name="Game">
+          <key key="shop" value="video_games"/>
+          <key key="name" value="Game"/>
+        </item>
+        <item name="GameStop">
+          <key key="shop" value="video_games"/>
+          <key key="name" value="GameStop"/>
+        </item>
+        <item name="Micromania">
+          <key key="shop" value="video_games"/>
+          <key key="name" value="Micromania"/>
+        </item>
+      </group>
+    </group>
+    <group name="tourism">
+      <group name="alpine_hut">
+        <item name="КОШ">
+          <key key="tourism" value="alpine_hut"/>
+          <key key="name" value="КОШ"/>
+        </item>
+      </group>
+      <group name="attraction">
+        <item name="Kursächsische Postmeilensäule">
+          <key key="tourism" value="attraction"/>
+          <key key="name" value="Kursächsische Postmeilensäule"/>
+        </item>
+        <item name="Lavoir">
+          <key key="tourism" value="attraction"/>
+          <key key="name" value="Lavoir"/>
+        </item>
+        <item name="OWŚ">
+          <key key="tourism" value="attraction"/>
+          <key key="name" value="OWŚ"/>
+        </item>
+        <item name="Sommerrodelbahn">
+          <key key="tourism" value="attraction"/>
+          <key key="name" value="Sommerrodelbahn"/>
+        </item>
+        <item name="Кладбище еврейское">
+          <key key="tourism" value="attraction"/>
+          <key key="name" value="Кладбище еврейское"/>
+        </item>
+        <item name="Колесо обозрения">
+          <key key="tourism" value="attraction"/>
+          <key key="name" value="Колесо обозрения"/>
+        </item>
+        <item name="Приусадебный парк">
+          <key key="tourism" value="attraction"/>
+          <key key="name" value="Приусадебный парк"/>
+        </item>
+        <item name="Усадьба">
+          <key key="tourism" value="attraction"/>
+          <key key="name" value="Усадьба"/>
+        </item>
+        <item name="Хозяйственный двор">
+          <key key="tourism" value="attraction"/>
+          <key key="name" value="Хозяйственный двор"/>
+        </item>
+        <item name="Часовня">
+          <key key="tourism" value="attraction"/>
+          <key key="name" value="Часовня"/>
+        </item>
+        <item name="дольмен">
+          <key key="tourism" value="attraction"/>
+          <key key="name" value="дольмен"/>
+        </item>
+      </group>
+      <group name="camp_site">
+        <item name="Camping Municipal">
+          <key key="tourism" value="camp_site"/>
+          <key key="name" value="Camping Municipal"/>
+        </item>
+        <item name="Camping municipal">
+          <key key="tourism" value="camp_site"/>
+          <key key="name" value="Camping municipal"/>
+        </item>
+        <item name="Campsite">
+          <key key="tourism" value="camp_site"/>
+          <key key="name" value="Campsite"/>
+        </item>
+      </group>
+      <group name="hotel">
+        <item name="Best Western">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Best Western"/>
+        </item>
+        <item name="Campanile">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Campanile"/>
+        </item>
+        <item name="City Hotel">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="City Hotel"/>
+        </item>
+        <item name="Comfort Inn">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Comfort Inn"/>
+        </item>
+        <item name="Comfort Inn &amp; Suites">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Comfort Inn &amp; Suites"/>
+        </item>
+        <item name="Comfort Suites">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Comfort Suites"/>
+        </item>
+        <item name="Country Inn &amp; Suites">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Country Inn &amp; Suites"/>
+        </item>
+        <item name="Courtyard by Marriott">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Courtyard by Marriott"/>
+        </item>
+        <item name="Crowne Plaza">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Crowne Plaza"/>
+        </item>
+        <item name="Days Inn">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Days Inn"/>
+        </item>
+        <item name="Econo Lodge">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Econo Lodge"/>
+        </item>
+        <item name="Embassy Suites">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Embassy Suites"/>
+        </item>
+        <item name="Extended Stay America">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Extended Stay America"/>
+        </item>
+        <item name="Fairfield Inn">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Fairfield Inn"/>
+        </item>
+        <item name="Fairfield Inn &amp; Suites">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Fairfield Inn &amp; Suites"/>
+        </item>
+        <item name="Formule 1">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Formule 1"/>
+        </item>
+        <item name="Grand Hotel">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Grand Hotel"/>
+        </item>
+        <item name="Hampton Inn">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Hampton Inn"/>
+        </item>
+        <item name="Hampton Inn &amp; Suites">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Hampton Inn &amp; Suites"/>
+        </item>
+        <item name="Hilton">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Hilton"/>
+        </item>
+        <item name="Hilton Garden Inn">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Hilton Garden Inn"/>
+        </item>
+        <item name="Holiday Inn">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Holiday Inn"/>
+        </item>
+        <item name="Holiday Inn Express">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Holiday Inn Express"/>
+        </item>
+        <item name="Holiday Inn Express &amp; Suites">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Holiday Inn Express &amp; Suites"/>
+        </item>
+        <item name="Homewood Suites">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Homewood Suites"/>
+        </item>
+        <item name="Hotel Central">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Hotel Central"/>
+        </item>
+        <item name="Hotel Europa">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Hotel Europa"/>
+        </item>
+        <item name="Hotel Ibis">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Hotel Ibis"/>
+        </item>
+        <item name="Hotel Krone">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Hotel Krone"/>
+        </item>
+        <item name="Hotel Panorama">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Hotel Panorama"/>
+        </item>
+        <item name="Hotel Post">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Hotel Post"/>
+        </item>
+        <item name="Hotel Royal">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Hotel Royal"/>
+        </item>
+        <item name="Hotel Victoria">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Hotel Victoria"/>
+        </item>
+        <item name="Hotel zur Post">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Hotel zur Post"/>
+        </item>
+        <item name="Hôtel Ibis">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Hôtel Ibis"/>
+        </item>
+        <item name="Hôtel de France">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Hôtel de France"/>
+        </item>
+        <item name="Ibis">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Ibis"/>
+        </item>
+        <item name="Ibis Budget">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Ibis Budget"/>
+        </item>
+        <item name="Krone">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Krone"/>
+        </item>
+        <item name="Kyriad">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Kyriad"/>
+        </item>
+        <item name="La Quinta">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="La Quinta"/>
+        </item>
+        <item name="Marriott">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Marriott"/>
+        </item>
+        <item name="Mercure">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Mercure"/>
+        </item>
+        <item name="Motel 6">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Motel 6"/>
+        </item>
+        <item name="Novotel">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Novotel"/>
+        </item>
+        <item name="Park Hotel">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Park Hotel"/>
+        </item>
+        <item name="Parkhotel">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Parkhotel"/>
+        </item>
+        <item name="Premier Inn">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Premier Inn"/>
+        </item>
+        <item name="Première Classe">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Première Classe"/>
+        </item>
+        <item name="Quality Inn">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Quality Inn"/>
+        </item>
+        <item name="Quality Inn &amp; Suites">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Quality Inn &amp; Suites"/>
+        </item>
+        <item name="Ramada">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Ramada"/>
+        </item>
+        <item name="Residence Inn">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Residence Inn"/>
+        </item>
+        <item name="Royal Hotel">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Royal Hotel"/>
+        </item>
+        <item name="Sheraton">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Sheraton"/>
+        </item>
+        <item name="Sleep Inn">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Sleep Inn"/>
+        </item>
+        <item name="Staybridge Suites">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Staybridge Suites"/>
+        </item>
+        <item name="Super 8">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Super 8"/>
+        </item>
+        <item name="Travelodge">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Travelodge"/>
+        </item>
+        <item name="Гостиница">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="Гостиница"/>
+        </item>
+        <item name="東横イン">
+          <key key="tourism" value="hotel"/>
+          <key key="name" value="東横イン"/>
+        </item>
+      </group>
+      <group name="motel">
+        <item name="Best Western">
+          <key key="tourism" value="motel"/>
+          <key key="name" value="Best Western"/>
+        </item>
+        <item name="Budget Inn">
+          <key key="tourism" value="motel"/>
+          <key key="name" value="Budget Inn"/>
+        </item>
+        <item name="Comfort Inn">
+          <key key="tourism" value="motel"/>
+          <key key="name" value="Comfort Inn"/>
+        </item>
+        <item name="Days Inn">
+          <key key="tourism" value="motel"/>
+          <key key="name" value="Days Inn"/>
+        </item>
+        <item name="Econo Lodge">
+          <key key="tourism" value="motel"/>
+          <key key="name" value="Econo Lodge"/>
+        </item>
+        <item name="Holiday Inn Express">
+          <key key="tourism" value="motel"/>
+          <key key="name" value="Holiday Inn Express"/>
+        </item>
+        <item name="Motel">
+          <key key="tourism" value="motel"/>
+          <key key="name" value="Motel"/>
+        </item>
+        <item name="Motel 6">
+          <key key="tourism" value="motel"/>
+          <key key="name" value="Motel 6"/>
+        </item>
+        <item name="Quality Inn">
+          <key key="tourism" value="motel"/>
+          <key key="name" value="Quality Inn"/>
+        </item>
+        <item name="Rodeway Inn">
+          <key key="tourism" value="motel"/>
+          <key key="name" value="Rodeway Inn"/>
+        </item>
+        <item name="Super 8">
+          <key key="tourism" value="motel"/>
+          <key key="name" value="Super 8"/>
+        </item>
+        <item name="Travelodge">
+          <key key="tourism" value="motel"/>
+          <key key="name" value="Travelodge"/>
+        </item>
+      </group>
+      <group name="museum">
+        <item name="Heimatmuseum">
+          <key key="tourism" value="museum"/>
+          <key key="name" value="Heimatmuseum"/>
+        </item>
+        <item name="Stadtmuseum">
+          <key key="tourism" value="museum"/>
+          <key key="name" value="Stadtmuseum"/>
+        </item>
+        <item name="Tájház">
+          <key key="tourism" value="museum"/>
+          <key key="name" value="Tájház"/>
+        </item>
+        <item name="Краеведческий музей">
+          <key key="tourism" value="museum"/>
+          <key key="name" value="Краеведческий музей"/>
+        </item>
+        <item name="Музей">
+          <key key="tourism" value="museum"/>
+          <key key="name" value="Музей"/>
+        </item>
+      </group>
+    </group>
+  </group>
+</presets>


### PR DESCRIPTION
Builds a JOSM preset file as briefly discussed at https://www.reddit.com/r/openstreetmap/comments/5x7ohz/consistent_naming_tagging_for_reoccuring_items/

The JOSM preset search considers the tags in the preset so the extra tags don't need to be in the name.

To make the presets easily available in JOSM all that needs to be done is to add a link to the raw github file here: https://josm.openstreetmap.de/wiki/PresetsSource .