### PR TITLE
Correct RadioShack to be one word

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -25764,14 +25764,14 @@
       "shop": "electronics"
     }
   },
-  "shop/electronics|Radio Shack": {
+  "shop/electronics|RadioShack": {
     "count": 371,
-    "match": ["shop/electronics|RadioShack"],
+    "match": ["shop/electronics|Radio Shack"],
     "tags": {
-      "brand": "Radio Shack",
+      "brand": "RadioShack",
       "brand:wikidata": "Q1195490",
       "brand:wikipedia": "en:RadioShack",
-      "name": "Radio Shack",
+      "name": "RadioShack",
       "shop": "electronics"
     }
   },


### PR DESCRIPTION
The brand is one word. Even the wikipedia article name included already is one word.

Signed-off-by: Tim Smith <tsmith@chef.io>