### PR TITLE
Add Swedish toy store chain Lekia (re: #1934)

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -31939,6 +31939,17 @@
       "shop": "toys"
     }
   },
+  "shop/toys|Lekia": {
+    "nocount": true,
+    "countryCodes": ["no", "sv"],
+    "tags": {
+      "brand": "Lekia",
+      "brand:wikidata": "Q56303274",
+      "brand:wikipedia": "sv:Lekia",
+      "name": "Lekia",
+      "shop": "toys"
+    }
+  },
   "shop/toys|Maxi Toys": {
     "count": 73,
     "tags": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -31941,7 +31941,7 @@
   },
   "shop/toys|Lekia": {
     "nocount": true,
-    "countryCodes": ["no", "sv"],
+    "countryCodes": ["no", "se"],
     "tags": {
       "brand": "Lekia",
       "brand:wikidata": "Q56303274",


### PR DESCRIPTION
Re: #1934.

This is a Swedish chain of toy stores, with >100 locations in Sweden and a couple in Norway.