### PR TITLE
Add match for Express Oil Change & Tire Engineers

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -34794,6 +34794,9 @@
   },
   "shop/tyres|Express Oil Change & Tire Engineers": {
     "count": 100,
+    "match": [
+      "shop/tires|Express Oil Change & Tire Engineers"
+    ],
     "tags": {
       "brand": "Express Oil Change & Tire Engineers",
       "brand:wikidata": "Q39057654",


### PR DESCRIPTION
We use shop/tyres, but this same store has popped up with shop/tires.

Signed-off-by: Tim Smith <tsmith@chef.io>