### PR TITLE
Added info and removed duplicates for a few car parts stores

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -16540,10 +16540,13 @@
       "shop/car_parts|Auto Zone",
       "shop/car_parts|Autozone",
       "shop/car_repair|Auto Zone",
+      "shop/car_repair|AutoZone",
       "shop/car_repair|Autozone"
     ],
     "tags": {
       "brand": "AutoZone",
+      "brand:wikidata": "Q4826087",
+      "brand:wikipedia": "en:AutoZone",
       "name": "AutoZone",
       "shop": "car_parts"
     }
@@ -16679,14 +16682,6 @@
       "brand:wikidata": "Q4654920",
       "brand:wikipedia": "en:ATS Euromaster",
       "name": "ATS Euromaster",
-      "shop": "car_repair"
-    }
-  },
-  "shop/car_repair|AutoZone": {
-    "count": 231,
-    "tags": {
-      "brand": "AutoZone",
-      "name": "AutoZone",
       "shop": "car_repair"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -16585,8 +16585,13 @@
   },
   "shop/car_parts|O'Reilly Auto Parts": {
     "count": 621,
+    "match": [
+      "shop/car_repair|O'Reilly Auto Parts"
+    ],
     "tags": {
       "brand": "O'Reilly Auto Parts",
+      "brand:wikidata": "Q7071951",
+      "brand:wikipedia": "en:O'Reilly Auto Parts",
       "name": "O'Reilly Auto Parts",
       "shop": "car_parts"
     }
@@ -16877,14 +16882,6 @@
       "brand:wikidata": "Q3317698",
       "brand:wikipedia": "en:Mobivia Groupe",
       "name": "Norauto",
-      "shop": "car_repair"
-    }
-  },
-  "shop/car_repair|O'Reilly Auto Parts": {
-    "count": 229,
-    "tags": {
-      "brand": "O'Reilly Auto Parts",
-      "name": "O'Reilly Auto Parts",
       "shop": "car_repair"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -16571,10 +16571,14 @@
     "count": 398,
     "match": [
       "shop/car_parts|NAPA",
-      "shop/car_parts|Napa Auto Parts"
+      "shop/car_parts|Napa Auto Parts",
+      "shop/car_repair|NAPA Auto Parts",
+      "shop/car_repair|Napa Auto Parts"
     ],
     "tags": {
       "brand": "NAPA Auto Parts",
+      "brand:wikidata": "Q6970842",
+      "brand:wikipedia": "en:National Automotive Parts Association",
       "name": "NAPA Auto Parts",
       "shop": "car_parts"
     }
@@ -16863,14 +16867,6 @@
       "brand:wikidata": "Q17104067",
       "brand:wikipedia": "en:Mr. Lube",
       "name": "Mr. Lube",
-      "shop": "car_repair"
-    }
-  },
-  "shop/car_repair|NAPA Auto Parts": {
-    "count": 80,
-    "tags": {
-      "brand": "NAPA Auto Parts",
-      "name": "NAPA Auto Parts",
       "shop": "car_repair"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -16523,8 +16523,13 @@
   },
   "shop/car_parts|Advance Auto Parts": {
     "count": 554,
+    "match": [
+      "shop/car_repair|Advance Auto Parts"
+    ],
     "tags": {
       "brand": "Advance Auto Parts",
+      "brand:wikidata": "Q4686051",
+      "brand:wikipedia": "en:Advance Auto Parts",
       "name": "Advance Auto Parts",
       "shop": "car_parts"
     }
@@ -16674,14 +16679,6 @@
       "brand:wikidata": "Q4654920",
       "brand:wikipedia": "en:ATS Euromaster",
       "name": "ATS Euromaster",
-      "shop": "car_repair"
-    }
-  },
-  "shop/car_repair|Advance Auto Parts": {
-    "count": 286,
-    "tags": {
-      "brand": "Advance Auto Parts",
-      "name": "Advance Auto Parts",
       "shop": "car_repair"
     }
   },


### PR DESCRIPTION
NAPA, Advance Auto Parts, AutoZone, and O'Reilly

These are all in one PR because they were all simple and shouldn't cause any PR-stopping problems.