### PR TITLE
Add Swedish chain of charity shops Myrorna (re: #1934)

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -17932,7 +17932,10 @@
   "shop/charity|Myrorna": {
     "nocount": true,
     "countryCodes": ["se"],
-    "match": ["shop/second_hand|Myrorna"],
+    "match": [
+      "shop/clothes|Myrorna",
+      "shop/second_hand|Myrorna"
+    ],
     "tags": {
       "brand": "Myrorna",
       "brand:wikidata": "Q10592609",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -17929,6 +17929,18 @@
       "shop": "charity"
     }
   },
+  "shop/charity|Myrorna": {
+    "nocount": true,
+    "countryCodes": ["se"],
+    "match": ["shop/second_hand|Myrorna"],
+    "tags": {
+      "brand": "Myrorna",
+      "brand:wikidata": "Q10592609",
+      "brand:wikipedia": "sv:Myrorna",
+      "name": "Myrorna",
+      "shop": "charity"
+    }
+  },
   "shop/charity|Oxfam": {
     "count": 268,
     "tags": {


### PR DESCRIPTION
Re: #1934.

This is a chain of charity shops operated by the Salvation Army in Sweden, with >30 locations.