### PR TITLE
Add a match to PacSun for Pac Sun

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -20929,6 +20929,7 @@
     }
   },
   "shop/clothes|PacSun": {
+    "match": ["shop/clothes|Pac Sun"],
     "nocount": true,
     "tags": {
       "brand": "PacSun",


### PR DESCRIPTION
It's mistagged a lot as two words

Signed-off-by: Tim Smith <tsmith@chef.io>