### PR TITLE
Add wiki for Lithuanian pharmacy Gintarinė vaistinė (fixes #656)

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -11804,9 +11804,12 @@
   },
   "amenity/pharmacy|Gintarinė vaistinė": {
     "count": 125,
+    "countryCodes": ["lt"],
     "tags": {
       "amenity": "pharmacy",
       "brand": "Gintarinė vaistinė",
+      "brand:wikidata": "Q15857801",
+      "brand:wikipedia": "lt:Gintarinė vaistinė",
       "healthcare": "pharmacy",
       "name": "Gintarinė vaistinė"
     }


### PR DESCRIPTION
Fixes #656.