### PR TITLE
Add additional matches for Men's Wearhouse

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -20400,6 +20400,11 @@
   },
   "shop/clothes|Men's Wearhouse": {
     "count": 165,
+    "match": [
+      "shop/clothes|Mens Wearhouse",
+      "shop/clothes|Men's Warehouse",
+      "shop/clothes|Mens Warehouse"
+    ],
     "tags": {
       "brand": "Men's Wearhouse",
       "brand:wikidata": "Q57405513",


### PR DESCRIPTION
There were 9 places in OSM where it was spelled Men's Warehouse. I fixed those, but this should help prevent that in the future.

Signed-off-by: Tim Smith <tsmith@chef.io>