### PR TITLE
 ignore "stadtmobil CarSharing-Station"

### DIFF
--- a/filter.json
+++ b/filter.json
@@ -387,7 +387,7 @@
         "Sportplatz",
         "Spożywczy",
         "Stacja paliw",
-        "stadtmobil CarSharing-Station"
+        "stadtmobil CarSharing-Station",
         "Station Service",
         "Supermarket",
         "Supermercado",

--- a/filter.json
+++ b/filter.json
@@ -387,6 +387,7 @@
         "Sportplatz",
         "Spożywczy",
         "Stacja paliw",
+        "stadtmobil CarSharing-Station"
         "Station Service",
         "Supermarket",
         "Supermercado",


### PR DESCRIPTION
This is not even a name but a description. Some iD users used that for car rental companies even outside Europe because it was suggested to them.