### PR TITLE
Add Walgreens information

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -12379,7 +12379,9 @@
   },
   "amenity/pharmacy|Walgreens": {
     "count": 3464,
+    "countryCodes": ["us"],
     "match": [
+      "amenity/pharmacy|Walgreens Pharmacy",
       "amenity/pharmacy|Walgreen's",
       "shop/convenience|Walgreens"
     ],
@@ -12387,17 +12389,10 @@
     "tags": {
       "amenity": "pharmacy",
       "brand": "Walgreens",
+      "brand:wikidata": "Q1591889",
+      "brand:wikipedia": "Walgreens",
       "healthcare": "pharmacy",
       "name": "Walgreens"
-    }
-  },
-  "amenity/pharmacy|Walgreens Pharmacy": {
-    "count": 117,
-    "tags": {
-      "amenity": "pharmacy",
-      "brand": "Walgreens Pharmacy",
-      "healthcare": "pharmacy",
-      "name": "Walgreens Pharmacy"
     }
   },
   "amenity/pharmacy|Walmart Pharmacy": {


### PR DESCRIPTION
Fixes https://github.com/osmlab/name-suggestion-index/issues/701

Note that I'm merging "Walgreens Pharmacy" into "Walgreens". I can't think of a Walgreens that doesn't have a pharmacy.