### PR TITLE
Add Polish electronics chain Komputronik

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -24156,6 +24156,17 @@
       "shop": "electronics"
     }
   },
+  "shop/electronics|Komputronik": {
+    "nocount": true,
+    "countryCodes": ["pl"],
+    "tags": {
+      "brand": "Komputronik",
+      "brand:wikidata": "Q11742085",
+      "brand:wikipedia": "pl:Komputronik",
+      "name": "Komputronik",
+      "shop": "electronics"
+    }
+  },
   "shop/electronics|La Curacao": {
     "count": 77,
     "tags": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -24158,6 +24158,7 @@
   },
   "shop/electronics|Komputronik": {
     "nocount": true,
+    "match": ["shop/computer|Komputronik"],
     "countryCodes": ["pl"],
     "tags": {
       "brand": "Komputronik",


### PR DESCRIPTION
Add Polish electronics chain Komputronik.

I'm not super sure about the tags. Most of the shops I'm finding on osm are `shop=computer`, but according to their [website](https://www.komputronik.pl/) they also sell TV's, phones etc...