### PR TITLE
Add wiki tags for the German beverage store 'Edeka Getränkemarkt'

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -17098,8 +17098,11 @@
   },
   "shop/beverages|Edeka Getränkemarkt": {
     "count": 80,
+    "countryCodes": ["de"],
     "tags": {
       "brand": "Edeka Getränkemarkt",
+      "brand:wikidata": "Q57450576",
+      "brand:wikipedia": "en:Edeka",
       "name": "Edeka Getränkemarkt",
       "shop": "beverages"
     }
@@ -32528,12 +32531,12 @@
     "count": 121,
     "tags": {
       "brand": "King Jouet",
-      "brand:en": "King Toy", 
+      "brand:en": "King Toy",
       "brand:wikidata": "Q3197009",
       "brand:wikipedia": "fr:King Jouet",
       "countryCodes": ["fr"],
       "name": "King Jouet",
-      "name:en": "King Toy", 
+      "name:en": "King Toy",
       "shop": "toys"
     }
   },


### PR DESCRIPTION
Fixes #1052
There are some unrelated changes, but this is just the removal of whitespaces by the build script or my editor 😄