### PR TITLE
remove generic term

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -22648,26 +22648,6 @@
       "shop": "convenience"
     }
   },
-  "shop/convenience|Sklep": {
-    "count": 111,
-    "tags": {
-      "brand": "Sklep",
-      "name": "Sklep",
-      "shop": "convenience"
-    }
-  },
-  "shop/convenience|Sklep spożywczy": {
-    "count": 856,
-    "matches": [
-      "shop/convenience|Sklep Spożywczy",
-      "shop/convenience|Sklep spożywczo-przemysłowy"
-    ],
-    "tags": {
-      "brand": "Sklep spożywczy",
-      "name": "Sklep spożywczy",
-      "shop": "convenience"
-    }
-  },
   "shop/convenience|Smíšené zboží": {
     "count": 60,
     "tags": {

--- a/config/filters.json
+++ b/config/filters.json
@@ -102,6 +102,7 @@
         "^salon( de coiffure| fryzjerski)?$",
         "^shop$",
         "^(pet)(\\sshop)?$",
+        "^sklep$",
         "^(sklep |)spożywczy$",
         "^sklep spożywczo-przemysłowy$",
         "^souvenirs$",


### PR DESCRIPTION
sklep is simply "shop" in Polish
sklep spożywczy is also completely generic and should rather not appear as a name (and 120% not as a brand)