### PR TITLE
Contribute more data (focus on Ivory Coast)

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -1272,12 +1272,14 @@
   },
   "amenity/bank|Bank of Africa": {
     "count": 77,
+    "match": ["Agence BOA", "BOA"],
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Africa",
       "brand:wikidata": "Q2882627",
       "brand:wikipedia": "en:Bank of Africa Group",
-      "name": "Bank of Africa"
+      "name": "Bank of Africa",
+      "short_name": "BOA"
     }
   },
   "amenity/bank|Bank of America": {
@@ -1561,6 +1563,24 @@
       "amenity": "bank",
       "brand": "Bicentenario",
       "name": "Bicentenario"
+    }
+  },
+  "amenity/bank|Bicici": {
+    "countryCodes": ["ci"],
+    "match": [
+      "amenity/bank|Agence BICICI",
+      "amenity/bank|BICICI",
+      "amenity/bank|Banque internationale pour le commerce et l'industrie de la Côte d'Ivoire",
+      "amenity/bank|Banque internationale pour le commerce et l‘industrie de la Côte d‘Ivoire"
+    ],
+    "nocount": true,
+    "tags": {
+      "amenity": "bank",
+      "brand": "Bicici",
+      "brand:wikidata": "Q1667302",
+      "brand:wikipedia": "fr:Banque internationale pour le commerce et l'industrie de la Côte d'Ivoire",
+      "name": "Bicici",
+      "official_name": "Banque internationale pour le commerce et l‘industrie de la Côte d‘Ivoire"
     }
   },
   "amenity/bank|Bradesco": {
@@ -2217,6 +2237,7 @@
   },
   "amenity/bank|Ecobank": {
     "count": 250,
+    "match": ["amenity/bank|Agence Ecobank"],
     "tags": {
       "amenity": "bank",
       "brand": "Ecobank",
@@ -3406,6 +3427,23 @@
       "amenity": "bank",
       "brand": "SEB",
       "name": "SEB"
+    }
+  },
+  "amenity/bank|SGBCI": {
+    "countryCodes": ["ci"],
+    "match": [
+      "amenity/bank|Agence SGBCI",
+      "amenity/bank|Société générale de banques en Côte d'Ivoire",
+      "amenity/bank|Société générale de banques en Côte d‘Ivoire"
+    ],
+    "nocount": true,
+    "tags": {
+      "amenity": "bank",
+      "brand": "SGBCI",
+      "brand:wikidata": "Q3488360",
+      "brand:wikipedia": "fr:Société générale de banques en Côte d'Ivoire",
+      "name": "SGBCI",
+      "official_name": "Société générale de banques en Côte d‘Ivoire"
     }
   },
   "amenity/bank|SNS Bank": {
@@ -9943,6 +9981,19 @@
   },
   "amenity/fuel|Oilibya": {
     "count": 160,
+    "match": [
+      "amenity/fuel|OLIBYA",
+      "amenity/fuel|OLYBIA",
+      "amenity/fuel|OiLibya",
+      "amenity/fuel|Oil Liby",
+      "amenity/fuel|Oil Lybia",
+      "amenity/fuel|OilLibia",
+      "amenity/fuel|OilLibya",
+      "amenity/fuel|OilLybia",
+      "amenity/fuel|Oilibia",
+      "amenity/fuel|Oilibiya",
+      "amenity/fuel|Oilybia"
+    ],
     "tags": {
       "amenity": "fuel",
       "brand": "Oilibya",
@@ -10781,6 +10832,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Total",
+      "brand:wikidate": "Q154037",
+      "brand:wikipedia": "fr:Total (entreprise)",
       "name": "Total"
     }
   },
@@ -10829,9 +10882,7 @@
   },
   "amenity/fuel|United": {
     "count": 221,
-    "match": [
-      "amenity/fuel|United Petroleum"
-    ],
+    "match": ["amenity/fuel|United Petroleum"],
     "nomatch": ["amenity/bank|United Bank"],
     "tags": {
       "amenity": "fuel",
@@ -15285,6 +15336,49 @@
       "name": "YMCA"
     }
   },
+  "office/telecommunication|MTN": {
+    "match": [
+      "office/telecommunication|Agence MTN",
+      "shop/mobile_phone|Agence MTN",
+      "shop/mobile_phone|MTN"
+    ],
+    "nocount": true,
+    "tags": {
+      "brand": "MTN",
+      "brand:wikidata": "Q1813361",
+      "brand:wikipedia": "en:MTN Group",
+      "name": "MTN",
+      "office": "telecommunication"
+    }
+  },
+  "office/telecommunication|Moov": {
+    "match": [
+      "office/telecommunication|Agence Moov",
+      "shop/mobile_phone|Agence Moov",
+      "shop/mobile_phone|Moov"
+    ],
+    "nocount": true,
+    "tags": {
+      "brand": "Moov",
+      "name": "Moov",
+      "office": "telecommunication"
+    }
+  },
+  "office/telecommunication|Orange": {
+    "match": [
+      "office/telecommunication|Agence Orange",
+      "shop/mobile_phone|Agence Orange",
+      "shop/mobile_phone|Orange"
+    ],
+    "nocount": true,
+    "tags": {
+      "brand": "Orange",
+      "brand:wikidata": "Q1431486",
+      "brand:wikipedia": "fr:Orange S.A.",
+      "name": "Orange",
+      "office": "telecommunication"
+    }
+  },
   "shop/alcohol|Alko": {
     "count": 172,
     "tags": {
@@ -16782,6 +16876,26 @@
       "name": "新华书店",
       "name:en": "Xinhua Bookstore",
       "shop": "books"
+    }
+  },
+  "shop/butcher|Coqivoire": {
+    "countryCodes": ["ci"],
+    "match": ["COQIVOIRE"],
+    "nocount": true,
+    "tags": {
+      "brand": "Coqivoire",
+      "butcher": "poultry",
+      "name": "Coqivoire"
+    }
+  },
+  "shop/butcher|Foani": {
+    "countryCodes": ["ci"],
+    "match": ["FOANI"],
+    "nocount": true,
+    "tags": {
+      "brand": "Foani",
+      "butcher": "poultry",
+      "name": "Foani"
     }
   },
   "shop/butcher|Gzella": {
@@ -26004,14 +26118,6 @@
       "shop": "mobile_phone"
     }
   },
-  "shop/mobile_phone|MTN": {
-    "count": 52,
-    "tags": {
-      "brand": "MTN",
-      "name": "MTN",
-      "shop": "mobile_phone"
-    }
-  },
   "shop/mobile_phone|MetroPCS": {
     "count": 250,
     "match": ["shop/mobile_phone|Metro PCS"],
@@ -26060,14 +26166,6 @@
     "tags": {
       "brand": "Optie1",
       "name": "Optie1",
-      "shop": "mobile_phone"
-    }
-  },
-  "shop/mobile_phone|Orange": {
-    "count": 828,
-    "tags": {
-      "brand": "Orange",
-      "name": "Orange",
       "shop": "mobile_phone"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -15336,49 +15336,6 @@
       "name": "YMCA"
     }
   },
-  "office/telecommunication|MTN": {
-    "match": [
-      "office/telecommunication|Agence MTN",
-      "shop/mobile_phone|Agence MTN",
-      "shop/mobile_phone|MTN"
-    ],
-    "nocount": true,
-    "tags": {
-      "brand": "MTN",
-      "brand:wikidata": "Q1813361",
-      "brand:wikipedia": "en:MTN Group",
-      "name": "MTN",
-      "office": "telecommunication"
-    }
-  },
-  "office/telecommunication|Moov": {
-    "match": [
-      "office/telecommunication|Agence Moov",
-      "shop/mobile_phone|Agence Moov",
-      "shop/mobile_phone|Moov"
-    ],
-    "nocount": true,
-    "tags": {
-      "brand": "Moov",
-      "name": "Moov",
-      "office": "telecommunication"
-    }
-  },
-  "office/telecommunication|Orange": {
-    "match": [
-      "office/telecommunication|Agence Orange",
-      "shop/mobile_phone|Agence Orange",
-      "shop/mobile_phone|Orange"
-    ],
-    "nocount": true,
-    "tags": {
-      "brand": "Orange",
-      "brand:wikidata": "Q1431486",
-      "brand:wikipedia": "fr:Orange S.A.",
-      "name": "Orange",
-      "office": "telecommunication"
-    }
-  },
   "shop/alcohol|Alko": {
     "count": 172,
     "tags": {
@@ -16884,6 +16841,7 @@
     "nocount": true,
     "tags": {
       "brand": "Coqivoire",
+      "brand:wikidata": "Q60183284",
       "butcher": "poultry",
       "name": "Coqivoire"
     }
@@ -16894,6 +16852,7 @@
     "nocount": true,
     "tags": {
       "brand": "Foani",
+      "brand:wikidata": "Q60183335",
       "butcher": "poultry",
       "name": "Foani"
     }
@@ -26118,6 +26077,21 @@
       "shop": "mobile_phone"
     }
   },
+  "shop/mobile_phone|MTN": {
+    "count": 52,
+    "match": [
+      "office/telecommunication|Agence MTN",
+      "office/telecommunication|MTN",
+      "shop/mobile_phone|Agence MTN"
+    ],
+    "tags": {
+      "brand": "MTN",
+      "brand:wikidata": "Q1813361",
+      "brand:wikipedia": "en:MTN Group",
+      "name": "MTN",
+      "shop": "mobile_phone"
+    }
+  },
   "shop/mobile_phone|MetroPCS": {
     "count": 250,
     "match": ["shop/mobile_phone|Metro PCS"],
@@ -26140,6 +26114,21 @@
       "brand:wikidata": "Q344744",
       "brand:wikipedia": "en:Debitel",
       "name": "Mobilcom Debitel",
+      "shop": "mobile_phone"
+    }
+  },
+  "shop/mobile_phone|Moov": {
+    "match": [
+      "office/telecommunication|Agence Moov",
+      "office/telecommunication|Moov",
+      "shop/mobile_phone|Agence Moov"
+    ],
+    "nocount": true,
+    "tags": {
+      "brand": "Moov",
+      "brand:wikidata": "Q3323637",
+      "brand:wikipedia": "fr:Moov Côte d'Ivoire",
+      "name": "Moov",
       "shop": "mobile_phone"
     }
   },
@@ -26166,6 +26155,21 @@
     "tags": {
       "brand": "Optie1",
       "name": "Optie1",
+      "shop": "mobile_phone"
+    }
+  },
+  "shop/mobile_phone|Orange": {
+    "count": 828,
+    "match": [
+      "office/telecommunication|Agence Orange",
+      "office/telecommunication|Orange",
+      "shop/mobile_phone|Agence Orange"
+    ],
+    "tags": {
+      "brand": "Orange",
+      "brand:wikidata": "Q1431486",
+      "brand:wikipedia": "fr:Orange S.A.",
+      "name": "Orange",
       "shop": "mobile_phone"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -16843,7 +16843,8 @@
       "brand": "Coqivoire",
       "brand:wikidata": "Q60183284",
       "butcher": "poultry",
-      "name": "Coqivoire"
+      "name": "Coqivoire",
+      "shop": "butcher"
     }
   },
   "shop/butcher|Foani": {
@@ -16854,7 +16855,8 @@
       "brand": "Foani",
       "brand:wikidata": "Q60183335",
       "butcher": "poultry",
-      "name": "Foani"
+      "name": "Foani",
+      "shop": "butcher"
     }
   },
   "shop/butcher|Gzella": {


### PR DESCRIPTION
Contribute more data (focus on Ivory Coast) and resolve #1547 

To discuss: This PR goes for office/telecommunication instead of shop/mobile_phone for the three cell phone carriers operating in Ivory Coast (MTN, Orange, Moov). All of these carriers also operate in other countries.

The situation in Ivory Coast: There are three types of facilities.

1. Facilities called “Agence” operated directly by MTN, Orange or Moov, offering services only for this carrier. You will visit one of these facilities (“Agence”) only for the “more complicate cases”. The most used services are
   - identification of SIM cards (associating them to a passport number)
   - unlook looked SIM cards
   - get new prepaid SIM cards
   - get new postpaid SIM cards (with contract)
   - unblock “Mobile Money” functions of SIM cards (passport requiered)
   - payment of bills (postpaid SIM)

2. For day-by-day operations like buying credit for your prepaid card or for sending or receiving mobile money, you will do this in one of the many, many private independent small shops that offer this service. These independent shops usually offer these services for all the three cell phone carriers in the same shop. Often these small shops to not have a proper noun but call themselves something like “MTN Orange Moov” to show that they sell services for all these carriers.

3. A new cell phone or smart phone you will buy in other shops, that do only sell smart phones, but do not sell any credit or SIM card. These shops often have normal proper nouns.

Reading the wiki, it seems to me that office=telecommunication is the correct tag for case 1, while shop=mobile_phone is the correct tag for case 3. Not sure what about case 2. All in all, I think it makes sense to treat MTN, Orange and Moov as case 1.