### PR TITLE
remove biletomat

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -14176,14 +14176,6 @@
       "name": "BKK-automata"
     }
   },
-  "amenity/vending_machine|Biletomat": {
-    "count": 68,
-    "tags": {
-      "amenity": "vending_machine",
-      "brand": "Biletomat",
-      "name": "Biletomat"
-    }
-  },
   "amenity/vending_machine|DHL Packstation": {
     "count": 64,
     "match": [

--- a/config/filters.json
+++ b/config/filters.json
@@ -48,6 +48,7 @@
         "^bakery$",
         "^barber(ia|shop|\\sshop)?$",
         "^berber$",
+        "^biletomat$",
         "^bistro$",
         "^blumen(laden)?$",
         "^bodega$",


### PR DESCRIPTION
it is a bit tricky as there is a company called biletomat but they are on line only (at least at this moment).

Biletomat is a generic term for a vending machine selling tickets, for example public transport tickets