### PR TITLE
Added wikidata for Batteries Plus Bulbs

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -23813,8 +23813,10 @@
   },
   "shop/electronics|Batteries Plus Bulbs": {
     "count": 86,
+    "match": ["shop/electronics|Batteries Plus"],
     "tags": {
       "brand": "Batteries Plus Bulbs",
+      "brand:wikidata": "Q17005157",
       "name": "Batteries Plus Bulbs",
       "shop": "electronics"
     }


### PR DESCRIPTION
Addresses #1428

Weirdly, this brand has a wikidata entry, but no wikipedia page. A la #1504 the
entry just won't have the "brand:wikipedia" tag for now.

Also added match for "Batteries Plus". This is their web address and wikidata
name, but I'm pretty sure all stores are branded "Batteries Plus Bulbs". If I
remember correctly when they started out there were some stores just called
"Batteries Plus" so that's probably where the URL and wikidata come from. I can
remove the match to "Batteries Plus" if ya'll think it's superfluous.