### PR TITLE
Disambiguate Home Hardware

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -1,13 +1,4 @@
 {
-  "shop/confectionery|Hemmakvall": {
-    "nocount": true,
-    "tags": {
-      "amenity": "confectionery",
-      "brand:wikipedia": "Hemmakväll",
-      "brand:wikidata": "Q10521791",
-      "name": "Hemmakväll"
-    }
-  },
   "amenity/bank|ABANCA": {
     "count": 102,
     "countryCodes": ["es"],
@@ -7285,6 +7276,13 @@
     }
   },
   "amenity/fast_food|Cinnabon": {
+    "match": [
+      "amenity/cafe|Cinnabon",
+      "amenity/restaurant|Cinnabon",
+      "shop/bakery|Cinnabon",
+      "shop/confectionery|Cinnabon",
+      "shop/pastry|Cinnabon"
+    ],
     "nocount": true,
     "tags": {
       "brand": "Cinnabon",
@@ -7293,7 +7291,7 @@
       "brand:wikipedia": "en:Cinnabon",
       "name": "Cinnabon",
       "amenity": "fast_food",
-      "cuisine": "cinnamon_roll"
+      "cuisine": "dessert"
     }
   },
   "amenity/fast_food|CoCo壱番屋": {
@@ -21542,6 +21540,15 @@
       "name": "Adyar Ananda Bhavan"
     }
   },
+  "shop/confectionery|Hemmakvall": {
+    "nocount": true,
+    "tags": {
+      "amenity": "confectionery",
+      "brand:wikipedia": "Hemmakväll",
+      "brand:wikidata": "Q10521791",
+      "name": "Hemmakväll"
+    }
+  },
   "shop/confectionery|Hussel": {
     "count": 89,
     "tags": {
@@ -26211,7 +26218,6 @@
     }
   },
   "shop/furniture|Crate & Barrel": {
-    "count": 90,
     "match": ["shop/furniture|Crate and Barrel"],
     "tags": {
       "brand": "Crate & Barrel",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -6094,10 +6094,11 @@
       "shop/coffee|Dutch Brother's",
       "shop/coffee|Dutch Brothers"
     ],
+    "nocount": true,
     "tags": {
       "amenity": "cafe",
       "brand": "Dutch Bros. Coffee",
-      "brand:wikipedia": "en:Dutch_Bros._Coffee",
+      "brand:wikipedia": "en:Dutch Bros. Coffee",
       "cuisine": "coffee_shop",
       "name": "Dutch Bros. Coffee"
     }
@@ -7063,6 +7064,7 @@
     }
   },
   "amenity/fast_food|Baja Fresh": {
+    "nocount": true,
     "tags": {
       "amenity": "fast_food",
       "brand": "Baja Fresh",
@@ -8329,6 +8331,17 @@
       "name": "Supermac's"
     }
   },
+  "amenity/fast_food|TCBY": {
+    "nocount": true,
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "TCBY",
+      "brand:wikidata": "Q7669631",
+      "brand:wikipedia": "en:TCBY",
+      "cuisine": "frozen_yogurt",
+      "name": "TCBY"
+    }
+  },
   "amenity/fast_food|Taco Bell": {
     "count": 3406,
     "match": ["amenity/restaurant|Taco Bell"],
@@ -8428,6 +8441,18 @@
       "brand:wikipedia": "en:The Pizza Company",
       "cuisine": "pizza",
       "name": "The Pizza Company"
+    }
+  },
+  "amenity/fast_food|Veggie Grill": {
+    "nocount": true,
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "Veggie Grill",
+      "brand:wikidata": "Q18636427",
+      "brand:wikipedia": "en:Veggie Grill",
+      "diet:vegan": "only",
+      "cuisine": "american",
+      "name": "Veggie Grill"
     }
   },
   "amenity/fast_food|Wendy's": {
@@ -11692,6 +11717,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Газпромнефть",
+      "brand:wikidata": "Q1461799",
+      "brand:wikipedia": "en:Gazprom Neft",
       "name": "Газпромнефть"
     }
   },
@@ -11958,6 +11985,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "บางจาก",
+      "brand:wikidata": "Q6579719",
+      "brand:wikipedia": "th:บางจาก คอร์ปอเรชัน",
       "name": "บางจาก"
     }
   },
@@ -11967,6 +11996,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "ป.ต.ท.",
+      "brand:wikidata": "Q1810389",
+      "brand:wikipedia": "th:ปตท.",
       "name": "ป.ต.ท."
     }
   },
@@ -11976,6 +12007,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "เชลล์",
+      "brand:wikidata": "Q18109",
+      "brand:wikipedia": "th:เชลล์",
       "name": "เชลล์"
     }
   },
@@ -13565,6 +13598,8 @@
     "tags": {
       "amenity": "pharmacy",
       "brand": "Ригла",
+      "brand:wikidata": "Q4394431",
+      "brand:wikipedia": "ru:Ригла",
       "healthcare": "pharmacy",
       "name": "Ригла"
     }
@@ -15039,7 +15074,7 @@
       "brand": "Nando's",
       "brand:wikidata": "Q3472954",
       "brand:wikipedia": "en:Nando's",
-      "cuisine": "portuguese",
+      "cuisine": "chicken;portuguese",
       "name": "Nando's"
     }
   },
@@ -16116,6 +16151,8 @@
     "tags": {
       "amenity": "vending_machine",
       "brand": "Tobaccoland",
+      "brand:wikidata": "Q1439872",
+      "brand:wikipedia": "de:Tobaccoland Automatengesellschaft",
       "name": "Tobaccoland"
     }
   },
@@ -16291,6 +16328,17 @@
       "brand:wikidata": "Q16971315",
       "brand:wikipedia": "en:Bargain Booze",
       "name": "Bargain Booze",
+      "shop": "alcohol"
+    }
+  },
+  "shop/alcohol|BevMo!": {
+    "match": ["shop/alcohol|BevMo"],
+    "nocount": true,
+    "tags": {
+      "brand": "BevMo!",
+      "brand:wikidata": "Q4899308",
+      "brand:wikipedia": "en:BevMo!",
+      "name": "BevMo!",
       "shop": "alcohol"
     }
   },
@@ -17308,6 +17356,14 @@
       "shop": "bed"
     }
   },
+  "shop/bed|Mattress Warehouse": {
+    "nocount": true,
+    "tags": {
+      "brand": "Mattress Warehouse",
+      "name": "Mattress Warehouse",
+      "shop": "bed"
+    }
+  },
   "shop/bed|Sleep Number": {
     "count": 58,
     "tags": {
@@ -17360,6 +17416,8 @@
     "count": 94,
     "tags": {
       "brand": "Fristo",
+      "brand:wikidata": "Q1465151",
+      "brand:wikipedia": "de:Fristo",
       "name": "Fristo",
       "shop": "beverages"
     }
@@ -19168,6 +19226,7 @@
     "nomatch": ["amenity/pharmacy|Walgreens"],
     "tags": {
       "brand": "Walgreens",
+      "brand:wikipedia": "en:Walgreens",
       "name": "Walgreens",
       "shop": "chemist"
     }
@@ -19177,6 +19236,7 @@
     "nomatch": ["amenity/pharmacy|Watsons"],
     "tags": {
       "brand": "Watsons",
+      "brand:wikipedia": "en:Watsons",
       "name": "Watsons",
       "shop": "chemist"
     }
@@ -19301,6 +19361,8 @@
     "count": 105,
     "tags": {
       "brand": "康是美",
+      "brand:wikidata": "Q11063876",
+      "brand:wikipedia": "zh:康是美藥妝店",
       "name": "康是美",
       "shop": "chemist"
     }
@@ -19414,6 +19476,16 @@
       "brand:wikidata": "Q2842931",
       "brand:wikipedia": "en:American Eagle Outfitters",
       "name": "American Eagle Outfitters",
+      "shop": "clothes"
+    }
+  },
+  "shop/clothes|Ann Taylor": {
+    "nocount": true,
+    "tags": {
+      "brand": "Ann Taylor",
+      "brand:wikidata": "Q4766699",
+      "brand:wikipedia": "en:Ann Inc.",
+      "name": "Ann Taylor",
       "shop": "clothes"
     }
   },
@@ -19936,8 +20008,11 @@
   },
   "shop/clothes|Express": {
     "count": 96,
+    "nomatch": ["shop/convenience|Express"],
     "tags": {
       "brand": "Express",
+      "brand:wikidata": "Q1384784",
+      "brand:wikipedia": "en:Express, Inc.",
       "name": "Express",
       "shop": "clothes"
     }
@@ -20235,6 +20310,8 @@
     "count": 121,
     "tags": {
       "brand": "Justice",
+      "brand:wikidata": "Q7857512",
+      "brand:wikipedia": "en:Tween Brands",
       "name": "Justice",
       "shop": "clothes"
     }
@@ -20346,6 +20423,8 @@
     "count": 93,
     "tags": {
       "brand": "Loft",
+      "brand:wikidata": "Q4766699",
+      "brand:wikipedia": "en:Ann Inc.",
       "name": "Loft",
       "shop": "clothes"
     }
@@ -20404,6 +20483,8 @@
     "count": 57,
     "tags": {
       "brand": "Marks & Spencer",
+      "brand:wikidata": "Q714491",
+      "brand:wikipedia": "en:Marks & Spencer",
       "name": "Marks & Spencer",
       "shop": "clothes"
     }
@@ -20692,6 +20773,16 @@
       "brand:wikidata": "Q3327046",
       "brand:wikipedia": "en:Oysho",
       "name": "Oysho",
+      "shop": "clothes"
+    }
+  },
+  "shop/clothes|PacSun": {
+    "nocount": true,
+    "tags": {
+      "brand": "PacSun",
+      "brand:wikidata": "Q7121857",
+      "brand:wikipedia": "en:PacSun",
+      "name": "PacSun",
       "shop": "clothes"
     }
   },
@@ -21544,7 +21635,7 @@
     "nocount": true,
     "tags": {
       "amenity": "confectionery",
-      "brand:wikipedia": "Hemmakväll",
+      "brand:wikipedia": "sv:Hemmakväll",
       "brand:wikidata": "Q10521791",
       "name": "Hemmakväll"
     }
@@ -22098,6 +22189,7 @@
   },
   "shop/convenience|Express": {
     "count": 56,
+    "nomatch": ["shop/clothes|Express"],
     "tags": {
       "brand": "Express",
       "name": "Express",
@@ -22823,17 +22915,29 @@
   "shop/convenience|Spar": {
     "count": 1269,
     "match": ["shop/convenience|SPAR"],
-    "nomatch": ["shop/convenience|Spar Express"],
+    "nomatch": [
+      "shop/convenience|Spar Express",
+      "shop/supermarket|Spar"
+    ],
     "tags": {
       "brand": "Spar",
+      "brand:wikidata": "Q610492",
+      "brand:wikipedia": "en:Spar (retailer)",
       "name": "Spar",
       "shop": "convenience"
     }
   },
   "shop/convenience|Spar Express": {
     "count": 59,
+    "match": ["shop/convenience|SPAR Express"],
+    "nomatch": [
+      "shop/convenience|Spar",
+      "shop/supermarket|Spar"
+    ],
     "tags": {
-      "brand": "Spar Express",
+      "brand": "Spar",
+      "brand:wikidata": "Q610492",
+      "brand:wikipedia": "en:Spar (retailer)",
       "name": "Spar Express",
       "shop": "convenience"
     }
@@ -22851,8 +22955,11 @@
   },
   "shop/convenience|Społem": {
     "count": 224,
+    "nomatch": ["shop/supermarket|Społem"],
     "tags": {
       "brand": "Społem",
+      "brand:wikidata": "Q11826043",
+      "brand:wikipedia": "pl:Powszechna Spółdzielnia Spożywców „Społem”",
       "name": "Społem",
       "shop": "convenience"
     }
@@ -24341,6 +24448,16 @@
       "shop": "cosmetics"
     }
   },
+  "shop/cosmetics|Origins": {
+    "nocount": true,
+    "tags": {
+      "brand": "Origins",
+      "brand:wikidata": "Q6643229",
+      "brand:wikipedia": "en:Origins (cosmetics)",
+      "name": "Origins",
+      "shop": "cosmetics"
+    }
+  },
   "shop/cosmetics|Rituals": {
     "count": 76,
     "tags": {
@@ -25802,14 +25919,14 @@
       "shop": "electronics"
     }
   },
-  "shop/electronics|Radio Shack": {
-    "count": 371,
-    "match": ["shop/electronics|RadioShack"],
+  "shop/electronics|RadioShack": {
+    "count": 91,
+    "match": ["shop/electronics|Radio Shack"],
     "tags": {
-      "brand": "Radio Shack",
+      "brand": "RadioShack",
       "brand:wikidata": "Q1195490",
       "brand:wikipedia": "en:RadioShack",
-      "name": "Radio Shack",
+      "name": "RadioShack",
       "shop": "electronics"
     }
   },
@@ -26165,7 +26282,23 @@
     "count": 111,
     "tags": {
       "brand": "Aaron's",
+      "brand:wikidata": "Q10397787",
+      "brand:wikipedia": "en:Aaron's, Inc.",
       "name": "Aaron's",
+      "shop": "furniture"
+    }
+  },
+  "shop/furniture|Ashley HomeStore": {
+    "match": [
+      "shop/furniture|Ashley Furniture",
+      "shop/furniture|Ashley Furniture HomeStore"
+    ],
+    "nocount": true,
+    "tags": {
+      "brand": "Ashley HomeStore",
+      "brand:wikidata": "Q4805437",
+      "brand:wikipedia": "en:Ashley HomeStore",
+      "name": "Ashley Furniture",
       "shop": "furniture"
     }
   },
@@ -26219,6 +26352,7 @@
   },
   "shop/furniture|Crate & Barrel": {
     "match": ["shop/furniture|Crate and Barrel"],
+    "nocount": true,
     "tags": {
       "brand": "Crate & Barrel",
       "brand:wikidata": "Q5182604",
@@ -26344,6 +26478,16 @@
       "brand:wikidata": "Q7313497",
       "brand:wikipedia": "en:Rent-A-Center",
       "name": "Rent-A-Center",
+      "shop": "furniture"
+    }
+  },
+  "shop/furniture|Restoration Hardware": {
+    "nocount": true,
+    "tags": {
+      "brand": "Restoration Hardware",
+      "brand:wikidata": "Q7316207",
+      "brand:wikipedia": "en:Restoration Hardware",
+      "name": "Restoration Hardware",
       "shop": "furniture"
     }
   },
@@ -26986,6 +27130,32 @@
       "brand:wikidata": "Q7085222",
       "brand:wikipedia": "en:Old Time Pottery",
       "name": "Old Time Pottery",
+      "shop": "houseware"
+    }
+  },
+  "shop/houseware|Sur La Table": {
+    "nocount": true,
+    "tags": {
+      "brand": "Sur La Table",
+      "brand:wikidata": "Q7645220",
+      "brand:wikipedia": "en:Sur La Table",
+      "name": "Sur La Table",
+      "shop": "houseware"
+    }
+  },
+  "shop/houseware|Tuesday Morning": {
+    "match": [
+      "shop/convenience|Tuesday Morning",
+      "shop/department_store|Tuesday Morning",
+      "shop/gift|Tuesday Morning",
+      "shop/variety_store|Tuesday Morninig"
+    ],
+    "nocount": true,
+    "tags": {
+      "brand": "Tuesday Morning",
+      "brand:wikidata": "Q7851426",
+      "brand:wikipedia": "en:Tuesday Morning",
+      "name": "Tuesday Morning",
       "shop": "houseware"
     }
   },
@@ -27788,6 +27958,17 @@
       "shop": "mobile_phone"
     }
   },
+  "shop/mobile_phone|U.S. Cellular": {
+    "match": ["shop/mobile_phone|US Cellular"],
+    "nocount": true,
+    "tags": {
+      "brand": "U.S. Cellular",
+      "brand:wikidata": "Q2466256",
+      "brand:wikipedia": "en:U.S. Cellular",
+      "name": "U.S. Cellular",
+      "shop": "mobile_phone"
+    }
+  },
   "shop/mobile_phone|Verizon Wireless": {
     "count": 780,
     "match": ["shop/mobile_phone|Verizon"],
@@ -28234,6 +28415,16 @@
       "brand:wikidata": "Q4808595",
       "brand:wikipedia": "en:GNC (store)",
       "name": "GNC",
+      "shop": "nutrition_supplements"
+    }
+  },
+  "shop/nutrition_supplements|The Vitamin Shoppe": {
+    "nocount": true,
+    "tags": {
+      "brand": "The Vitamin Shoppe",
+      "brand:wikidata": "Q7772938",
+      "brand:wikipedia": "en:The Vitamin Shoppe",
+      "name": "The Vitamin Shoppe",
       "shop": "nutrition_supplements"
     }
   },
@@ -28763,6 +28954,16 @@
       "brand:wikidata": "Q875796",
       "brand:wikipedia": "en:Fressnapf",
       "name": "Maxi Zoo",
+      "shop": "pet"
+    }
+  },
+  "shop/pet|Mud Bay": {
+    "nocount": true,
+    "tags": {
+      "brand": "Mud Bay",
+      "brand:wikidata": "Q30324179",
+      "brand:wikipedia": "en:Mud Bay pet store",
+      "name": "Mud Bay",
       "shop": "pet"
     }
   },
@@ -29396,6 +29597,16 @@
       "shop": "sports"
     }
   },
+  "shop/sports|Bass Pro Shops": {
+    "nocount": true,
+    "tags": {
+      "brand": "Bass Pro Shops",
+      "brand:wikidata": "Q4867953",
+      "brand:wikipedia": "en:Bass Pro Shops",
+      "name": "Bass Pro Shops",
+      "shop": "sports"
+    }
+  },
   "shop/sports|Big 5 Sporting Goods": {
     "count": 121,
     "tags": {
@@ -29403,6 +29614,17 @@
       "brand:wikidata": "Q4904902",
       "brand:wikipedia": "en:Big 5 Sporting Goods",
       "name": "Big 5 Sporting Goods",
+      "shop": "sports"
+    }
+  },
+  "shop/sports|Cabela's": {
+    "match": ["shop/sports|Cabelas"],
+    "nocount": true,
+    "tags": {
+      "brand": "Cabela's",
+      "brand:wikidata": "Q2793714",
+      "brand:wikipedia": "en:Cabela's",
+      "name": "Cabela's",
       "shop": "sports"
     }
   },
@@ -29624,6 +29846,16 @@
       "brand": "Pagro",
       "brand:wikidata": "Q57550022",
       "name": "Pagro",
+      "shop": "stationery"
+    }
+  },
+  "shop/stationery|Paper Source": {
+    "nocount": true,
+    "tags": {
+      "brand": "Paper Source",
+      "brand:wikidata": "Q25000269",
+      "brand:wikipedia": "en:Paper Source",
+      "name": "Paper Source",
       "shop": "stationery"
     }
   },
@@ -30517,8 +30749,13 @@
   },
   "shop/supermarket|Despar": {
     "count": 224,
+    "countryCodes": ["it"],
+    "match": [
+      "shop/supermarket|DESPAR",
+      "shop/supermarket|deSPAR"
+    ],
     "tags": {
-      "brand": "Despar",
+      "brand": "Spar",
       "brand:wikidata": "Q610492",
       "brand:wikipedia": "en:Spar (retailer)",
       "name": "Despar",
@@ -32118,6 +32355,17 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Pick 'n Save": {
+    "match": ["shop/supermarket|Pick n Save"],
+    "nocount": true,
+    "tags": {
+      "brand": "Pick 'n Save",
+      "brand:wikidata": "Q7371288",
+      "brand:wikipedia": "en:Roundy's",
+      "name": "Pick 'n Save",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|Pick n Pay": {
     "count": 200,
     "match": ["shop/supermarket|Pick 'n Pay"],
@@ -32601,17 +32849,25 @@
   "shop/supermarket|Spar": {
     "count": 2995,
     "match": ["shop/supermarket|SPAR"],
-    "nomatch": ["shop/convenience|Spar Express"],
+    "nomatch": [
+      "shop/convenience|Spar",
+      "shop/convenience|Spar Express"
+    ],
     "tags": {
       "brand": "Spar",
+      "brand:wikidata": "Q610492",
+      "brand:wikipedia": "en:Spar (retailer)",
       "name": "Spar",
       "shop": "supermarket"
     }
   },
   "shop/supermarket|Społem": {
     "count": 137,
+    "nomatch": ["shop/convenience|Społem"],
     "tags": {
       "brand": "Społem",
+      "brand:wikidata": "Q11826043",
+      "brand:wikipedia": "pl:Powszechna Spółdzielnia Spożywców „Społem”",
       "name": "Społem",
       "shop": "supermarket"
     }
@@ -34693,6 +34949,17 @@
       "brand:wikipedia": "en:Swatch",
       "name": "Swatch",
       "shop": "watches"
+    }
+  },
+  "shop/wholesale|BJ's Wholesale Club": {
+    "nocount": true,
+    "tags": {
+      "brand": "BJ's Wholesale Club",
+      "brand:wikidata": "Q4835754",
+      "brand:wikipedia": "en:BJ's Wholesale Club",
+      "name": "BJ's Wholesale Club",
+      "shop": "wholesale",
+      "operator": "BJ's Wholesale Club"
     }
   },
   "shop/wholesale|Costco": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -25253,6 +25253,20 @@
       "shop": "doityourself"
     }
   },
+  "shop/doityourself|Home Building Centre": {
+    "countryCodes": ["ca"],
+    "nocount": true,
+    "nomatch": [
+      "shop/hardware|Home Hardware Building Centre"
+    ],
+    "tags": {
+      "brand": "Home Hardware",
+      "brand:wikidata": "Q3139611",
+      "brand:wikipedia": "en:Home Hardware",
+      "name": "Home Building Centre",
+      "shop": "doityourself"
+    }
+  },
   "shop/doityourself|Home Depot": {
     "count": 1173,
     "match": [
@@ -25267,11 +25281,16 @@
       "shop": "doityourself"
     }
   },
-  "shop/doityourself|Home Hardware": {
-    "count": 193,
+  "shop/doityourself|Home Hardware Building Centre": {
+    "countryCodes": ["ca"],
+    "match": ["shop/doityourself|Home Hardware"],
+    "nocount": true,
+    "nomatch": ["shop/hardware|Home Hardware"],
     "tags": {
       "brand": "Home Hardware",
-      "name": "Home Hardware",
+      "brand:wikidata": "Q3139611",
+      "brand:wikipedia": "en:Home Hardware",
+      "name": "Home Hardware Building Centre",
       "shop": "doityourself"
     }
   },
@@ -26927,8 +26946,14 @@
   },
   "shop/hardware|Home Hardware": {
     "count": 123,
+    "countryCodes": ["ca"],
+    "nomatch": [
+      "shop/doityourself|Home Hardware Building Centre"
+    ],
     "tags": {
       "brand": "Home Hardware",
+      "brand:wikidata": "Q3139611",
+      "brand:wikipedia": "en:Home Hardware",
       "name": "Home Hardware",
       "shop": "hardware"
     }


### PR DESCRIPTION
As documented [here](https://www.homehardware.ca/about-home-hardware), there are three different types of Home Hardware stores (not counting Home Furniture), one of which is a shop=hardware, one of which is a shop=doityourself, and one is both.  I'm adding the first one as shop=hardware, and the later two as shop=doityourself.  Similar to Walmart (shop=department_store), Walmart Neighborhood Market (shop=supermarket), and Walmart Supercentre (both).