### PR TITLE
fixes#2315 Updates co-op store information.

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -22249,8 +22249,8 @@
     ],
     "tags": {
       "brand": "Federated Co-operatives",
-      "brand:wikidata": "Q5440676",
-      "brand:wikipedia": "en:Federated Co-operatives",
+      "brand:wikidata": "Q3277439",
+      "brand:wikipedia": "en:Co-op Food",
       "name": "Co-op",
       "shop": "convenience"
     }
@@ -30724,8 +30724,8 @@
     ],
     "tags": {
       "brand": "Federated Co-operatives",
-      "brand:wikidata": "Q5440676",
-      "brand:wikipedia": "en:Federated Co-operatives",
+      "brand:wikidata": "Q3277439",
+      "brand:wikipedia": "en:Co-op Food",
       "name": "Co-op",
       "shop": "supermarket"
     }


### PR DESCRIPTION
fixes #2315 Updated co-op convenience and superstore information in config/canonical.json file. Used the information in the issue request to replace the old set of information. 