### PR TITLE
United Dairy Farmers

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -10994,6 +10994,25 @@
       "name": "Turmöl"
     }
   },
+  "amenity/fuel|UDF Fuel": {
+    "match": [
+      "amenity/fuel|UDF",
+      "amenity/fuel|UDF Fuels",
+      "amenity/fuel|United Dairy Farmers"
+    ],
+    "nocount": true,
+    "nomatch": [
+      "shop/convenience|United Dairy Farmers"
+    ],
+    "tags": {
+      "amenity": "fuel",
+      "brand": "United Dairy Farmers",
+      "brand:wikidata": "Q7887677",
+      "brand:wikipedia": "en:United Dairy Farmers",
+      "name": "UDF Fuel",
+      "short_name": "UDF"
+    }
+  },
   "amenity/fuel|Ultramar": {
     "count": 631,
     "nomatch": ["shop/convenience|Ultramar"],
@@ -21995,12 +22014,24 @@
   },
   "shop/convenience|United Dairy Farmers": {
     "count": 67,
+    "match": [
+      "amenity/ice_cream|UDF",
+      "amenity/ice_cream|United Dairy Farmers",
+      "shop/convenience|UDF",
+      "shop/ice_cream|UDF",
+      "shop/ice_cream|United Dairy Farmers"
+    ],
+    "nomatch": [
+      "amenity/fuel|United Dairy Farmers"
+    ],
     "tags": {
+      "amenity": "ice_cream",
       "brand": "United Dairy Farmers",
       "brand:wikidata": "Q7887677",
       "brand:wikipedia": "en:United Dairy Farmers",
       "name": "United Dairy Farmers",
-      "shop": "convenience"
+      "shop": "convenience",
+      "short_name": "UDF"
     }
   },
   "shop/convenience|Utile": {


### PR DESCRIPTION
A United Dairy Farmers store isn’t just a convenience store: it’s also an ice cream parlor, and neither is subordinate to the other in terms of prominence. A UDF store location is always mapped as a single POI. At a typical location, the ice cream parlor isn’t well separated from the rest of the convenience store: you order ice cream and pay for groceries at the same counter, though seating is in a separate room at some locations.

Added an entry for UDF gas stations, which are mapped as separate POIs. Both entries now have a `short_name` tag and more search terms.