### PR TITLE
Remove 'Parkhotel' because it is a generic name

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -31382,10 +31382,10 @@
     "match": ["shop/supermarket|TESCO"],
     "tags": {
       "brand": "Tesco",
-      "name": "Tesco",
-      "shop": "supermarket",
       "brand:wikidata": "Q487494",
       "brand:wikipedia": "en:Tesco",
+      "name": "Tesco",
+      "shop": "supermarket"
     }
   },
   "shop/supermarket|Tesco Express": {
@@ -33531,14 +33531,6 @@
       "brand:wikidata": "Q420545",
       "brand:wikipedia": "en:Novotel",
       "name": "Novotel",
-      "tourism": "hotel"
-    }
-  },
-  "tourism/hotel|Parkhotel": {
-    "count": 65,
-    "tags": {
-      "brand": "Parkhotel",
-      "name": "Parkhotel",
       "tourism": "hotel"
     }
   },

--- a/config/filters.json
+++ b/config/filters.json
@@ -101,7 +101,7 @@
         "^hospedaje$",
         "^(h|m)otel$",
         "^hotel (central|panorama|royal|victoria|post|zur post)$",
-        "^(central|grand|palace|park) hotel$",
+        "^(central|grand|palace|park)(\\s)?hotel$",
         "^indipend\\.$",
         "^(independent\\s)?(cng|filling|fuel|gas|lpg|petrol)(\\s(station|pump))?$",
         "^istanbul(\\skebab)?$",

--- a/dist/discardNames.json
+++ b/dist/discardNames.json
@@ -4001,6 +4001,7 @@
   "tourism/hotel|Hotel zur Post": 58,
   "tourism/hotel|Palace Hotel": 56,
   "tourism/hotel|Park Hotel": 99,
+  "tourism/hotel|Parkhotel": 65,
   "tourism/hotel|hotel": 51,
   "tourism/hotel|Гостиница": 175,
   "tourism/information|1": 95,

--- a/dist/keepNames.json
+++ b/dist/keepNames.json
@@ -4086,7 +4086,6 @@
   "tourism/hotel|Mercure": 119,
   "tourism/hotel|Motel 6": 95,
   "tourism/hotel|Novotel": 175,
-  "tourism/hotel|Parkhotel": 65,
   "tourism/hotel|Premier Inn": 414,
   "tourism/hotel|Première Classe": 72,
   "tourism/hotel|Quality Inn": 228,


### PR DESCRIPTION
'Parkhotel' is not a brand but a generic name. Fixes #1865
I also ran `npm run build` which is why there are some other changes in the Tesco section (the build failed, so I needed to remove a comma).
Maybe it would be a good idea to add a CI like Travis which validates the generated JSON files?