### PR TITLE
Add some more information for a German bakery

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -16718,6 +16718,7 @@
   },
   "shop/bakery|Steinecke": {
     "count": 286,
+    "countryCodes": ["de"],
     "tags": {
       "brand": "Steinecke",
       "name": "Steinecke",


### PR DESCRIPTION
Steinecke is a Germany bakery which does not exist in any other countries. 
There are 286 counts, but actually this is a local bakery and does only exist in some parts of Germany, so there is no Wikipedia or Wikidata entry for it...
This PR fixes #1027