### PR TITLE
Add VCA Animal Hospital

### DIFF
--- a/brands/amenity/veterinary.json
+++ b/brands/amenity/veterinary.json
@@ -8,5 +8,16 @@
       "brand:wikipedia": "en:Banfield Pet Hospital",
       "name": "Banfield Pet Hospital"
     }
+  },
+  "amenity/veterinary|VCA Animal Hospital": {
+    "countryCodes": ["ca", "us"],
+    "nocount": true,
+    "tags": {
+      "amenity": "veterinary",
+      "brand": "VCA Animal Hospital",
+      "brand:wikidata": "Q7906620",
+      "brand:wikipedia": "en:VCA Animal Hospitals",
+      "name": "VCA Animal Hospital"
+    }
   }
 }


### PR DESCRIPTION
There's 817 of these in the US and Canada, but most of them are tagged incorrectly in OSM.

Signed-off-by: Tim Smith <tsmith@chef.io>