### PR TITLE
Removed pseudo-generic Vision Plus entry

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -26534,14 +26534,6 @@
       "shop": "optician"
     }
   },
-  "shop/optician|Vision Plus": {
-    "count": 59,
-    "tags": {
-      "brand": "Vision Plus",
-      "name": "Vision Plus",
-      "shop": "optician"
-    }
-  },
   "shop/optician|Visionworks": {
     "count": 59,
     "tags": {

--- a/config/filters.json
+++ b/config/filters.json
@@ -215,6 +215,7 @@
         "^vegyesbolt$",
         "^venezia$",
         "^virágbolt$",
+	"^Vision\\sPlus$",
         "^(clinica\\s)?veterinari(a|o)$",
         "^(clinique\\s)?vétérinaire$",
         "^warung$",

--- a/dist/discardNames.json
+++ b/dist/discardNames.json
@@ -4081,6 +4081,7 @@
   "shop/optician|Optica": 184,
   "shop/optician|Optical Center": 161,
   "shop/optician|Optika": 68,
+  "shop/optician|Vision Plus": 59,
   "shop/optician|Оптика": 441,
   "shop/outdoor|Рыболов": 91,
   "shop/pawnbroker|Lombard": 67,

--- a/dist/keepNames.json
+++ b/dist/keepNames.json
@@ -3169,7 +3169,6 @@
   "shop/optician|Synoptik": 60,
   "shop/optician|Synsam": 58,
   "shop/optician|Vision Express": 232,
-  "shop/optician|Vision Plus": 59,
   "shop/optician|Visionworks": 59,
   "shop/optician|แว่นท็อปเจริญ": 96,
   "shop/optician|メガネスーパー": 86,


### PR DESCRIPTION
This one is really tricky so I need some advice/consensus.

There are a lot of unrelated "Vision Plus" opticians, which would suggest a generic name. That said, it wasn't hard to find at least one small chain of opticians with multiple locations in the same area (in this case Washington state).

Here is a small sample of generic Vision Pluses:
http://www.visionplustx.com/
https://www.nhs.uk/Services/opticians/Overview/DefaultView.aspx?id=16671

and the chain in Washington. Some (if not all) of the 14 locations have their own websites, which can vary wildly in style and branding:
http://www.visionpluswa.com/
http://www.vpmillcreek.com/
https://www.visionplusballard.com/

Vision Plus Washington does not have any wiki entries. There is a wikipedia entry for VisionPLUS, which is a financial software application.

So my current thought is to just make Vision Plus a generic brand (i.e., this PR). The logic here is that:

a) There is no wiki data for Vision Plus Washington
b) There are other non-affiliated Vision Pluses all over the US (and at least one in the UK)
c) People on the ground in Washington will see Vision Plus and know what it means (hopefully)

This is similar to #1868, but in this case it's a question of one brand and a bunch of generics.

edit: forgot to mention VisionPLUS financial company