### PR TITLE
Add country codes and missing wikidata for supermarkets

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -3245,6 +3245,7 @@
   },
   "shop/supermarket|Supercor": {
     "count": 52,
+    "countryCodes": ["es", "pt"],
     "tags": {
       "brand": "Supercor",
       "brand:wikidata": "Q6135841",
@@ -3255,6 +3256,7 @@
   },
   "shop/supermarket|Supersol": {
     "count": 62,
+    "countryCodes": ["ar", "es", "ma", "uy"],
     "tags": {
       "brand": "Supersol",
       "name": "Supersol",
@@ -3263,6 +3265,7 @@
   },
   "shop/supermarket|Superspar": {
     "count": 54,
+    "countryCodes": ["es", "za"],
     "tags": {
       "brand": "Superspar",
       "brand:wikidata": "Q610492",
@@ -3273,6 +3276,7 @@
   },
   "shop/supermarket|Tegut": {
     "count": 91,
+    "countryCodes": ["de"],
     "match": ["shop/supermarket|tegut"],
     "tags": {
       "brand": "Tegut",
@@ -3340,6 +3344,7 @@
   },
   "shop/supermarket|The Co-operative Food": {
     "count": 1170,
+    "countryCodes": ["gb"],
     "match": [
       "shop/supermarket|Co-operative Food",
       "shop/supermarket|The Co-operative"
@@ -3368,6 +3373,7 @@
   },
   "shop/supermarket|Todis": {
     "count": 64,
+    "countryCodes": ["it"],
     "tags": {
       "brand": "Todis",
       "brand:wikidata": "Q3992174",
@@ -3389,7 +3395,11 @@
   },
   "shop/supermarket|Top Market": {
     "count": 51,
+    "countryCodes": ["pl"],
     "tags": {
+      "brand": "Top Market",
+      "brand:wikidata": "Q9360044",
+      "brand:wikipedia": "pl:Top Market",
       "name": "Top Market",
       "shop": "supermarket"
     }
@@ -3418,6 +3428,7 @@
   },
   "shop/supermarket|Trader Joe's": {
     "count": 400,
+    "countryCodes": ["us"],
     "tags": {
       "brand": "Trader Joe's",
       "brand:wikidata": "Q688825",
@@ -3428,6 +3439,7 @@
   },
   "shop/supermarket|Treff 3000": {
     "count": 92,
+    "countryCodes": ["de"],
     "tags": {
       "brand": "Treff 3000",
       "brand:wikidata": "Q701755",
@@ -3519,14 +3531,18 @@
   },
   "shop/supermarket|Volg": {
     "count": 248,
+    "countryCodes": ["ch", "li"],
     "tags": {
       "brand": "Volg",
+      "brand:wikidata": "Q2530746",
+      "brand:wikipedia": "de: Volg",
       "name": "Volg",
       "shop": "supermarket"
     }
   },
   "shop/supermarket|Vomar": {
     "count": 51,
+    "countryCodes": ["nl"],
     "tags": {
       "brand": "Vomar",
       "brand:wikidata": "Q3202837",
@@ -3536,6 +3552,7 @@
     }
   },
   "shop/supermarket|Vons": {
+    "countryCodes": ["us"],
     "nocount": true,
     "tags": {
       "brand": "Vons",
@@ -3620,7 +3637,7 @@
   },
   "shop/supermarket|Whole Foods Market": {
     "count": 186,
-    "countryCodes": ["gb", "us"],
+    "countryCodes": ["ca", "gb", "us"],
     "match": ["shop/supermarket|Whole Foods"],
     "tags": {
       "brand": "Whole Foods Market",
@@ -3678,6 +3695,7 @@
   },
   "shop/supermarket|Your Independent Grocer": {
     "countryCodes": ["ca"],
+    "match": ["shop/supermarket|Independent"],
     "nocount": true,
     "tags": {
       "brand": "Your Independent Grocer",
@@ -3700,6 +3718,7 @@
   },
   "shop/supermarket|fakta": {
     "count": 293,
+    "countryCodes": ["dk"],
     "tags": {
       "brand": "fakta",
       "brand:wikidata": "Q3172238",

--- a/config/canonical.json
+++ b/config/canonical.json
@@ -35771,6 +35771,7 @@
   },
   "shop/supermarket|Supercor": {
     "count": 52,
+    "countryCodes": ["es", "pt"],
     "tags": {
       "brand": "Supercor",
       "brand:wikidata": "Q6135841",
@@ -35781,6 +35782,7 @@
   },
   "shop/supermarket|Supersol": {
     "count": 62,
+    "countryCodes": ["ma", "es", "ar", "uy"],
     "tags": {
       "brand": "Supersol",
       "name": "Supersol",
@@ -35789,6 +35791,7 @@
   },
   "shop/supermarket|Superspar": {
     "count": 54,
+    "countryCodes": ["es", "za"],
     "tags": {
       "brand": "Superspar",
       "brand:wikidata": "Q610492",
@@ -35799,6 +35802,7 @@
   },
   "shop/supermarket|Tegut": {
     "count": 91,
+    "countryCodes": ["de"],
     "match": ["shop/supermarket|tegut"],
     "tags": {
       "brand": "Tegut",
@@ -35866,6 +35870,7 @@
   },
   "shop/supermarket|The Co-operative Food": {
     "count": 1170,
+    "countryCodes": ["gb"],
     "match": [
       "shop/supermarket|Co-operative Food",
       "shop/supermarket|The Co-operative"
@@ -35894,6 +35899,7 @@
   },
   "shop/supermarket|Todis": {
     "count": 64,
+    "countryCodes": ["it"],
     "tags": {
       "brand": "Todis",
       "brand:wikidata": "Q3992174",
@@ -35915,7 +35921,11 @@
   },
   "shop/supermarket|Top Market": {
     "count": 51,
+    "countryCodes": ["pl"],
     "tags": {
+      "brand": "Top Market",
+      "brand:wikidata": "Q9360044",
+      "brand:wikipedia": "pl:Top Market",
       "name": "Top Market",
       "shop": "supermarket"
     }
@@ -35944,6 +35954,7 @@
   },
   "shop/supermarket|Trader Joe's": {
     "count": 400,
+    "countryCodes": ["us"],
     "tags": {
       "brand": "Trader Joe's",
       "brand:wikidata": "Q688825",
@@ -35954,6 +35965,7 @@
   },
   "shop/supermarket|Treff 3000": {
     "count": 92,
+    "countryCodes": ["de"],
     "tags": {
       "brand": "Treff 3000",
       "brand:wikidata": "Q701755",
@@ -36045,14 +36057,18 @@
   },
   "shop/supermarket|Volg": {
     "count": 248,
+    "countryCodes": ["ch", "li"],
     "tags": {
       "brand": "Volg",
+      "brand:wikidata": "Q2530746",
+      "brand:wikipedia": "de: Volg",
       "name": "Volg",
       "shop": "supermarket"
     }
   },
   "shop/supermarket|Vomar": {
     "count": 51,
+    "countryCodes": ["nl"],
     "tags": {
       "brand": "Vomar",
       "brand:wikidata": "Q3202837",
@@ -36063,6 +36079,7 @@
   },
   "shop/supermarket|Vons": {
     "nocount": true,
+    "countryCodes": ["us"],
     "tags": {
       "brand": "Vons",
       "brand:wikidata": "Q7941609",
@@ -36146,7 +36163,7 @@
   },
   "shop/supermarket|Whole Foods Market": {
     "count": 186,
-    "countryCodes": ["gb", "us"],
+    "countryCodes": ["ca", "gb", "us"],
     "match": ["shop/supermarket|Whole Foods"],
     "tags": {
       "brand": "Whole Foods Market",
@@ -36204,6 +36221,7 @@
   },
   "shop/supermarket|Your Independent Grocer": {
     "countryCodes": ["ca"],
+    "match": ["shop/supermarket|Independent"],
     "nocount": true,
     "tags": {
       "brand": "Your Independent Grocer",
@@ -36226,6 +36244,7 @@
   },
   "shop/supermarket|fakta": {
     "count": 293,
+    "countryCodes": ["dk"],
     "tags": {
       "brand": "fakta",
       "brand:wikidata": "Q3172238",


### PR DESCRIPTION
Fill in some of the country codes based on wikipedia / overpass turbo searches. Also fills in a few missing wikidata entries.

Signed-off-by: Tim Smith <tsmith@chef.io>