### PR TITLE
Added info about amenity/fast_food|Стардог fixes#445

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -7953,8 +7953,11 @@
   },
   "amenity/fast_food|Стардог!s": {
     "count": 58,
+    "countryCodes": ["ru"],
     "tags": {
       "amenity": "fast_food",
+      "brand:wikidata": "Q4439856",
+      "brand:wikipedia": "ru:Стардогс",  
       "brand": "Стардог!s",
       "name": "Стардог!s"
     }


### PR DESCRIPTION
For issue #445 

Edited config/canonical.json (entry for amenity/fast_food|Стардог!s):

Added tags for brand:wikidata and brand:wikipedia
Added "countryCodes"