### PR TITLE
 Add data tags for a number of Japanese restaurants.

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -8118,8 +8118,8 @@
       "brand:en": "Stardog!s",
       "brand:wikidata": "Q4439856",
       "brand:wikipedia": "ru:Стардогс",
-      "nam:en": "Stardog!s",
-      "name": "Стардог!s"
+      "name": "Стардог!s",
+      "name:en": "Stardog!s"
     }
   },
   "amenity/fast_food|Суши Wok": {
@@ -14639,8 +14639,8 @@
       "brand:en": "Hanamarūdon",
       "brand:wikidata": "Q11275674",
       "brand:wikipedia": "ja:はなまるうどん",
-      "nam:en": "Hanamarūdon",
-      "name": "はなまるうどん"
+      "name": "はなまるうどん",
+      "name:en": "Hanamarūdon"
     }
   },
   "amenity/restaurant|びっくりドンキー": {
@@ -14691,8 +14691,8 @@
       "brand:en": "Coco's",
       "brand:wikidata": "Q11301951",
       "brand:wikipedia": "ja:ココスジャパン",
-      "nam:en": "Coco's",
-      "name": "ココス"
+      "name": "ココス",
+      "name:en": "Coco's"
     }
   },
   "amenity/restaurant|サイゼリヤ": {
@@ -14808,8 +14808,8 @@
       "brand:en": "Royal Host",
       "brand:wikidata": "Q11120884",
       "brand:wikipedia": "ja:ロイヤルホスト",
-      "nam:en": "Royal Host",
-      "name": "ロイヤルホスト"
+      "name": "ロイヤルホスト",
+      "name:en": "Royal Host"
     }
   },
   "amenity/restaurant|丸亀製麺": {
@@ -14872,8 +14872,8 @@
       "brand:wikidata": "Q11435522",
       "brand:wikipedia": "ja:大戸屋ホールディングス",
       "cuisine": "japanese",
-      "nam:en": "Ootoya",
-      "name": "大戸屋"
+      "name": "大戸屋",
+      "name:en": "Ootoya"
     }
   },
   "amenity/restaurant|大阪王将": {
@@ -14884,8 +14884,8 @@
       "brand:en": "Osaka Ohsho",
       "brand:wikidata": "Q48743717",
       "brand:wikipedia": "ja:大阪王将",
-      "nam:en": "Osaka Ohsho",
-      "name": "大阪王将"
+      "name": "大阪王将",
+      "name:en": "Osaka Ohsho"
     }
   },
   "amenity/restaurant|天下一品": {
@@ -14909,8 +14909,8 @@
       "brand:wikidata": "Q11450866",
       "brand:wikipedia": "ja:安楽亭",
       "cuisine": "barbecue",
-      "nam:en": "Anrakutei",
-      "name": "安楽亭"
+      "name": "安楽亭",
+      "name:en": "Anrakutei"
     }
   },
   "amenity/restaurant|日高屋": {


### PR DESCRIPTION
Adds details for はなまるうどん, びっくりドンキー, やよい軒, ガスト, ココス, ジョイフル, ジョナサン, ジョリーパスタ,  デニーズ,  バーミヤン, ロイヤルホスト, 日高屋, 大戸屋, 安楽亭, 牛角, and 大阪王将. Resolves #924,  resolves #925, resolves #926, resolves #927, resolves #928, resolves #929, resolves #931, resolves #932, resolves #933, resolves #934, resolves #935, resolves #939, resolves #940, resolves #941, resolves #942, and resolves #944. 

Also corrects typo.