### PR TITLE
Added wiki tags for First Commercial Bank

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -5231,10 +5231,15 @@
   },
   "amenity/bank|第一商業銀行": {
     "count": 184,
+    "countryCodes": ["tw"],
     "tags": {
       "amenity": "bank",
       "brand": "第一商業銀行",
-      "name": "第一商業銀行"
+      "brand:en": "First Commercial Bank",
+      "brand:wikidata": "Q11602128",
+      "brand:wikipedia": "zh:第一商業銀行",
+      "name": "第一商業銀行",
+      "name:en": "First Commercial Bank"
     }
   },
   "amenity/bank|聯邦商業銀行": {


### PR DESCRIPTION
Closes #362

Regarding `brand:en` and `name:en`:
Although their main website's URL is [firstbank.com.tw](https://www.firstbank.com.tw/), on the [English site](https://firstloan.firstbank.com.tw/FCB/en_index.html), they call themselves the First Commercial Bank.