### PR TITLE
Add VinMart and VinMart+ data

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -22032,8 +22032,11 @@
   },
   "shop/convenience|VinMart+": {
     "count": 538,
+    "countryCodes": ["vn"],
     "tags": {
       "brand": "VinMart+",
+      "brand:wikidata": "Q60245505",
+      "brand:wikipedia": "vi:VinMart",
       "name": "VinMart+",
       "shop": "convenience"
     }
@@ -23784,14 +23787,6 @@
       "brand:wikidata": "Q183538",
       "brand:wikipedia": "de:Woolworth Deutschland",
       "name": "Woolworth",
-      "shop": "department_store"
-    }
-  },
-  "shop/department_store|vinmart": {
-    "count": 199,
-    "tags": {
-      "brand": "vinmart",
-      "name": "vinmart",
       "shop": "department_store"
     }
   },
@@ -31488,6 +31483,18 @@
       "brand:wikidata": "Q5858167",
       "brand:wikipedia": "es:Vea (supermercado)",
       "name": "Vea",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|VinMart": {
+    "countryCodes": ["vn"],
+    "match": ["shop/department_store|vinmart"],
+    "nocount": true,
+    "tags": {
+      "brand": "VinMart",
+      "brand:wikidata": "Q60245505",
+      "brand:wikipedia": "vi:VinMart",
+      "name": "VinMart",
       "shop": "supermarket"
     }
   },


### PR DESCRIPTION
Closes #1403 and Closes #1306

I'm opening this change as a PR for review as I'm personally unsure whether these two store chains should be using the same wikipedia/wikidata information.

For a reference point, I looked at the existing data for "Tesco" and "Tesco Express" which are both using `en:Tesco` and `Q487494` so there is precedent. However, "VinMart" is a supermarket while "VinMart+" a convenience store (according to wikipedia) - I don't know whether that changes things.

Also not sure how to feel about changing the tagging of VinMart to `shop/supermarket` as opposed to `shop/department_store`. It looks like all of the existing instances were added by one user, but perhaps they have more accurate surveyed knowledge than wikipedia which suggests it's a supermarket.