### PR TITLE
Add wiki tags for French bank Crédit maritime

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -2018,6 +2018,8 @@
     "tags": {
       "amenity": "bank",
       "brand": "Crédit Maritime",
+      "brand:wikidata": "Q17176866",
+      "brand:wikipedia": "fr:Crédit maritime",
       "name": "Crédit Maritime"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -2015,6 +2015,7 @@
   },
   "amenity/bank|Crédit Maritime": {
     "count": 54,
+    "countryCodes": ["fr"],
     "tags": {
       "amenity": "bank",
       "brand": "Crédit Maritime",


### PR DESCRIPTION
- Add Wikipedia page [[fr:Crédit maritime]]
  https://fr.wikipedia.org/wiki/Cr%C3%A9dit_maritime

- Add Wikidata item [[Q17176866]]
  https://www.wikidata.org/wiki/Q17176866

Fixes #250