### PR TITLE
Fix typo

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -25744,8 +25744,8 @@
     "nomatch": ["amenity/fuel|Sprint"],
     "tags": {
       "brand": "Sprint",
+      "brand:wikidata": "Q301965",
       "brand:wikipedia": "en:Sprint Corporation",
-      "brand:wkidata": "Q301965",
       "name": "Sprint",
       "shop": "mobile_phone"
     }
@@ -25755,8 +25755,8 @@
     "match": ["shop/mobile_phone|T Mobile"],
     "tags": {
       "brand": "T-Mobile",
+      "brand:wikidata": "Q327634",
       "brand:wikipedia": "en:T-Mobile",
-      "brand:wkidata": "Q327634",
       "name": "T-Mobile",
       "shop": "mobile_phone"
     }


### PR DESCRIPTION
Noticed the typo (`brand:wkidata`) when it was suggested by my text editor.