### PR TITLE
Resolve duplicate name warning for Giant

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -17142,6 +17142,7 @@
   },
   "shop/bicycle|Giant": {
     "count": 65,
+    "nomatch": ["shop/supermarket|Giant"],
     "tags": {
       "brand": "Giant",
       "name": "Giant",
@@ -29857,6 +29858,7 @@
   },
   "shop/supermarket|Giant": {
     "count": 281,
+    "nomatch": ["shop/bicycle|Giant"],
     "tags": {
       "brand": "Giant",
       "name": "Giant",


### PR DESCRIPTION
The bicycle shop and supermarket are different.

But for the supermarket, there's definitely multiple brands in different countries. 
Possibly for the bicycle shops as well. 

Those are not resolved here.
Will need to do something like suggested in #1880