### PR TITLE
dress barn

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -18334,6 +18334,8 @@
     "count": 165,
     "tags": {
       "brand": "Dress Barn",
+      "brand:wikidata": "Q5307031",
+      "brand:wikipedia": "en:Ascena Retail Group",
       "name": "Dress Barn",
       "shop": "clothes"
     }


### PR DESCRIPTION
Resolves #1162

> Ascena Retail Group, Inc. (formerly Dress Barn and doing business as Dressbarn) is an American retailer of women's clothing.

see [Wikidata entry](https://www.wikidata.org/wiki/Q5307031)

see [Wikipedia entry](https://en.wikipedia.org/wiki/Ascena_Retail_Group)