### PR TITLE
Add brand:wikidata and brand:wikipedia for Canadian gas stations

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -9586,6 +9586,7 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Crevier",
+      "brand:wikidata": "Q61743451",
       "name": "Crevier"
     }
   },
@@ -9784,9 +9785,12 @@
   },
   "amenity/fuel|Fas Gas": {
     "count": 159,
+    "match": ["amenity/fuel|Fas Gas Plus"],
     "tags": {
       "amenity": "fuel",
       "brand": "Fas Gas",
+      "brand:wikidata": "Q61743505",
+      "brand:wikipedia": "en:Parkland Fuel",
       "name": "Fas Gas"
     }
   },
@@ -9967,6 +9971,7 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Harnois",
+      "brand:wikidata": "Q61743558",
       "name": "Harnois"
     }
   },
@@ -10304,6 +10309,7 @@
     "tags": {
       "amenity": "fuel",
       "brand": "MacEwen",
+      "brand:wikidata": "Q61740335",
       "name": "MacEwen"
     }
   },
@@ -10629,6 +10635,8 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Petro-Canada",
+      "brand:wikidata": "Q1208279",
+      "brand:wikipedia": "en:Petro-Canada",
       "name": "Petro-Canada"
     }
   },
@@ -10637,6 +10645,7 @@
     "tags": {
       "amenity": "fuel",
       "brand": "Petro-T",
+      "brand:wikidata": "Q61743540",
       "name": "Petro-T"
     }
   },
@@ -22616,6 +22625,8 @@
     "nomatch": ["amenity/fuel|Petro-Canada"],
     "tags": {
       "brand": "Petro-Canada",
+      "brand:wikidata": "Q1208279",
+      "brand:wikipedia": "en:Petro-Canada",
       "name": "Petro-Canada",
       "shop": "convenience"
     }


### PR DESCRIPTION
Some gas stations don't have Wikipedia articles, so I created Wikidata items for them and added them.  Closes #531, closes #516, closes #499, closes #484, and closes #475.