### PR TITLE
Added wiki tags for 2 electronics shops in Taiwan

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -24156,17 +24156,27 @@
   },
   "shop/electronics|全國電子": {
     "count": 93,
+    "countryCodes": ["tw"],
     "tags": {
       "brand": "全國電子",
+      "brand:en": "E-life Mall",
+      "brand:wikidata": "Q10891540",
+      "brand:wikipedia": "zh:全國電子",
       "name": "全國電子",
+      "name:en": "E-life Mall",
       "shop": "electronics"
     }
   },
   "shop/electronics|燦坤3C": {
     "count": 77,
+    "countryCodes": ["tw"],
     "tags": {
       "brand": "燦坤3C",
+      "brand:en": "Tsannkuen 3C",
+      "brand:wikidata": "Q11569285",
+      "brand:wikipedia": "zh:燦坤",
       "name": "燦坤3C",
+      "name:en": "Tsannkuen 3C",
       "shop": "electronics"
     }
   },


### PR DESCRIPTION
Closes #1449, Closes #1450 

I'm a bit uncertain regarding the English names, what should be considered as the "correct" way, since the official websites do not appear to have this info.

e.g. for Tsannkuen whether it's Tsannkuen or Tsann Kuen and if the 3C should be attached. 
For this one, I followed the [Wikimedia Commons category name](https://commons.wikimedia.org/wiki/Category:Tsannkuen_3C).

For the other, I followed the casing in the [Wikipedia article](https://zh.wikipedia.org/zh-sg/%E5%85%A8%E5%9C%8B%E9%9B%BB%E5%AD%90).