### PR TITLE
Merge duplicate Marshalls and add wiki tags. 

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -18834,14 +18834,6 @@
       "shop": "clothes"
     }
   },
-  "shop/clothes|Marshalls": {
-    "count": 285,
-    "tags": {
-      "brand": "Marshalls",
-      "name": "Marshalls",
-      "shop": "clothes"
-    }
-  },
   "shop/clothes|Massimo Dutti": {
     "count": 134,
     "tags": {
@@ -23118,8 +23110,11 @@
   },
   "shop/department_store|Marshalls": {
     "count": 78,
+    "match": ["shop/clothes|Marshalls"],
     "tags": {
       "brand": "Marshalls",
+      "brand:wikidata": "Q15903261",
+      "brand:wikipedia": "en:Marshalls",
       "name": "Marshalls",
       "shop": "department_store"
     }


### PR DESCRIPTION
shop=department_store is less common in the data than shop=clothes but the stores are larger and offer a wider range of merchandise.