### PR TITLE
Contribution

### DIFF
--- a/canonical.json
+++ b/canonical.json
@@ -328,6 +328,14 @@
             "coop"
         ]
     },
+    "Coqivoire":{
+        "matches":[
+            "COQIVOIRE"
+        ],
+        "tags":{
+            "butcher":"poultry"
+        }
+    },
     "Costa":{
         "matches":[
             "Costa Coffee"
@@ -512,6 +520,14 @@
         "matches":[
             "Five Guys Burgers and Fries"
         ]
+    },
+    "Foani":{
+        "matches":[
+            "FOANI"
+        ],
+        "tags":{
+            "butcher":"poultry"
+        }
     },
     "Freshmarket":{
         "matches":[
@@ -917,6 +933,25 @@
         "matches":[
             "Obi"
         ]
+    },
+    "Oilibya":{
+        "matches":[
+            "OiLibya",
+            "OilLibya",
+            "Oilybia",
+            "Oilibia",
+            "OilLybia",
+            "Oil Libya",
+            "Oil Lybia",
+            "OilLibia",
+            "Oilibiya",
+            "OLIBYA",
+            "OLYBIA"
+        ],
+        "tags":{
+            "brand":"Oilibya"
+            "name:ar":"أويليبيا"
+        }
     },
     "OTP":{
         "matches":[


### PR DESCRIPTION
Matches various spelling errors of Oilibya fuel stations. While “Oilibya” is clearly the most popular in OSM, there are various miss-spellings. The combination i+l+i is difficult to read, the the font type they use for their fuel stations doesn’t make it easier either.

Adds also Coqivoire and Foani, two butcher franchaises that are quite popular in Ivory Coast, with automatic refinement tags (`"butcher":"poultry"`).