### PR TITLE
Add wiki links to additional banks

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -2506,6 +2506,8 @@
     "tags": {
       "amenity": "bank",
       "brand": "First National Bank",
+      "brand:wikidata": "Q5426765",
+      "brand:wikipedia": "en:F.N.B. Corporation",
       "name": "First National Bank"
     }
   },
@@ -3087,6 +3089,8 @@
     "tags": {
       "amenity": "bank",
       "brand": "Macro",
+      "brand:wikidata": "Q2335199",
+      "brand:wikipedia": "en:Banco Macro",
       "name": "Macro"
     }
   },
@@ -3115,6 +3119,8 @@
     "tags": {
       "amenity": "bank",
       "brand": "Mercantil",
+      "brand:wikidata": "Q6818004",
+      "brand:wikipedia": "en:Mercantil Servicios Financieros",
       "name": "Mercantil"
     }
   },


### PR DESCRIPTION
The only one here that might be a bit controversial is FNB corporation. There are a few banks in the US that use the First National Bank name, but they append their local to the name so there's First National Bank of Omaha and such. This seems to be the only actual FNB as a full name and it's quite common through the east coast according to their website. Long term it might be a good idea to add First National of Omaha and First National of Texas so that folks don't attempt to use this tag when that's what they really want. Based on overpass queries we have a bit of that to cleanup already.

Signed-off-by: Tim Smith <tsmith@chef.io>