### PR TITLE
Added info for Светофор, Командор and Десяточка supermarkets

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -34163,8 +34163,11 @@
   },
   "shop/supermarket|Светофор": {
     "count": 116,
+    "countryCodes": ["ru"],
     "tags": {
       "brand": "Светофор",
+      "brand:en": "Svetofor",
+      "brand:wikidata": "Q61875920",
       "name": "Светофор",
       "shop": "supermarket"
     }

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -33914,8 +33914,11 @@
   },
   "shop/supermarket|Десяточка": {
     "count": 55,
+    "countryCodes": ["ru"],
     "tags": {
       "brand": "Десяточка",
+      "brand:en": "Desyatochka",
+      "brand:wikidata": "Q61876182",
       "name": "Десяточка",
       "shop": "supermarket"
     }
@@ -33972,8 +33975,11 @@
   },
   "shop/supermarket|Командор": {
     "count": 78,
+    "countryCodes": ["ru"],
     "tags": {
       "brand": "Командор",
+      "brand:en": "Komandor",
+      "brand:wikidata": "Q61876152",
       "name": "Командор",
       "shop": "supermarket"
     }


### PR DESCRIPTION
Resolving #1785 

- Made a wikidata entry for Светофор supermarket
- Added wikidata, countrycodes and brand:en in config/canonical.json
- Build successful ✅