### PR TITLE
Add Claim Jumper restaurant

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -14700,6 +14700,20 @@
       "name": "Cici's Pizza"
     }
   },
+  "amenity/restaurant|Claim Jumper": {
+    "nocount": true,
+    "tags": {
+      "amenity": "restaurant",
+      "brand": "Claim Jumper",
+      "brand:wikidata": "Q5125081",
+      "brand:wikipedia": "en:Claim Jumper",
+      "cuisine": "american",
+      "operator": "Landry's",
+      "operator:wikidata": "Q3217105",
+      "operator:wikipedia": "en:Landry's, Inc.",
+      "name": "Claim Jumper"
+    }
+  },
   "amenity/restaurant|Comedor": {
     "count": 98,
     "tags": {


### PR DESCRIPTION
Operated by Landry's which actually runs a few other restaurants we have in OSM.

Signed-off-by: Tim Smith <tsmith@chef.io>