### PR TITLE
Adds more fuel Wikipedia entries

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -11033,6 +11033,7 @@
   },
   "amenity/fuel|Tela": {
     "count": 201,
+    "countryCodes": ["kh"],
     "tags": {
       "amenity": "fuel",
       "brand": "Tela",
@@ -11041,6 +11042,7 @@
   },
   "amenity/fuel|Tempo": {
     "count": 82,
+    "countryCodes": ["ca"],
     "tags": {
       "amenity": "fuel",
       "brand": "Tempo",
@@ -11063,6 +11065,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Tesco",
+      "brand:wikidata": "Q17145596",
+      "brand:wikipedia": "en:Tesco Corporation",
       "name": "Tesco"
     }
   },
@@ -11072,22 +11076,30 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Texaco",
+      "brand:wikidata": "Q775060",
+      "brand:wikipedia": "en:Texaco",
       "name": "Texaco"
     }
   },
   "amenity/fuel|Tinq": {
     "count": 225,
+    "countryCodes": ["nl"],
     "tags": {
       "amenity": "fuel",
       "brand": "Tinq",
+      "brand:wikidata": "Q2132028",
+      "brand:wikipedia": "nl:Tinq",
       "name": "Tinq"
     }
   },
   "amenity/fuel|Topaz": {
     "count": 129,
+    "countryCodes": ["ie"],
     "tags": {
       "amenity": "fuel",
       "brand": "Topaz",
+      "brand:wikidata": "Q7824764",
+      "brand:wikipedia": "en:Topaz Energy",
       "name": "Topaz"
     }
   },
@@ -11101,6 +11113,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Total",
+      "brand:wikidata": "Q154037",
+      "brand:wikipedia": "en:Total S.A.",
       "name": "Total"
     }
   },
@@ -11123,10 +11137,13 @@
   },
   "amenity/fuel|Turkey Hill": {
     "count": 109,
+    "countryCodes": ["us"],
     "nomatch": ["shop/convenience|Turkey Hill"],
     "tags": {
       "amenity": "fuel",
       "brand": "Turkey Hill",
+      "brand:wikidata": "Q42376970",
+      "brand:wikipedia": "en:Turkey Hill Minit Markets",
       "name": "Turkey Hill"
     }
   },
@@ -11135,6 +11152,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Turmöl",
+      "brand:wikidata": "Q1473279",
+      "brand:wikipedia": "de:Turmöl",
       "name": "Turmöl"
     }
   },
@@ -11144,6 +11163,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Ultramar",
+      "brand:wikidata": "Q3548078",
+      "brand:wikipedia": "en:Ultramar",
       "name": "Ultramar"
     }
   },
@@ -11183,6 +11204,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Valero",
+      "brand:wikidata": "Q1283291",
+      "brand:wikipedia": "en:Valero Energy",
       "name": "Valero"
     }
   },
@@ -11191,6 +11214,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Viada",
+      "brand:wikidata": "Q12663942",
+      "brand:wikipedia": "en:Lukoil Baltija",
       "name": "Viada"
     }
   },
@@ -11267,9 +11292,12 @@
   },
   "amenity/fuel|Z": {
     "count": 99,
+    "countryCodes": ["nz"],
     "tags": {
       "amenity": "fuel",
       "brand": "Z",
+      "brand:wikidata": "Q8063337",
+      "brand:wikipedia": "en:Z Energy",
       "name": "Z"
     }
   },
@@ -11286,6 +11314,7 @@
   },
   "amenity/fuel|din-X": {
     "count": 52,
+    "countryCodes": ["se"],
     "tags": {
       "amenity": "fuel",
       "brand": "din-X",
@@ -11313,6 +11342,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "АЗС",
+      "brand:wikidata": "Q12122687",
+      "brand:wikipedia": "uk:Мережа АЗС Приват",
       "name": "АЗС"
     }
   },
@@ -11326,9 +11357,12 @@
   },
   "amenity/fuel|БРСМ-Нафта": {
     "count": 74,
+    "countryCodes": ["ua"],
     "tags": {
       "amenity": "fuel",
       "brand": "БРСМ-Нафта",
+      "brand:wikidata": "Q56356523",
+      "brand:wikipedia": "uk:БРСМ-Нафта",
       "name": "БРСМ-Нафта"
     }
   },
@@ -11349,6 +11383,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Белоруснефть",
+      "brand:wikidata": "Q4082693",
+      "brand:wikipedia": "ru:Белоруснефть",
       "name": "Белоруснефть"
     }
   },
@@ -11395,10 +11431,13 @@
   },
   "amenity/fuel|КазМунайГаз": {
     "count": 152,
+    "countryCodes": ["kz"],
     "nomatch": ["shop/convenience|КазМунайГаз"],
     "tags": {
       "amenity": "fuel",
       "brand": "КазМунайГаз",
+      "brand:wikidata": "Q1417227",
+      "brand:wikipedia": "en:KazMunayGas",
       "name": "КазМунайГаз"
     }
   },
@@ -11409,14 +11448,19 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Лукойл",
+      "brand:wikidata": "Q329347",
+      "brand:wikipedia": "ru:Лукойл",
       "name": "Лукойл"
     }
   },
   "amenity/fuel|Макпетрол": {
     "count": 107,
+    "countryCodes": ["mk"],
     "tags": {
       "amenity": "fuel",
       "brand": "Макпетрол",
+      "brand:wikidata": "Q1886438",
+      "brand:wikipedia": "en:Makpetrol",
       "name": "Макпетрол"
     }
   },
@@ -11433,6 +11477,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "НК Альянс",
+      "brand:wikidata": "Q4063700",
+      "brand:wikipedia": "ru:Альянс (компания)",
       "name": "НК Альянс"
     }
   },
@@ -11486,9 +11532,12 @@
   },
   "amenity/fuel|Петрол": {
     "count": 140,
+    "countryCodes": ["bg"],
     "tags": {
       "amenity": "fuel",
       "brand": "Петрол",
+      "brand:wikidata": "Q24315",
+      "brand:wikipedia": "en:Petrol AD",
       "name": "Петрол"
     }
   },
@@ -11710,6 +11759,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "中国石化 Sinopec",
+      "brand:wikidata": "Q831445",
+      "brand:wikipedia": "zh:中国石化",
       "name": "中国石化 Sinopec"
     }
   },


### PR DESCRIPTION
closes #561, closes #562, closes #567, closes #570, closes #576, closes #577, closes #584, closes #586. Also adds Wiki data for a bunch more that didn't have issues. 

issue #585 (Метан) means methane, issue #589 (Октан) means Octane, and issue #591 (Пропан) means propane. So their entries can probably be removed. 

Except for a couple more random ones, I think that pretty much does it for fuel entries that have Wikipedia pages. 