### PR TITLE
Add wiki tags for French electronics chain Boulanger (fixes #1429)

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -24920,8 +24920,11 @@
   },
   "shop/electronics|Boulanger": {
     "count": 78,
+    "countryCodes": ["fr"],
     "tags": {
       "brand": "Boulanger",
+      "brand:wikidata": "Q2921695",
+      "brand:wikipedia": "fr:Boulanger (entreprise)",
       "name": "Boulanger",
       "shop": "electronics"
     }


### PR DESCRIPTION
Fixes #1429.