### PR TITLE
More Japanese Brands (part 2)

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -6311,6 +6311,22 @@
       "name": "Prime"
     }
   },
+  "amenity/cafe|Pronto": {
+    "countryCodes": ["jp"],
+    "match": ["amenity/cafe|プロント"],
+    "nocount": true,
+    "tags": {
+      "amenity": "cafe",
+      "brand": "PRONTO",
+      "brand:wikidata": "Q11336224",
+      "brand:wikipedia": "ja:プロントコーポレーション",
+      "operator": "株式会社 プロントコーポレーション",
+      "operator:en": "PRONTO Corporation",
+      "cuisine": "coffee_shop",
+      "name": "Pronto",
+      "alt_name:ja": "プロント"
+    }
+  },
   "amenity/cafe|Pumpkin": {
     "countryCodes": ["gb"],
     "match": [
@@ -9091,6 +9107,7 @@
   "amenity/fast_food|ドミノ・ピザ": {
     "countryCodes": ["jp"],
     "match": ["amenity/restaurant|ドミノ・ピザ"],
+    "nocount": true,
     "tags": {
       "amenity": "fast_food",
       "brand": "ドミノ・ピザ",
@@ -16226,6 +16243,7 @@
   "amenity/restaurant|いきなり！ステーキ": {
     "countryCodes": ["jp"],
     "match": ["amenity/restaurant|いきなりステーキ"],
+    "nocount": true,
     "tags": {
       "amenity": "restaurant",
       "brand": "いきなり！ステーキ",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -16232,6 +16232,7 @@
       "brand:en": "Ikinari Steak",
       "brand:wikidata": "Q21652405",
       "brand:wikipedia": "ja:いきなり！ステーキ",
+      "cusine": "steak_house",
       "name": "いきなり！ステーキ",
       "name:en": "Ikinari Steak"
     }
@@ -16566,6 +16567,7 @@
       "brand:en": "Hanaya Yohei",
       "brand:wikidata": "Q11276815",
       "brand:wikipedia": "ja:華屋与兵衛 (レストラン)",
+      "cusine": "japanese",
       "name": "華屋与兵衛",
       "name:en": "Hanaya Yohei",
       "operator": "株式会社ゼンショーホールディングス",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -9202,7 +9202,9 @@
       "brand:wikidata": "Q776272",
       "brand:wikipedia": "ja:吉野家",
       "name": "吉野家",
-      "name:en": "Yoshinoya"
+      "name:en": "Yoshinoya",
+      "operator": "株式会社吉野家ホールディングス",
+      "operator:en": "Yoshinoya Holdings Co., Ltd."
     }
   },
   "amenity/fast_food|富士そば": {
@@ -12576,6 +12578,23 @@
       "brand:wikipedia": "en:Sweet Frog",
       "cuisine": "frozen_yogurt",
       "name": "sweetFrog"
+    }
+  },
+  "amenity/ice_cream|サーティワンアイスクリーム": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "amenity": "ice_cream",
+      "brand": "バスキン・ロビンス",
+      "brand:en": "Baskin-Robbins",
+      "brand:wikidata": "Q11280824",
+      "brand:wikipedia": "ja:サーティワンアイスクリーム",
+      "cuisine": "ice_cream",
+      "name": "サーティワンアイスクリーム",
+      "official_name:en": "31 Ice Cream",
+      "name:en": "Baskin-Robbins",
+      "operator": "B-R サーティワン アイスクリーム株式会社",
+      "operator:en": "B-R 31 Ice Cream Co., Ltd."
     }
   },
   "amenity/money_transfer|Express Union": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -16530,6 +16530,23 @@
       "name:en": "Gyū-Kaku"
     }
   },
+  "amenity/restaurant|華屋与兵衛": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "amenity": "restaurant",
+      "brand": "華屋与兵衛",
+      "brand:en": "Hanaya Yohei",
+      "brand:wikidata": "Q11276815",
+      "brand:wikipedia": "ja:華屋与兵衛 (レストラン)",
+      "name": "華屋与兵衛",
+      "name:en": "Hanaya Yohei",
+      "operator": "株式会社ゼンショーホールディングス",
+      "operator:en": "Zensho Holdings Co., Ltd.",
+      "operator:wikidata": "Q8069229",
+      "operator:wikipedia": "ja:ゼンショー"
+    }
+  },
   "amenity/restaurant|餃子の王将": {
     "count": 255,
     "countryCodes": ["jp"],

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -18327,6 +18327,21 @@
       "shop": "books"
     }
   },
+  "shop/books|メロンブックス": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "brand": "メロンブックス",
+      "brand:en": "Melonbooks",
+      "brand:wikidata": "Q10851653",
+      "brand:wikipedia": "ja:メロンブックス",
+      "name": "メロンブックス",
+      "name:en": "Melonbooks",
+      "operator": "株式会社メロンブックス",
+      "operator:en": "Melonbooks Inc.",
+      "shop": "books"
+    }
+  },
   "shop/books|リブロ": {
     "countryCodes": ["jp"],
     "nocount": true,
@@ -18352,6 +18367,21 @@
       "name:en": "Books Sanseido",
       "operator": "株式会社 三省堂書店",
       "operator:en": "SANSEIDO BOOKSTORE LTD.",
+      "shop": "books"
+    }
+  },
+  "shop/books|文教堂": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "brand": "文教堂",
+      "brand:en": "Bunkyodo",
+      "brand:wikidata": "Q11499974",
+      "brand:wikipedia": "ja:文教堂",
+      "name": "文教堂",
+      "name:en": "Bunkyodo",
+      "operator": "株式会社文教堂グループホールディングス",
+      "operator:en": "Bunkyodo Group Holdings Co., Ltd.",
       "shop": "books"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -9090,6 +9090,21 @@
       "name:en": "Pizza Hut"
     }
   },
+  "amenity/fast_food|フレッシュネスバーガー": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "フレッシュネスバーガー",
+      "brand:en": "Freshness Burger",
+      "brand:wikidata": "Q5503087",
+      "brand:wikipedia": "ja:フレッシュネスバーガー",
+      "cuisine": "burger",
+      "name": "フレッシュネスバーガー",
+      "name:en": "Freshness Burger",
+      "name:ko": "프레쉬니스 버거"
+    }
+  },
   "amenity/fast_food|マクドナルド": {
     "count": 1445,
     "countryCodes": ["jp"],

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -18367,6 +18367,21 @@
       "shop": "books"
     }
   },
+  "shop/books|未来屋書店": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "brand": "未来屋書店",
+      "brand:en": "Miraiya Shoten",
+      "brand:wikidata": "Q11519563",
+      "brand:wikipedia": "ja:未来屋書店",
+      "name": "未来屋書店",
+      "name:en": "Miraiya Shoten",
+      "operator": "株式会社未来屋書店",
+      "operator:en": "Miraiya Shoten Co.,Ltd.",
+      "shop": "books"
+    }
+  },
   "shop/butcher|Coqivoire": {
     "countryCodes": ["ci"],
     "nocount": true,

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -6323,8 +6323,7 @@
       "operator": "株式会社 プロントコーポレーション",
       "operator:en": "PRONTO Corporation",
       "cuisine": "coffee_shop",
-      "name": "Pronto",
-      "alt_name:ja": "プロント"
+      "name": "Pronto"
     }
   },
   "amenity/cafe|Pumpkin": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -9003,6 +9003,20 @@
       "name:en": "Hotto Motto"
     }
   },
+  "amenity/fast_food|ゆで太郎": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "ゆで太郎",
+      "brand:en": "Yudetaro",
+      "brand:wikidata": "Q11280824",
+      "brand:wikipedia": "ja:ゆで太郎",
+      "cuisine": "noodle",
+      "name": "ゆで太郎",
+      "name:en": "Yudetaro"
+    }
+  },
   "amenity/fast_food|オリジン弁当": {
     "count": 96,
     "countryCodes": ["jp"],
@@ -9088,6 +9102,22 @@
       "cuisine": "pizza",
       "name": "ピザハット",
       "name:en": "Pizza Hut"
+    }
+  },
+  "amenity/fast_food|ピザーラ": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "ピザーラ",
+      "brand:en": "Pizza-La",
+      "brand:wikidata": "Q7199948",
+      "brand:wikipedia": "ja:ピザーラ",
+      "operator": "株式会社フォーシーズ",
+      "operator:en": "Four Seas Inc.",
+      "cuisine": "pizza",
+      "name": "ピザーラ",
+      "name:en": "Pizza-La"
     }
   },
   "amenity/fast_food|フレッシュネスバーガー": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -7441,6 +7441,7 @@
   },
   "amenity/fast_food|CoCo壱番屋": {
     "count": 244,
+    "countryCodes": ["cn", "jp"],
     "match": ["amenity/restaurant|CoCo壱番屋"],
     "tags": {
       "amenity": "fast_food",
@@ -9057,6 +9058,22 @@
       "name": "スシロー",
       "name:en": "Sushiro",
       "name:zh": "壽司郎"
+    }
+  },
+  "amenity/fast_food|ドミノ・ピザ": {
+    "countryCodes": ["jp"],
+    "match": ["amenity/restaurant|ドミノ・ピザ"],
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "ドミノ・ピザ",
+      "brand:en": "Domino’s",
+      "brand:wikidata": "Q839466",
+      "brand:wikipedia": "ja:ドミノ・ピザ",
+      "cuisine": "pizza",
+      "name": "ドミノ・ピザ",
+      "name:en": "Domino’s Pizza",
+      "operator": "株式会社ドミノ・ピザ ジャパン",
+      "operator:en": "Domino's Pizza Japan, Inc."
     }
   },
   "amenity/fast_food|ピザハット": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -18299,6 +18299,21 @@
       "shop": "books"
     }
   },
+  "shop/books|あおい書店": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "brand": "あおい書店",
+      "brand:en": "aoi",
+      "brand:wikidata": "Q11256783",
+      "brand:wikipedia": "ja:あおい書店",
+      "name": "あおい書店",
+      "name:en": "aoi bookstore",
+      "operator": "株式会社あおい書店",
+      "operator:en": "aoisyoten Co., Ltd.",
+      "shop": "books"
+    }
+  },
   "shop/books|ブックオフ": {
     "count": 156,
     "countryCodes": ["jp"],
@@ -18322,6 +18337,21 @@
       "brand:wikipedia": "ja:リブロ",
       "name": "リブロ",
       "name:en": "Libro",
+      "shop": "books"
+    }
+  },
+  "shop/books|三省堂書店": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "brand": "三省堂書店",
+      "brand:en": "Books Sanseido",
+      "brand:wikidata": "Q10866539",
+      "brand:wikipedia": "ja:三省堂書店",
+      "name": "三省堂書店",
+      "name:en": "Books Sanseido",
+      "operator": "株式会社 三省堂書店",
+      "operator:en": "SANSEIDO BOOKSTORE LTD.",
       "shop": "books"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -25374,19 +25374,6 @@
       "shop": "department_store"
     }
   },
-  "shop/department_store|東急ハンズ": {
-    "countryCodes": ["jp"],
-    "nocount": true,
-    "tags": {
-      "brand": "東急ハンズ",
-      "brand:en": "Tokyu Hands",
-      "brand:wikidata": "Q859212",
-      "brand:wikipedia": "ja:東急ハンズ",
-      "name": "東急ハンズ",
-      "name:en": "Tokyu Hands",
-      "shop": "department_store"
-    }
-  },
   "shop/department_store|Kohl's": {
     "count": 456,
     "match": ["shop/clothes|Kohl's"],
@@ -25630,6 +25617,19 @@
     "tags": {
       "brand": "Épicerie",
       "name": "Épicerie",
+      "shop": "department_store"
+    }
+  },
+  "shop/department_store|東急ハンズ": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "brand": "東急ハンズ",
+      "brand:en": "Tokyu Hands",
+      "brand:wikidata": "Q859212",
+      "brand:wikipedia": "ja:東急ハンズ",
+      "name": "東急ハンズ",
+      "name:en": "Tokyu Hands",
       "shop": "department_store"
     }
   },
@@ -35851,21 +35851,25 @@
       "shop": "variety_store"
     }
   },
-  "shop/variety_store|ドン キホーテ": {
+  "shop/variety_store|ドン・キホーテ": {
     "countryCodes": ["jp"],
     "match": [
       "shop/supermarket|ドン キホーテ",
       "shop/supermarket|ドン・キホーテ",
-      "shop/variety_store|ドン・キホーテ"
+      "shop/variety_store|ドン キホーテ"
     ],
     "nocount": true,
     "tags": {
-      "brand": "ドン キホーテ",
+      "brand": "ドン・キホーテ",
       "brand:en": "Don Quijote",
       "brand:wikidata": "Q1185381",
-      "brand:wikipedia": "ja:ドン キホーテ",
-      "name": "ドン キホーテ",
+      "brand:wikipedia": "ja:ドン・キホーテ (企業)",
+      "name": "ドン・キホーテ",
       "name:en": "Don Quijote",
+      "operator": "パン・パシフィック・インターナショナルホールディングス",
+      "operator:en": "Pan Pacific International Holdings Corporation",
+      "operator:wikipedia": "ja:パン・パシフィック・インターナショナルホールディングス",
+      "operator:wikidata": "Q16485533",
       "short_name": "ドンキ",
       "short_name:en": "Donki",
       "shop": "variety_store"

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -6323,7 +6323,9 @@
       "operator": "株式会社 プロントコーポレーション",
       "operator:en": "PRONTO Corporation",
       "cuisine": "coffee_shop",
-      "name": "Pronto"
+      "official_name": "Pronto Caffè & Bar",
+      "name": "Pronto",
+      "name:ja": "プロント"
     }
   },
   "amenity/cafe|Pumpkin": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -25314,6 +25314,22 @@
       "shop": "deli"
     }
   },
+  "shop/deli|京樽": {
+    "countryCodes": ["jp"],
+    "match": ["amenity/fast_food|京樽"],
+    "nocount": true,
+    "tags": {
+      "brand": "京樽",
+      "brand:en": "Kyotaru",
+      "brand:wikidata": "Q11374503",
+      "brand:wikipedia": "ja:京樽",
+      "name": "京樽",
+      "name:en": "Kyotaru",
+      "shop": "deli",
+      "operator": "株式会社吉野家ホールディングス",
+      "operator:en": "Yoshinoya Holdings Co., Ltd."
+    }
+  },
   "shop/department_store|Argos": {
     "count": 101,
     "tags": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -18620,6 +18620,23 @@
       "shop": "butcher"
     }
   },
+  "shop/butcher|肉のハナマサ": {
+    "countryCodes": ["jp"],
+    "match": ["shop/butcher|ハナマサ"],
+    "nocount": true,
+    "tags": {
+      "brand": "ハナマサ",
+      "brand:en": "Hanamasa",
+      "brand:wikidata": "Q11326564",
+      "brand:wikipedia": "ja:ハナマサ",
+      "operator": "株式会社 花正",
+      "operator:en": "Hanamasa Co., Ltd.",
+      "butcher": "beef",
+      "name": "肉のハナマサ",
+      "name:en": "Hanamasa Meat",
+      "shop": "butcher"
+    }
+  },
   "shop/car_parts|Advance Auto Parts": {
     "count": 554,
     "match": [

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -6764,6 +6764,20 @@
       "name:en": "Starbucks"
     }
   },
+  "amenity/cafe|珈琲館": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "amenity": "cafe",
+      "brand": "珈琲館",
+      "brand:en": "Kohikan",
+      "brand:wikidata": "Q11573290",
+      "brand:wikipedia": "ja:珈琲館",
+      "cuisine": "coffee_shop",
+      "name": "珈琲館",
+      "name:en": "Kohikan"
+    }
+  },
   "amenity/cafe|스타벅스": {
     "count": 82,
     "countryCodes": ["kr"],
@@ -16207,6 +16221,19 @@
       "amenity": "restaurant",
       "brand": "Якитория",
       "name": "Якитория"
+    }
+  },
+  "amenity/restaurant|いきなり！ステーキ": {
+    "countryCodes": ["jp"],
+    "match": ["amenity/restaurant|いきなりステーキ"],
+    "tags": {
+      "amenity": "restaurant",
+      "brand": "いきなり！ステーキ",
+      "brand:en": "Ikinari Steak",
+      "brand:wikidata": "Q21652405",
+      "brand:wikipedia": "ja:いきなり！ステーキ",
+      "name": "いきなり！ステーキ",
+      "name:en": "Ikinari Steak"
     }
   },
   "amenity/restaurant|はなまるうどん": {


### PR DESCRIPTION
This is a second pull request, the previous one was  #2365. Add business brands about books, restaurants, ice cream and fast food. Also, I add operator key to "Don Quijote" brand and fixes Wikipedia article. Thanks.

- About Baskin-Robbins: Because BR is a registered trademark in Japan, the official name key is added (31 Ice Cream). Moreover, the name tag contains the global franchise mark (in "name:ja" tag is the official name in japanese). More info in [Wikipedia](https://ja.wikipedia.org/wiki/%E3%83%90%E3%82%B9%E3%82%AD%E3%83%B3%E3%83%BB%E3%83%AD%E3%83%93%E3%83%B3%E3%82%B9).
- About Tokyu Hands: I run "npm build" and its position is changed.
- About CoCo (japanese brand): I added _"countryCodes": ["jp","cn"],_. 
- About Pronto. I sure what "Pronto" is in official_name key, from italian-language, and goes to "name" key, too. The japanese name is "プロント" but is for easy pronunciation for Japanese people, so it goes to "name:ja" key. See [website](https://www.pronto.co.jp/global/).