### PR TITLE
Add Coop Prix to index, re #1934.

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -29215,6 +29215,7 @@
   },
   "shop/supermarket|Coop Prix": {
     "nocount": true
+    "countryCodes": ["no"],
     "tags": {
       "brand": "Coop Prix",
       "brand:wikidata": "Q5167705",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -29213,6 +29213,16 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Coop Prix": {
+    "nocount": true
+    "tags": {
+      "brand": "Coop Prix",
+      "brand:wikidata": "Q5167705",
+      "brand:wikipedia": "no:Coop Prix",
+      "name": "Coop Prix",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|CRAI": {
     "count": 76,
     "tags": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -29213,17 +29213,6 @@
       "shop": "supermarket"
     }
   },
-  "shop/supermarket|Coop Prix": {
-    "nocount": true
-    "countryCodes": ["no"],
-    "tags": {
-      "brand": "Coop Prix",
-      "brand:wikidata": "Q5167705",
-      "brand:wikipedia": "no:Coop Prix",
-      "name": "Coop Prix",
-      "shop": "supermarket"
-    }
-  },
   "shop/supermarket|CRAI": {
     "count": 76,
     "tags": {
@@ -29492,6 +29481,17 @@
     "tags": {
       "brand": "Coop Konsum",
       "name": "Coop Konsum",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|Coop Prix": {
+    "nocount": true,
+    "countryCodes": ["no"],
+    "tags": {
+      "brand": "Coop Prix",
+      "brand:wikidata": "Q5167705",
+      "brand:wikipedia": "no:Coop Prix",
+      "name": "Coop Prix",
       "shop": "supermarket"
     }
   },


### PR DESCRIPTION
A bit of a corner case as the individual stores often include the [city they are located in in the name](http://overpass-turbo.eu/s/CVc), but they do operate under the brand.