### PR TITLE
Add wiki tags for Swiss electronics chain Interdiscount (fixes #1434)

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -25010,8 +25010,11 @@
   },
   "shop/electronics|Interdiscount": {
     "count": 64,
+    "countryCodes": ["ch"],
     "tags": {
       "brand": "Interdiscount",
+      "brand:wikidata": "Q1665980",
+      "brand:wikipedia": "de:Interdiscount",
       "name": "Interdiscount",
       "shop": "electronics"
     }


### PR DESCRIPTION
Fixes #1434.