### PR TITLE
Add Wikipedia data for fuel stations

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -8906,6 +8906,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Asda",
+      "brand:wikidata": "Q297410",
+      "brand:wikipedia": "en:Asda",
       "name": "Asda"
     }
   },
@@ -8915,14 +8917,19 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Auchan",
+      "brand:wikidata": "Q758603",
+      "brand:wikipedia": "en:Auchan",
       "name": "Auchan"
     }
   },
   "amenity/fuel|Avanti": {
     "count": 106,
+    "countryCodes": ["at"],
     "tags": {
       "amenity": "fuel",
       "brand": "Avanti",
+      "brand:wikidata": "Q168238",
+      "brand:wikipedia": "en:OMV",
       "name": "Avanti"
     }
   },
@@ -9114,6 +9121,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Carrefour Market",
+      "brand:wikidata": "Q217599",
+      "brand:wikipedia": "en:Carrefour",
       "name": "Carrefour Market"
     }
   },
@@ -9126,6 +9135,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Casey's General Store",
+      "brand:wikidata": "Q2940968",
+      "brand:wikipedia": "en:Casey's General Stores",
       "name": "Casey's General Store"
     }
   },
@@ -9144,6 +9155,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Ceypetco",
+      "brand:wikidata": "Q5065795",
+      "brand:wikipedia": "en:Ceylon Petroleum Corporation",
       "name": "Ceypetco"
     }
   },
@@ -9162,6 +9175,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Circle K",
+      "brand:wikidata": "Q3268010",
+      "brand:wikipedia": "en:Circle K",
       "name": "Circle K"
     }
   },
@@ -9171,6 +9186,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Citgo",
+      "brand:wikidata": "Q2974437",
+      "brand:wikipedia": "en:Citgo",
       "name": "Citgo"
     }
   },
@@ -9204,10 +9221,13 @@
   },
   "amenity/fuel|Coles Express": {
     "count": 338,
+    "countryCodes": ["au"],
     "nomatch": ["shop/convenience|Coles Express"],
     "tags": {
       "amenity": "fuel",
       "brand": "Coles Express",
+      "brand:wikidata": "Q5144653",
+      "brand:wikipedia": "en:Coles Express",
       "name": "Coles Express"
     }
   },
@@ -9223,9 +9243,12 @@
   },
   "amenity/fuel|Copec": {
     "count": 620,
+    "countryCodes": ["cl"],
     "tags": {
       "amenity": "fuel",
       "brand": "Copec",
+      "brand:wikidata": "Q11681461",
+      "brand:wikipedia": "en:Empresas Copec",
       "name": "Copec"
     }
   },
@@ -9239,9 +9262,12 @@
   },
   "amenity/fuel|Cosmo": {
     "count": 87,
+    "countryCodes": ["jp"],
     "tags": {
       "amenity": "fuel",
       "brand": "Cosmo",
+      "brand:wikidata": "Q2498318",
+      "brand:wikipedia": "en:Cosmo Oil Company",
       "name": "Cosmo"
     }
   },
@@ -9270,6 +9296,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Couche-Tard",
+      "brand:wikidata": "Q2836957",
+      "brand:wikipedia": "en:Alimentation Couche-Tard",
       "name": "Couche-Tard"
     }
   },
@@ -9291,12 +9319,15 @@
   },
   "amenity/fuel|Cumberland Farms": {
     "count": 117,
+    "countryCodes": ["us"],
     "nomatch": [
       "shop/convenience|Cumberland Farms"
     ],
     "tags": {
       "amenity": "fuel",
       "brand": "Cumberland Farms",
+      "brand:wikidata": "Q1143685",
+      "brand:wikipedia": "en:Cumberland Farms",
       "name": "Cumberland Farms"
     }
   },
@@ -9320,9 +9351,12 @@
   },
   "amenity/fuel|Domo": {
     "count": 58,
+    "countryCodes": ["ca"],
     "tags": {
       "amenity": "fuel",
       "brand": "Domo",
+      "brand:wikidata": "Q5291326",
+      "brand:wikipedia": "en:Domo Gasoline",
       "name": "Domo"
     }
   },
@@ -9399,6 +9433,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Engen",
+      "brand:wikidata": "Q3054251",
+      "brand:wikipedia": "en:Engen Petroleum",
       "name": "Engen"
     }
   },
@@ -9422,6 +9458,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Erg",
+      "brand:wikidata": "Q739503",
+      "brand:wikipedia": "it:ERG (azienda)",
       "name": "Erg"
     }
   },
@@ -9485,6 +9523,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Firezone",
+      "brand:wikidata": "Q14628080",
+      "brand:wikipedia": "nl:Firezone",
       "name": "Firezone"
     }
   },
@@ -9493,6 +9533,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Flying J",
+      "brand:wikidata": "Q1434601",
+      "brand:wikipedia": "en:Pilot Flying J",
       "name": "Flying J"
     }
   },
@@ -9521,6 +9563,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "GALP",
+      "brand:wikidata": "Q1492739",
+      "brand:wikipedia": "en:Galp Energia",
       "name": "GALP"
     }
   },
@@ -9591,6 +9635,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Gulf",
+      "brand:wikidata": "Q1296860",
+      "brand:wikipedia": "en:Gulf Oil",
       "name": "Gulf"
     }
   },
@@ -9599,6 +9645,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Gull",
+      "brand:wikidata": "Q5617739",
+      "brand:wikipedia": "en:Gull Petroleum",
       "name": "Gull"
     }
   },
@@ -9659,11 +9707,14 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Hess",
+      "brand:wikidata": "Q1615684",
+      "brand:wikipedia": "en:Hess Corporation",
       "name": "Hess"
     }
   },
   "amenity/fuel|Hindustan Petroleum": {
     "count": 101,
+    "countryCodes": ["in"],
     "tags": {
       "amenity": "fuel",
       "brand": "Hindustan Petroleum",


### PR DESCRIPTION
closes #456, closes #1658 , closes #469, closes #471, closes #473, closes #478, closes #481, closes #482, closes #485, closes #489, closes #494, closes #495, closes #501. The PR also adds Wikipedia data for some places fuel places that don't have issues connected to them. 