### PR TITLE
Add wiki tags for Austrian electronic chain Hartlauer (fixes #1433)

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -25002,8 +25002,11 @@
   },
   "shop/electronics|Hartlauer": {
     "count": 71,
+    "countryCodes": ["at"],
     "tags": {
       "brand": "Hartlauer",
+      "brand:wikidata": "Q1587223",
+      "brand:wikipedia": "de:Hartlauer",
       "name": "Hartlauer",
       "shop": "electronics"
     }


### PR DESCRIPTION
Fixes #1433.