### PR TITLE
adding validator for brand:wikipedia

### DIFF
--- a/schema/canonical.json
+++ b/schema/canonical.json
@@ -56,7 +56,8 @@
                         "match":        { "not" : {} },
                         "nomatch":      { "not" : {} },
                         "nocount":      { "not" : {} },
-                        "tags":         { "not" : {} }
+                        "tags":         { "not" : {} },
+                        "brand:wikipedia": {"type": "string", "pattern": "^\\S+:([^\\s\\_]+\\s?)+$"}
                     }
                 }
             }


### PR DESCRIPTION
Hey, I've added a validator to catch underscores in brand:wikipedia.
Let me know if this works for you / if this should be handled differently