### PR TITLE
Research for: amenity/charging_station|Enel - stazione di ricarica

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -6432,6 +6432,8 @@
     "tags": {
       "amenity": "charging_station",
       "brand": "Enel - stazione di ricarica",
+      "brand:wikidata": "Q651222",
+      "brand:wikipedia": "en:Enel",
       "name": "Enel - stazione di ricarica"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -6429,6 +6429,7 @@
   },
   "amenity/charging_station|Enel - stazione di ricarica": {
     "count": 227,
+    "countryCodes": ["it"],
     "tags": {
       "amenity": "charging_station",
       "brand": "Enel - stazione di ricarica",


### PR DESCRIPTION
Hello, this is my first PR here, so please let me know if I did any error :)

I tackled issue #413. 

Relevant brand is Enel: 
- [wikipedia](https://en.wikipedia.org/wiki/Enel) 
- [wikidata](https://www.wikidata.org/wiki/Q651222)

I added the `"it"` "countryCodes` tag as I suspect that the name "stazione di ricarica" ( Italian ) refers to a specific Italian occurrence of the item.

Thank you!