### PR TITLE
k kiosk: added countryCodes and nomatch

### DIFF
--- a/brands/shop/kiosk.json
+++ b/brands/shop/kiosk.json
@@ -72,6 +72,8 @@
   },
   "shop/kiosk|k kiosk": {
     "count": 64,
+    "countryCodes": ["ch"],
+    "nomatch": ["shop/newsagent|k kiosk"],
     "match": [
       "shop/kiosk|K Kiosk",
       "shop/kiosk|kkiosk"
@@ -79,7 +81,6 @@
     "tags": {
       "brand": "k kiosk",
       "brand:wikidata": "Q60381703",
-      "brand:wikipedia": "it:K Kiosk",
       "name": "k kiosk",
       "shop": "kiosk"
     }

--- a/brands/shop/kiosk.json
+++ b/brands/shop/kiosk.json
@@ -81,6 +81,7 @@
     "tags": {
       "brand": "k kiosk",
       "brand:wikidata": "Q60381703",
+      "brand:wikipedia": "it:K Kiosk",
       "name": "k kiosk",
       "shop": "kiosk"
     }


### PR DESCRIPTION
* k kiosk can also be a newsagent
* Removed link to Italian Wikipedia, as also/mostly used in German speaking region