### PR TITLE
Added info for Days Inn and removed motel entry

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -33353,8 +33353,11 @@
   },
   "tourism/hotel|Days Inn": {
     "count": 322,
+    "match": ["tourism/motel|Days Inn"],
     "tags": {
       "brand": "Days Inn",
+      "brand:wikidata": "Q1047239",
+      "brand:wikipedia": "en:Days Inn",
       "name": "Days Inn",
       "tourism": "hotel"
     }
@@ -33758,14 +33761,6 @@
     "tags": {
       "brand": "Best Western",
       "name": "Best Western",
-      "tourism": "motel"
-    }
-  },
-  "tourism/motel|Days Inn": {
-    "count": 118,
-    "tags": {
-      "brand": "Days Inn",
-      "name": "Days Inn",
       "tourism": "motel"
     }
   },


### PR DESCRIPTION
Wikipedia lists industry as Hotel, not motel, and there were more matches for
hotel.