### PR TITLE
fix #1459 - generic hungarian words/translations - not a brand.  

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -25408,14 +25408,6 @@
       "shop": "florist"
     }
   },
-  "shop/florist|Virágbolt": {
-    "count": 80,
-    "tags": {
-      "brand": "Virágbolt",
-      "name": "Virágbolt",
-      "shop": "florist"
-    }
-  },
   "shop/florist|Квіти": {
     "count": 95,
     "tags": {

--- a/config/filters.json
+++ b/config/filters.json
@@ -185,6 +185,7 @@
         "^trafik(a)?$",
         "^urząd pocztowy$",
         "^venezia$",
+        "^virágbolt$",
         "^(clinica\\s)?veterinari(a|o)$",
         "^(clinique\\s)?vétérinaire$",
         "^warung$",

--- a/dist/discardNames.json
+++ b/dist/discardNames.json
@@ -3803,6 +3803,7 @@
   "shop/florist|Blumen": 77,
   "shop/florist|Blumenladen": 70,
   "shop/florist|Kwiaciarnia": 224,
+  "shop/florist|Virágbolt": 80,
   "shop/funeral_directors|Funeraria": 75,
   "shop/funeral_directors|Ритуал": 61,
   "shop/funeral_directors|Ритуальные услуги": 174,

--- a/dist/keepNames.json
+++ b/dist/keepNames.json
@@ -3075,7 +3075,6 @@
   "shop/florist|Florărie": 73,
   "shop/florist|Interflora": 84,
   "shop/florist|Monceau Fleurs": 83,
-  "shop/florist|Virágbolt": 80,
   "shop/florist|Квіти": 95,
   "shop/florist|Мир цветов": 51,
   "shop/florist|Орхидея": 52,


### PR DESCRIPTION
fix #1459 
Generic word

Virágbolt =  Hungarian word/translation for a "flower shop".

Removed.