### PR TITLE
Update Enel and E-WALD charger entries

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -6928,23 +6928,30 @@
       "name": "ChargePoint"
     }
   },
-  "amenity/charging_station|E-WALD Ladestation": {
-    "count": 61,
+  "amenity/charging_station|E-WALD": {
+    "match": [
+      "amenity/charging_station|E-WALD Ladestation"
+    ],
+    "nocount": true,
     "tags": {
       "amenity": "charging_station",
-      "brand": "E-WALD Ladestation",
-      "name": "E-WALD Ladestation"
+      "brand": "E-WALD",
+      "brand:wikidata": "Q61804335",
+      "name": "E-WALD"
     }
   },
-  "amenity/charging_station|Enel - stazione di ricarica": {
-    "count": 227,
+  "amenity/charging_station|Enel": {
     "countryCodes": ["it"],
+    "match": [
+      "amenity/charging_station|Enel - stazione di ricarica"
+    ],
+    "nocount": true,
     "tags": {
       "amenity": "charging_station",
-      "brand": "Enel - stazione di ricarica",
+      "brand": "Enel",
       "brand:wikidata": "Q651222",
       "brand:wikipedia": "en:Enel",
-      "name": "Enel - stazione di ricarica"
+      "name": "Enel"
     }
   },
   "amenity/charging_station|Tesla Supercharger": {


### PR DESCRIPTION
Stazione di ricarica isn't part of the brand name and therefore shouldn't be in the name tag. The same goes for Ladestation.

Signed-off-by: Tim Smith <tsmith@chef.io>