### PR TITLE
add wikidata and wikipedia for amenity/bank|ING

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -2452,6 +2452,8 @@
     "tags": {
       "amenity": "bank",
       "brand": "ING",
+      "brand:wikidata": "Q645708",
+      "brand:wikipedia": "en:ING Group",
       "name": "ING"
     }
   },


### PR DESCRIPTION
ING is a Dutch multinational banking and financial services corporation.

[ING Group website](https://www.ing.com/Home.htm)  
[wikipedia](https://en.wikipedia.org/wiki/ING_Group)  
[wikidata](https://www.wikidata.org/wiki/Q645708)  

Thank you!