### PR TITLE
Add the correct wikidata item for 'Nahkauf'

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -30711,8 +30711,7 @@
     "match": ["shop/supermarket|nahkauf"],
     "tags": {
       "brand": "Nahkauf",
-      "brand:wikidata": "Q573266",
-      "brand:wikipedia": "en:REWE Group",
+      "brand:wikidata": "Q57515238",
       "name": "Nahkauf",
       "shop": "supermarket"
     }


### PR DESCRIPTION
Follow-up of #1947
I added the correct wikidata item and removed the link to the wikipedia entry of the "Rewe Group" because this is too generic and is not the actual brand...