### PR TITLE
Add DXL Men's Apparel

### DIFF
--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -490,6 +490,18 @@
       "shop": "clothes"
     }
   },
+  "shop/clothes|DXL Men's Apparel:": {
+    "nocount": true,
+    "tags": {
+      "brand": "DXL Men's Apparel:",
+      "brand:wikidata": "Q61981830",
+      "clothes": "oversize;men",
+      "name": "DXL Men's Apparel:",
+      "operator:wikidata": "Q5050852",
+      "operator:wikipedia": "en:Destination XL Group",
+      "shop": "clothes"
+    }
+  },
   "shop/clothes|David's Bridal": {
     "count": 62,
     "tags": {


### PR DESCRIPTION
I created a new wikidata entry that linked back to the parent group. The sign is DXL Mens Apparel, but their about page has it as Men's so I used that.

Signed-off-by: Tim Smith <tsmith@chef.io>