### PR TITLE
correcting kyriad entry, wikidata now more specific

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -33568,6 +33568,7 @@
   },
   "tourism/hotel|Kyriad": {
     "count": 76,
+    "countryCodes": ["fr"],
     "tags": {
       "brand": "Kyriad",
       "brand:wikidata": "Q11751808",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -33568,11 +33568,10 @@
   },
   "tourism/hotel|Kyriad": {
     "count": 76,
-    "countryCodes": ["fr"],
     "tags": {
       "brand": "Kyriad",
-      "brand:wikidata": "Q529212",
-      "brand:wikipedia": "fr:Louvre Hotels Group",
+      "brand:wikidata": "Q11751808",
+      "brand:wikipedia": "pl:Kyriad",
       "name": "Kyriad",
       "tourism": "hotel"
     }


### PR DESCRIPTION
fixes #1862 
The Kyriad hotels _do_ belong to the [Groupe du Louvre](https://en.wikipedia.org/wiki/Groupe_du_Louvre), however they do have their own [wikidata entry](https://www.wikidata.org/wiki/Q11751808) with a [corresponding wikipedia article](https://pl.wikipedia.org/wiki/Kyriad)