### PR TITLE
Add additional matches for AT&T stores

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -27334,6 +27334,10 @@
     }
   },
   "shop/mobile_phone|AT&T": {
+    "match": [
+      "shop/electronics|AT&T",
+      "shop/electronics|ATT"
+    ],
     "count": 787,
     "tags": {
       "brand": "AT&T",


### PR DESCRIPTION
This shows up incorrectly a lot in OSM.

Signed-off-by: Tim Smith <tsmith@chef.io>