### PR TITLE
tiger mart (ExxonMobil)

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -21423,6 +21423,8 @@
     "count": 53,
     "tags": {
       "brand": "Tiger Mart",
+      "brand:wikidata": "Q156238",
+      "brand:wikipedia": "en:ExxonMobil",
       "name": "Tiger Mart",
       "shop": "convenience"
     }

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -21423,8 +21423,7 @@
     "count": 53,
     "tags": {
       "brand": "Tiger Mart",
-      "brand:wikidata": "Q156238",
-      "brand:wikipedia": "en:ExxonMobil",
+      "brand:wikidata": "Q57643977",
       "name": "Tiger Mart",
       "shop": "convenience"
     }


### PR DESCRIPTION
Resolves #1303

"Tiger Marts" are associated with ExxonMobil brand gas stations, such as the one mapped in [this vicinity](https://www.openstreetmap.org/search?query=tiger%20mart#map=19/38.89707/-104.83232).

Added [Wikipedia](https://en.wikipedia.org/wiki/ExxonMobil) and [Wikidata](https://www.wikidata.org/wiki/Q156238) entries for Exxon.
