### PR TITLE
Added tags for Gamm Vert #1477

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -24688,8 +24688,11 @@
   },
   "shop/garden_centre|Gamm Vert": {
     "count": 272,
+    "countryCodes": ["fr"],
     "tags": {
       "brand": "Gamm Vert",
+      "brand:wikidata": "Q3095006",
+      "brand:wikipedia": "fr:Gamm Vert",
       "name": "Gamm Vert",
       "shop": "garden_centre"
     }


### PR DESCRIPTION
There is "No label defined" for the title on the [Wikidata site](https://www.wikidata.org/wiki/Q3095006), but it does reference Gamm Vert and its Wikipedia entry.