### PR TITLE
Add Einstein Bros. Bagels.

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -6995,6 +6995,24 @@
       "name": "Dunkin' Donuts"
     }
   },
+  "amenity/fast_food|Einstein Bros. Bagels": {
+    "nocount": true,
+    "match": [
+      "amenity/fast_food|Einstein Bros Bagels",
+      "amenity/fast_food|Einstein Brothers Bagels",
+      "amenity/restaurant|Einstein Bros Bagels",
+      "amenity/restaurant|Einstein Bros. Bagels",
+      "amenity/restaurant|Einstein Brothers Bagels"
+    ],
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "Einstein Bros. Bagels",
+      "brand:wikidata": "Q5349788",
+      "brand:wikipedia": "en:Einstein Bros. Bagels",
+      "cuisine": "bagel",
+      "name": "Einstein Bros. Bagels"
+    }
+  },
   "amenity/fast_food|El Pollo Loco": {
     "count": 158,
     "tags": {


### PR DESCRIPTION
236 occurrences https://overpass-turbo.eu/s/Db8 spread mostly across 4 amenity/shops:

fast_food: 90
cafe: 79
restaurant: 32
bakery: 28

33 entries mention coffee, but I think cuisine=bagel aligns with other fast_food entries better than anything coffee related.