### PR TITLE
Add Banco BPM and wiki tags

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -521,14 +521,6 @@
       "name": "BPI"
     }
   },
-  "amenity/bank|BPM": {
-    "count": 52,
-    "tags": {
-      "amenity": "bank",
-      "brand": "BPM",
-      "name": "BPM"
-    }
-  },
   "amenity/bank|BRD": {
     "count": 298,
     "tags": {
@@ -612,6 +604,7 @@
   },
   "amenity/bank|Banca Popolare di Milano": {
     "count": 123,
+    "match": ["amenity/bank|BPM"],
     "tags": {
       "amenity": "bank",
       "brand": "Banca Popolare di Milano",
@@ -734,6 +727,16 @@
       "brand:wikidata": "Q4854076",
       "brand:wikipedia": "en:Banco Azteca",
       "name": "Banco Azteca"
+    }
+  },
+  "amenity/bank|Banco BPM": {
+    "nocount": true,
+    "tags": {
+      "amenity": "bank",
+      "brand": "Banco BPM",
+      "brand:wikidata": "Q27331643",
+      "brand:wikipedia": "en:Banco BPM",
+      "name": "Banco BPM"
     }
   },
   "amenity/bank|Banco Caja Social": {


### PR DESCRIPTION
(closes #195)

* added BPM as a less popular match for Banca Popolare di Milano
* after a merger the new organization is branded as "Banco BPM" with Wikidata Q27331643, so I added a new entry for this.