### PR TITLE
Correct country code Sweden sv → se

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -26971,7 +26971,7 @@
   },
   "shop/optician|Synoptik": {
     "count": 60,
-    "countryCodes": ["sv"],
+    "countryCodes": ["se"],
     "tags": {
       "brand": "Synoptik",
       "brand:wikidata": "Q10687541",
@@ -26982,7 +26982,7 @@
   },
   "shop/optician|Synsam": {
     "count": 58,
-    "countryCodes": ["fi", "no", "sv"],
+    "countryCodes": ["fi", "no", "se"],
     "tags": {
       "brand": "Synsam",
       "brand:wikidata": "Q12004589",


### PR DESCRIPTION
Change country code for Sweden from `sv` to `se` in 2 entries.