### PR TITLE
Add Freshii restaurant

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -14846,6 +14846,18 @@
       "name": "Frankie & Benny's"
     }
   },
+  "amenity/restaurant|Freshii": {
+    "match": ["amenity/fast_food|Freshii"],
+    "nocount": true,
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "Freshii",
+      "brand:wikidata": "Q5503051",
+      "brand:wikipedia": "en:Freshii",
+      "cuisine": "salad",
+      "name": "Freshii"
+    }
+  },
   "amenity/restaurant|Friendly's": {
     "count": 120,
     "countryCodes": ["us"],

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -14850,7 +14850,7 @@
     "match": ["amenity/fast_food|Freshii"],
     "nocount": true,
     "tags": {
-      "amenity": "fast_food",
+      "amenity": "restaurant",
       "brand": "Freshii",
       "brand:wikidata": "Q5503051",
       "brand:wikipedia": "en:Freshii",


### PR DESCRIPTION
This is commonly found on OSM as either a restaurant or fast_food. Based
on the wikipedia page it's actually fast casual dining which we map to
restaurant based on other fast casual restaurants.

Signed-off-by: Tim Smith <tsmith@chef.io>