### PR TITLE
Add Mattress Warehouse

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -17333,6 +17333,14 @@
       "shop": "bed"
     }
   },
+  "shop/bed|Mattress Warehouse": {
+    "nocount": true,
+    "tags": {
+      "brand": "Mattress Warehouse",
+      "name": "Mattress Warehouse",
+      "shop": "bed"
+    }
+  },
   "shop/bed|Sleep Number": {
     "count": 58,
     "tags": {


### PR DESCRIPTION
This one is odd. There's a large number of these stores on the east coast in the US, but for some reason there's no wikipedia article. Apparently mattresses aren't cool to write about.

Signed-off-by: Tim Smith <tsmith@chef.io>