### PR TITLE
Collapse TGP into a single entry

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -13903,15 +13903,17 @@
   },
   "amenity/pharmacy|TGP": {
     "count": 349,
-    "tags": {"amenity": "pharmacy", "name": "TGP"}
-  },
-  "amenity/pharmacy|The Generics Pharmacy": {
     "countryCodes": ["ph"],
+    "match": [
+      "amenity/pharmacy|The Generics Pharmacy"
+    ],
     "tags": {
       "amenity": "pharmacy",
       "brand": "The Generics Pharmacy",
+      "brand:wikidata": "Q61948677",
       "healthcare": "pharmacy",
-      "name": "The Generics Pharmacy"
+      "name": "TGP",
+      "official_name": "The Generics Pharmacy"
     }
   },
   "amenity/pharmacy|Unichem Pharmacy": {


### PR DESCRIPTION
I created a wikipedia entry for this and I added the official_name tag.
The signs and branding are all TGP, but the name is really The Generics
Pharmacy.

Signed-off-by: Tim Smith <tsmith@chef.io>