### PR TITLE
Add Swedish jewelry chain Guldfynd (re: #1934)

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -25685,6 +25685,17 @@
       "shop": "jewelry"
     }
   },
+  "shop/jewelry|Guldfynd": {
+    "nocount": true,
+    "countryCodes": ["se"],
+    "tags": {
+      "brand": "Guldfynd",
+      "brand:wikidata": "Q49099223",
+      "brand:wikipedia": "sv:Guldfynd",
+      "name": "Guldfynd",
+      "shop": "jewelry"
+    }
+  },
   "shop/jewelry|H Samuel": {
     "count": 72,
     "tags": {


### PR DESCRIPTION
Add jewelry chain Guldfynd, with 100+ locations in Sweden.