### PR TITLE
add wikidata and wikipedia for amenity/bank|UniCredit Bank

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -3749,6 +3749,8 @@
     "tags": {
       "amenity": "bank",
       "brand": "UniCredit Bank",
+      "brand:wikidata": "Q45568",
+      "brand:wikipedia": "en:UniCredit",
       "name": "UniCredit Bank"
     }
   },


### PR DESCRIPTION
This fixes #321

UniCredit is an Italian banking and financial service company.

[UniCredit bank website](https://www.unicreditgroup.eu/en.html)  
[wikipedia](https://en.wikipedia.org/wiki/UniCredit)  
[wikidata](https://www.wikidata.org/wiki/Q45568)  