### PR TITLE
Add Swedish bookstore chain Akademibokhandeln

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -16380,6 +16380,17 @@
       "shop": "bookmaker"
     }
   },
+  "shop/books|Akademibokhandeln": {
+    "nocount": true,
+    "countryCodes": ["se"],
+    "tags": {
+      "brand": "Akademibokhandeln",
+      "brand:wikidata": "Q10403918",
+      "brand:wikipedia": "sv:Akademibokhandeln",
+      "name": "Akademibokhandeln",
+      "shop": "books"
+    }
+  },
   "shop/books|Barnes & Noble": {
     "count": 504,
     "tags": {


### PR DESCRIPTION
Add Swedish bookstore chain Akademibokhandeln, with 100+ locations.