### PR TITLE
Add wikidata and wikipedia for amenity/bank|Postbank

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -3141,18 +3141,16 @@
   },
   "amenity/bank|Postbank": {
     "count": 588,
+    "countryCodes": ["de"],
+    "match": [
+      "amenity/bank|Postbank Finanzcenter"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "Postbank",
+      "brand:wikidata": "Q708835",
+      "brand:wikipedia": "en:Deutsche Postbank",
       "name": "Postbank"
-    }
-  },
-  "amenity/bank|Postbank Finanzcenter": {
-    "count": 68,
-    "tags": {
-      "amenity": "bank",
-      "brand": "Postbank Finanzcenter",
-      "name": "Postbank Finanzcenter"
     }
   },
   "amenity/bank|Prima banka": {


### PR DESCRIPTION
Merged with "Postbank Finanzcenter". See #300 

Postbank is a German banking and financial services company.

[Postbank website](https://www.postbank.de)
[wikipedia](https://en.wikipedia.org/wiki/Deutsche_Postbank)
[wikidata](https://www.wikidata.org/wiki/Q708835)