### PR TITLE
Add Mud Bay pet store

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -28737,6 +28737,16 @@
       "shop": "pet"
     }
   },
+  "shop/pet|Mud Bay": {
+    "nocount": true,
+    "tags": {
+      "brand": "Mud Bay",
+      "brand:wikidata": "Q30324179",
+      "brand:wikipedia": "en:Mud Bay pet store",
+      "name": "Mud Bay",
+      "shop": "pet"
+    }
+  },
   "shop/pet|Pet Supplies Plus": {
     "count": 72,
     "tags": {


### PR DESCRIPTION
A pacifiic northwest US pet store that's been expanding rapidly in the last few years.

Signed-off-by: Tim Smith <tsmith@chef.io>