### PR TITLE
Add tags for Auchan Drive and Auchen Supermarché. Fixes #1652.

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -28154,7 +28154,7 @@
     "tags": {
       "brand": "Auchan",
       "brand:wikidata": "Q758603",
-      "brand:wikipedia": "en:Auchan",
+      "brand:wikipedia": "fr:Auchan",
       "name": "Auchan",
       "shop": "supermarket"
     }
@@ -28163,7 +28163,23 @@
     "count": 53,
     "tags": {
       "brand": "Auchan Drive",
+      "brand:wikidata": "Q2870659",
+      "brand:wikipedia": "fr:Auchan Drive",
       "name": "Auchan Drive",
+      "operator:wikidata": "Q758603",
+      "operator:wikipedia": "fr:Auchan",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|Auchan Supermarché": {
+    "nocount": true,
+    "tags": {
+      "brand": "Auchan Supermarché",
+      "brand:wikidata": "Q3484790",
+      "brand:wikipedia": "fr:Auchan Supermarché",
+      "name": "Auchan Supermarché",
+      "operator:wikidata": "Q758603",
+      "operator:wikipedia": "fr:Auchan",
       "shop": "supermarket"
     }
   },


### PR DESCRIPTION
Submitted as a PR because I'm not quite sure the parent company really operates the 3 brands, and because "Auchen Drive" isn't quite a shop, they prepare online grocery orders for pickup.