### PR TITLE
Add 8 wikidata/wikipedia associations

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -8927,10 +8927,13 @@
   },
   "amenity/fuel|EKO": {
     "count": 205,
+    "countryCodes": ["ca"],
     "match": ["amenity/fuel|Eko"],
     "tags": {
       "amenity": "fuel",
       "brand": "EKO",
+      "brand:wikidata": "Q3045934",
+      "brand:wikipedia": "fr:EKO",
       "name": "EKO"
     }
   },
@@ -28056,6 +28059,8 @@
     "nomatch": ["amenity/fuel|Auchan"],
     "tags": {
       "brand": "Auchan",
+      "brand:wikidata": "Q758603",
+      "brand:wikipedia": "en:Auchan",
       "name": "Auchan",
       "shop": "supermarket"
     }
@@ -28144,8 +28149,11 @@
   },
   "shop/supermarket|Biocoop": {
     "count": 144,
+    "countryCodes": ["fr"],
     "tags": {
       "brand": "Biocoop",
+      "brand:wikidata": "Q2904039",
+      "brand:wikipedia": "fr:Biocoop",
       "name": "Biocoop",
       "shop": "supermarket"
     }
@@ -28525,6 +28533,8 @@
     "count": 94,
     "tags": {
       "brand": "Costcutter",
+      "brand:wikidata": "Q5175072",
+      "brand:wikipedia": "en:Costcutter",
       "name": "Costcutter",
       "shop": "supermarket"
     }
@@ -28609,14 +28619,19 @@
     "count": 229,
     "tags": {
       "brand": "Delhaize",
+      "brand:wikidata": "Q1184173",
+      "brand:wikipedia": "fr:Delhaize",
       "name": "Delhaize",
       "shop": "supermarket"
     }
   },
   "shop/supermarket|Delikatesy Centrum": {
     "count": 278,
+    "countryCodes": ["pl"],
     "tags": {
       "brand": "Delikatesy Centrum",
+      "brand:wikidata": "Q11693824",
+      "brand:wikipedia": "pl:Delikatesy Centrum",
       "name": "Delikatesy Centrum",
       "shop": "supermarket"
     }
@@ -28788,8 +28803,11 @@
   },
   "shop/supermarket|Ekono": {
     "count": 78,
+    "countryCodes": ["cl"],
     "tags": {
       "brand": "Ekono",
+      "brand:wikidata": "Q2842729",
+      "brand:wikipedia": "es:Ekono",
       "name": "Ekono",
       "shop": "supermarket"
     }
@@ -28839,6 +28857,8 @@
     "count": 360,
     "tags": {
       "brand": "Eurospar",
+      "brand:wikidata": "Q12309283",
+      "brand:wikipedia": "da:Eurospar",
       "name": "Eurospar",
       "shop": "supermarket"
     }


### PR DESCRIPTION
Added links for wikidata and wikipedia, plus, when appropriate, countryCodes, to : 
- EKO (amenity/fuel), 
- Auchan (supermarket),
- Biocoop (supermarket),
- Costcutter (supermarket),
- Delhaize (supermarket), solves #1669,
- Delikatesy Centrum (supermarket),
- Ekono (supermarket), solves #1678, 
- Eurospar (supermarket).