### PR TITLE
Added wikidata and wikipedia tags for amenity/fuel|Aral

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -8450,6 +8450,7 @@
   },
   "amenity/fuel|Aral": {
     "count": 1410,
+    "countryCodes": ["de"],
     "match": [
       "amenity/fuel|ARAL",
       "amenity/fuel|Aral Tankstelle",
@@ -8459,6 +8460,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Aral",
+      "brand:wikidata": "Q565734",
+      "brand:wikipedia": "en:Aral AG",
       "name": "Aral"
     }
   },


### PR DESCRIPTION
Aral is a german gas station company.

[Aral website](https://www.aral.de)
[wikipedia](https://en.wikipedia.org/wiki/Aral_AG)
[wikidata](https://www.wikidata.org/wiki/Q565734)

#455 