### PR TITLE
Japanese spelling update

### DIFF
--- a/canonical.json
+++ b/canonical.json
@@ -1544,7 +1544,7 @@
             "すき家 (SUKIYA)"
         ],
         "tags":{
-            "name:en":"SUKIYA"
+            "name:en":"Sukiya"
         }
     },
     "カフェ・ド・クリエ":{
@@ -1577,7 +1577,7 @@
             "サンクス (sunkus)"
         ],
         "tags":{
-            "name:en":"sunkus"
+            "name:en":"Sunkus"
         }
     },
     "サークルK":{
@@ -1596,9 +1596,9 @@
             "name:en":"Starbucks"
         }
     },
-    "セブンイレブン":{
+    "セブン-イレブン":{
         "matches":[
-            "セブン-イレブン",
+            "セブンイレブン",
             "セブン-イレブン (Seven-Eleven)",
             "セブン-イレブン (Seven-Eleven) "
         ],
@@ -1606,12 +1606,13 @@
             "name:en":"7-Eleven"
         }
     },
-    "ドトール":{
+    "ドトールコーヒーショップ":{
         "matches":[
-            "ドトールコーヒーショップ (DOUTOR)"
+            "ドトールコーヒーショップ (DOUTOR)",
+            "ドトール"          
         ],
         "tags":{
-            "name:en":"DOUTOR"
+            "name:en":"Doutor"
         }
     },
     "ファミリーマート":{
@@ -1645,7 +1646,7 @@
             "モスバーガー (MOS BURGER)"
         ],
         "tags":{
-            "name:en":"MOS BURGER"
+            "name:en":"Mos Burger"
         }
     },
     "ローソン":{
@@ -1653,7 +1654,7 @@
             "ローソン (LAWSON)"
         ],
         "tags":{
-            "name:en":"LAWSON"
+            "name:en":"Lawson"
         }
     },
     "出光":{
@@ -1661,7 +1662,7 @@
             "出光 (IDEMITSU)"
         ],
         "tags":{
-            "name:en":"IDEMITSU"
+            "name:en":"Idemitsu"
         }
     },
     "松屋":{


### PR DESCRIPTION
Changed some of correct/incorrect spelling of poi names in Japanese conforming to the recommended Naming Sample of Japanese community below.
https://wiki.openstreetmap.org/wiki/JA:Naming_sample