### PR TITLE
Add entries for Foodland chains in the US, Australia, and Hawaii

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -1228,6 +1228,22 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|FoodLand~(US)": {
+    "countryCodes": ["us"],
+    "nocount": true,
+    "nomatch": [
+      "shop/supermarket|Foodland~(Australia)",
+      "shop/supermarket|Foodland~(Canada)",
+      "shop/supermarket|Foodland~(Hawaii)"
+    ],
+    "tags": {
+      "brand": "FoodLand",
+      "brand:wikidata": "Q5465271",
+      "brand:wikipedia": "en:FoodLand",
+      "name": "FoodLand",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|FoodMaxx": {
     "countryCodes": ["us"],
     "nocount": true,
@@ -1240,13 +1256,50 @@
       "shop": "supermarket"
     }
   },
-  "shop/supermarket|Foodland": {
-    "count": 225,
+  "shop/supermarket|Foodland~(Australia)": {
+    "countryCodes": ["au"],
+    "nocount": true,
+    "nomatch": [
+      "shop/supermarket|Foodland~(Canada)",
+      "shop/supermarket|Foodland~(Hawaii)",
+      "shop/supermarket|Foodland~(US)"
+    ],
+    "tags": {
+      "brand": "Foodland",
+      "brand:wikidata": "Q5465555",
+      "brand:wikipedia": "en:Foodland (South Australia)",
+      "name": "Foodland",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|Foodland~(Canada)": {
     "countryCodes": ["ca"],
+    "nocount": true,
+    "nomatch": [
+      "shop/supermarket|Foodland~(Australia)",
+      "shop/supermarket|Foodland~(Hawaii)",
+      "shop/supermarket|Foodland~(US)"
+    ],
     "tags": {
       "brand": "Foodland",
       "brand:wikidata": "Q5465554",
       "brand:wikipedia": "en:Foodland",
+      "name": "Foodland",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|Foodland~(Hawaii)": {
+    "countryCodes": ["us"],
+    "nocount": true,
+    "nomatch": [
+      "shop/supermarket|Foodland~(Australia)",
+      "shop/supermarket|Foodland~(Canada)",
+      "shop/supermarket|Foodland~(US)"
+    ],
+    "tags": {
+      "brand": "Foodland",
+      "brand:wikidata": "Q5465560",
+      "brand:wikipedia": "en:Foodland Hawaii",
       "name": "Foodland",
       "shop": "supermarket"
     }


### PR DESCRIPTION
There are a few large Foodland chains with wikidata / wikipedia entries. This adds them matching the pattern used elsewhere when we have the same brand in multiple regions.

Signed-off-by: Tim Smith <tsmith@chef.io>