### PR TITLE
Filter out Księgarnia

### DIFF
--- a/config/filters.json
+++ b/config/filters.json
@@ -148,6 +148,7 @@
         "^kebab(ai|\\shouse)?$",
         "^kitchen$",
         "^kisbolt$",
+        "^księgarnia$",
         "^kwiaciarnia$",
         "^ladestation$",
         "^lékárna$",


### PR DESCRIPTION
This shows up 51 times in the new planet data and is Polish for bookstore. Adding the filter now so can update the allnames file.

Signed-off-by: Tim Smith <tsmith@chef.io>