### PR TITLE
Add wiki tags to 2 German travel agencies

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -30064,7 +30064,7 @@
   },
   "shop/supermarket|Hoogvliet": {
     "count": 70,
-    "countryCodes": ["nl"], 
+    "countryCodes": ["nl"],
     "tags": {
       "brand": "Hoogvliet",
       "brand:wikidata": "Q1642179",
@@ -32554,16 +32554,22 @@
   },
   "shop/travel_agency|DER Reisebüro": {
     "count": 63,
+    "countryCodes": ["de"],
     "tags": {
       "brand": "DER Reisebüro",
+      "brand:wikidata": "Q56729186",
+      "brand:wikipedia": "de:Deutsches Reisebüro",
       "name": "DER Reisebüro",
       "shop": "travel_agency"
     }
   },
   "shop/travel_agency|First Reisebüro": {
     "count": 60,
+    "countryCodes": ["de"],
     "tags": {
       "brand": "First Reisebüro",
+      "brand:wikidata": "Q573103",
+      "brand:wikipedia": "en:TUI Group",
       "name": "First Reisebüro",
       "shop": "travel_agency"
     }


### PR DESCRIPTION
Fixes #1827
Fixes #1828
Confirmed with overpass that they only exist in Germany...