### PR TITLE
Add Hyatt hotels

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -35422,6 +35422,17 @@
       "tourism": "hotel"
     }
   },
+  "tourism/hotel|Grand Hyatt": {
+    "nocount": true,
+    "tags": {
+      "brand": "Grand Hyatt",
+      "brand:wikidata": "Q1425063",
+      "brand:wikipedia": "en:Hyatt",
+      "name": "Grand Hyatt",
+      "operator": "Hyatt",
+      "tourism": "hotel"
+    }
+  },
   "tourism/hotel|Hampton Inn": {
     "count": 445,
     "match": [
@@ -35496,6 +35507,61 @@
       "brand:wikidata": "Q5890701",
       "brand:wikipedia": "en:Homewood Suites by Hilton",
       "name": "Homewood Suites",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|Hyatt": {
+    "nocount": true,
+    "tags": {
+      "brand": "Hyatt",
+      "brand:wikidata": "Q1425063",
+      "brand:wikipedia": "en:Hyatt",
+      "name": "Hyatt",
+      "operator": "Hyatt",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|Hyatt Centric": {
+    "nocount": true,
+    "tags": {
+      "brand": "Hyatt Centric",
+      "brand:wikidata": "Q1425063",
+      "brand:wikipedia": "en:Hyatt",
+      "name": "Hyatt Centric",
+      "operator": "Hyatt",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|Hyatt House": {
+    "nocount": true,
+    "tags": {
+      "brand": "Hyatt House",
+      "brand:wikidata": "Q1425063",
+      "brand:wikipedia": "en:Hyatt",
+      "name": "Hyatt House",
+      "operator": "Hyatt",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|Hyatt Place": {
+    "nocount": true,
+    "tags": {
+      "brand": "Hyatt Place",
+      "brand:wikidata": "Q1425063",
+      "brand:wikipedia": "en:Hyatt",
+      "name": "Hyatt Place",
+      "operator": "Hyatt",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|Hyatt Regency": {
+    "nocount": true,
+    "tags": {
+      "brand": "Hyatt Regency",
+      "brand:wikidata": "Q1425063",
+      "brand:wikipedia": "en:Hyatt",
+      "name": "Hyatt Regency",
+      "operator": "Hyatt",
       "tourism": "hotel"
     }
   },
@@ -35595,6 +35661,17 @@
       "brand:wikidata": "Q420545",
       "brand:wikipedia": "en:Novotel",
       "name": "Novotel",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|Park Hyatt": {
+    "nocount": true,
+    "tags": {
+      "brand": "Park Hyatt",
+      "brand:wikidata": "Q1425063",
+      "brand:wikipedia": "en:Hyatt",
+      "name": "Park Hyatt",
+      "operator": "Hyatt",
       "tourism": "hotel"
     }
   },


### PR DESCRIPTION
Adds the various Hyatt brand hotels with the operator of Hyatt. The Wikipedia page covers each of these brands.

Signed-off-by: Tim Smith <tsmith@chef.io>