### PR TITLE
Added info about amenity/fast_food|Крошка Картошка fixes #442

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -7902,8 +7902,11 @@
   },
   "amenity/fast_food|Крошка Картошка": {
     "count": 82,
+    "countryCodes": ["ru"],
     "tags": {
       "amenity": "fast_food",
+      "brand:wikidata": "Q4241838",
+      "brand:wikipedia": "ru:Крошка Картошка",
       "brand": "Крошка Картошка",
       "name": "Крошка Картошка"
     }


### PR DESCRIPTION
For issue #442 

Edited config/canonical.json (entry for amenity/fast_food|Крошка Картошка):

Added tags for brand:wikidata and brand:wikipedia
Added "countryCodes"