### PR TITLE
Taco Bell is Tex-Mex

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -8137,7 +8137,7 @@
       "brand": "Taco Bell",
       "brand:wikidata": "Q752941",
       "brand:wikipedia": "en:Taco Bell",
-      "cuisine": "mexican",
+      "cuisine": "tex-mex",
       "name": "Taco Bell"
     }
   },


### PR DESCRIPTION
We currently have Taco Bell as `cuisine=mexican`, based on common usage, whereas [the wiki recommends](https://wiki.openstreetmap.org/wiki/Key:cuisine#Cuisine_.28ethnicity.29) using the more obscure `tex-mex` instead – and I’d tend to agree. Taco Bell doesn’t ever include “Mexican” in the brand name, as Chipotle and Qdoba sometimes do.

https://github.com/osmlab/name-suggestion-index/blob/418be28cd2323ec8383cec2aaab5d17bc264a3d9/config/canonical.json#L8132-L8143

[![](https://upload.wikimedia.org/wikipedia/commons/thumb/d/d7/Naked_Burrito_Bowl_at_Taco_Bell_in_Iso_Omena.jpg/640px-Naked_Burrito_Bowl_at_Taco_Bell_in_Iso_Omena.jpg)](https://commons.wikimedia.org/wiki/File:Naked_Burrito_Bowl_at_Taco_Bell_in_Iso_Omena.jpg)
_Not especially Mexican…_