### PR TITLE
Add missing cuisine tags to restaurants

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -7196,6 +7196,7 @@
       "brand": "Booster Juice",
       "brand:wikidata": "Q4943796",
       "brand:wikipedia": "en:Booster Juice",
+      "cuisine": "juice",
       "name": "Booster Juice"
     }
   },
@@ -7207,6 +7208,7 @@
       "brand": "Boston Market",
       "brand:wikidata": "Q603617",
       "brand:wikipedia": "en:Boston Market",
+      "cuisine": "american",
       "name": "Boston Market"
     }
   },
@@ -7218,6 +7220,7 @@
       "brand": "Braum's",
       "brand:wikidata": "Q4958263",
       "brand:wikipedia": "en:Braum's",
+      "cuisine": "american",
       "name": "Braum's"
     }
   },
@@ -14534,6 +14537,7 @@
       "brand": "Big Boy",
       "brand:wikidata": "Q4386779",
       "brand:wikipedia": "en:Big Boy Restaurants",
+      "cuisine": "burger",
       "name": "Big Boy"
     }
   },


### PR DESCRIPTION
These were throwing errors in the build. Based off their menus and wikipedia entries.

Signed-off-by: Tim Smith <tsmith@chef.io>