### PR TITLE
Bojangles

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -6642,11 +6642,19 @@
       "name": "Bob's"
     }
   },
-  "amenity/fast_food|Bojangles": {
+  "amenity/fast_food|Bojangles'": {
     "count": 153,
+    "match": [
+      "amenity/fast_food|Bojangles"
+      "amenity/restaurant|Bojangles"
+      "amenity/restaurant|Bojangles'"
+    ],
     "tags": {
       "amenity": "fast_food",
       "brand": "Bojangles",
+      "brand:wikidata": "Q891163",
+      "brand:wikipedia": "en:Bojangles' Famous Chicken 'n Biscuits",
+      "cuisine": "chicken",
       "name": "Bojangles"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -6651,11 +6651,11 @@
     ],
     "tags": {
       "amenity": "fast_food",
-      "brand": "Bojangles",
+      "brand": "Bojangles'",
       "brand:wikidata": "Q891163",
       "brand:wikipedia": "en:Bojangles' Famous Chicken 'n Biscuits",
       "cuisine": "chicken",
-      "name": "Bojangles"
+      "name": "Bojangles'"
     }
   },
   "amenity/fast_food|Booster Juice": {


### PR DESCRIPTION
#426. The ' at the end of the name matches the official branding but is less common in existing data.