### PR TITLE
Add new banks and supermarkets now present in OSM

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -7336,7 +7336,8 @@
     "match": [
       "amenity/fast_food|DQ",
       "amenity/ice_cream|Dairy Queen",
-      "amenity/restaurant|Dairy Queen"
+      "amenity/restaurant|Dairy Queen",
+      "amenity/fast_food|DQ Grill & Chill"
     ],
     "tags": {
       "amenity": "fast_food",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -3736,8 +3736,18 @@
       "name": "Seylan Bank"
     }
   },
+  "amenity/bank|Siam Commercial Bank": {
+    "count": 53,
+    "tags": {
+      "amenity": "bank",
+      "brand": "Siam Commercial Bank",
+      "brand:wikidata": "Q2038986",
+      "brand:wikipedia": "en:Siam Commercial Bank",
+      "name": "Siam Commercial Bank"
+    }
+  },
   "amenity/bank|Sicoob": {
-    "count": 82,
+    "count": 96,
     "tags": {
       "amenity": "bank",
       "brand": "Sicoob",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -43,7 +43,9 @@
     }
   },
   "amenity/bank|ANZ": {
-    "count": 386,
+    "count": 397,
+    "countryCodes": ["au", "nz"],
+    "match": ["amenity/bank|ANZ Bank"],
     "tags": {
       "amenity": "bank",
       "brand": "ANZ",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -1139,8 +1139,15 @@
       "name": "Banco de Desarrollo Banrural"
     }
   },
+  "amenity/bank|Banco de Fomento Angola (BFA)": {
+    "count": 65,
+    "tags": {
+      "amenity": "bank",
+      "name": "Banco de Fomento Angola (BFA)"
+    }
+  },
   "amenity/bank|Banco de Occidente": {
-    "count": 120,
+    "count": 125,
     "tags": {
       "amenity": "bank",
       "brand": "Banco de Occidente",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -3800,8 +3800,18 @@
       "name": "Sonali Bank"
     }
   },
+  "amenity/bank|South Indian Bank": {
+    "count": 58,
+    "tags": {
+      "amenity": "bank",
+      "brand": "South Indian Bank",
+      "brand:wikipedia": "en:South Indian Bank",
+      "brand:wikidata": "Q2044973",
+      "name": "South Indian Bank"
+    }
+  },
   "amenity/bank|Sparda-Bank": {
-    "count": 268,
+    "count": 270,
     "tags": {
       "amenity": "bank",
       "brand": "Sparda-Bank",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -4642,7 +4642,8 @@
     }
   },
   "amenity/bank|Открытие": {
-    "count": 119,
+    "count": 131,
+    "match": ["amenity/bank|Банк \"Открытие\""],
     "tags": {
       "amenity": "bank",
       "brand": "Открытие",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -33355,10 +33355,20 @@
     }
   },
   "shop/supermarket|Volg": {
-    "count": 244,
+    "count": 248,
     "tags": {
       "brand": "Volg",
       "name": "Volg",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|Vomar": {
+    "count": 51,
+    "tags": {
+      "brand": "Vomar",
+      "brand:wikidata": "Q3202837",
+      "brand:wikipedia": "nl:Vomar",
+      "name": "Vomar",
       "shop": "supermarket"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -34764,8 +34764,16 @@
       "shop": "variety_store"
     }
   },
+  "shop/variety_store|Centrakor": {
+    "count": 56,
+    "countryCodes": ["fr"],
+    "tags": {
+      "name": "Centrakor",
+      "shop": "variety_store"
+    }
+  },
   "shop/variety_store|Dollar General": {
-    "count": 461,
+    "count": 635,
     "match": [
       "shop/convenience|Dollar General",
       "shop/department_store|Dollar General",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -4243,14 +4243,21 @@
   },
   "amenity/bank|Volksbank": {
     "count": 2584,
-    "match": [
-      "amenity/bank|Volksbank Köln Bonn eG"
-    ],
     "tags": {
       "amenity": "bank",
       "brand": "Volksbank",
-      "brand:wikidata": "Q41680844",
+      "brand:wikidata": "Q695110",
       "brand:wikipedia": "en:Volksbank",
+      "name": "Volksbank"
+    }
+  },
+  "amenity/bank|Volksbank Köln Bonn eG": {
+    "nocount": true,
+    "tags": {
+      "amenity": "bank",
+      "brand": "Volksbank Köln Bonn eG",
+      "brand:wikidata": "Q41680844",
+      "brand:wikipedia": "de:Volksbank Köln Bonn",
       "name": "Volksbank"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -1357,8 +1357,19 @@
       "name": "Bank Muamalat"
     }
   },
+  "amenity/bank|Bank Pekao": {
+    "count": 53,
+    "countryCodes": ["pl"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Bank Pekao",
+      "brand:wikidata": "Q806642",
+      "brand:wikipedia": "en:Bank Pekao",
+      "name": "Bank Pekao"
+    }
+  },
   "amenity/bank|Bank Rakyat": {
-    "count": 52,
+    "count": 55,
     "tags": {
       "amenity": "bank",
       "brand": "Bank Rakyat",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -43,7 +43,7 @@
     }
   },
   "amenity/bank|ANZ": {
-    "count": 397,
+    "count": 386,
     "countryCodes": ["au", "nz"],
     "match": ["amenity/bank|ANZ Bank"],
     "tags": {
@@ -87,7 +87,7 @@
     }
   },
   "amenity/bank|Access Bank": {
-    "count": 51,
+    "nocount": true,
     "tags": {
       "amenity": "bank",
       "brand:wikidata": "Q4672420",
@@ -610,7 +610,7 @@
     }
   },
   "amenity/bank|BPI": {
-    "count": 617,
+    "count": 595,
     "match": [
       "amenity/bank|BPI Family Savings Bank",
       "amenity/bank|Bank of the Philippine Islands"
@@ -1141,14 +1141,14 @@
     }
   },
   "amenity/bank|Banco de Fomento Angola (BFA)": {
-    "count": 65,
+    "nocount": true,
     "tags": {
       "amenity": "bank",
       "name": "Banco de Fomento Angola (BFA)"
     }
   },
   "amenity/bank|Banco de Occidente": {
-    "count": 125,
+    "count": 120,
     "tags": {
       "amenity": "bank",
       "brand": "Banco de Occidente",
@@ -1358,8 +1358,8 @@
     }
   },
   "amenity/bank|Bank Pekao": {
-    "count": 53,
     "countryCodes": ["pl"],
+    "nocount": true,
     "tags": {
       "amenity": "bank",
       "brand": "Bank Pekao",
@@ -1369,7 +1369,7 @@
     }
   },
   "amenity/bank|Bank Rakyat": {
-    "count": 55,
+    "count": 52,
     "tags": {
       "amenity": "bank",
       "brand": "Bank Rakyat",
@@ -2933,7 +2933,7 @@
     }
   },
   "amenity/bank|Kotak Mahindra Bank": {
-    "count": 54,
+    "nocount": true,
     "tags": {
       "amenity": "bank",
       "brand:wikidata": "Q2040404",
@@ -2942,7 +2942,7 @@
     }
   },
   "amenity/bank|Kreissparkasse": {
-    "count": 592,
+    "count": 594,
     "match": ["amenity/bank|Kreissparkasse Köln"],
     "tags": {
       "amenity": "bank",
@@ -3737,7 +3737,7 @@
     }
   },
   "amenity/bank|Siam Commercial Bank": {
-    "count": 53,
+    "nocount": true,
     "tags": {
       "amenity": "bank",
       "brand": "Siam Commercial Bank",
@@ -3747,7 +3747,7 @@
     }
   },
   "amenity/bank|Sicoob": {
-    "count": 96,
+    "count": 82,
     "tags": {
       "amenity": "bank",
       "brand": "Sicoob",
@@ -3801,7 +3801,7 @@
     }
   },
   "amenity/bank|South Indian Bank": {
-    "count": 58,
+    "nocount": true,
     "tags": {
       "amenity": "bank",
       "brand": "South Indian Bank",
@@ -3811,7 +3811,7 @@
     }
   },
   "amenity/bank|Sparda-Bank": {
-    "count": 270,
+    "count": 268,
     "tags": {
       "amenity": "bank",
       "brand": "Sparda-Bank",
@@ -4242,7 +4242,7 @@
     }
   },
   "amenity/bank|Volksbank": {
-    "count": 2531,
+    "count": 2584,
     "match": [
       "amenity/bank|Volksbank Köln Bonn eG"
     ],
@@ -4255,7 +4255,7 @@
     }
   },
   "amenity/bank|Volksbank Raiffeisenbank": {
-    "count": 72,
+    "count": 74,
     "match": [
       "amenity/bank|Volks- und Raiffeisenbank"
     ],
@@ -4642,7 +4642,7 @@
     }
   },
   "amenity/bank|Открытие": {
-    "count": 131,
+    "count": 119,
     "match": ["amenity/bank|Банк \"Открытие\""],
     "tags": {
       "amenity": "bank",
@@ -4945,7 +4945,7 @@
     }
   },
   "amenity/bank|بانک انصار": {
-    "count": 212,
+    "count": 174,
     "tags": {
       "amenity": "bank",
       "brand": "بانک انصار",
@@ -4953,7 +4953,7 @@
     }
   },
   "amenity/bank|بانک ایران زمین": {
-    "count": 54,
+    "nocount": true,
     "tags": {
       "amenity": "bank",
       "brand": "بانک ایران زمین",
@@ -4963,7 +4963,7 @@
     }
   },
   "amenity/bank|بانک تجارت": {
-    "count": 574,
+    "count": 518,
     "tags": {
       "amenity": "bank",
       "brand": "بانک تجارت",
@@ -5318,7 +5318,7 @@
     }
   },
   "amenity/bank|中信银行": {
-    "count": 53,
+    "nocount": true,
     "tags": {
       "amenity": "bank",
       "brand": "中信银行",
@@ -5329,7 +5329,7 @@
     }
   },
   "amenity/bank|中国农业银行": {
-    "count": 267,
+    "count": 248,
     "tags": {
       "amenity": "bank",
       "brand": "中国农业银行",
@@ -7419,9 +7419,9 @@
     "count": 1748,
     "match": [
       "amenity/fast_food|DQ",
+      "amenity/fast_food|DQ Grill & Chill",
       "amenity/ice_cream|Dairy Queen",
-      "amenity/restaurant|Dairy Queen",
-      "amenity/fast_food|DQ Grill & Chill"
+      "amenity/restaurant|Dairy Queen"
     ],
     "tags": {
       "amenity": "fast_food",
@@ -33285,8 +33285,8 @@
     }
   },
   "shop/supermarket|Tuodì": {
-    "count": 51,
     "countryCodes": ["it"],
+    "nocount": true,
     "tags": {
       "brand": "Tuodì",
       "brand:wikidata": "Q3706995",
@@ -33296,7 +33296,7 @@
     }
   },
   "shop/supermarket|U Express": {
-    "count": 150,
+    "count": 141,
     "countryCodes": ["fr"],
     "nomatch": [
       "amenity/fuel|Super U",
@@ -33366,7 +33366,7 @@
     }
   },
   "shop/supermarket|Volg": {
-    "count": 248,
+    "count": 244,
     "tags": {
       "brand": "Volg",
       "name": "Volg",
@@ -33374,7 +33374,7 @@
     }
   },
   "shop/supermarket|Vomar": {
-    "count": 51,
+    "nocount": true,
     "tags": {
       "brand": "Vomar",
       "brand:wikidata": "Q3202837",
@@ -34786,15 +34786,15 @@
     }
   },
   "shop/variety_store|Centrakor": {
-    "count": 56,
     "countryCodes": ["fr"],
+    "nocount": true,
     "tags": {
       "name": "Centrakor",
       "shop": "variety_store"
     }
   },
   "shop/variety_store|Dollar General": {
-    "count": 635,
+    "count": 461,
     "match": [
       "shop/convenience|Dollar General",
       "shop/department_store|Dollar General",
@@ -34962,7 +34962,7 @@
     }
   },
   "shop/variety_store|Tokmanni": {
-    "count": 93,
+    "nocount": true,
     "tags": {
       "name": "Tokmanni",
       "brand": "Tokmanni",
@@ -34972,7 +34972,7 @@
     }
   },
   "shop/variety_store|Wilko": {
-    "count": 77,
+    "count": 68,
     "tags": {
       "brand": "Wilko",
       "brand:wikidata": "Q8002536",
@@ -35495,7 +35495,7 @@
     }
   },
   "tourism/hotel|La Quinta": {
-    "count": 84,
+    "count": 77,
     "match": [
       "tourism/hotel|La Quinta Inn & Suites",
       "tourism/hotel|La Quinta Inns & Suites"

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -610,9 +610,10 @@
     }
   },
   "amenity/bank|BPI": {
-    "count": 595,
+    "count": 617,
     "match": [
-      "amenity/bank|BPI Family Savings Bank"
+      "amenity/bank|BPI Family Savings Bank",
+      "amenity/bank|Bank of the Philippine Islands"
     ],
     "tags": {
       "amenity": "bank",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -34932,8 +34932,18 @@
       "shop": "variety_store"
     }
   },
+  "shop/variety_store|Tokmanni": {
+    "count": 93,
+    "tags": {
+      "name": "Tokmanni",
+      "brand": "Tokmanni",
+      "brand:wikidata": "Q13423470",
+      "brand:wikipedia": "fi:Tokmanni",
+      "shop": "variety_store"
+    }
+  },
   "shop/variety_store|Wilko": {
-    "count": 68,
+    "count": 77,
     "tags": {
       "brand": "Wilko",
       "brand:wikidata": "Q8002536",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -33284,8 +33284,19 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Tuodì": {
+    "count": 51,
+    "countryCodes": ["it"],
+    "tags": {
+      "brand": "Tuodì",
+      "brand:wikidata": "Q3706995",
+      "brand:wikipedia": "it:Tuodì",
+      "name": "Tuodì",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|U Express": {
-    "count": 141,
+    "count": 150,
     "countryCodes": ["fr"],
     "nomatch": [
       "amenity/fuel|Super U",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -2920,8 +2920,17 @@
       "name": "Komerční banka"
     }
   },
+  "amenity/bank|Kotak Mahindra Bank": {
+    "count": 54,
+    "tags": {
+      "amenity": "bank",
+      "brand:wikidata": "Q2040404",
+      "brand:wikipedia": "en:Kotak Mahindra Bank",
+      "name": "Kotak Mahindra Bank"
+    }
+  },
   "amenity/bank|Kreissparkasse": {
-    "count": 594,
+    "count": 592,
     "match": ["amenity/bank|Kreissparkasse Köln"],
     "tags": {
       "amenity": "bank",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -86,6 +86,15 @@
       "name": "AXA"
     }
   },
+  "amenity/bank|Access Bank": {
+    "count": 51,
+    "tags": {
+      "amenity": "bank",
+      "brand:wikidata": "Q4672420",
+      "brand:wikipedia": "en:Access Bank Group",
+      "name": "Access Bank"
+    }
+  },
   "amenity/bank|Agrani Bank Limited অগ্রণী ব্যাংক লিমিটেড": {
     "count": 60,
     "countryCodes": ["bd"],

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -35456,8 +35456,9 @@
     }
   },
   "tourism/hotel|La Quinta": {
-    "count": 77,
+    "count": 84,
     "match": [
+      "tourism/hotel|La Quinta Inn & Suites",
       "tourism/hotel|La Quinta Inns & Suites"
     ],
     "tags": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -4945,15 +4945,25 @@
     }
   },
   "amenity/bank|بانک انصار": {
-    "count": 174,
+    "count": 212,
     "tags": {
       "amenity": "bank",
       "brand": "بانک انصار",
       "name": "بانک انصار"
     }
   },
+  "amenity/bank|بانک ایران زمین": {
+    "count": 54,
+    "tags": {
+      "amenity": "bank",
+      "brand": "بانک ایران زمین",
+      "brand:wikidata": "Q5934423",
+      "brand:wikipedia": "en:Iran Zamin Bank",
+      "name": "بانک ایران زمین"
+    }
+  },
   "amenity/bank|بانک تجارت": {
-    "count": 518,
+    "count": 574,
     "tags": {
       "amenity": "bank",
       "brand": "بانک تجارت",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -5317,8 +5317,19 @@
       "name:en": "Shanghai Commercial and Savings Bank"
     }
   },
+  "amenity/bank|中信银行": {
+    "count": 53,
+    "tags": {
+      "amenity": "bank",
+      "brand": "中信银行",
+      "brand:en": "China CITIC Bank",
+      "brand:wikidata": "Q38960",
+      "brand:wikipedia": "en:China CITIC Bank",
+      "name": "中信银行"
+    }
+  },
   "amenity/bank|中国农业银行": {
-    "count": 248,
+    "count": 267,
     "tags": {
       "amenity": "bank",
       "brand": "中国农业银行",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -4242,17 +4242,20 @@
     }
   },
   "amenity/bank|Volksbank": {
-    "count": 2584,
+    "count": 2531,
+    "match": [
+      "amenity/bank|Volksbank Köln Bonn eG"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "Volksbank",
-      "brand:wikidata": "Q695110",
+      "brand:wikidata": "Q41680844",
       "brand:wikipedia": "en:Volksbank",
       "name": "Volksbank"
     }
   },
   "amenity/bank|Volksbank Raiffeisenbank": {
-    "count": 74,
+    "count": 72,
     "match": [
       "amenity/bank|Volks- und Raiffeisenbank"
     ],


### PR DESCRIPTION
After updating the allnames file from a new planet file a number of new banks and supermarkets popped up. I'm going to begin slowly adding them as I do research and add Wikipedia / Wikidata entries. I also added new matches that will prevent duplicate entries with that new allnames data.