### PR TITLE
Add the Renaissance Hotels brand

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -35660,6 +35660,18 @@
       "tourism": "hotel"
     }
   },
+  "tourism/hotel|Renaissance Hotel": {
+    "nocount": true,
+    "tags": {
+      "brand": "Renaissance Hotels",
+      "brand:wikidata": "Q2143252",
+      "brand:wikipedia": "en:Renaissance Hotels",
+      "operator": "Marriott International",
+      "operator:wikidata": "Q1141173",
+      "operator:wikipedia": "en:Marriott International",
+      "tourism": "hotel"
+    }
+  },
   "tourism/hotel|Residence Inn": {
     "count": 120,
     "tags": {


### PR DESCRIPTION
I left out the name here since they are all uniquely named based on the
city they're in, but this will be useful to get the proper brand /
operator tags in place.

@bhousel Will leaving out the name tag here preserve the unique name while applying all the other tags?

Signed-off-by: Tim Smith <tsmith@chef.io>