### PR TITLE
meineke

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -16827,6 +16827,8 @@
     "count": 77,
     "tags": {
       "brand": "Meineke",
+      "brand:wikidata": "Q6810159",
+      "brand:wikipedia": "en:Meineke Car Care Centers",
       "name": "Meineke",
       "shop": "car_repair"
     }


### PR DESCRIPTION
Resolves #1110

> Previously known as Meineke Discount Mufflers, the company changed its name to Meineke Car Care Centers in 2003...

See [wikidata entry](https://www.wikidata.org/wiki/Q6810159)

see [wikipedia entry](https://en.wikipedia.org/wiki/Meineke_Car_Care_Centers)