### PR TITLE
Fixing trailing comma

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -31385,7 +31385,7 @@
       "name": "Tesco",
       "shop": "supermarket",
       "brand:wikidata": "Q487494",
-      "brand:wikipedia": "en:Tesco",
+      "brand:wikipedia": "en:Tesco"
     }
   },
   "shop/supermarket|Tesco Express": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -31382,10 +31382,10 @@
     "match": ["shop/supermarket|TESCO"],
     "tags": {
       "brand": "Tesco",
-      "name": "Tesco",
-      "shop": "supermarket",
       "brand:wikidata": "Q487494",
-      "brand:wikipedia": "en:Tesco"
+      "brand:wikipedia": "en:Tesco",
+      "name": "Tesco",
+      "shop": "supermarket"
     }
   },
   "shop/supermarket|Tesco Express": {


### PR DESCRIPTION
Hey!
Build was crashing, so I ran canonical through a validator, turns out there was a trailing comma in one of those thousand lines. Removed it quickly, and now the build works :+1: 