### PR TITLE
Add wiki tags to Argentine electronics chain Musimundo (fixes #1438)

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -24973,8 +24973,11 @@
   },
   "shop/electronics|Musimundo": {
     "count": 55,
+    "countryCodes": ["ar"],
     "tags": {
       "brand": "Musimundo",
+      "brand:wikidata": "Q6034719",
+      "brand:wikipedia": "es:Musimundo",
       "name": "Musimundo",
       "shop": "electronics"
     }


### PR DESCRIPTION
Fixes #1438.