### PR TITLE
Add wiki tags to Portuguese electronics chain Worten (fixes #1442)

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -25071,8 +25071,11 @@
   },
   "shop/electronics|Worten": {
     "count": 51,
+    "countryCodes": ["es", "pt"],
     "tags": {
       "brand": "Worten",
+      "brand:wikipedia": "pt:Worten",
+      "brand:wikidata": "Q10394039",
       "name": "Worten",
       "shop": "electronics"
     }


### PR DESCRIPTION
Fixes #1442.