### PR TITLE
Filter out coffee standa and kiosks

### DIFF
--- a/config/filters.json
+++ b/config/filters.json
@@ -26,6 +26,7 @@
     "discardKeys": [
         "^amenity/bank\\|(Bank Zachodni|BZ) WBK$",
         "^amenity/bank\\|PKO$",
+        "^amenity/cafe\\|Kiosque( à)? café$",
         "^amenity/fast_food\\|(antalya|asia\\s(bistro|imbiss|wok)|city\\spizza|KFC/Taco\\sBell)$",
         "^amenity/restaurant\\|(adria|akropolis|aroma|asia|athen|athos|bahnhof|bamboo|bären|bella\\s(vista|napoli)|belvedere)",
         "^amenity/restaurant\\|(canteen|cantina|capri|carpe\\sdiem|casa(\\s)?(blanca|mia)|china\\s(buffet|garden|house|king|star|town|wok))",


### PR DESCRIPTION
There's 140 of these in the new world data. This adds the filter ahead
of updating the data so we don't end up these generic names.

Signed-off-by: Tim Smith <tsmith@chef.io>