### PR TITLE
Multiple additions on shoes.json

### DIFF
--- a/brands/shop/shoes.json
+++ b/brands/shop/shoes.json
@@ -191,6 +191,7 @@
     "countryCodes": ["tr", "al"],
     "tags": {
       "brand": "FLO",
+      "brand:wikidata": "Q61994802",
       "name": "FLO",
       "shop": "shoes"
     }

--- a/brands/shop/shoes.json
+++ b/brands/shop/shoes.json
@@ -1,10 +1,12 @@
 {
   "shop/shoes|ABCマート": {
     "count": 51,
-    "countryCodes": ["jp"],
+    "countryCodes": ["jp", "kr", "tw"],
     "tags": {
       "brand": "ABCマート",
       "brand:ja": "ABCマート",
+      "brand:wikidata": "Q11188787",
+      "brand:wikipedia": "en:ABC-Mart",
       "name": "ABCマート",
       "name:ja": "ABCマート",
       "shop": "shoes"
@@ -43,12 +45,16 @@
   },
   "shop/shoes|Besson Chaussures": {
     "count": 135,
+    "countryCodes": ["fr"],
     "tags": {
       "brand": "Besson Chaussures",
       "brand:wikidata": "Q2899930",
       "brand:wikipedia": "fr:Besson Chaussures",
       "name": "Besson Chaussures",
-      "shop": "shoes"
+      "shop": "shoes",
+      "operator": "Vivarte",
+      "operator:wikidata": "fr:Vivarte",
+      "operator:wikipedia": "Q3561446"
     }
   },
   "shop/shoes|Birkenstock": {
@@ -182,6 +188,7 @@
   },
   "shop/shoes|FLO": {
     "count": 51,
+    "countryCodes": ["tr", "al"],
     "tags": {
       "brand": "FLO",
       "name": "FLO",
@@ -210,8 +217,11 @@
   },
   "shop/shoes|Gabor": {
     "count": 52,
+    "countryCodes": ["de", "it"],
     "tags": {
       "brand": "Gabor",
+      "brand:wikidata": "Q1488760",
+      "brand:wikipedia": "de:Gabor Shoes",
       "name": "Gabor",
       "shop": "shoes"
     }
@@ -358,13 +368,7 @@
   },
   "shop/shoes|Reno": {
     "count": 244,
-    "countryCodes": [
-      "at",
-      "ch",
-      "de",
-      "hu",
-      "sk"
-    ],
+    "countryCodes": ["at", "ch", "de", "hu", "sk"],
     "tags": {
       "brand": "Reno",
       "brand:wikidata": "Q2144204",


### PR DESCRIPTION
- ABCマート: Added two more country codes, Wikidata code, and Wikipedia link.
- Besson Chaussures: Added country code. A Wikipedia shop for this page does not exist, but I managed to find their operator information - so I added these too.
- FLO: Added country codes. Wikipedia page doesn't exist.
- Gabor: Added country codes, Wikidata code, and Wikipedia link.
