### PR TITLE
Add wiki entries for evgo

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -6962,7 +6962,10 @@
     "tags": {
       "amenity": "charging_station",
       "brand": "eVgo",
-      "name": "eVgo"
+      "brand:wikidata": "Q61803820",
+      "name": "eVgo",
+      "operator:wikidata": "Q6955139",
+      "operator:wikipedia": "en:NRG Energy"
     }
   },
   "amenity/cinema|Cinema City": {


### PR DESCRIPTION
I created a wikidata entry for evgo since only the parent company existed.

Signed-off-by: Tim Smith <tsmith@chef.io>