### PR TITLE
Updated info for Comfort [Inn|Suites]

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -33153,24 +33153,25 @@
   },
   "tourism/hotel|Comfort Inn": {
     "count": 321,
+    "match": [
+      "tourism/hotel|Comfort Inn & Suites"
+    ],
+    "nomatch": ["tourism/hotel|Comfort Suites"],
     "tags": {
       "brand": "Comfort Inn",
+      "brand:wikidata": "Q1075788",
+      "brand:wikipedia": "en:Choice Hotels",
       "name": "Comfort Inn",
-      "tourism": "hotel"
-    }
-  },
-  "tourism/hotel|Comfort Inn & Suites": {
-    "count": 91,
-    "tags": {
-      "brand": "Comfort Inn & Suites",
-      "name": "Comfort Inn & Suites",
       "tourism": "hotel"
     }
   },
   "tourism/hotel|Comfort Suites": {
     "count": 169,
+    "nomatch": ["tourism/hotel|Comfort Inn"],
     "tags": {
       "brand": "Comfort Suites",
+      "brand:wikidata": "Q1075788",
+      "brand:wikipedia": "en:Choice Hotels",
       "name": "Comfort Suites",
       "tourism": "hotel"
     }

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -33153,15 +33153,22 @@
   },
   "tourism/hotel|Comfort Inn": {
     "count": 321,
-    "match": [
-      "tourism/hotel|Comfort Inn & Suites"
-    ],
     "nomatch": ["tourism/hotel|Comfort Suites"],
     "tags": {
       "brand": "Comfort Inn",
       "brand:wikidata": "Q1075788",
       "brand:wikipedia": "en:Choice Hotels",
       "name": "Comfort Inn",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|Comfort Inn & Suites": {
+    "count": 91,
+    "tags": {
+      "brand": "Comfort Inn & Suites",
+      "brand:wikidata": "Q1075788",
+      "brand:wikipedia": "en:Choice Hotels",
+      "name": "Comfort Inn & Suites",
       "tourism": "hotel"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -33153,6 +33153,7 @@
   },
   "tourism/hotel|Comfort Inn": {
     "count": 321,
+    "match": ["tourism/motel|Comfort Inn"],
     "nomatch": ["tourism/hotel|Comfort Suites"],
     "tags": {
       "brand": "Comfort Inn",
@@ -33677,14 +33678,6 @@
     "tags": {
       "brand": "Budget Inn",
       "name": "Budget Inn",
-      "tourism": "motel"
-    }
-  },
-  "tourism/motel|Comfort Inn": {
-    "count": 134,
-    "tags": {
-      "brand": "Comfort Inn",
-      "name": "Comfort Inn",
       "tourism": "motel"
     }
   },


### PR DESCRIPTION
Addresses #1843 and #1841

This is a little tricky because Comfort Inn & Suites does not officially exist
anymore. According to Choice Hotels (the parent company) Comfort Inn and Comfort
Suites are two distinct brands. For this reason I added each one to the other's
"nomatch" tag. This might not be the right call.

I also removed the entry for "Comfort Inn & Suites" but set it to match with
"Comfort Inn" because if you go to the Choice Hotels page for "Comfort Inn &
Suites" you are redirected to the "Comfort Inn" reservation page.