### PR TITLE
Add 11 new supermarkets

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -31784,6 +31784,16 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Jan Linders": {
+    "nocount": true,
+    "tags": {
+      "brand": "Jan Linders",
+      "brand:wikidata": "Q2200982",
+      "brand:wikipedia": "nl:Jan Linders Supermarkten",
+      "name": "Jan Linders",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|Jewel-Osco": {
     "count": 81,
     "countryCodes": ["us"],
@@ -31995,6 +32005,26 @@
       "brand:wikidata": "Q151954",
       "brand:wikipedia": "en:Lidl",
       "name": "Lidl",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|Lincolnshire Co-op": {
+    "nocount": true,
+    "tags": {
+      "brand": "Lincolnshire Co-op",
+      "brand:wikidata": "Q6551231",
+      "brand:wikipedia": "en:Lincolnshire Co-operative",
+      "name": "Lincolnshire Co-op",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|Linella": {
+    "nocount": true,
+    "tags": {
+      "brand": "Linella",
+      "brand:wikidata": "Q61085990",
+      "brand:wikipedia": "ro:Linella",
+      "name": "Linella",
       "shop": "supermarket"
     }
   },
@@ -32979,6 +33009,16 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Save-On-Foods": {
+    "nocount": true,
+    "tags": {
+      "brand": "Save-On-Foods",
+      "brand:wikidata": "Q7427974",
+      "brand:wikipedia": "en:Save-On-Foods",
+      "name": "Save-On-Foods",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|Schnucks": {
     "match": ["shop/supermarket|Schnuck's"],
     "nocount": true,
@@ -33189,6 +33229,17 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Super 1 Foods": {
+    "nocount": true,
+    "tags": {
+      "brand": "Super 1 Foods",
+      "brand:wikidata": "Q7642102",
+      "name": "Super 1 Foods",
+      "operator:wikidata": "Q7642102",
+      "operator:wikipedia": "en:Brookshire Grocery Company",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|Super C": {
     "count": 68,
     "tags": {
@@ -33196,6 +33247,16 @@
       "brand:wikidata": "Q3504127",
       "brand:wikipedia": "en:Super C (supermarket)",
       "name": "Super C",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|Super One Foods": {
+    "nocount": true,
+    "tags": {
+      "brand": "Super One Foods",
+      "brand:wikidata": "Q17108733",
+      "brand:wikipedia": "en:Super One Foods",
+      "name": "Super One Foods",
       "shop": "supermarket"
     }
   },
@@ -33244,6 +33305,16 @@
       "brand:wikidata": "Q6135762",
       "brand:wikipedia": "es:Superama",
       "name": "Superama",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|Supercor": {
+    "nocount": true,
+    "tags": {
+      "brand": "Supercor",
+      "brand:wikidata": "Q6135841",
+      "brand:wikipedia": "es:Supercor",
+      "name": "Supercor",
       "shop": "supermarket"
     }
   },
@@ -33853,6 +33924,16 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Виталюр": {
+    "nocount": true,
+    "tags": {
+      "brand": "Виталюр",
+      "brand:wikidata": "Q55663075",
+      "brand:wikipedia": "ru:Виталюр",
+      "name": "Виталюр",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|Вопак": {
     "count": 57,
     "countryCodes": ["ua"],
@@ -34177,6 +34258,16 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Таврия В": {
+    "nocount": true,
+    "tags": {
+      "brand": "Таврия В",
+      "brand:wikidata": "Q61823146",
+      "brand:wikipedia": "uk:Таврія В",
+      "name": "Таврия В",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|Фора": {
     "count": 173,
     "countryCodes": ["ua"],
@@ -34398,6 +34489,16 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|家乐福": {
+    "nocount": true,
+    "tags": {
+      "brand": "家乐福",
+      "brand:wikidata": "Q217599",
+      "brand:wikipedia": "wuu:家乐福",
+      "name": "家乐福",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|惠康 Wellcome": {
     "count": 62,
     "countryCodes": ["hk"],
@@ -34421,6 +34522,18 @@
       "brand:wikipedia": "ja:業務スーパー",
       "name": "業務スーパー",
       "name:en": "Gyōmu sūpā",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|沃尔玛": {
+    "nocount": true,
+    "tags": {
+      "brand": "沃尔玛",
+      "brand:en": "Walmart",
+      "brand:wikidata": "Q483551",
+      "brand:wikipedia": "wuu:沃尔玛",
+      "name:en": "Walmart",
+      "name": "沃尔玛",
       "shop": "supermarket"
     }
   },


### PR DESCRIPTION
There are 50 or more of each of these stores in the new planet data except for Super One Foods, which is a smaller chain from North Dakota / Wisconsin that I added so people wouldn't mis-tag with Super 1 Foods which is from Texas.

Signed-off-by: Tim Smith <tsmith@chef.io>