### PR TITLE
Add Mattress Warehouse wikidata entry

### DIFF
--- a/brands/shop/bed.json
+++ b/brands/shop/bed.json
@@ -32,8 +32,10 @@
   },
   "shop/bed|Mattress Warehouse": {
     "count": 61,
+    "countryCodes": ["us"],
     "tags": {
       "brand": "Mattress Warehouse",
+      "brand:wikidata": "Q61995079",
       "name": "Mattress Warehouse",
       "shop": "bed"
     }


### PR DESCRIPTION
I created a wikidata page for Mattress Warehouse.

Signed-off-by: Tim Smith <tsmith@chef.io>