### PR TITLE
Add a filter for "bike sharing"

### DIFF
--- a/config/filters.json
+++ b/config/filters.json
@@ -67,6 +67,7 @@
         "^(the )?barber(ia|shop|\\sshop)?$",
         "^berber$",
         "^biletomat$",
+        "^bike sharing$",
         "^bistro$",
         "^blumen(laden)?$",
         "^bodega$",


### PR DESCRIPTION
This shows up in the new allnames update. I'm adding it here as part of
the prep for updating the data. It doesn't actually filter anything
until we update to the new world data.

Signed-off-by: Tim Smith <tsmith@chef.io>