### PR TITLE
Add French fabric store Mondial Tissus (re: #1934) + correct Eurospin/EuroSpin duplicate to EuroSpin

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -24419,17 +24419,18 @@
   },
   "shop/fabric|Mondial Tissus": {
     "nocount": true,
+    "countryCodes": ["fr"],
+    "match": [
+      "shop/curtain|Mondial Tissus",
+      "shop/department_store|Mondial Tissus"
+    ],
     "tags": {
       "brand": "Mondial Tissus",
       "brand:wikidata": "Q17635288",
       "brand:wikipedia": "fr:Mondial Tissus",
       "name": "Mondial Tissus",
       "shop": "fabric"
-    },
-    "match": [
-      "shop/curtain|Mondial Tissus",
-      "shop/department_store|Mondial Tissus"
-    ]
+    }
   },
   "shop/fabric|Ткани": {
     "count": 140,
@@ -28824,6 +28825,7 @@
   },
   "shop/supermarket|EuroSpin": {
     "count": 152,
+    "countryCodes": ["it", "si"],
     "match": ["shop/supermarket|Eurospin"],
     "tags": {
       "brand": "EuroSpin",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -28826,7 +28826,7 @@
     "count": 152,
     "match": ["shop/supermarket|Eurospin"],
     "tags": {
-      "brand": "EuroSpin",
+      "brand": "EuroSpin,
       "brand:wikidata": "Q1374674",
       "brand:wikipedia": "it:EuroSpin",
       "name": "EuroSpin",
@@ -28838,14 +28838,6 @@
     "tags": {
       "brand": "Eurospar",
       "name": "Eurospar",
-      "shop": "supermarket"
-    }
-  },
-  "shop/supermarket|Eurospin": {
-    "count": 369,
-    "tags": {
-      "brand": "Eurospin",
-      "name": "Eurospin",
       "shop": "supermarket"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -28826,7 +28826,7 @@
     "count": 152,
     "match": ["shop/supermarket|Eurospin"],
     "tags": {
-      "brand": "EuroSpin,
+      "brand": "EuroSpin",
       "brand:wikidata": "Q1374674",
       "brand:wikipedia": "it:EuroSpin",
       "name": "EuroSpin",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -24417,6 +24417,20 @@
       "shop": "erotic"
     }
   },
+  "shop/fabric|Mondial Tissus": {
+    "nocount": true,
+    "tags": {
+      "brand": "Mondial Tissus",
+      "brand:wikidata": "Q17635288",
+      "brand:wikipedia": "fr:Mondial Tissus",
+      "name": "Mondial Tissus",
+      "shop": "fabric"
+    },
+    "match": [
+      "shop/curtain|Mondial Tissus",
+      "shop/department_store|Mondial Tissus"
+    ]
+  },
   "shop/fabric|Ткани": {
     "count": 140,
     "tags": {
@@ -28810,8 +28824,11 @@
   },
   "shop/supermarket|EuroSpin": {
     "count": 152,
+    "match": ["shop/supermarket|Eurospin"],
     "tags": {
       "brand": "EuroSpin",
+      "brand:wikidata": "Q1374674",
+      "brand:wikipedia": "it:EuroSpin",
       "name": "EuroSpin",
       "shop": "supermarket"
     }


### PR DESCRIPTION
Hi, 
I added a brand (re: #1934) and fixed a duplicate (adding thus Wikidata and Wikipedia to the correct item). If those modifications are Ok, I'd likely continue to work on adding Wikidata/Wikipedia references, it's a nice project to help connect OSM to them !