### PR TITLE
babies-r-us

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -15186,6 +15186,8 @@
     "count": 64,
     "tags": {
       "brand": "Babies R Us",
+      "brand:wikidata": "Q696334",
+      "brand:wikipedia": "en:Toys \"R\" Us",
       "name": "Babies R Us",
       "shop": "baby_goods"
     }


### PR DESCRIPTION
Resolves #981

This is a brand of Toys "R" Us, the parent company - which is in bankruptcy and I thought closed all Babies R Us stores.

see [Wikidata](https://www.wikidata.org/wiki/Q696334) and [Wikipedia](https://en.wikipedia.org/wiki/Toys_%22R%22_Us#Babies_%22R%22_Us) entries for Toys "R" Us.