### PR TITLE
Add wikipedia entry for Only store

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -20868,7 +20868,10 @@
     "count": 137,
     "tags": {
       "brand": "Only",
+      "brand:wikidata": "Q61799370",
       "name": "Only",
+      "operator:wikidata": "Q28172489",
+      "operator:wikipedia": "Bestseller (company)",
       "shop": "clothes"
     }
   },


### PR DESCRIPTION
It's a European Denim brand. I created the wikidata page which is basically empty since there wasn't one.

Signed-off-by: Tim Smith <tsmith@chef.io>