### PR TITLE
Add matches for Wingstop

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -15752,6 +15752,11 @@
   },
   "amenity/restaurant|Wingstop": {
     "count": 51,
+    "match": [
+      "amenity/fast_food|Wing Stop",
+      "amenity/fast_food|Wingstop",
+      "amenity/restaurant|Wing Stop"
+    ],
     "tags": {
       "amenity": "restaurant",
       "brand": "Wingstop",


### PR DESCRIPTION
There are actually more mis-tags of this than the correct usage. I
created a Maproulette challenge to clean it up, but we should make sure
that we correct this in the future with a proper match.

https://maproulette.org/mr3/challenge/3678/

Signed-off-by: Tim Smith <tsmith@chef.io>