### PR TITLE
Update Deutsche Post entries

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -12928,6 +12928,7 @@
   },
   "amenity/post_box|Deutsche Post": {
     "count": 158,
+    "countryCodes": ["de"],
     "match": [
       "amenity/post_box|Deutsche Post AG"
     ],
@@ -12937,6 +12938,8 @@
     "tags": {
       "amenity": "post_box",
       "brand": "Deutsche Post",
+      "brand:wikidata": "Q157645",
+      "brand:wikipedia": "en:Deutsche Post",
       "name": "Deutsche Post"
     }
   },
@@ -13062,21 +13065,17 @@
   },
   "amenity/post_office|Deutsche Post": {
     "count": 591,
+    "countryCodes": ["de"],
     "match": [
-      "amenity/post_office|Deutsche Post AG"
+      "amenity/post_office|Deutsche Post AG",
+      "amenity/post_office|Deutsche Post Filiale"
     ],
     "tags": {
       "amenity": "post_office",
       "brand": "Deutsche Post",
+      "brand:wikidata": "Q157645",
+      "brand:wikipedia": "en:Deutsche Post",
       "name": "Deutsche Post"
-    }
-  },
-  "amenity/post_office|Deutsche Post Filiale": {
-    "count": 72,
-    "tags": {
-      "amenity": "post_office",
-      "brand": "Deutsche Post Filiale",
-      "name": "Deutsche Post Filiale"
     }
   },
   "amenity/post_office|Fancourier": {


### PR DESCRIPTION
Merge the two post_office entries, and add country codes and Wikipedia and Wikidata links to the remaining Deutsche Post entries.

---

Also, apparently I added the missing trailing newline to this file when I saved it in Emacs. Should I remove it?