### PR TITLE
Remove a generic name

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -5670,14 +5670,6 @@
       "name": "Eiscafe Venezia"
     }
   },
-  "amenity/cafe|Eisdiele": {
-    "count": 89,
-    "tags": {
-      "amenity": "cafe",
-      "brand": "Eisdiele",
-      "name": "Eisdiele"
-    }
-  },
   "amenity/cafe|Espresso House": {
     "count": 155,
     "tags": {

--- a/config/filters.json
+++ b/config/filters.json
@@ -75,6 +75,7 @@
         "^drinks$",
         "^droguer(i|í)a$",
         "^eczane$",
+        "^eisdiele",
         "^exchange$",
         "^euroshop$",
         "^farm(a|à|á)ci(a|à|á|e)$",

--- a/dist/discardNames.json
+++ b/dist/discardNames.json
@@ -166,6 +166,7 @@
   "amenity/cafe|Cafétéria": 58,
   "amenity/cafe|Coffee": 51,
   "amenity/cafe|Coffee Shop": 211,
+  "amenity/cafe|Eisdiele": 89,
   "amenity/cafe|Internet Cafe": 99,
   "amenity/cafe|Kafe": 64,
   "amenity/cafe|Бистро": 87,

--- a/dist/keepNames.json
+++ b/dist/keepNames.json
@@ -662,7 +662,6 @@
   "amenity/cafe|Eiscafe Dolomiti": 51,
   "amenity/cafe|Eiscafe Venezia": 132,
   "amenity/cafe|Eiscafé Venezia": 87,
-  "amenity/cafe|Eisdiele": 89,
   "amenity/cafe|Espresso House": 155,
   "amenity/cafe|Havanna": 87,
   "amenity/cafe|Insomnia": 53,


### PR DESCRIPTION
This PR removes the generic German name 'Eisdiele' which just means ice cream parlor
Fixes #387