### PR TITLE
add 7 sets of wikidata/wikipedia/English names for banks

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -5021,10 +5021,15 @@
   },
   "amenity/bank|京都中央信用金庫": {
     "count": 56,
+    "countryCodes": ["jp"],
     "tags": {
       "amenity": "bank",
       "brand": "京都中央信用金庫",
-      "name": "京都中央信用金庫"
+      "brand:en": "Kyoto Chuo Shinkin Bank",
+      "brand:wikidata": "Q11374844",
+      "brand:wikipedia": "jp:京都中央信用金庫",
+      "name": "京都中央信用金庫",
+      "name:en": "Kyoto Chuo Shinkin Bank"
     }
   },
   "amenity/bank|京都銀行": {
@@ -5044,7 +5049,11 @@
     "tags": {
       "amenity": "bank",
       "brand": "元大商業銀行",
-      "name": "元大商業銀行"
+      "brand:en": "Yuanta Commercial Bank",
+      "brand:wikidata": "Q10889602",
+      "brand:wikipedia": "zh:元大商業銀行",
+      "name": "元大商業銀行",
+      "name:en": "Yuanta Commercial Bank"
     }
   },
   "amenity/bank|兆豐國際商業銀行": {
@@ -5157,7 +5166,11 @@
     "tags": {
       "amenity": "bank",
       "brand": "大眾商業銀行",
-      "name": "大眾商業銀行"
+      "brand:en": "Ta Chong Commercial Bank",
+      "brand:wikidata": "Q10937047",
+      "brand:wikipedia": "zh:大眾商業銀行",
+      "name": "大眾商業銀行",
+      "name:en": "Ta Chong Commercial Bank"
     }
   },
   "amenity/bank|安泰商業銀行": {
@@ -5165,7 +5178,11 @@
     "tags": {
       "amenity": "bank",
       "brand": "安泰商業銀行",
-      "name": "安泰商業銀行"
+      "brand:en": "Entie Commercial Bank",
+      "brand:wikidata": "Q10946952",
+      "brand:wikipedia": "zh:安泰商業銀行",
+      "name": "安泰商業銀行",
+      "name:en": "Entie Commercial Bank"
     }
   },
   "amenity/bank|工商银行": {
@@ -5217,7 +5234,11 @@
     "tags": {
       "amenity": "bank",
       "brand": "板信商業銀行",
-      "name": "板信商業銀行"
+      "brand:en": "Bank of Panshin",
+      "brand:wikidata": "Q11104946",
+      "brand:wikipedia": "zh:板信商業銀行",
+      "name": "板信商業銀行",
+      "name:en": "Bank of Panshin"
     }
   },
   "amenity/bank|横浜銀行": {
@@ -5295,7 +5316,11 @@
     "tags": {
       "amenity": "bank",
       "brand": "臺灣中小企業銀行",
-      "name": "臺灣中小企業銀行"
+      "brand:en": "Taiwan Business Bank",
+      "brand:wikidata": "Q15913812",
+      "brand:wikipedia": "zh:臺灣中小企業銀行",
+      "name": "臺灣中小企業銀行",
+      "name:en": "Taiwan Business Bank"
     }
   },
   "amenity/bank|臺灣土地銀行": {
@@ -5315,7 +5340,11 @@
     "tags": {
       "amenity": "bank",
       "brand": "臺灣新光商業銀行",
-      "name": "臺灣新光商業銀行"
+      "brand:en": "Shin Kong Commercial Bank",
+      "brand:wikidata": "Q15909616",
+      "brand:wikipedia": "zh:臺灣新光商業銀行",
+      "name": "臺灣新光商業銀行",
+      "name:en": "Shin Kong Commercial Bank"
     }
   },
   "amenity/bank|臺灣銀行": {


### PR DESCRIPTION
- 京都中央信用金庫 #353
- 元大商業銀行 #354
- 大眾商業銀行 #357
- 安泰商業銀行 #358
- 板信商業銀行 #360
- 臺灣中小企業銀行 #364
- 臺灣新光商業銀行 #365