### PR TITLE
Add wiki tags for Spanish supermarket chain Alimerka (fixes #1651)

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -28829,9 +28829,12 @@
   },
   "shop/supermarket|Alimerka": {
     "count": 108,
+    "countryCodes": ["es"],
     "tags": {
       "brand": "Alimerka",
       "name": "Alimerka",
+      "brand:wikidata": "Q16482738",
+      "brand:wikipedia": "es:Alimerka",
       "shop": "supermarket"
     }
   },


### PR DESCRIPTION
Fixes #1651.