### PR TITLE
More Japanese Brands (part 3)

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -25390,6 +25390,7 @@
       "brand:wikipedia": "ja:ローソン・スリーエフ",
       "name": "ローソン・スリーエフ",
       "name:en": "Lawson･Three F",
+      "name:ko": "로손·쓰리에프",
       "shop": "convenience",
       "operator": "株式会社エル・ティーエフ",
       "operator:en": "L･TF Co., Ltd."

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -7070,6 +7070,24 @@
       "operator:wikipedia": "en:NRG Energy"
     }
   },
+  "amenity/cinema|109シネマズ": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "amenity": "cinema",
+      "brand": "109シネマズ",
+      "brand:en": "109 Cinemas",
+      "brand:wikidata": "Q10854269",
+      "brand:wikipedia": "ja:109シネマズ",
+      "name": "109シネマズ",
+      "name:en": "109 Cinemas",
+      "name:ko": "109 시네마즈",
+      "operator": "株式会社 東急レクリエーション",
+      "operator:en": "Tokyu Recreation Co., Ltd.",
+      "operator:wikipedia": "ja:東急レクリエーション",
+      "operator:wikidata": "Q11527011"
+    }
+  },
   "amenity/cinema|Cinema City": {
     "count": 64,
     "tags": {
@@ -7144,6 +7162,21 @@
       "name": "Odeon"
     }
   },
+  "amenity/cinema|TOHOシネマズ": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "amenity": "cinema",
+      "brand": "TOHOシネマズ",
+      "brand:en": "TOHO CINEMAS",
+      "brand:wikidata": "Q11235261",
+      "brand:wikipedia": "ja:TOHOシネマズ",
+      "operator": "TOHOシネマズ株式会社",
+      "operator:en": "TOHO CINEMAS LTD.",
+      "name": "TOHOシネマズ",
+      "name:en": "Toho Cinemas"
+    }
+  },
   "amenity/cinema|Октябрь": {
     "count": 51,
     "tags": {
@@ -7165,6 +7198,21 @@
       "operator:en": "Aeon Entertainment Co., Ltd.",
       "name": "イオンシネマ",
       "name:en": "AEON Cinema"
+    }
+  },
+  "amenity/cinema|ユナイテッド・シネマ": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "amenity": "cinema",
+      "brand": "ユナイテッド・シネマ",
+      "brand:en": "United Cinemas",
+      "brand:wikidata": "Q11345629",
+      "brand:wikipedia": "ja:ユナイテッド・シネマ",
+      "operator": "ユナイテッド・シネマ株式会社",
+      "operator:en": "UNITED CINEMAS CO., LTD.",
+      "name": "ユナイテッド・シネマ",
+      "name:en": "United Cinemas"
     }
   },
   "amenity/dentist|Aspen Dental": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -25190,6 +25190,11 @@
       "brand:wikipedia": "en:7-Eleven",
       "name": "セブン-イレブン",
       "name:en": "7-Eleven",
+      "official_name:en": "Seven-Eleven",
+      "operator": "株式会社セブン&アイ・ホールディングス",
+      "operator:en": "Seven & I Holdings Co., Ltd.",
+      "operator:wikidata": "Q639447",
+      "operator:wikipedia": "en:Seven & I Holdings Co.",
       "shop": "convenience"
     }
   },
@@ -25293,6 +25298,7 @@
       "brand:wikipedia": "ja:ローソン",
       "name": "ローソン",
       "name:en": "Lawson",
+      "name:ko": "로손",
       "shop": "convenience"
     }
   },
@@ -35399,6 +35405,7 @@
   "shop/supermarket|イトーヨーカドー": {
     "count": 73,
     "countryCodes": ["jp"],
+    "match": ["shop/supermarket|イトーヨーカ堂"],
     "tags": {
       "brand": "イトーヨーカドー",
       "brand:en": "Ito-Yokado",
@@ -35485,6 +35492,23 @@
       "name": "ヨークベニマル",
       "name:en": "York Benimaru",
       "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|ヨークマート": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "brand": "ヨークマート",
+      "brand:en": "YorkMart",
+      "brand:wikidata": "Q11346201",
+      "brand:wikipedia": "ja:ヨークマート",
+      "name": "ヨークマート",
+      "name:en": "YorkMart",
+      "shop": "supermarket",
+      "operator": "株式会社セブン&アイ・ホールディングス",
+      "operator:en": "Seven & I Holdings Co., Ltd.",
+      "operator:wikidata": "Q639447",
+      "operator:wikipedia": "en:Seven & I Holdings Co."
     }
   },
   "shop/supermarket|ライフ": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -9249,6 +9249,20 @@
       "name:en": "MOS Burger"
     }
   },
+  "amenity/fast_food|ラーメン二郎": {
+    "countryCodes": ["jp"],
+    "match": ["amenity/restaurant|ラーメン二郎"],
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "ラーメン二郎",
+      "brand:en": "Ramen Jiro",
+      "brand:wikidata": "Q11347765",
+      "brand:wikipedia": "ja:ラーメン二郎",
+      "name": "ラーメン二郎",
+      "name:en": "Ramen Jiro",
+      "cusine": "noodle"
+    }
+  },
   "amenity/fast_food|ロッテリア": {
     "count": 111,
     "countryCodes": ["jp"],
@@ -9288,6 +9302,7 @@
       "brand:en": "Fuji Soba",
       "brand:wikidata": "Q11414722",
       "brand:wikipedia": "ja:名代富士そば",
+      "cusine": "noodle",
       "name": "富士そば",
       "name:en": "Fuji Soba"
     }
@@ -9343,6 +9358,20 @@
       "brand:wikipedia": "zh:松屋食品",
       "name": "松屋",
       "name:en": "Matsuya Foods"
+    }
+  },
+  "amenity/fast_food|箱根そば": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "箱根そば",
+      "brand:en": "Hakone Soba",
+      "brand:wikidata": "Q11603345",
+      "brand:wikipedia": "ja:箱根そば",
+      "name": "箱根そば",
+      "name:en": "Hakone Soba",
+      "cusine": "noodle"
     }
   },
   "amenity/fast_food|肯德基": {
@@ -16346,6 +16375,8 @@
       "brand:wikipedia": "ja:カプリチョーザ",
       "name": "カプリチョーザ",
       "name:en": "Capricciosa",
+      "operator": "株式会社伊太利亜飯店華婦里蝶座",
+      "operator:en": "Italia-Hanten Capricciosa Co., Ltd",
       "cusine": "italian"
     }
   },
@@ -16372,7 +16403,8 @@
       "brand:wikidata": "Q11301951",
       "brand:wikipedia": "ja:ココスジャパン",
       "name": "ココス",
-      "name:en": "Coco's"
+      "name:en": "Coco's",
+      "name:ko": "코코스"
     }
   },
   "amenity/restaurant|サイゼリヤ": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -5337,6 +5337,19 @@
       "name:en": "Mizuho Bank"
     }
   },
+  "amenity/bank|ゆうちょ銀行": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "amenity": "bank",
+      "brand": "ゆうちょ銀行",
+      "brand:en": "Japan Post Bank",
+      "brand:wikidata": "Q907103",
+      "brand:wikipedia": "ja:ゆうちょ銀行",
+      "name": "ゆうちょ銀行",
+      "name:en": "Japan Post Bank"
+    }
+  },
   "amenity/bank|りそな銀行": {
     "count": 163,
     "countryCodes": ["jp"],
@@ -5703,6 +5716,22 @@
       "brand:wikipedia": "en:China Merchants Bank",
       "name": "招商银行",
       "name:en": "China Merchants Bank"
+    }
+  },
+  "amenity/bank|日本銀行": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "amenity": "bank",
+      "brand": "日本銀行",
+      "brand:en": "Bank of Japan",
+      "brand:wikidata": "Q333101",
+      "brand:wikipedia": "ja:日本銀行",
+      "name": "日本銀行",
+      "name:en": "Bank of Japan",
+      "name:es": "Banco de Japón",
+      "name:ko": "일본은행",
+      "name:zh": "日本银行"
     }
   },
   "amenity/bank|板信商業銀行": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -24265,6 +24265,20 @@
       "shop": "convenience"
     }
   },
+  "shop/convenience|miniピアゴ": {
+    "countryCodes": ["jp"],
+    "match": ["shop/convenience|ミニピアゴ"],
+    "nocount": true,
+    "tags": {
+      "brand": "miniピアゴ",
+      "brand:en": "mini Piago",
+      "brand:wikidata": "Q11188499",
+      "brand:wikipedia": "ja:miniピアゴ",
+      "name": "miniピアゴ",
+      "name:en": "mini Piago",
+      "shop": "convenience"
+    }
+  },
   "shop/convenience|Épicerie": {
     "count": 65,
     "tags": {
@@ -25153,6 +25167,19 @@
       "shop": "convenience"
     }
   },
+  "shop/convenience|アンスリー": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "brand": "アンスリー",
+      "brand:en": "Ansuri",
+      "brand:wikidata": "Q17192555",
+      "brand:wikipedia": "ja:アンスリー",
+      "name": "アンスリー",
+      "name:en": "Ansuri",
+      "shop": "convenience"
+    }
+  },
   "shop/convenience|サンクス": {
     "count": 790,
     "countryCodes": ["jp"],
@@ -25209,8 +25236,11 @@
     "count": 6280,
     "countryCodes": ["jp"],
     "match": [
+      "shop/convenience|セブン−イレブン",
       "shop/convenience|セブンイレブン",
-      "shop/convenience|セブンイレブン(Seven-Eleven)"
+      "shop/convenience|セブンイレブン(7-11)",
+      "shop/convenience|セブンイレブン(Seven-Eleven)",
+      "shop/convenience|セブンーイレブン"
     ],
     "tags": {
       "brand": "セブン-イレブン",
@@ -25320,6 +25350,7 @@
   "shop/convenience|ローソン": {
     "count": 5088,
     "countryCodes": ["jp"],
+    "match": ["shop/convenience|ﾛｰｿﾝ"],
     "tags": {
       "brand": "ローソン",
       "brand:en": "LAWSON",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -5729,9 +5729,6 @@
       "brand:wikipedia": "ja:日本銀行",
       "name": "日本銀行",
       "name:en": "Bank of Japan",
-      "name:es": "Banco de Japón",
-      "name:ko": "일본은행",
-      "name:zh": "日本银行"
     }
   },
   "amenity/bank|板信商業銀行": {
@@ -7111,7 +7108,6 @@
       "brand:wikipedia": "ja:109シネマズ",
       "name": "109シネマズ",
       "name:en": "109 Cinemas",
-      "name:ko": "109 시네마즈",
       "operator": "株式会社 東急レクリエーション",
       "operator:en": "Tokyu Recreation Co., Ltd.",
       "operator:wikipedia": "ja:東急レクリエーション",
@@ -9344,9 +9340,7 @@
       "brand:wikipedia": "ja:マクドナルド",
       "cuisine": "burger",
       "name": "マクドナルド",
-      "name:en": "McDonald's",
-      "name:ko": "맥도날드",
-      "name:zh": "麦当劳"
+      "name:en": "McDonald's"
     }
   },
   "amenity/fast_food|ミスタードーナツ": {
@@ -16532,8 +16526,7 @@
       "brand:wikidata": "Q11301951",
       "brand:wikipedia": "ja:ココスジャパン",
       "name": "ココス",
-      "name:en": "Coco's",
-      "name:ko": "코코스"
+      "name:en": "Coco's"
     }
   },
   "amenity/restaurant|サイゼリヤ": {
@@ -25358,7 +25351,6 @@
       "brand:wikipedia": "ja:ローソン",
       "name": "ローソン",
       "name:en": "Lawson",
-      "name:ko": "로손",
       "shop": "convenience"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -35581,7 +35581,7 @@
       "operator": "株式会社セブン&アイ・ホールディングス",
       "operator:en": "Seven & I Holdings Co., Ltd.",
       "operator:wikidata": "Q639447",
-      "operator:wikipedia": "en:Seven & I Holdings Co."
+      "operator:wikipedia": "ja:セブン&アイ・ホールディングス"
     }
   },
   "shop/supermarket|ライフ": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -25375,6 +25375,26 @@
       "shop": "convenience"
     }
   },
+  "shop/convenience|ローソン・スリーエフ": {
+    "countryCodes": ["jp"],
+    "match": [
+      "shop/convenience|LAWSON+スリーエフ",
+      "shop/convenience|ローソン+スリーエフ",
+      "shop/convenience|ﾛｰｿﾝ・スリーエフ"
+    ],
+    "nocount": true,
+    "tags": {
+      "brand": "ローソン・スリーエフ",
+      "brand:en": "LAWSON･Three F",
+      "brand:wikidata": "Q24866804",
+      "brand:wikipedia": "ja:ローソン・スリーエフ",
+      "name": "ローソン・スリーエフ",
+      "name:en": "Lawson･Three F",
+      "shop": "convenience",
+      "operator": "株式会社エル・ティーエフ",
+      "operator:en": "L･TF Co., Ltd."
+    }
+  },
   "shop/convenience|全家": {
     "count": 560,
     "tags": {

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -6342,6 +6342,7 @@
     "countryCodes": ["jp"],
     "match": ["amenity/cafe|プロント"],
     "nocount": true,
+    "nomatch": ["shop/convenience|Coop Pronto"],
     "tags": {
       "amenity": "cafe",
       "brand": "PRONTO",
@@ -7150,6 +7151,21 @@
       "brand:wikidata": "Q5120901",
       "brand:wikipedia": "en:Cineworld",
       "name": "Cineworld"
+    }
+  },
+  "amenity/cinema|MOVIX": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "amenity": "cinema",
+      "brand": "MOVIX",
+      "brand:wikidata": "Q11532184",
+      "brand:wikipedia": "ja:松竹マルチプレックスシアターズ",
+      "operator": "株式会社松竹マルチプレックスシアターズ",
+      "operator:en": "Shochiku Multiplex Theatres, Ltd.",
+      "name": "MOVIX",
+      "official_name": "松竹マルチプレックスシアターズ",
+      "official_name:en": "Shochiku Multiplex Theatres"
     }
   },
   "amenity/cinema|Odeon": {
@@ -9127,6 +9143,7 @@
   "amenity/fast_food|ほっともっと": {
     "count": 244,
     "countryCodes": ["jp"],
+    "nomatch": ["shop/deli|ほっともっと"],
     "tags": {
       "amenity": "fast_food",
       "brand": "ほっともっと",
@@ -17388,6 +17405,7 @@
   "shop/baby_goods|西松屋": {
     "count": 65,
     "countryCodes": ["jp"],
+    "nomatch": ["shop/clothes|西松屋"],
     "tags": {
       "brand": "西松屋",
       "brand:en": "Nishimatsuya Chain",
@@ -22448,6 +22466,19 @@
       "shop": "clothes"
     }
   },
+  "shop/clothes|ライトオン": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "brand": "ライトオン",
+      "brand:en": "Right-on",
+      "brand:wikidata": "Q11346416",
+      "brand:wikipedia": "ja:ライトオン",
+      "name": "ライトオン",
+      "name:en": "Right-on",
+      "shop": "clothes"
+    }
+  },
   "shop/clothes|ワークマン": {
     "count": 103,
     "countryCodes": ["jp"],
@@ -22476,8 +22507,13 @@
   },
   "shop/clothes|西松屋": {
     "count": 153,
+    "nomatch": ["shop/baby_goods|西松屋"],
     "tags": {
       "brand": "西松屋",
+      "brand:en": "Nishimatsuya Chain",
+      "brand:wikidata": "Q11628761",
+      "brand:wikipedia": "ja:西松屋",
+      "clothes": "children",
       "name": "西松屋",
       "shop": "clothes"
     }
@@ -23027,6 +23063,7 @@
   },
   "shop/convenience|Coop Pronto": {
     "count": 55,
+    "nomatch": ["amenity/cafe|Pronto"],
     "tags": {
       "brand": "Coop Pronto",
       "brand:wikidata": "Q1129777",
@@ -25574,6 +25611,7 @@
   "shop/deli|ほっともっと": {
     "count": 72,
     "countryCodes": ["jp"],
+    "nomatch": ["shop/fast_food|ほっともっと"],
     "tags": {
       "brand": "ほっともっと",
       "brand:en": "Hotto Motto",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -7152,6 +7152,21 @@
       "name": "Октябрь"
     }
   },
+  "amenity/cinema|イオンシネマ": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "amenity": "cinema",
+      "brand": "イオンシネマ",
+      "brand:en": "AEON Cinema",
+      "brand:wikidata": "Q17192792",
+      "brand:wikipedia": "ja:イオンエンターテイメント",
+      "operator": "イオンエンターテイメント株式会社",
+      "operator:en": "Aeon Entertainment Co., Ltd.",
+      "name": "イオンシネマ",
+      "name:en": "AEON Cinema"
+    }
+  },
   "amenity/dentist|Aspen Dental": {
     "countryCodes": ["us"],
     "match": ["healthcare/dentist/Aspen Dental"],
@@ -9176,6 +9191,23 @@
       "name:en": "Pizza Hut"
     }
   },
+  "amenity/fast_food|ピザ・カリフォルニア": {
+    "countryCodes": ["jp"],
+    "match": ["amenity/fast_food|ピザ カリフォルニア"],
+    "nocount": true,
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "ピザ・カリフォルニア",
+      "brand:en": "Pizza California",
+      "brand:wikidata": "Q191615",
+      "brand:wikipedia": "ja:ピザ・カリフォルニア",
+      "cuisine": "pizza",
+      "name": "ピザ・カリフォルニア",
+      "name:en": "Pizza California",
+      "operator": "株式会社ピーシーエス",
+      "operator:en": "PCS Inc."
+    }
+  },
   "amenity/fast_food|ピザーラ": {
     "countryCodes": ["jp"],
     "nocount": true,
@@ -9218,7 +9250,9 @@
       "brand:wikipedia": "ja:マクドナルド",
       "cuisine": "burger",
       "name": "マクドナルド",
-      "name:en": "McDonald's"
+      "name:en": "McDonald's",
+      "name:ko": "맥도날드",
+      "name:zh": "麦当劳"
     }
   },
   "amenity/fast_food|ミスタードーナツ": {
@@ -9252,6 +9286,7 @@
   "amenity/fast_food|ラーメン二郎": {
     "countryCodes": ["jp"],
     "match": ["amenity/restaurant|ラーメン二郎"],
+    "nocount": true,
     "tags": {
       "amenity": "fast_food",
       "brand": "ラーメン二郎",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -16335,6 +16335,20 @@
       "name:en": "YAYOI"
     }
   },
+  "amenity/restaurant|カプリチョーザ": {
+    "countryCodes": ["jp"],
+    "nocount": true,
+    "tags": {
+      "amenity": "restaurant",
+      "brand": "カプリチョーザ",
+      "brand:en": "Capricciosa",
+      "brand:wikidata": "Q11294660",
+      "brand:wikipedia": "ja:カプリチョーザ",
+      "name": "カプリチョーザ",
+      "name:en": "Capricciosa",
+      "cusine": "italian"
+    }
+  },
   "amenity/restaurant|ガスト": {
     "count": 603,
     "countryCodes": ["jp"],
@@ -30314,6 +30328,16 @@
       "brand:wikidata": "Q1636668",
       "brand:wikipedia": "en:Humanic",
       "name": "Humanic",
+      "shop": "shoes"
+    }
+  },
+  "shop/shoes|Hush Puppies": {
+    "nocount": true,
+    "tags": {
+      "brand": "Hush Puppies",
+      "brand:wikidata": "Q1828588",
+      "brand:wikipedia": "en:Hush Puppies",
+      "name": "Hush Puppies",
       "shop": "shoes"
     }
   },

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -25382,7 +25382,6 @@
       "brand:wikipedia": "ja:ローソン・スリーエフ",
       "name": "ローソン・スリーエフ",
       "name:en": "Lawson･Three F",
-      "name:ko": "로손·쓰리에프",
       "shop": "convenience",
       "operator": "株式会社エル・ティーエフ",
       "operator:en": "L･TF Co., Ltd."

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -20280,9 +20280,16 @@
   },
   "shop/clothes|AOKI": {
     "count": 143,
+    "countryCodes": ["jp"],
     "tags": {
       "brand": "AOKI",
+      "brand:wikidata": "Q11189480",
+      "brand:wikipedia": "ja:AOKIホールディングス",
+      "clothes": "men",
       "name": "AOKI",
+      "name:ja": "アオキ",
+      "operator": "株式会社AOKIホールディングス",
+      "operator:en": "AOKI Holdings Inc.",
       "shop": "clothes"
     }
   },


### PR DESCRIPTION
This is a third pull request, the previous pulls were #2365 and #2367. Add business brands about cinema, banks, restaurants, convenience stores and clothes. Thanks.

- Also, Added Hush Puppies brand
- About 7-Eleven: Added alternative typos with "-"
- About Nishimatsuya Chain, Hotto Motto and Pronto: Add NoMatch.
- About Ito-Yokado. Add Match (writed in Wikipedia Article)
- There are different numbers in "count" from this pull request, build from npm.