### PR TITLE
Halfords

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -16095,14 +16095,6 @@
       "shop": "bicycle"
     }
   },
-  "shop/bicycle|Halfords": {
-    "count": 164,
-    "tags": {
-      "brand": "Halfords",
-      "name": "Halfords",
-      "shop": "bicycle"
-    }
-  },
   "shop/bicycle|サイクルベースあさひ": {
     "count": 105,
     "countryCodes": ["jp"],
@@ -16561,8 +16553,14 @@
   },
   "shop/car_parts|Halfords": {
     "count": 114,
+    "match": ["shop/bicycle|Halfords"],
+    "nomatch": [
+      "shop/car_repair|Halfords Autocentre"
+    ],
     "tags": {
       "brand": "Halfords",
+      "brand:wikidata": "Q3398786",
+      "brand:wikipedia": "en:Halfords",
       "name": "Halfords",
       "shop": "car_parts"
     }
@@ -16802,6 +16800,7 @@
   "shop/car_repair|Halfords Autocentre": {
     "count": 51,
     "match": ["shop/car_repair|Halfords"],
+    "nomatch": ["shop/car_parts|Halfords"],
     "tags": {
       "brand": "Halfords Auocentre",
       "brand:wikidata": "Q5641894",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -16562,6 +16562,7 @@
       "brand:wikidata": "Q3398786",
       "brand:wikipedia": "en:Halfords",
       "name": "Halfords",
+      "service:bicycle:retail": true,
       "shop": "car_parts"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -16562,7 +16562,7 @@
       "brand:wikidata": "Q3398786",
       "brand:wikipedia": "en:Halfords",
       "name": "Halfords",
-      "service:bicycle:retail": true,
+      "service:bicycle:retail": "yes",
       "shop": "car_parts"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -16799,14 +16799,14 @@
       "shop": "car_repair"
     }
   },
-  "shop/car_repair|Halfords": {
-    "count": 56,
-    "match": [
-      "shop/car_repair|Halfords Autocentre"
-    ],
+  "shop/car_repair|Halfords Autocentre": {
+    "count": 51,
+    "match": ["shop/car_repair|Halfords"],
     "tags": {
-      "brand": "Halfords",
-      "name": "Halfords",
+      "brand": "Halfords Auocentre",
+      "brand:wikidata": "Q5641894",
+      "brand:wikipedia": "en:Halfords Autocentre",
+      "name": "Halfords Autocentre",
       "shop": "car_repair"
     }
   },


### PR DESCRIPTION
Two things done here, one easy and one not so cut-and-dry:

1. Halfords Autocentre is clearly a related but separate brand from Halfords. They have individual wikipedia and wikidata entries. To minimize confusion I enforced the canonical car_repair|Halfords Autocentre over car_repair|Halfords, which had slightly more matches.

2. The brand Halfords is a little trickier. According to the [wikidata](https://www.wikidata.org/wiki/Q3398786) this is a car_parts store. But from [wikipedia](https://en.wikipedia.org/wiki/Halfords) and their [website](https://www.halfords.com/) it is clear that they also sell bicycles and camping gear. Furthermore, there are more matches for bicycle|Halfords than car_parts|Halfords. In the current PR I've made car_parts the canonical category and have it match to bicycle, but clearly more OSM users view this as a bicycle shop so I'm not sure this is correct. Halfords' own website title bar even lists "Bikes, Cycling" before car parts.

I also had the thought of adding a match for shop/outdoor|Halfords as a preliminary strike on someone using that tag after they buy a tent or whatever. This is currently not in the PR because I'm worried it might be too cute or convoluted. Opinions welcome!