### PR TITLE
Add Pick 'n Save

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -32089,6 +32089,17 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Pick 'n Save": {
+    "match": ["shop/supermarket|Pick n Save"],
+    "nocount": true,
+    "tags": {
+      "brand": "Pick 'n Save",
+      "brand:wikidata": "Q7371288",
+      "brand:wikipedia": "en:Roundy's",
+      "name": "Pick 'n Save",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|Pick n Pay": {
     "count": 200,
     "match": ["shop/supermarket|Pick 'n Pay"],


### PR DESCRIPTION
Wisconsin supermarket chain run by Roundy's.

Signed-off-by: Tim Smith <tsmith@chef.io>