### PR TITLE
Added wiki tags for Japanese restaurant chain 夢庵

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -15612,10 +15612,15 @@
   },
   "amenity/restaurant|夢庵": {
     "count": 80,
+    "countryCodes": ["jp"],
     "tags": {
       "amenity": "restaurant",
       "brand": "夢庵",
-      "name": "夢庵"
+      "brand:en": "Yumean",
+      "brand:wikidata": "Q11253593",
+      "brand:wikipedia": "ja:すかいらーく",
+      "name": "夢庵",
+      "name:en": "Yumean"
     }
   },
   "amenity/restaurant|大戸屋": {


### PR DESCRIPTION
Re: #938
I added the wiki tags and English name/brand for this restaurant chain found across Japan.