### PR TITLE
Adding Canadian grocery chains

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -30734,6 +30734,18 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Farm Boy": {
+    "countryCodes": ["ca"],
+    "match": ["shop/greengrocer|Farm Boy"],
+    "nocount": true,
+    "tags": {
+      "brand": "Farm Boy",
+      "brand:wikidata": "Q5435469",
+      "brand:wikipedia": "en:Farm Boy",
+      "name": "Farm Boy",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|Farmfoods": {
     "count": 155,
     "tags": {
@@ -31442,6 +31454,17 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Loblaws": {
+    "countryCodes": ["ca"],
+    "nocount": true,
+    "tags": {
+      "brand": "Loblaws",
+      "brand:wikidata": "Q3257626",
+      "brand:wikipedia": "en:Loblaws",
+      "name": "Lonblaws",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|Londis": {
     "count": 51,
     "tags": {
@@ -31731,11 +31754,14 @@
       "shop": "supermarket"
     }
   },
-  "shop/supermarket|Metro": {
-    "count": 427,
-    "nomatch": ["amenity/bank|Metrobank"],
+  "shop/supermarket|Metro~(Canada)": {
+    "countryCodes": ["ca"],
+    "nocount": true,
+    "nomatch": ["shop/wholesale|Metro"],
     "tags": {
       "brand": "Metro",
+      "brand:wikidata": "Q1145669",
+      "brand:wikipedia": "en:Metro Inc.",
       "name": "Metro",
       "shop": "supermarket"
     }
@@ -33037,6 +33063,17 @@
       "brand:wikidata": "Q3249145",
       "brand:wikipedia": "en:Woolworths Supermarkets",
       "name": "Woolworths",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|Your Independent Grocer": {
+    "countryCodes": ["ca"],
+    "nocount": true,
+    "tags": {
+      "brand": "Your Independent Grocer",
+      "brand:wikidata": "Q8058833",
+      "brand:wikipedia": "en:Your Independent Grocer",
+      "name": "Your Independent Grocer",
       "shop": "supermarket"
     }
   },
@@ -34627,6 +34664,21 @@
       "brand:wikidata": "Q704606",
       "brand:wikipedia": "en:Makro",
       "name": "Makro",
+      "shop": "wholesale"
+    }
+  },
+  "shop/wholesale|Metro": {
+    "match": ["shop/supermarket|Metro"],
+    "nocount": true,
+    "nomatch": [
+      "amenity/bank|Metrobank",
+      "shop/supermarket|Metro~(Canada)"
+    ],
+    "tags": {
+      "brand": "Metro",
+      "brand:wikidata": "Q13610282",
+      "brand:wikipedia": "en:Metro Cash and Carry",
+      "name": "Metro",
       "shop": "wholesale"
     }
   },


### PR DESCRIPTION
Adding Loblaws, Your Independent Grocer, Farm Boy, and Metro,  Also adding Metro Cash&Carry to disambiguate.