### PR TITLE
Add a match for Office Depot

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -29518,6 +29518,7 @@
   },
   "shop/stationery|Office Depot": {
     "count": 466,
+    "match": ["shop/stationery|OfficeDepot"],
     "tags": {
       "brand": "Office Depot",
       "brand:wikidata": "Q1337797",


### PR DESCRIPTION
Allow it to show up when people use the wrong name.

Signed-off-by: Tim Smith <tsmith@chef.io>