### PR TITLE
Add additional matches for HomeGoods

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -26907,6 +26907,11 @@
   },
   "shop/houseware|HomeGoods": {
     "nocount": true,
+    "match": [
+      "shop/houseware|Home Goods",
+      "shop/interior_decoration|Home Goods",
+      "shop/interior_decoration|HomeGoods"
+    ],
     "tags": {
       "brand": "HomeGoods",
       "brand:wikidata": "Q5887941",


### PR DESCRIPTION
This never popped up for me because I was typing it as 2 words, which according to OSM a lot of people have been doing. I just closed out the MapRoulette project to update them all.

Signed-off-by: Tim Smith <tsmith@chef.io>