### PR TITLE
Add wiki tags for Swedish supermarket chain Hemköp (fixes #1690)

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -29961,8 +29961,11 @@
   },
   "shop/supermarket|Hemköp": {
     "count": 97,
+    "countryCodes": ["se"],
     "tags": {
       "brand": "Hemköp",
+      "brand:wikidata": "Q10521746",
+      "brand:wikipedia": "sv:Hemköp",
       "name": "Hemköp",
       "shop": "supermarket"
     }


### PR DESCRIPTION
Fixes #1690.