### PR TITLE
Add logos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
-.DS_Store
+/config/secrets.json
 /node_modules/
+
+.DS_Store
 npm-debug.log
 package-lock.json
+
 *.bz2
 *.osm
 *.pbf

--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -2,6 +2,10 @@
   "amenity/bank|ABANCA": {
     "count": 124,
     "countryCodes": ["es"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAbanca%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/921290003019390976/Uu67Ff1X_bigger.jpg"
+    },
     "match": ["amenity/bank|Abanca"],
     "tags": {
       "amenity": "bank",
@@ -13,6 +17,9 @@
   },
   "amenity/bank|ABN AMRO": {
     "count": 144,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FABN-AMRO%20Logo%20new%20colors.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "ABN AMRO",
@@ -23,6 +30,9 @@
   },
   "amenity/bank|ABSA": {
     "count": 117,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FABSA%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "ABSA",
@@ -46,6 +56,9 @@
   "amenity/bank|ANZ": {
     "count": 397,
     "countryCodes": ["au", "nz"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FANZ-Logo-2009.svg&width=100"
+    },
     "match": ["amenity/bank|ANZ Bank"],
     "tags": {
       "amenity": "bank",
@@ -58,6 +71,9 @@
   "amenity/bank|ASB Bank": {
     "count": 53,
     "countryCodes": ["nz"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FASB%20Bank%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "ASB Bank",
@@ -69,6 +85,9 @@
   "amenity/bank|ATB Financial": {
     "count": 80,
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FATB%20Financial%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "ATB Financial",
@@ -80,6 +99,10 @@
   },
   "amenity/bank|AXA": {
     "count": 137,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAXA%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/889516666341777408/xMlsr4cx_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "AXA",
@@ -112,6 +135,9 @@
   "amenity/bank|Agribank": {
     "count": 79,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAgriBank-logo.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Agribank",
@@ -123,6 +149,10 @@
   "amenity/bank|Akbank": {
     "count": 196,
     "countryCodes": ["tr"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAkbank%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/852502450363920385/YiR5nt6j_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Akbank",
@@ -165,6 +195,9 @@
   },
   "amenity/bank|Alpha Bank": {
     "count": 406,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAlpha%20Bank%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Alpha Bank",
@@ -176,6 +209,9 @@
   "amenity/bank|Andhra Bank": {
     "count": 123,
     "countryCodes": ["in"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAndhra%20bank.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Andhra Bank",
@@ -210,6 +246,9 @@
   "amenity/bank|Arvest Bank": {
     "count": 58,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FArvest%20Bank%20Logo.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Arvest Bank",
@@ -267,6 +306,9 @@
   },
   "amenity/bank|Axis Bank": {
     "count": 250,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAXISBank%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Axis Bank",
@@ -277,6 +319,9 @@
   },
   "amenity/bank|BAC": {
     "count": 77,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBac%20credomatic%20logo.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "BAC",
@@ -288,6 +333,9 @@
   },
   "amenity/bank|BAWAG PSK": {
     "count": 97,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBAWAG%20P.S.K.%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "BAWAG PSK",
@@ -299,6 +347,9 @@
   "amenity/bank|BB&T": {
     "count": 581,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBB%26T%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "BB&T",
@@ -311,6 +362,9 @@
   "amenity/bank|BBBank": {
     "count": 60,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBBBank%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "BBBank",
@@ -324,6 +378,9 @@
   },
   "amenity/bank|BBVA": {
     "count": 1642,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogotipo%20de%20BBVA.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "BBVA",
@@ -336,6 +393,9 @@
   "amenity/bank|BBVA Bancomer": {
     "count": 246,
     "countryCodes": ["mx"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBancomer.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "BBVA Bancomer",
@@ -350,6 +410,9 @@
   "amenity/bank|BBVA Compass": {
     "count": 114,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBBVACompasslogo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "BBVA Compass",
@@ -365,6 +428,9 @@
   "amenity/bank|BBVA Continental": {
     "count": 93,
     "countryCodes": ["pe"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBbvacontinental.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "BBVA Continental",
@@ -376,6 +442,9 @@
   "amenity/bank|BBVA Francés": {
     "count": 169,
     "countryCodes": ["es"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBBVA%20Franc%C3%A9s%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "BBVA Francés",
@@ -409,6 +478,9 @@
   },
   "amenity/bank|BCP~(Bolivia)": {
     "countryCodes": ["bo"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogobcp.png&width=100"
+    },
     "nocount": true,
     "nomatch": [
       "amenity/bank|BCP~(France)",
@@ -426,6 +498,9 @@
   },
   "amenity/bank|BCP~(France)": {
     "countryCodes": ["fr"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMillennium%20bcp%20small.jpg&width=100"
+    },
     "match": [
       "amenity/bank|Banque BCP~(France)",
       "amenity/bank|BanqueBCP~(France)"
@@ -446,6 +521,9 @@
   },
   "amenity/bank|BCP~(Luxembourg)": {
     "countryCodes": ["lu"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMillennium%20bcp%20small.jpg&width=100"
+    },
     "match": [
       "amenity/bank|Banque BCP~(Luxembourg)",
       "amenity/bank|BanqueBCP~(Luxembourg)"
@@ -466,6 +544,9 @@
   },
   "amenity/bank|BCP~(Peru)": {
     "countryCodes": ["pe"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogobcp.png&width=100"
+    },
     "match": [
       "amenity/bank|Banco de Crédito del Perú"
     ],
@@ -486,6 +567,9 @@
   "amenity/bank|BCR": {
     "count": 253,
     "countryCodes": ["cr"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLOGO%20BCR.svg&width=100"
+    },
     "match": ["amenity/bank|Banco de Costa Rica"],
     "tags": {
       "amenity": "bank",
@@ -499,6 +583,9 @@
   "amenity/bank|BDO": {
     "count": 600,
     "countryCodes": ["ph"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBDO%20Unibank%20(logo).svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "BDO",
@@ -521,6 +608,9 @@
   },
   "amenity/bank|BMCE Bank": {
     "count": 251,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBMCE%20Bank.jpg&width=100"
+    },
     "match": ["amenity/bank|BMCE"],
     "tags": {
       "amenity": "bank",
@@ -544,6 +634,9 @@
   "amenity/bank|BMN": {
     "count": 69,
     "countryCodes": ["es"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBMN%20nuevo%20logo.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "BMN",
@@ -554,6 +647,9 @@
   },
   "amenity/bank|BMO": {
     "count": 237,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank%20of%20Montreal%20Logo.svg&width=100"
+    },
     "match": [
       "amenity/bank|BMO Bank of Montreal"
     ],
@@ -569,6 +665,10 @@
   "amenity/bank|BMO Harris Bank": {
     "count": 116,
     "countryCodes": ["us"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/bmoharrisbank/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1013794087177252865/VqKUfm99_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "BMO Harris Bank",
@@ -618,6 +718,9 @@
   },
   "amenity/bank|BNP Paribas": {
     "count": 1244,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1800794741/logo_pour_twitter_bigger.JPG"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "BNP Paribas",
@@ -638,6 +741,9 @@
   },
   "amenity/bank|BOC": {
     "count": 103,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChinese%20Bank%20of%20China.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "BOC",
@@ -686,6 +792,9 @@
   "amenity/bank|BRI": {
     "count": 342,
     "countryCodes": ["id"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20BRI.png&width=100"
+    },
     "match": ["amenity/bank|Bank BRI"],
     "tags": {
       "amenity": "bank",
@@ -712,6 +821,9 @@
   "amenity/bank|BW-Bank": {
     "count": 94,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBaden-W%C3%BCrttembergische%20Bank%20text%20logo%20black.svg&width=100"
+    },
     "match": ["Baden-Württembergische Bank"],
     "tags": {
       "amenity": "bank",
@@ -744,6 +856,9 @@
   "amenity/bank|Banca Intesa": {
     "count": 103,
     "countryCodes": ["rs"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBiblogo.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banca Intesa",
@@ -758,6 +873,9 @@
   "amenity/bank|Banca March": {
     "count": 63,
     "countryCodes": ["es"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo-BM-Color.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banca March",
@@ -769,6 +887,9 @@
   "amenity/bank|Banca Popolare di Milano": {
     "count": 129,
     "countryCodes": ["it"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanca%20Popolare%20di%20Milano%20logo.svg&width=100"
+    },
     "match": ["amenity/bank|BPM"],
     "tags": {
       "amenity": "bank",
@@ -882,6 +1003,9 @@
   "amenity/bank|Banco AV Villas": {
     "count": 64,
     "countryCodes": ["co"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20AV%20Villas%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco AV Villas",
@@ -896,6 +1020,9 @@
   "amenity/bank|Banco Agrario": {
     "count": 89,
     "countryCodes": ["co"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20Agrario%20de%20Colombia%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Agrario",
@@ -907,6 +1034,9 @@
   "amenity/bank|Banco Agrario de Colombia": {
     "count": 74,
     "countryCodes": ["co"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20Agrario%20de%20Colombia%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Agrario de Colombia",
@@ -917,6 +1047,9 @@
   },
   "amenity/bank|Banco Azteca": {
     "count": 165,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Banco%20Azteca.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Azteca",
@@ -938,6 +1071,9 @@
   "amenity/bank|Banco Caja Social": {
     "count": 75,
     "countryCodes": ["co"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20Caja%20Social%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Caja Social",
@@ -960,6 +1096,9 @@
   "amenity/bank|Banco Continental": {
     "count": 68,
     "countryCodes": ["pe"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBbvacontinental.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Continental",
@@ -986,6 +1125,9 @@
   "amenity/bank|Banco Falabella": {
     "count": 61,
     "countryCodes": ["cl", "co", "pe"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20Falabella%20Logo.svg&width=100"
+    },
     "nomatch": [
       "shop/department_store|Falabella"
     ],
@@ -1012,6 +1154,9 @@
   },
   "amenity/bank|Banco G&T Continental": {
     "count": 85,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20G%26T.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco G&T Continental",
@@ -1034,6 +1179,9 @@
   },
   "amenity/bank|Banco Industrial": {
     "count": 102,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo-banco-industrial-arg.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Industrial",
@@ -1078,6 +1226,9 @@
   },
   "amenity/bank|Banco Nación": {
     "count": 476,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20Naci%C3%B3n%20de%20Argentina.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Nación",
@@ -1092,6 +1243,9 @@
   "amenity/bank|Banco Pastor": {
     "count": 83,
     "countryCodes": ["es"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20pastor168x78.gif%3Bpv91c0cc0e0080a771.gif&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Pastor",
@@ -1123,6 +1277,9 @@
   "amenity/bank|Banco Popular": {
     "count": 704,
     "countryCodes": ["pr", "us", "vi"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogoPopularGrupoSantander.png&width=100"
+    },
     "match": ["amenity/bank|Popular"],
     "tags": {
       "amenity": "bank",
@@ -1150,6 +1307,9 @@
   "amenity/bank|Banco Provincia": {
     "count": 192,
     "countryCodes": ["ar"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20Provincia%20isologo%202017.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Provincia",
@@ -1163,6 +1323,9 @@
   },
   "amenity/bank|Banco Sabadell": {
     "count": 223,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBSabadell%20POS%20COL.jpg&width=100"
+    },
     "match": [
       "amenity/bank|Banc Sabadell",
       "amenity/bank|Sabadell"
@@ -1192,6 +1355,9 @@
   },
   "amenity/bank|Banco Santander": {
     "count": 219,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20Santander%20Logotipo.svg&width=100"
+    },
     "nomatch": ["amenity/bank|Santander"],
     "tags": {
       "amenity": "bank",
@@ -1224,6 +1390,9 @@
   },
   "amenity/bank|Banco de Bogotá": {
     "count": 182,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20de%20Bogot%C3%A1%20logo.svg&width=100"
+    },
     "match": ["amenity/bank|Banco de Bogota"],
     "tags": {
       "amenity": "bank",
@@ -1235,6 +1404,9 @@
   },
   "amenity/bank|Banco de Chile": {
     "count": 189,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20de%20Chile%20Logo.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco de Chile",
@@ -1245,6 +1417,9 @@
   },
   "amenity/bank|Banco de Desarrollo Banrural": {
     "count": 81,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNuevo%20Logo%20Banrural.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco de Desarrollo Banrural",
@@ -1263,6 +1438,9 @@
   },
   "amenity/bank|Banco de Occidente": {
     "count": 126,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20de%20Occidente%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco de Occidente",
@@ -1273,6 +1451,9 @@
   },
   "amenity/bank|Banco de Venezuela": {
     "count": 99,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20de%20Venezuela%20logo.svg&width=100"
+    },
     "match": ["amenity/bank|De Venezuela"],
     "tags": {
       "amenity": "bank",
@@ -1284,6 +1465,9 @@
   },
   "amenity/bank|Banco de la Nación~(Argentina)": {
     "countryCodes": ["ar"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20Naci%C3%B3n%20de%20Argentina.jpg&width=100"
+    },
     "nocount": true,
     "tags": {
       "amenity": "bank",
@@ -1295,6 +1479,9 @@
   },
   "amenity/bank|Banco de la Nación~(Peru)": {
     "countryCodes": ["pe"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogobn.gif&width=100"
+    },
     "nocount": true,
     "tags": {
       "amenity": "bank",
@@ -1334,6 +1521,9 @@
   },
   "amenity/bank|Banco do Brasil": {
     "count": 1644,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20do%20Brasil%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco do Brasil",
@@ -1344,6 +1534,9 @@
   },
   "amenity/bank|Banco do Nordeste": {
     "count": 79,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20BNB%20(1).svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banco do Nordeste",
@@ -1354,6 +1547,9 @@
   },
   "amenity/bank|Bancolombia": {
     "count": 252,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBancolombia%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Bancolombia",
@@ -1364,6 +1560,9 @@
   },
   "amenity/bank|Bancomer": {
     "count": 274,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBancomer.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Bancomer",
@@ -1395,6 +1594,9 @@
   },
   "amenity/bank|Bangkok Bank": {
     "count": 83,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Bangkok%20Bank%20Public%20Company%20Limited.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Bangkok Bank",
@@ -1405,6 +1607,9 @@
   },
   "amenity/bank|Bank Al Habib": {
     "count": 90,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBankalhabiblogo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Al Habib",
@@ -1415,6 +1620,9 @@
   },
   "amenity/bank|Bank Alfalah": {
     "count": 105,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank%20Alfalah's%20new%20Chevron%20Logo.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Alfalah",
@@ -1445,6 +1653,9 @@
   },
   "amenity/bank|Bank Mandiri": {
     "count": 344,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank%20Mandiri%20(1998-2008).svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Mandiri",
@@ -1486,6 +1697,9 @@
   "amenity/bank|Bank Pekao": {
     "count": 54,
     "countryCodes": ["pl"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank%20Pekao%20SA%20Logo%20(2017).svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Pekao",
@@ -1518,6 +1732,11 @@
   },
   "amenity/bank|Bank of America": {
     "count": 2147,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank%20of%20America%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/BankofAmerica/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1063471185533566977/m2LMFXdd_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of America",
@@ -1548,6 +1767,9 @@
   },
   "amenity/bank|Bank of China": {
     "count": 158,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChinese%20Bank%20of%20China.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of China",
@@ -1588,6 +1810,9 @@
   },
   "amenity/bank|Bank of Ireland": {
     "count": 174,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank-of-Ireland-Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Ireland",
@@ -1608,6 +1833,9 @@
   },
   "amenity/bank|Bank of Montreal": {
     "count": 154,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank%20of%20Montreal%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Montreal",
@@ -1618,6 +1846,9 @@
   },
   "amenity/bank|Bank of New Zealand": {
     "count": 65,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank%20of%20New%20Zealand%202008%20new%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of New Zealand",
@@ -1628,6 +1859,10 @@
   },
   "amenity/bank|Bank of Scotland": {
     "count": 120,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank%20of%20Scotland%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/902447929742553092/UfYosl_o_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Scotland",
@@ -1638,6 +1873,9 @@
   },
   "amenity/bank|Bank of the West": {
     "count": 202,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1103424843482058752/wb7kFeSw_bigger.png"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of the West",
@@ -1648,6 +1886,9 @@
   },
   "amenity/bank|Bankia": {
     "count": 764,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBankia%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Bankia",
@@ -1658,6 +1899,9 @@
   },
   "amenity/bank|Bankinter": {
     "count": 174,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBankinter.svg&width=100"
+    },
     "nomatch": ["amenity/bank|Interbank"],
     "tags": {
       "amenity": "bank",
@@ -1679,6 +1923,9 @@
   },
   "amenity/bank|Banorte": {
     "count": 344,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanorte.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Banorte",
@@ -1717,6 +1964,9 @@
   },
   "amenity/bank|Banque Populaire": {
     "count": 1150,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo-BP-VF%2BS.jpg&width=100"
+    },
     "match": ["amenity/bank|Banque populaire"],
     "tags": {
       "amenity": "bank",
@@ -1746,6 +1996,10 @@
   },
   "amenity/bank|Barclays": {
     "count": 1136,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBarclays%20logo.svg.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1064539548020105216/OATR1eRO_bigger.jpg"
+    },
     "match": ["amenity/bank|Barclays Bank"],
     "tags": {
       "amenity": "bank",
@@ -1765,6 +2019,9 @@
   },
   "amenity/bank|Belfius": {
     "count": 317,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBelfius.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Belfius",
@@ -1785,6 +2042,10 @@
   },
   "amenity/bank|Berliner Volksbank": {
     "count": 65,
+    "logos": {
+      "facebook": "https://graph.facebook.com/BerlinerVolksbank/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/812233506394869760/Gp7rbIgx_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Berliner Volksbank",
@@ -1820,6 +2081,9 @@
   },
   "amenity/bank|Bradesco": {
     "count": 1093,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAg%20jucelino.jpg&width=100"
+    },
     "match": ["amenity/bank|Banco Bradesco"],
     "tags": {
       "amenity": "bank",
@@ -1883,6 +2147,9 @@
   },
   "amenity/bank|CIC": {
     "count": 860,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCICBanqueLogo.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "CIC",
@@ -1903,6 +2170,9 @@
   },
   "amenity/bank|CIMB Bank": {
     "count": 79,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCIMB%20Group%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "CIMB Bank",
@@ -1913,6 +2183,9 @@
   },
   "amenity/bank|CIMB Niaga": {
     "count": 73,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20cimbniaga.gif&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "CIMB Niaga",
@@ -1933,6 +2206,9 @@
   },
   "amenity/bank|Caisse Desjardins": {
     "count": 135,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDesjardins%20Group%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Caisse Desjardins",
@@ -1943,6 +2219,9 @@
   },
   "amenity/bank|Caisse d'Épargne": {
     "count": 1753,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/963786966771863554/TO9mBEU1_bigger.jpg"
+    },
     "match": ["amenity/bank|Caisse d'épargne"],
     "tags": {
       "amenity": "bank",
@@ -1954,6 +2233,9 @@
   },
   "amenity/bank|Caixa Econômica Federal": {
     "count": 809,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCaixa%20Econ%C3%B4mica%20Federal.svg&width=100"
+    },
     "match": [
       "amenity/bank|Caixa",
       "amenity/bank|CaixaBank"
@@ -1968,6 +2250,9 @@
   },
   "amenity/bank|Caixa Geral de Depósitos": {
     "count": 408,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCaixa%20Geral%20de%20Dep%C3%B3sitos%20logo.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Caixa Geral de Depósitos",
@@ -1978,6 +2263,9 @@
   },
   "amenity/bank|Caixabank": {
     "count": 178,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20CaixaBank.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Caixabank",
@@ -2054,6 +2342,9 @@
   },
   "amenity/bank|Canara Bank": {
     "count": 320,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCanara%20Bank%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Canara Bank",
@@ -2074,6 +2365,11 @@
   },
   "amenity/bank|Capital One": {
     "count": 164,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCapital%20One%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/capitalone/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1006893718098665472/Mh3fEzCO_bigger.jpg"
+    },
     "match": ["amenity/bank|Capital One Bank"],
     "tags": {
       "amenity": "bank",
@@ -2095,6 +2391,9 @@
   },
   "amenity/bank|Cariparma": {
     "count": 61,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20de%20Cariparma.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Cariparma",
@@ -2125,6 +2424,9 @@
   },
   "amenity/bank|CatalunyaCaixa": {
     "count": 104,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20cx%20original.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "CatalunyaCaixa",
@@ -2153,6 +2455,11 @@
   },
   "amenity/bank|Chase": {
     "count": 1946,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChase%20logo%202007.svg&width=100",
+      "facebook": "https://graph.facebook.com/chase/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/748885874516094980/ywt_aKRx_bigger.jpg"
+    },
     "match": ["amenity/bank|Chase Bank"],
     "tags": {
       "amenity": "bank",
@@ -2164,6 +2471,9 @@
   },
   "amenity/bank|China Bank": {
     "count": 176,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChina%20Bank%20logo%20wiki.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "China Bank",
@@ -2184,6 +2494,9 @@
   },
   "amenity/bank|China Construction Bank": {
     "count": 67,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChina%20Construction%20Bank%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "China Construction Bank",
@@ -2194,6 +2507,10 @@
   },
   "amenity/bank|Citibank": {
     "count": 515,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCitibank.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/926109116233166848/xR88n-q7_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Citibank",
@@ -2214,6 +2531,9 @@
   },
   "amenity/bank|Clydesdale Bank": {
     "countryCodes": ["gb"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/875682015106007042/Ogpdl-Lh_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "amenity": "bank",
@@ -2234,6 +2554,9 @@
   },
   "amenity/bank|Comerica Bank": {
     "count": 92,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FComerica%20Inc.%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Comerica Bank",
@@ -2270,6 +2593,11 @@
   },
   "amenity/bank|Commerzbank": {
     "count": 873,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCommerzbank%20(2009).svg&width=100",
+      "facebook": "https://graph.facebook.com/commerzbank/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1078215156583284736/z3ZQRXOo_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Commerzbank",
@@ -2280,6 +2608,10 @@
   },
   "amenity/bank|Commonwealth Bank": {
     "count": 430,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCommonwealth%20Bank%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/706619944633389058/8ohO3e8b_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Commonwealth Bank",
@@ -2290,6 +2622,9 @@
   },
   "amenity/bank|Community Bank": {
     "count": 70,
+    "logos": {
+      "facebook": "https://graph.facebook.com/communitybankna/picture?type=square"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Community Bank",
@@ -2320,6 +2655,9 @@
   },
   "amenity/bank|Credicoop": {
     "count": 129,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo-banco-Credicoop.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Credicoop",
@@ -2330,6 +2668,9 @@
   },
   "amenity/bank|Credit Suisse": {
     "count": 100,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCredit%20Suisse%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Credit Suisse",
@@ -2360,6 +2701,10 @@
   },
   "amenity/bank|Crédit Agricole": {
     "count": 3106,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Credit%20Agricole.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/752428920335691776/1HVlh5nH_bigger.jpg"
+    },
     "match": ["amenity/bank|Credit Agricole"],
     "tags": {
       "amenity": "bank",
@@ -2382,6 +2727,9 @@
   },
   "amenity/bank|Crédit Mutuel": {
     "count": 1268,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Cr%C3%A9dit%20Mutuel.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Crédit Mutuel",
@@ -2392,6 +2740,9 @@
   },
   "amenity/bank|Crédit Mutuel de Bretagne": {
     "count": 361,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1008694686410838017/iW0u40ZL_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Crédit Mutuel de Bretagne",
@@ -2422,6 +2773,11 @@
   },
   "amenity/bank|Cбербанк": {
     "count": 73,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSberbank%20logo.png&width=100",
+      "facebook": "https://graph.facebook.com/sberbank/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1095637173980856320/Dlp96K30_bigger.png"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Cбербанк",
@@ -2432,6 +2788,9 @@
   },
   "amenity/bank|Danske Bank": {
     "count": 168,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDanske%20Bank%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Danske Bank",
@@ -2452,6 +2811,9 @@
   },
   "amenity/bank|Denizbank": {
     "count": 80,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDenizBank%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Denizbank",
@@ -2462,6 +2824,9 @@
   },
   "amenity/bank|Desjardins": {
     "count": 93,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDesjardins%20Group%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Desjardins",
@@ -2472,6 +2837,11 @@
   },
   "amenity/bank|Deutsche Bank": {
     "count": 1015,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDeutsche%20Bank%20logo%20without%20wordmark.svg&width=100",
+      "facebook": "https://graph.facebook.com/DeutscheBank/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1024584150945345536/apqlB2id_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Deutsche Bank",
@@ -2513,6 +2883,9 @@
   },
   "amenity/bank|Ecobank": {
     "count": 267,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEcobank%20Logo.svg&width=100"
+    },
     "match": ["amenity/bank|Agence Ecobank"],
     "tags": {
       "amenity": "bank",
@@ -2541,6 +2914,9 @@
   "amenity/bank|Erste Bank": {
     "count": 211,
     "countryCodes": ["at", "hr", "hu"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FErste%20Bank%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Erste Bank",
@@ -2579,6 +2955,9 @@
   },
   "amenity/bank|Federal Bank": {
     "count": 107,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFederal%20Bank.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Federal Bank",
@@ -2597,6 +2976,9 @@
   },
   "amenity/bank|Fifth Third Bank": {
     "count": 328,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1013779792141914120/FJ0U_8zw_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Fifth Third Bank",
@@ -2665,6 +3047,9 @@
   },
   "amenity/bank|Galicia": {
     "count": 208,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20galicia%20logo.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Galicia",
@@ -2695,6 +3080,9 @@
   },
   "amenity/bank|Getin Bank": {
     "count": 128,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGetin%20Bank%20Logo.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Getin Bank",
@@ -2736,6 +3124,10 @@
   },
   "amenity/bank|HDFC Bank": {
     "count": 274,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHDFC-Bank-Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/HDFC.bank/picture?type=square"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "HDFC Bank",
@@ -2756,6 +3148,9 @@
   },
   "amenity/bank|HSBC": {
     "count": 1790,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHSBC.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "HSBC",
@@ -2786,6 +3181,9 @@
   },
   "amenity/bank|Handelsbanken": {
     "count": 270,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHandelsbanken.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Handelsbanken",
@@ -2806,6 +3204,9 @@
   },
   "amenity/bank|Hong Leong Bank": {
     "count": 74,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHong%20Leong%20Bank.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Hong Leong Bank",
@@ -2836,6 +3237,9 @@
   },
   "amenity/bank|HypoVereinsbank": {
     "count": 386,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/950681154906095618/sFON4jIk_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "HypoVereinsbank",
@@ -2846,6 +3250,9 @@
   },
   "amenity/bank|ICBC": {
     "count": 176,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FICBC%20logo.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "ICBC",
@@ -2856,6 +3263,9 @@
   },
   "amenity/bank|ICICI Bank": {
     "count": 263,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FICICI%20Bank%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "ICICI Bank",
@@ -2866,6 +3276,9 @@
   },
   "amenity/bank|IDBI Bank": {
     "count": 79,
+    "logos": {
+      "facebook": "https://graph.facebook.com/IDBIBank/picture?type=square"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "IDBI Bank",
@@ -2876,6 +3289,9 @@
   },
   "amenity/bank|ING": {
     "count": 606,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FING%20Group%20N.V.%20Logo.svg&width=100"
+    },
     "match": ["amenity/bank|ING Bank"],
     "tags": {
       "amenity": "bank",
@@ -2887,6 +3303,9 @@
   },
   "amenity/bank|ING Bank Śląski": {
     "count": 154,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FING%20Group%20N.V.%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "ING Bank Śląski",
@@ -2918,6 +3337,9 @@
   },
   "amenity/bank|Indian Overseas Bank": {
     "count": 125,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FIndian%20Overseas%20Bank%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Indian Overseas Bank",
@@ -2928,6 +3350,9 @@
   },
   "amenity/bank|Interbank": {
     "count": 154,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FInterbank%20Logo.jpg&width=100"
+    },
     "nomatch": ["amenity/bank|Bankinter"],
     "tags": {
       "amenity": "bank",
@@ -2939,6 +3364,9 @@
   },
   "amenity/bank|Intesa Sanpaolo": {
     "count": 168,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Sanpaolo.gif&width=100"
+    },
     "match": [
       "amenity/bank|Intesa San Paolo",
       "amenity/bank|Intesa SanPaolo"
@@ -2953,6 +3381,9 @@
   },
   "amenity/bank|Itaú": {
     "count": 892,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FItau.svg&width=100"
+    },
     "match": [
       "amenity/bank|Banco Itaú",
       "amenity/bank|Itau"
@@ -2967,6 +3398,9 @@
   },
   "amenity/bank|JS Bank": {
     "count": 55,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJS%20Bank%20-%20New%20logo%202011%20-%20Copy.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "JS Bank",
@@ -2987,6 +3421,10 @@
   },
   "amenity/bank|Jyske Bank": {
     "count": 51,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJyske%20Bank%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1062308131567517702/0I4wgGmc_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Jyske Bank",
@@ -2997,6 +3435,9 @@
   },
   "amenity/bank|K&H Bank": {
     "count": 84,
+    "logos": {
+      "facebook": "https://graph.facebook.com/dontsokosan/picture?type=square"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "K&H Bank",
@@ -3047,6 +3488,9 @@
   },
   "amenity/bank|Key Bank": {
     "count": 301,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKeyBank.png&width=100"
+    },
     "match": ["amenity/bank|KeyBank"],
     "tags": {
       "amenity": "bank",
@@ -3058,6 +3502,9 @@
   },
   "amenity/bank|Komerční banka": {
     "count": 192,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKomer%C4%8Dn%C3%AD%20banka%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Komerční banka",
@@ -3089,6 +3536,9 @@
   },
   "amenity/bank|Kutxabank": {
     "count": 194,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKutxabank.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Kutxabank",
@@ -3099,6 +3549,9 @@
   },
   "amenity/bank|LCL": {
     "count": 978,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/899663758662017024/JLvGAjAM_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "LCL",
@@ -3109,6 +3562,9 @@
   },
   "amenity/bank|La Banque Postale": {
     "count": 144,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/877443340551282689/fZlNq46c_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "La Banque Postale",
@@ -3119,6 +3575,9 @@
   },
   "amenity/bank|La Caixa": {
     "count": 1074,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFundaci%C3%B3n%20bancaria%20la%20caixa.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "La Caixa",
@@ -3129,6 +3588,9 @@
   },
   "amenity/bank|Laboral Kutxa": {
     "count": 77,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Laboral%20Kutxa.JPG&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Laboral Kutxa",
@@ -3155,6 +3617,9 @@
   },
   "amenity/bank|Liberbank": {
     "count": 249,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLbk.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Liberbank",
@@ -3188,6 +3653,9 @@
   },
   "amenity/bank|M&T Bank": {
     "count": 251,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1096422949081341953/zTOinsUb_bigger.png"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "M&T Bank",
@@ -3209,6 +3677,9 @@
   },
   "amenity/bank|MONETA Money Bank": {
     "count": 85,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Moneta%20Money%20Bank.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "MONETA Money Bank",
@@ -3219,6 +3690,9 @@
   },
   "amenity/bank|Macro": {
     "count": 219,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Banco%20Macro.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Macro",
@@ -3229,6 +3703,10 @@
   },
   "amenity/bank|Maybank": {
     "count": 291,
+    "logos": {
+      "facebook": "https://graph.facebook.com/Maybank/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1535622354/Maybank_Refreshed_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Maybank",
@@ -3284,6 +3762,9 @@
   "amenity/bank|Millennium Bank": {
     "count": 362,
     "countryCodes": ["pl"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank%20Millenium.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Millennium Bank",
@@ -3295,6 +3776,9 @@
   "amenity/bank|Millennium bcp": {
     "count": 300,
     "countryCodes": ["pt"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMillennium%20bcp%20small.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Millennium bcp",
@@ -3343,6 +3827,9 @@
   },
   "amenity/bank|NatWest": {
     "count": 518,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNatwest-logo.jpg&width=100"
+    },
     "match": [
       "amenity/bank|Nat West",
       "amenity/bank|Natwest"
@@ -3365,6 +3852,9 @@
   },
   "amenity/bank|Nationwide": {
     "count": 394,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/770597713893285888/ItnmL0YM_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Nationwide",
@@ -3375,6 +3865,9 @@
   },
   "amenity/bank|Navy Federal Credit Union": {
     "count": 70,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/963505271728427011/XoP8-Xam_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Navy Federal Credit Union",
@@ -3395,6 +3888,9 @@
   },
   "amenity/bank|Nordea": {
     "count": 315,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNordea%20logo16.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Nordea",
@@ -3405,6 +3901,9 @@
   },
   "amenity/bank|Novo Banco": {
     "count": 147,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogotipo%20Novo%20Banco.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Novo Banco",
@@ -3415,6 +3914,9 @@
   },
   "amenity/bank|OLB": {
     "count": 57,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOldenburgische%20landesbank%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "OLB",
@@ -3425,6 +3927,9 @@
   },
   "amenity/bank|OTP": {
     "count": 88,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOtp%20bank%20Logo.svg&width=100"
+    },
     "match": ["amenity/bank|OTP Bank"],
     "tags": {
       "amenity": "bank",
@@ -3436,6 +3941,9 @@
   },
   "amenity/bank|Oberbank": {
     "count": 115,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOberbank%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Oberbank",
@@ -3446,6 +3954,10 @@
   },
   "amenity/bank|Occidental de Descuento": {
     "count": 67,
+    "logos": {
+      "facebook": "https://graph.facebook.com/BODOficial/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/948214548519112704/QopepRkh_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Occidental de Descuento",
@@ -3456,6 +3968,9 @@
   },
   "amenity/bank|Oldenburgische Landesbank": {
     "count": 67,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOldenburgische%20landesbank%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Oldenburgische Landesbank",
@@ -3504,6 +4019,9 @@
   },
   "amenity/bank|PKO BP": {
     "count": 546,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogotyp%20PKO%20BP.svg&width=100"
+    },
     "match": ["amenity/bank|PKO Bank Polski"],
     "tags": {
       "amenity": "bank",
@@ -3554,6 +4072,9 @@
   },
   "amenity/bank|Patagonia": {
     "count": 115,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Banco%20Patagonia.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Patagonia",
@@ -3564,6 +4085,9 @@
   },
   "amenity/bank|Pekao SA": {
     "count": 209,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank%20Pekao%20SA%20Logo%20(2017).svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Pekao SA",
@@ -3616,6 +4140,9 @@
   "amenity/bank|Postbank": {
     "count": 589,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPostbank-Logo.svg&width=100"
+    },
     "match": [
       "amenity/bank|Postbank Finanzcenter"
     ],
@@ -3657,6 +4184,9 @@
   },
   "amenity/bank|Punjab National Bank": {
     "count": 161,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPunjab%20National%20Bank.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Punjab National Bank",
@@ -3683,6 +4213,10 @@
   },
   "amenity/bank|RBS": {
     "count": 183,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGaelic%20scottish%20RBS.JPG&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1069030098744090624/9HLo73Y8_bigger.jpg"
+    },
     "match": [
       "amenity/bank|Royal Bank of Scotland"
     ],
@@ -3743,6 +4277,9 @@
   "amenity/bank|Regions Bank": {
     "count": 287,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRegions-Financial-Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Regions Bank",
@@ -3753,6 +4290,9 @@
   },
   "amenity/bank|Republic Bank": {
     "count": 115,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20Republic%20Bank%20of%20Trinidad%20and%20Tobago.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Republic Bank",
@@ -3763,6 +4303,9 @@
   },
   "amenity/bank|SEB": {
     "count": 125,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSEB%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "SEB",
@@ -3805,6 +4348,9 @@
   },
   "amenity/bank|Santander": {
     "count": 4012,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/977265312969232384/7W4a261r_bigger.jpg"
+    },
     "match": [
       "amenity/bank|Santander Consumer Bank"
     ],
@@ -3819,6 +4365,9 @@
   },
   "amenity/bank|Santander Río": {
     "count": 285,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSantanderrio%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Santander Río",
@@ -3829,6 +4378,9 @@
   },
   "amenity/bank|Santander Totta": {
     "count": 327,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanco%20Santander%20Logotipo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Santander Totta",
@@ -3839,6 +4391,11 @@
   },
   "amenity/bank|Sberbank": {
     "count": 125,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSberbank%20logo.png&width=100",
+      "facebook": "https://graph.facebook.com/sberbank/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1095637173980856320/Dlp96K30_bigger.png"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Sberbank",
@@ -3849,6 +4406,9 @@
   },
   "amenity/bank|Scotiabank": {
     "count": 1265,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Scotiabank%20(Kanada).svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Scotiabank",
@@ -3859,6 +4419,9 @@
   },
   "amenity/bank|Security Bank": {
     "count": 198,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FThe%20Security%20Bank%20Logo%201.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Security Bank",
@@ -3919,6 +4482,11 @@
   },
   "amenity/bank|Société Générale": {
     "count": 1246,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSoci%C3%A9t%C3%A9%20G%C3%A9n%C3%A9rale.svg&width=100",
+      "facebook": "https://graph.facebook.com/societegenerale/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/864410937113026560/6BaFBxxe_bigger.jpg"
+    },
     "match": ["amenity/bank|Societe Generale"],
     "tags": {
       "amenity": "bank",
@@ -3929,6 +4497,9 @@
     }
   },
   "amenity/bank|Sonali Bank": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSonali%20Bank%20logo.JPG&width=100"
+    },
     "match": [
       "amenity/bank|Sonali Bank Limited সোনালী ব্যাংক লিমিটেড"
     ],
@@ -3953,6 +4524,9 @@
   },
   "amenity/bank|Sparda-Bank": {
     "count": 269,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSparda%20Bank%202003%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Sparda-Bank",
@@ -4013,6 +4587,9 @@
   },
   "amenity/bank|State Bank of India": {
     "count": 1182,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FState-Bank-of-India-Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "State Bank of India",
@@ -4033,6 +4610,9 @@
   },
   "amenity/bank|SunTrust": {
     "count": 257,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSunTrust%20Banks%20logo.svg&width=100"
+    },
     "match": ["amenity/bank|SunTrust Bank"],
     "tags": {
       "amenity": "bank",
@@ -4044,6 +4624,9 @@
   },
   "amenity/bank|Supervielle": {
     "count": 91,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSupervielle%20logo14.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Supervielle",
@@ -4054,6 +4637,9 @@
   },
   "amenity/bank|Swedbank": {
     "count": 255,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSwedbank%20skylt.JPG&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Swedbank",
@@ -4094,6 +4680,9 @@
   },
   "amenity/bank|TD Canada Trust": {
     "count": 737,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FToronto-Dominion%20Bank%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "TD Canada Trust",
@@ -4114,6 +4703,10 @@
   },
   "amenity/bank|TSB": {
     "count": 321,
+    "logos": {
+      "facebook": "https://graph.facebook.com/TSBbankUK/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/798144740319490048/7LtCm8Wx_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "TSB",
@@ -4134,6 +4727,9 @@
   },
   "amenity/bank|Targobank": {
     "count": 220,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTargobank%20logo.svg&width=100"
+    },
     "match": ["amenity/bank|Targo Bank"],
     "tags": {
       "amenity": "bank",
@@ -4145,6 +4741,9 @@
   },
   "amenity/bank|Tatra banka": {
     "count": 74,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTatra%20banka%20logo.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Tatra banka",
@@ -4155,6 +4754,9 @@
   },
   "amenity/bank|Türkiye İş Bankası": {
     "count": 88,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FT%C3%BCrkiye%20%C4%B0%C5%9F%20Bankas%C4%B1%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Türkiye İş Bankası",
@@ -4198,6 +4800,11 @@
   },
   "amenity/bank|UBS": {
     "count": 183,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUBS%20Logo.png&width=100",
+      "facebook": "https://graph.facebook.com/UBSglobal/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/463961659552194560/GJz60zCa_bigger.jpeg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "UBS",
@@ -4218,6 +4825,9 @@
   },
   "amenity/bank|UCPB": {
     "count": 131,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUCPB%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "UCPB",
@@ -4228,6 +4838,9 @@
   },
   "amenity/bank|UOB": {
     "count": 148,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUOB%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "UOB",
@@ -4238,6 +4851,9 @@
   },
   "amenity/bank|US Bank": {
     "count": 659,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FU.S.%20Bancorp%20logo.svg&width=100"
+    },
     "match": ["amenity/bank|U.S. Bank"],
     "tags": {
       "amenity": "bank",
@@ -4269,6 +4885,10 @@
   },
   "amenity/bank|UniCredit Bank": {
     "count": 296,
+    "logos": {
+      "facebook": "https://graph.facebook.com/UniCreditItalia/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/938454142338596864/uYxN76cQ_bigger.jpg"
+    },
     "match": [
       "amenity/bank|UniCredit",
       "amenity/bank|Unicredit",
@@ -4294,6 +4914,9 @@
   },
   "amenity/bank|Union Bank of India": {
     "count": 58,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUnion%20Bank%20of%20India%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Union Bank of India",
@@ -4304,6 +4927,9 @@
   },
   "amenity/bank|UnionBank~(Philippines)": {
     "countryCodes": ["ph"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUnionBankPH.png&width=100"
+    },
     "match": [
       "amenity/bank|Union Bank of the Philippines"
     ],
@@ -4356,6 +4982,10 @@
   },
   "amenity/bank|Vakıfbank": {
     "count": 118,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FVak%C4%B1fbank%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/936498306443825152/hQND1CQK_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Vakıfbank",
@@ -4386,6 +5016,9 @@
   },
   "amenity/bank|Volksbank": {
     "count": 2531,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20German%20Volksbanken%20Raiffeisenbanken.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Volksbank",
@@ -4417,6 +5050,9 @@
   },
   "amenity/bank|VÚB": {
     "count": 115,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FVUB.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "VÚB",
@@ -4427,6 +5063,9 @@
   },
   "amenity/bank|Washington Federal": {
     "count": 87,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWashington%20Federal%20Logo.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Washington Federal",
@@ -4437,6 +5076,10 @@
   },
   "amenity/bank|Wells Fargo": {
     "count": 2413,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWells%20Fargo%20Bank.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1088877344624758784/OH8VFkEY_bigger.jpg"
+    },
     "match": ["amenity/bank|Wells Fargo Bank"],
     "tags": {
       "amenity": "bank",
@@ -4448,6 +5091,9 @@
   },
   "amenity/bank|Western Union": {
     "count": 500,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWestern%20Union%20logo.svg&width=100"
+    },
     "nomatch": [
       "amenity/money_transfer|Western Union"
     ],
@@ -4461,6 +5107,9 @@
   },
   "amenity/bank|Westpac": {
     "count": 362,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWestpac%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Westpac",
@@ -4481,6 +5130,9 @@
   },
   "amenity/bank|Yorkshire Bank": {
     "count": 92,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/875682560315097088/YOR4LIIO_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Yorkshire Bank",
@@ -4501,6 +5153,9 @@
   },
   "amenity/bank|Zagrebačka banka": {
     "count": 58,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FZagreba%C4%8Dka-banka-Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Zagrebačka banka",
@@ -4511,6 +5166,10 @@
   },
   "amenity/bank|Zenith Bank": {
     "count": 61,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FZenith%20Bank%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/880350862647980032/mvRee-i3_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Zenith Bank",
@@ -4521,6 +5180,9 @@
   },
   "amenity/bank|Ziraat Bankası": {
     "count": 253,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FZiraat%20Bankas%C4%B1%20logo.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Ziraat Bankası",
@@ -4531,6 +5193,9 @@
   },
   "amenity/bank|mBank": {
     "count": 87,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMbank-logo.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "mBank",
@@ -4541,6 +5206,10 @@
   },
   "amenity/bank|ČSOB": {
     "count": 215,
+    "logos": {
+      "facebook": "https://graph.facebook.com/csob/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/628559002696179712/lJy6YbMv_bigger.png"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "ČSOB",
@@ -4551,6 +5220,9 @@
   },
   "amenity/bank|Česká spořitelna": {
     "count": 245,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCeska%20Sporitelna.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Česká spořitelna",
@@ -4561,6 +5233,9 @@
   },
   "amenity/bank|İş Bankası": {
     "count": 162,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FT%C3%BCrkiye%20%C4%B0%C5%9F%20Bankas%C4%B1%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "İş Bankası",
@@ -4611,6 +5286,10 @@
   },
   "amenity/bank|Альфа-Банк": {
     "count": 334,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAlfa-Bank.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1104892558231175168/VxvVVCy0_bigger.png"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Альфа-Банк",
@@ -4682,6 +5361,10 @@
   },
   "amenity/bank|ВТБ": {
     "count": 783,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FVTB%20Logo%202018.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1054295031916453888/lvi_M_Cc_bigger.jpg"
+    },
     "match": ["amenity/bank|ВТБ Банк Москвы"],
     "tags": {
       "amenity": "bank",
@@ -4705,6 +5388,9 @@
   },
   "amenity/bank|Газпромбанк": {
     "count": 186,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGazprombank.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Газпромбанк",
@@ -4725,6 +5411,9 @@
   },
   "amenity/bank|Казкоммерцбанк": {
     "count": 73,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FQazkom%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Казкоммерцбанк",
@@ -4769,6 +5458,9 @@
   },
   "amenity/bank|ОТП Банк": {
     "count": 65,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOtp%20bank%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "ОТП Банк",
@@ -4781,6 +5473,9 @@
   },
   "amenity/bank|Обединена Българска Банка": {
     "count": 59,
+    "logos": {
+      "facebook": "https://graph.facebook.com/UnitedBulgarianBank/picture?type=square"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Обединена Българска Банка",
@@ -4803,6 +5498,10 @@
   "amenity/bank|Ощадбанк": {
     "count": 979,
     "countryCodes": ["ua"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOschadbank%20(uk).png&width=100",
+      "facebook": "https://graph.facebook.com/oschadbank/picture?type=square"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Ощадбанк",
@@ -4816,6 +5515,9 @@
   "amenity/bank|ПУМБ": {
     "count": 89,
     "countryCodes": ["ua"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFUIB%20eng%20300.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "ПУМБ",
@@ -4840,6 +5542,9 @@
   },
   "amenity/bank|ПриватБанк": {
     "count": 1073,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F%D0%9F%D1%80%D0%B8%D0%B2%D0%B0%D1%82%D0%91%D0%B0%D0%BD%D0%BA.png&width=100"
+    },
     "match": ["amenity/bank|Приватбанк"],
     "tags": {
       "amenity": "bank",
@@ -4865,6 +5570,9 @@
   },
   "amenity/bank|Промсвязьбанк": {
     "count": 139,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F%D0%9F%D1%80%D0%BE%D0%BC%D1%81%D0%B2%D1%8F%D0%B7%D1%8C%D0%B1%D0%B0%D0%BD%D0%BA%20logo%20NEW%202008.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Промсвязьбанк",
@@ -4899,6 +5607,9 @@
   },
   "amenity/bank|Райффайзен Банк Аваль": {
     "count": 146,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F%D0%A0%D0%B0%D0%B9%D1%84%D1%84%D0%B0%D0%B9%D0%B7%D0%B5%D0%BD%20%D0%B1%D0%B0%D0%BD%D0%BA%20%D0%90%D0%B2%D0%B0%D0%BB%D1%8C%20(%D0%BB%D0%BE%D0%B3%D0%BE%D1%82%D0%B8%D0%BF).gif&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Райффайзен Банк Аваль",
@@ -4911,6 +5622,9 @@
   },
   "amenity/bank|Росбанк": {
     "count": 225,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRosbank%20logo%20en.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Росбанк",
@@ -4975,6 +5689,11 @@
   },
   "amenity/bank|УкрСиббанк": {
     "count": 201,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUKRSIBBANK%20logo%20new.jpg&width=100",
+      "facebook": "https://graph.facebook.com/UKRSIBBANK/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1050668865787584513/uWRJYm_Y_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "УкрСиббанк",
@@ -4987,6 +5706,9 @@
   },
   "amenity/bank|Укргазбанк": {
     "count": 57,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUkrgasbank%20logo.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "Укргазбанк",
@@ -5047,6 +5769,9 @@
   "amenity/bank|בנק הפועלים": {
     "count": 122,
     "countryCodes": ["il"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank%20Hapoalim%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "בנק הפועלים",
@@ -5140,6 +5865,9 @@
   },
   "amenity/bank|بانک رفاه": {
     "count": 202,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRefah-Bank-Logo.png&width=100"
+    },
     "match": ["amenity/bank|بانک رفاه کارگران"],
     "tags": {
       "amenity": "bank",
@@ -5213,6 +5941,9 @@
   },
   "amenity/bank|بانک صادرات": {
     "count": 827,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank%20Saderat%20Iran%20logo.png&width=100"
+    },
     "match": ["amenity/bank|بانک صادرات ایران"],
     "tags": {
       "amenity": "bank",
@@ -5238,6 +5969,9 @@
   },
   "amenity/bank|بانک مسکن": {
     "count": 486,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank%20maskan.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "بانک مسکن",
@@ -5250,6 +5984,9 @@
   },
   "amenity/bank|بانک ملت": {
     "count": 711,
+    "logos": {
+      "facebook": "https://graph.facebook.com/bankmellat.official/picture?type=square"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "بانک ملت",
@@ -5361,6 +6098,9 @@
   "amenity/bank|ธนาคารกรุงเทพ": {
     "count": 126,
     "countryCodes": ["th"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Bangkok%20Bank%20Public%20Company%20Limited.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "ธนาคารกรุงเทพ",
@@ -5436,6 +6176,10 @@
   "amenity/bank|みずほ銀行": {
     "count": 276,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMizuho%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/902036508672106496/L8rp7WY6_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "みずほ銀行",
@@ -5450,6 +6194,9 @@
   },
   "amenity/bank|ゆうちょ銀行": {
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJapan%20Post%20Bank%20Logo.svg&width=100"
+    },
     "nocount": true,
     "tags": {
       "amenity": "bank",
@@ -5464,6 +6211,9 @@
   "amenity/bank|りそな銀行": {
     "count": 164,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FResona%20Bank%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "りそな銀行",
@@ -5478,6 +6228,9 @@
   },
   "amenity/bank|三井住友銀行": {
     "count": 242,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSumitomo%20Mitsui%20Banking%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "三井住友銀行",
@@ -5490,6 +6243,11 @@
   },
   "amenity/bank|三菱東京UFJ銀行": {
     "count": 237,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMitsubishi-MUFG-Logo-Vector.svg&width=100",
+      "facebook": "https://graph.facebook.com/bk.mufg.jp/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/719462699218808833/nMfaWJzX_bigger.jpg"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "三菱東京UFJ銀行",
@@ -5525,6 +6283,9 @@
   },
   "amenity/bank|中国农业银行": {
     "count": 268,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAgricultural%20Bank%20of%20China%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "中国农业银行",
@@ -5537,6 +6298,9 @@
   },
   "amenity/bank|中国工商银行": {
     "count": 279,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FICBC%20logo.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "中国工商银行",
@@ -5549,6 +6313,9 @@
   },
   "amenity/bank|中国建设银行": {
     "count": 229,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChina%20Construction%20Bank%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "中国建设银行",
@@ -5561,6 +6328,9 @@
   },
   "amenity/bank|中国邮政储蓄银行": {
     "count": 125,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPostal%20Savings%20Bank%20of%20China%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "中国邮政储蓄银行",
@@ -5573,6 +6343,9 @@
   },
   "amenity/bank|中国银行": {
     "count": 349,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChinese%20Bank%20of%20China.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "中国银行",
@@ -5597,6 +6370,9 @@
   },
   "amenity/bank|交通银行": {
     "count": 99,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank%20of%20Communications%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "交通银行",
@@ -5668,6 +6444,9 @@
   },
   "amenity/bank|农业银行": {
     "count": 90,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAgricultural%20Bank%20of%20China%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "农业银行",
@@ -5703,6 +6482,9 @@
   },
   "amenity/bank|台中商業銀行": {
     "count": 81,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTcbbank%20headoffice.JPG&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "台中商業銀行",
@@ -5739,6 +6521,9 @@
   },
   "amenity/bank|合作金庫商業銀行": {
     "count": 270,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDepartment%20of%20Business%2C%20Taiwan%20Cooperative%20Bank%2020171216.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "合作金庫商業銀行",
@@ -5787,6 +6572,9 @@
   },
   "amenity/bank|工商银行": {
     "count": 173,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FICBC%20logo.png&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "工商银行",
@@ -5799,6 +6587,9 @@
   },
   "amenity/bank|建设银行": {
     "count": 107,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChina%20Construction%20Bank%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "建设银行",
@@ -5809,6 +6600,9 @@
   },
   "amenity/bank|彰化商業銀行": {
     "count": 181,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCentral%20Branch%2C%20Chang%20Hwa%20Bank%2020101213.jpg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "彰化商業銀行",
@@ -5833,6 +6627,9 @@
   },
   "amenity/bank|日本銀行": {
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1695648060/medama_moji_jp_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "amenity": "bank",
@@ -5870,6 +6667,9 @@
   },
   "amenity/bank|永豐商業銀行": {
     "count": 128,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBank%20SinoPac%20logo%2020121103.gif&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "永豐商業銀行",
@@ -5890,6 +6690,9 @@
   },
   "amenity/bank|玉山商業銀行": {
     "count": 135,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FE.SUN%20Bank.svg&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "玉山商業銀行",
@@ -6025,6 +6828,9 @@
   "amenity/bank|국민은행": {
     "count": 210,
     "countryCodes": ["kr"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKB%20logo.svg&width=100"
+    },
     "match": ["amenity/bank|국민은행 (Gungmin Bank)"],
     "tags": {
       "amenity": "bank",
@@ -6110,6 +6916,9 @@
   "amenity/bank|하나은행": {
     "count": 108,
     "countryCodes": ["kr"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKEB%20head%20office.JPG&width=100"
+    },
     "tags": {
       "amenity": "bank",
       "brand": "하나은행",

--- a/brands/amenity/bicycle_rental.json
+++ b/brands/amenity/bicycle_rental.json
@@ -1,6 +1,10 @@
 {
   "amenity/bicycle_rental|Call a Bike": {
     "count": 102,
+    "logos": {
+      "facebook": "https://graph.facebook.com/callabike.de/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/717248526577696768/xXCluQwj_bigger.jpg"
+    },
     "tags": {
       "amenity": "bicycle_rental",
       "brand": "Call a Bike",

--- a/brands/amenity/bureau_de_change.json
+++ b/brands/amenity/bureau_de_change.json
@@ -17,6 +17,9 @@
   },
   "amenity/bureau_de_change|Travelex": {
     "count": 96,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTravelex%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "bureau_de_change",
       "brand": "Travelex",

--- a/brands/amenity/cafe.json
+++ b/brands/amenity/cafe.json
@@ -14,6 +14,9 @@
   },
   "amenity/cafe|Barista": {
     "count": 68,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBarista%20Lavazza%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "cafe",
       "brand": "Barista",
@@ -55,6 +58,10 @@
   },
   "amenity/cafe|Caffè Nero": {
     "count": 300,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCafe%C3%A8%20Nero.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1057675352519127040/d98c8otP_bigger.jpg"
+    },
     "match": [
       "amenity/cafe|Cafe Nero",
       "amenity/cafe|Caffe Nero"
@@ -200,6 +207,11 @@
   },
   "amenity/cafe|Costa": {
     "count": 1086,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCosta%20Coffee%20Logo%20white%20on%20red.png&width=100",
+      "facebook": "https://graph.facebook.com/costacoffee/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1061947908487045120/XbTGtO_n_bigger.jpg"
+    },
     "match": ["amenity/cafe|Costa Coffee"],
     "tags": {
       "amenity": "cafe",
@@ -265,6 +277,9 @@
   },
   "amenity/cafe|Havanna": {
     "count": 93,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHavanna%20textlogo.png&width=100"
+    },
     "tags": {
       "amenity": "cafe",
       "brand": "Havanna",
@@ -320,6 +335,9 @@
   },
   "amenity/cafe|McCafé": {
     "count": 82,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMcCaf%C3%A9%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "cafe",
       "brand": "McCafé",
@@ -343,6 +361,9 @@
   "amenity/cafe|Patisserie Valerie": {
     "count": 59,
     "countryCodes": ["gb"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/554927969131450368/GlWflhTg_bigger.jpeg"
+    },
     "tags": {
       "amenity": "cafe",
       "brand": "Patisserie Valerie",
@@ -354,6 +375,9 @@
   },
   "amenity/cafe|Peet's Coffee": {
     "count": 71,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/992434236694003712/WK9W-PIP_bigger.jpg"
+    },
     "match": ["amenity/cafe|Peet's Coffee & Tea"],
     "tags": {
       "amenity": "cafe",
@@ -409,6 +433,9 @@
   },
   "amenity/cafe|Second Cup": {
     "count": 236,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSecond%20cup%20logo15.png&width=100"
+    },
     "tags": {
       "amenity": "cafe",
       "brand": "Second Cup",
@@ -420,6 +447,9 @@
   },
   "amenity/cafe|Segafredo": {
     "count": 108,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSegafredo%20Zanetti%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "cafe",
       "brand": "Segafredo",
@@ -431,6 +461,10 @@
   },
   "amenity/cafe|Starbucks": {
     "count": 9139,
+    "logos": {
+      "facebook": "https://graph.facebook.com/Starbucks/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/968173455580397568/Qe0pSZTk_bigger.jpg"
+    },
     "match": [
       "amenity/cafe|Starbuck's",
       "amenity/cafe|Starbucks Coffee",
@@ -455,6 +489,9 @@
   },
   "amenity/cafe|The Coffee Bean & Tea Leaf": {
     "count": 157,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/795705145224871936/EgPtlFnT_bigger.jpg"
+    },
     "tags": {
       "amenity": "cafe",
       "brand": "The Coffee Bean & Tea Leaf",
@@ -477,6 +514,9 @@
   },
   "amenity/cafe|Tim Hortons": {
     "count": 2399,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTim%20Hortons%20Logo.svg&width=100"
+    },
     "match": [
       "amenity/fast_food|Tim Hortons",
       "amenity/restaurant|Tim Hortons"
@@ -636,6 +676,10 @@
   },
   "amenity/cafe|Старбакс": {
     "count": 71,
+    "logos": {
+      "facebook": "https://graph.facebook.com/Starbucks/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/968173455580397568/Qe0pSZTk_bigger.jpg"
+    },
     "tags": {
       "amenity": "cafe",
       "brand": "Старбакс",
@@ -686,6 +730,9 @@
   "amenity/cafe|Шоколадница": {
     "count": 327,
     "countryCodes": ["ru"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F%D0%A8%D0%BE%D0%BA%D0%BE%20%D0%BB%D0%BE%D0%B3%D0%BE%202014-02-24%2013-26.jpg&width=100"
+    },
     "match": ["amenity/cafe|Шоколад"],
     "tags": {
       "amenity": "cafe",
@@ -710,6 +757,9 @@
   "amenity/cafe|ארומה": {
     "count": 70,
     "countryCodes": ["il"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/685142792/22652_260580577421_260578287421_3292057_2769906_n_bigger.jpg"
+    },
     "tags": {
       "amenity": "cafe",
       "brand": "ארומה",
@@ -789,6 +839,9 @@
   "amenity/cafe|コメダ珈琲店": {
     "count": 253,
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/komeda.coffee/picture?type=square"
+    },
     "tags": {
       "amenity": "cafe",
       "brand": "コメダ珈琲店",
@@ -821,6 +874,10 @@
   "amenity/cafe|スターバックス": {
     "count": 635,
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/Starbucks/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/968173455580397568/Qe0pSZTk_bigger.jpg"
+    },
     "tags": {
       "amenity": "cafe",
       "brand": "スターバックス",
@@ -837,6 +894,9 @@
   "amenity/cafe|タリーズコーヒー": {
     "count": 275,
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1079584745/logo_bigger.jpg"
+    },
     "tags": {
       "amenity": "cafe",
       "brand": "タリーズコーヒー",
@@ -869,6 +929,10 @@
   "amenity/cafe|星巴克": {
     "count": 289,
     "countryCodes": ["cn", "tw"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/Starbucks/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/968173455580397568/Qe0pSZTk_bigger.jpg"
+    },
     "tags": {
       "amenity": "cafe",
       "brand": "星巴克",
@@ -897,6 +961,10 @@
   "amenity/cafe|스타벅스": {
     "count": 103,
     "countryCodes": ["kr"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/Starbucks/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/968173455580397568/Qe0pSZTk_bigger.jpg"
+    },
     "tags": {
       "amenity": "cafe",
       "brand": "스타벅스",

--- a/brands/amenity/car_rental.json
+++ b/brands/amenity/car_rental.json
@@ -1,6 +1,9 @@
 {
   "amenity/car_rental|Alamo": {
     "count": 74,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAlamo%20Rent%20a%20Car%20(logo).svg&width=100"
+    },
     "tags": {
       "amenity": "car_rental",
       "brand": "Alamo",
@@ -11,6 +14,9 @@
   },
   "amenity/car_rental|Avis": {
     "count": 593,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAvis%20logo.svg&width=100"
+    },
     "match": ["amenity/car_rental|AVIS"],
     "tags": {
       "amenity": "car_rental",
@@ -22,6 +28,10 @@
   },
   "amenity/car_rental|Budget": {
     "count": 265,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBudget%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/883026939396489216/IyHzSi7o_bigger.jpg"
+    },
     "tags": {
       "amenity": "car_rental",
       "brand": "Budget",
@@ -31,6 +41,11 @@
     }
   },
   "amenity/car_rental|Dollar": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDollar%20Car%20Rental%20Logo.gif&width=100",
+      "facebook": "https://graph.facebook.com/DollarCarRental/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/961319984281501696/9suWOBjO_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "amenity": "car_rental",
@@ -42,6 +57,9 @@
   },
   "amenity/car_rental|Enterprise": {
     "count": 584,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEnterprise%20Rent-A-Car%20Logo.svg&width=100"
+    },
     "match": [
       "amenity/car_rental|Enterprise Rent-A-Car",
       "amenity/car_rental|Enterprise Rent-a-Car"
@@ -56,6 +74,9 @@
   },
   "amenity/car_rental|Europcar": {
     "count": 732,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEuropcar%20coach.jpg&width=100"
+    },
     "tags": {
       "amenity": "car_rental",
       "brand": "Europcar",
@@ -66,6 +87,11 @@
   },
   "amenity/car_rental|Hertz": {
     "count": 788,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHertz%20logo.jpg&width=100",
+      "facebook": "https://graph.facebook.com/hertz/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/954041705753276421/XxgGo14K_bigger.jpg"
+    },
     "tags": {
       "amenity": "car_rental",
       "brand": "Hertz",
@@ -76,6 +102,10 @@
   },
   "amenity/car_rental|Localiza": {
     "count": 80,
+    "logos": {
+      "facebook": "https://graph.facebook.com/localizahertz/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/903454479646949376/_2Ls8Jl9_bigger.jpg"
+    },
     "tags": {
       "amenity": "car_rental",
       "brand": "Localiza",
@@ -86,6 +116,9 @@
   },
   "amenity/car_rental|Sixt": {
     "count": 372,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSixt-Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "car_rental",
       "brand": "Sixt",
@@ -96,6 +129,11 @@
   },
   "amenity/car_rental|Thrifty": {
     "count": 99,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FThrifty-Rent-A-Car-Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/ThriftyCarRental/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1084825122005934081/gby3ctAp_bigger.jpg"
+    },
     "tags": {
       "amenity": "car_rental",
       "brand": "Thrifty",

--- a/brands/amenity/car_sharing.json
+++ b/brands/amenity/car_sharing.json
@@ -27,6 +27,10 @@
   },
   "amenity/car_sharing|Zipcar": {
     "count": 77,
+    "logos": {
+      "facebook": "https://graph.facebook.com/zipcar/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1053314713852039169/qm2pijjG_bigger.jpg"
+    },
     "tags": {
       "amenity": "car_sharing",
       "brand": "Zipcar",
@@ -36,6 +40,9 @@
     }
   },
   "amenity/car_sharing|stadtmobil": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FStadtmobil%20logo.svg&width=100"
+    },
     "match": [
       "amenity/car_sharing|stadtmobil CarSharing-Station"
     ],

--- a/brands/amenity/charging_station.json
+++ b/brands/amenity/charging_station.json
@@ -32,6 +32,11 @@
   },
   "amenity/charging_station|Enel": {
     "countryCodes": ["it"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEnel%20Group%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/enelsharing/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/692308215632117760/uOujBhQV_bigger.png"
+    },
     "match": [
       "amenity/charging_station|Enel - stazione di ricarica"
     ],

--- a/brands/amenity/cinema.json
+++ b/brands/amenity/cinema.json
@@ -18,6 +18,9 @@
   },
   "amenity/cinema|Cinema City": {
     "count": 66,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCinema%20City.svg&width=100"
+    },
     "tags": {
       "amenity": "cinema",
       "brand": "Cinema City",
@@ -28,6 +31,11 @@
   },
   "amenity/cinema|Cinemark": {
     "count": 108,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCinemark%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/cinemarkoficial/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/740686854589124608/M-Hrp9WB_bigger.jpg"
+    },
     "tags": {
       "amenity": "cinema",
       "brand": "Cinemark",
@@ -47,6 +55,9 @@
     }
   },
   "amenity/cinema|Cineplanet": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F2015-11-30%20lunes%20162542%20-%20Cineplanet.jpg&width=100"
+    },
     "nocount": true,
     "tags": {
       "amenity": "cinema",
@@ -61,6 +72,11 @@
   },
   "amenity/cinema|Cinepolis": {
     "count": 101,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCin%C3%A9polis%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/cinepolisbrasil/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/882658486596890624/ZtkJn_Ti_bigger.jpg"
+    },
     "match": ["amenity/cinema|Cinépolis"],
     "tags": {
       "amenity": "cinema",
@@ -72,6 +88,9 @@
   },
   "amenity/cinema|Cineworld": {
     "count": 75,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/854986890575065089/WujkAUca_bigger.jpg"
+    },
     "tags": {
       "amenity": "cinema",
       "brand": "Cineworld",
@@ -97,6 +116,10 @@
   },
   "amenity/cinema|Odeon": {
     "count": 88,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOdeon%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/761156055153991680/Rfb_aZyw_bigger.jpg"
+    },
     "tags": {
       "amenity": "cinema",
       "brand": "Odeon",
@@ -145,6 +168,9 @@
   },
   "amenity/cinema|ユナイテッド・シネマ": {
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/857443773231513600/PRdKnkLq_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "amenity": "cinema",

--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -1,6 +1,9 @@
 {
   "amenity/fast_food|A&W~(Canada)": {
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCanadian%20aandw%20ne.JPG&width=100"
+    },
     "match": ["amenity/restaurant|A&W~(Canada)"],
     "nocount": true,
     "nomatch": ["amenity/fast_food|A&W~(USA)"],
@@ -15,6 +18,11 @@
   },
   "amenity/fast_food|A&W~(USA)": {
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FA%26W%20restaurant%20in%20Page%2C%20Arizona.jpeg&width=100",
+      "facebook": "https://graph.facebook.com/awrestaurants/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1088812256266280961/fxA2BYsd_bigger.jpg"
+    },
     "match": ["amenity/restaurant|A&W~(USA)"],
     "nocount": true,
     "nomatch": ["amenity/fast_food|A&W~(Canada)"],
@@ -56,6 +64,10 @@
   },
   "amenity/fast_food|Arby's": {
     "count": 1945,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FArbys%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1009067909325434880/8lPM-MoY_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Arby's",
@@ -67,6 +79,10 @@
   },
   "amenity/fast_food|Auntie Anne's": {
     "count": 58,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAuntie%20Anne's%20logo%20and%20slogan.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/932650838715138050/qoHMEcgU_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Auntie Annes",
       "amenity/restaurant|Auntie Anne's",
@@ -82,6 +98,9 @@
     }
   },
   "amenity/fast_food|Baja Fresh": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20Baja%20Fresh.png&width=100"
+    },
     "nocount": true,
     "tags": {
       "amenity": "fast_food",
@@ -93,6 +112,9 @@
     }
   },
   "amenity/fast_food|Bembos": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBembos%20logo15.png&width=100"
+    },
     "nocount": true,
     "tags": {
       "amenity": "fast_food",
@@ -106,6 +128,9 @@
   "amenity/fast_food|Bob's": {
     "count": 110,
     "countryCodes": ["ao", "br", "cl", "pt"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBob's.jpg&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Bob's",
@@ -144,6 +169,9 @@
   },
   "amenity/fast_food|Boston Market": {
     "count": 132,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/980893756713914368/OXoghMaW_bigger.jpg"
+    },
     "match": ["amenity/restaurant|Boston Market"],
     "tags": {
       "amenity": "fast_food",
@@ -170,6 +198,11 @@
   },
   "amenity/fast_food|Burger King": {
     "count": 7950,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBurger%20King%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/burgerking/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1100502735533850624/2S9-lzTL_bigger.png"
+    },
     "match": [
       "amenity/fast_food|Burguer King",
       "amenity/restaurant|Burger King"
@@ -208,6 +241,10 @@
   },
   "amenity/fast_food|Captain D's": {
     "count": 87,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCaptain%20D's%20Logo%202012.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/908041454945157120/j8k-uxVB_bigger.jpg"
+    },
     "match": ["amenity/restaurant|Captain D's"],
     "tags": {
       "amenity": "fast_food",
@@ -220,6 +257,11 @@
   },
   "amenity/fast_food|Carl's Jr.": {
     "count": 623,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCarls%20logo%20(1).png&width=100",
+      "facebook": "https://graph.facebook.com/carlsjr/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1017422604280455168/LM6k35kD_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Carl's Jr",
       "amenity/fast_food|Carls Jr."
@@ -247,6 +289,10 @@
   },
   "amenity/fast_food|Chick-fil-A": {
     "count": 1141,
+    "logos": {
+      "facebook": "https://graph.facebook.com/ChickfilA/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/984417024506986496/PNkWrGYH_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Chick-Fil-A",
       "amenity/restaurant|Chick-Fil-A",
@@ -263,6 +309,9 @@
   },
   "amenity/fast_food|Chicken Express": {
     "count": 99,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChickenexpress%20Logo.jpg&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Chicken Express",
@@ -290,6 +339,10 @@
   },
   "amenity/fast_food|Chipotle": {
     "count": 896,
+    "logos": {
+      "facebook": "https://graph.facebook.com/chipotle/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1045423190779072512/S6n9DjC4_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Chipotle Mexican Grill",
       "amenity/restaurant|Chipotle",
@@ -318,6 +371,9 @@
   },
   "amenity/fast_food|Church's Chicken": {
     "count": 319,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChurch's%20Chicken%20restaurant%20Detroit%20Michigan.JPG&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Church's Chicken",
@@ -357,6 +413,9 @@
   "amenity/fast_food|CoCo壱番屋": {
     "count": 264,
     "countryCodes": ["cn", "jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/cocoichicurry/picture?type=square"
+    },
     "match": ["amenity/restaurant|CoCo壱番屋"],
     "tags": {
       "amenity": "fast_food",
@@ -371,6 +430,9 @@
   },
   "amenity/fast_food|Cook Out": {
     "count": 110,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/879157452322811904/eAV9B6Mf_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Cook Out",
@@ -382,6 +444,10 @@
   },
   "amenity/fast_food|Culver's": {
     "count": 686,
+    "logos": {
+      "facebook": "https://graph.facebook.com/culvers/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/2768318328/172da9cbfcfe325576229213e9e35e1d_bigger.png"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Culver's",
@@ -393,6 +459,10 @@
   },
   "amenity/fast_food|DQ Grill & Chill": {
     "count": 55,
+    "logos": {
+      "facebook": "https://graph.facebook.com/dairyqueen/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1025394910596218880/5oGbznax_bigger.jpg"
+    },
     "nomatch": ["amenity/fast_food|Dairy Queen"],
     "tags": {
       "amenity": "fast_food",
@@ -406,6 +476,10 @@
   },
   "amenity/fast_food|Dairy Queen": {
     "count": 1879,
+    "logos": {
+      "facebook": "https://graph.facebook.com/dairyqueen/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1025394910596218880/5oGbznax_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|DQ",
       "amenity/ice_cream|Dairy Queen",
@@ -436,6 +510,9 @@
   },
   "amenity/fast_food|Del Taco": {
     "count": 308,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20Del%20Taco.png&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Del Taco",
@@ -447,6 +524,11 @@
   },
   "amenity/fast_food|Domino's Pizza": {
     "count": 2517,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDomino's%20pizza%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/dominospizza.es/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1011247337241497600/HzYCHfRy_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Domino's",
       "amenity/fast_food|Dominos",
@@ -467,6 +549,9 @@
   },
   "amenity/fast_food|Dunkin' Donuts": {
     "count": 1219,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDunkin'%20logo.svg&width=100"
+    },
     "match": [
       "amenity/cafe|Dunkin Donuts",
       "amenity/cafe|Dunkin' Donuts",
@@ -504,6 +589,9 @@
   },
   "amenity/fast_food|El Pollo Loco": {
     "count": 185,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FElpolloloco-logo.png&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "El Pollo Loco",
@@ -524,6 +612,9 @@
   },
   "amenity/fast_food|Extreme Pita": {
     "count": 62,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FExtremePita%20Web%20Stacked.jpg&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Extreme Pita",
@@ -560,6 +651,10 @@
   },
   "amenity/fast_food|Five Guys": {
     "count": 703,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFive%20Guys%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/918493706747080705/eT3NLcPB_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Five Guys Burgers and Fries",
       "amenity/restaurant|Five Guys"
@@ -588,6 +683,9 @@
     }
   },
   "amenity/fast_food|Freebirds": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUpdated%20Freebirds%20Logo.png&width=100"
+    },
     "nocount": true,
     "tags": {
       "amenity": "fast_food",
@@ -637,6 +735,9 @@
   "amenity/fast_food|Hallo Pizza": {
     "count": 88,
     "countryCodes": ["de"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/Hallo.Pizza.Deutschland/picture?type=square"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Hallo Pizza",
@@ -648,6 +749,10 @@
   },
   "amenity/fast_food|Hardee's": {
     "count": 785,
+    "logos": {
+      "facebook": "https://graph.facebook.com/hardees/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1070418727743696909/FXN-NxmV_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Hardees",
       "amenity/restaurant|Hardee's",
@@ -665,6 +770,9 @@
   "amenity/fast_food|Harvey's": {
     "count": 184,
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHarveyslogo2.jpg&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Harvey's",
@@ -676,6 +784,9 @@
   },
   "amenity/fast_food|Hesburger": {
     "count": 233,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHesburger%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Hesburger",
@@ -698,6 +809,9 @@
   },
   "amenity/fast_food|Hungry Jacks": {
     "count": 218,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHungry%20Jack's.svg&width=100"
+    },
     "match": ["amenity/fast_food|Hungry Jack's"],
     "tags": {
       "amenity": "fast_food",
@@ -710,6 +824,9 @@
   },
   "amenity/fast_food|In-N-Out Burger": {
     "count": 263,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFlickr%20kafka4prez%20524498734--In-N-Out%20inflatable%20drink.jpg&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "In-N-Out Burger",
@@ -721,6 +838,11 @@
   },
   "amenity/fast_food|Jack in the Box": {
     "count": 1060,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJackInTheBoxLogo.svg&width=100",
+      "facebook": "https://graph.facebook.com/jackinthebox/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/884895157417426944/13srW9K7_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Jack In The Box"
     ],
@@ -735,6 +857,9 @@
   },
   "amenity/fast_food|Jamba Juice": {
     "count": 195,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/982006427400134657/a1HipFeD_bigger.jpg"
+    },
     "match": ["amenity/cafe|Jamba Juice"],
     "tags": {
       "amenity": "fast_food",
@@ -763,6 +888,11 @@
   },
   "amenity/fast_food|Jimmy John's": {
     "count": 755,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJimmy%20Johns%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/jimmyjohns/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1037431734936236040/ymCJHxcS_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Jimmy Johns",
       "amenity/restaurant|Jimmy John's",
@@ -790,6 +920,11 @@
   },
   "amenity/fast_food|KFC": {
     "count": 7000,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKFC%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/KFC/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/882415249164349443/Kt9XxCbA_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Kentucky Fried Chicken",
       "amenity/restaurant|KFC"
@@ -806,6 +941,10 @@
   "amenity/fast_food|Kochlöffel": {
     "count": 79,
     "countryCodes": ["de", "pl", "tr"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKochloeffel-Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/150339531648289/picture?type=square"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Kochlöffel",
@@ -817,6 +956,11 @@
   },
   "amenity/fast_food|Kotipizza": {
     "count": 101,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKotipizza.svg&width=100",
+      "facebook": "https://graph.facebook.com/kotipizza/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/700636315373572096/xgIultAt_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Kotipizza",
@@ -828,6 +972,11 @@
   },
   "amenity/fast_food|Krispy Kreme": {
     "count": 106,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKrispy%20Kreme%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/KrispyKreme/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1055221624511909890/GdpUK4A__bigger.jpg"
+    },
     "match": ["amenity/cafe|Krispy Kreme"],
     "tags": {
       "amenity": "fast_food",
@@ -881,6 +1030,10 @@
   },
   "amenity/fast_food|Lotteria": {
     "count": 94,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLottria%20Sanyo-Himeji%20Eki.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/867982456468549632/L-Nz2YgP_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Lotteria",
@@ -905,6 +1058,9 @@
   },
   "amenity/fast_food|Max": {
     "count": 62,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMax%20(Restaurant)%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Max",
@@ -916,6 +1072,11 @@
   },
   "amenity/fast_food|McDonald's": {
     "count": 20011,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMcDonald's%20Golden%20Arches.svg&width=100",
+      "facebook": "https://graph.facebook.com/mcdonalds/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1062729780032872448/UDkaj5UU_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Mc Donald's",
       "amenity/fast_food|Mc Donalds",
@@ -983,6 +1144,9 @@
   },
   "amenity/fast_food|Nordsee": {
     "count": 226,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNordseelogo.png&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Nordsee",
@@ -1061,6 +1225,11 @@
   },
   "amenity/fast_food|Papa John's": {
     "count": 862,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPapaJohnsRD.JPG&width=100",
+      "facebook": "https://graph.facebook.com/papajohns/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1045750148062752768/f0VAdbsq_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Papa John's Pizza",
       "amenity/fast_food|Papa Johns",
@@ -1078,6 +1247,9 @@
   },
   "amenity/fast_food|Papa Murphy's": {
     "count": 188,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPapa%20Murphy's%20logo.svg&width=100"
+    },
     "match": ["amenity/restaurant|Papa Murphy's"],
     "tags": {
       "amenity": "fast_food",
@@ -1135,6 +1307,11 @@
   },
   "amenity/fast_food|Pizza Hut Delivery": {
     "count": 114,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPizza%20Hut%201967-1999%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/pizzahut.japan/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/930129320730804224/Hp-ga-Kp_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Pizza Hut",
@@ -1146,6 +1323,11 @@
   },
   "amenity/fast_food|Pizza Hut Express": {
     "count": 68,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPizza%20Hut%201967-1999%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/pizzahut.japan/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/930129320730804224/Hp-ga-Kp_bigger.jpg"
+    },
     "match": ["amenity/fast_food|Pizza Hut"],
     "nomatch": ["amenity/restaurant|Pizza Hut"],
     "tags": {
@@ -1198,6 +1380,9 @@
   },
   "amenity/fast_food|Pollo Campero": {
     "count": 140,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPolloCampero%20Logo.png&width=100"
+    },
     "match": ["amenity/restaurant|Pollo Campero"],
     "tags": {
       "amenity": "fast_food",
@@ -1227,6 +1412,9 @@
   },
   "amenity/fast_food|Popeye's": {
     "count": 511,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20Popeyes%20Chicken%20and%20Biscuits.png&width=100"
+    },
     "match": [
       "amenity/fast_food|Popeyes",
       "amenity/fast_food|Popeyes Louisiana Kitchen"
@@ -1242,6 +1430,9 @@
   },
   "amenity/fast_food|Potbelly": {
     "count": 64,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPotbellyLogo.jpg&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Potbelly",
@@ -1252,6 +1443,10 @@
     }
   },
   "amenity/fast_food|Pret A Manger": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPretAManger%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1082259867694518272/b0YUd44-_bigger.jpg"
+    },
     "match": [
       "amenity/cafe|Pret A Manger",
       "amenity/cafe|Pret a Manger"
@@ -1268,6 +1463,9 @@
   },
   "amenity/fast_food|Qdoba": {
     "count": 156,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1096276554278006784/bc6yyO2O_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Qdoba Mexican Grill",
       "amenity/restaurant|Qdoba",
@@ -1284,6 +1482,9 @@
   },
   "amenity/fast_food|Quick": {
     "count": 325,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%202015%20Quick.svg&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Quick",
@@ -1309,6 +1510,9 @@
     }
   },
   "amenity/fast_food|Raising Cane's": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRaising%20Cane's%20Chicken%20Fingers%20logo.png&width=100"
+    },
     "match": [
       "amenity/fast_food|Raising Cane's Chicken Fingers"
     ],
@@ -1336,6 +1540,9 @@
   "amenity/fast_food|Red Rooster": {
     "count": 212,
     "countryCodes": ["au"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRR%20LogoTag%20C.jpg&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Red Rooster",
@@ -1347,6 +1554,9 @@
   },
   "amenity/fast_food|Sbarro": {
     "count": 80,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20Sbarro%2C%20LLC.png&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Sbarro",
@@ -1357,6 +1567,9 @@
     }
   },
   "amenity/fast_food|Schlotzsky's": {
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/962489958572396544/bFYkKcHG_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Schlotzsky's Deli"
     ],
@@ -1372,6 +1585,10 @@
   },
   "amenity/fast_food|Shake Shack": {
     "count": 57,
+    "logos": {
+      "facebook": "https://graph.facebook.com/shakeshack/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1014173331178868737/MkJlzcZG_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Shake Shack",
@@ -1395,6 +1612,9 @@
   },
   "amenity/fast_food|Smashburger": {
     "count": 72,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSmashburgerlogo.jpg&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Smashburger",
@@ -1406,6 +1626,9 @@
   },
   "amenity/fast_food|Smoothie King": {
     "count": 67,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1103771067930284032/T59TuM7U_bigger.png"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Smoothie King",
@@ -1445,6 +1668,11 @@
   },
   "amenity/fast_food|Subway": {
     "count": 13949,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSubway%202016%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/subway/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/763049278306652160/1AgT2EJt_bigger.jpg"
+    },
     "match": [
       "amenity/cafe|Subway",
       "amenity/fast_food|SubWay",
@@ -1474,6 +1702,10 @@
     }
   },
   "amenity/fast_food|TCBY": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTCBY%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/913455806053457920/eRwVFlvD_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "amenity": "fast_food",
@@ -1486,6 +1718,11 @@
   },
   "amenity/fast_food|Taco Bell": {
     "count": 3727,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTacobellsunnyvale.jpg&width=100",
+      "facebook": "https://graph.facebook.com/tacobell/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/918972315991384064/qwetpLdA_bigger.jpg"
+    },
     "match": ["amenity/restaurant|Taco Bell"],
     "tags": {
       "amenity": "fast_food",
@@ -1509,6 +1746,10 @@
   },
   "amenity/fast_food|Taco Cabana": {
     "count": 73,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTaco%20Cabana%20Dallas%20sign.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/963481894573588480/trE6tyZ__bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Taco Cabana",
@@ -1531,6 +1772,9 @@
   },
   "amenity/fast_food|Taco John's": {
     "count": 175,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTaco%20Johns%20Athens%20OH%20USA.JPG&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Taco John's",
@@ -1553,6 +1797,9 @@
   },
   "amenity/fast_food|Telepizza": {
     "count": 392,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20telepizza.svg&width=100"
+    },
     "match": ["amenity/restaurant|Telepizza"],
     "tags": {
       "amenity": "fast_food",
@@ -1584,6 +1831,9 @@
   },
   "amenity/fast_food|The Habit Burger Grill": {
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FThe%20Habit%20Burger%20Grill%20Logo.jpg&width=100"
+    },
     "match": [
       "amenity/fast_food|Habit Burger",
       "amenity/fast_food|The Habit Burger",
@@ -1614,6 +1864,9 @@
   },
   "amenity/fast_food|Togo's": {
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTogo's%20logo.png&width=100"
+    },
     "match": [
       "amenity/fast_food|Togos",
       "amenity/restaurant|Togo's",
@@ -1644,6 +1897,11 @@
   },
   "amenity/fast_food|Wendy's": {
     "count": 3769,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWendys%20Logo.jpg&width=100",
+      "facebook": "https://graph.facebook.com/wendys/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1092808008495697920/KLL2tBvv_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Wendys",
       "amenity/fast_food|Wendy’s",
@@ -1660,6 +1918,9 @@
   },
   "amenity/fast_food|Whataburger": {
     "count": 827,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/714930979320803328/YiW1tsHC_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Whataburger",
@@ -1671,6 +1932,11 @@
   },
   "amenity/fast_food|White Castle": {
     "count": 197,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWhite%20Castle%20Sign.JPG&width=100",
+      "facebook": "https://graph.facebook.com/WhiteCastle/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1096784833420947457/2_rPw7gx_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "White Castle",
@@ -1682,6 +1948,9 @@
   },
   "amenity/fast_food|Wienerschnitzel": {
     "count": 87,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWienerschnitzel%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Wienerschnitzel",
@@ -1693,6 +1962,9 @@
   },
   "amenity/fast_food|Wimpy": {
     "count": 178,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20Wimpy.svg&width=100"
+    },
     "match": ["amenity/restaurant|Wimpy"],
     "tags": {
       "amenity": "fast_food",
@@ -1705,6 +1977,10 @@
   },
   "amenity/fast_food|Zaxby's": {
     "count": 276,
+    "logos": {
+      "facebook": "https://graph.facebook.com/Zaxbys/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/935931068787589121/x0ZZAy8b_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Zaxbys",
       "amenity/restaurant|Zaxby's",
@@ -1729,6 +2005,11 @@
   },
   "amenity/fast_food|Бургер Кинг": {
     "count": 531,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBurger%20King%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/burgerking/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1100502735533850624/2S9-lzTL_bigger.png"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Бургер Кинг",
@@ -1753,6 +2034,11 @@
   },
   "amenity/fast_food|Макдоналдс": {
     "count": 543,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMcDonald's%20Golden%20Arches.svg&width=100",
+      "facebook": "https://graph.facebook.com/mcdonalds/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1062729780032872448/UDkaj5UU_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Макдоналдс",
@@ -1765,6 +2051,11 @@
     }
   },
   "amenity/fast_food|Папа Джонс": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPapaJohnsRD.JPG&width=100",
+      "facebook": "https://graph.facebook.com/papajohns/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1045750148062752768/f0VAdbsq_bigger.jpg"
+    },
     "match": ["amenity/cafe|Папа Джонс"],
     "nocount": true,
     "tags": {
@@ -1807,6 +2098,9 @@
   "amenity/fast_food|Стардог!s": {
     "count": 59,
     "countryCodes": ["ru"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FStardog!s%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "Стардог!s",
@@ -1834,6 +2128,10 @@
   },
   "amenity/fast_food|Теремок": {
     "count": 177,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTeremok%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1094897514707369986/ODOisras_bigger.jpg"
+    },
     "match": [
       "amenity/cafe|Теремок",
       "shop/convenience|Теремок"
@@ -1851,6 +2149,9 @@
   "amenity/fast_food|מקדונלד'ס": {
     "count": 82,
     "countryCodes": ["il"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMcDonald's%20IL%20WV.JPG&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "מקדונלד'ס",
@@ -1883,6 +2184,9 @@
   "amenity/fast_food|かっぱ寿司": {
     "count": 93,
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://abs.twimg.com/sticky/default_profile_images/default_profile_bigger.png"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "かっぱ寿司",
@@ -1918,6 +2222,10 @@
   "amenity/fast_food|くら寿司": {
     "count": 117,
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/Kurasushi/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/877481639319818241/3mm7wZ57_bigger.jpg"
+    },
     "match": ["amenity/restaurant|くら寿司"],
     "tags": {
       "amenity": "fast_food",
@@ -1935,6 +2243,9 @@
   "amenity/fast_food|すき家": {
     "count": 695,
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1074928090885672960/nTgKn0jh_bigger.jpg"
+    },
     "match": ["amenity/restaurant|すき家"],
     "tags": {
       "amenity": "fast_food",
@@ -1951,6 +2262,9 @@
   "amenity/fast_food|なか卯": {
     "count": 205,
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/999109688582008832/evpixQ34_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "なか卯",
@@ -1982,6 +2296,9 @@
   "amenity/fast_food|ほっかほっか亭": {
     "count": 77,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHokka-Hokka%20Tei%20logo.gif&width=100"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "ほっかほっか亭",
@@ -1997,6 +2314,9 @@
   "amenity/fast_food|ほっともっと": {
     "count": 256,
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1099849032661315585/e5zgKssc_bigger.png"
+    },
     "nomatch": ["shop/deli|ほっともっと"],
     "tags": {
       "amenity": "fast_food",
@@ -2044,6 +2364,11 @@
   "amenity/fast_food|ケンタッキーフライドチキン": {
     "count": 381,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKFC%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/KFC/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/882415249164349443/Kt9XxCbA_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "ケンタッキーフライドチキン",
@@ -2060,6 +2385,11 @@
   "amenity/fast_food|サブウェイ": {
     "count": 73,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSubway%202016%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/subway/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/763049278306652160/1AgT2EJt_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "サブウェイ",
@@ -2076,6 +2406,10 @@
   "amenity/fast_food|スシロー": {
     "count": 122,
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/akindosushiro/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/742153071115960321/DQcBIANV_bigger.jpg"
+    },
     "match": ["amenity/restaurant|スシロー"],
     "tags": {
       "amenity": "fast_food",
@@ -2093,6 +2427,11 @@
   },
   "amenity/fast_food|ドミノ・ピザ": {
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDomino's%20pizza%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/dominospizza.es/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1011247337241497600/HzYCHfRy_bigger.jpg"
+    },
     "match": ["amenity/restaurant|ドミノ・ピザ"],
     "nocount": true,
     "tags": {
@@ -2111,6 +2450,11 @@
   "amenity/fast_food|ピザハット": {
     "count": 57,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPizza%20Hut%201967-1999%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/pizzahut.japan/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/930129320730804224/Hp-ga-Kp_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "ピザハット",
@@ -2126,6 +2470,11 @@
   },
   "amenity/fast_food|ピザ・カリフォルニア": {
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPizza%20Hut%201967-1999%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/pizzahut.japan/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/930129320730804224/Hp-ga-Kp_bigger.jpg"
+    },
     "match": ["amenity/fast_food|ピザ カリフォルニア"],
     "nocount": true,
     "tags": {
@@ -2175,6 +2524,11 @@
   "amenity/fast_food|マクドナルド": {
     "count": 1514,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMcDonald's%20Golden%20Arches.svg&width=100",
+      "facebook": "https://graph.facebook.com/mcdonalds/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1062729780032872448/UDkaj5UU_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "マクドナルド",
@@ -2191,6 +2545,11 @@
   "amenity/fast_food|ミスタードーナツ": {
     "count": 224,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPon%20de%20ring%20with%20brown%20sugar%20by%20Kanko.jpg&width=100",
+      "facebook": "https://graph.facebook.com/misdo.jp/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1068070635442585600/fxPOHMTE_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "ミスタードーナツ",
@@ -2207,6 +2566,10 @@
   "amenity/fast_food|モスバーガー": {
     "count": 608,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMOS-Burger-Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/712033394109124608/kVGTqBLR_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "モスバーガー",
@@ -2238,6 +2601,10 @@
   "amenity/fast_food|ロッテリア": {
     "count": 115,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLottria%20Sanyo-Himeji%20Eki.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/867982456468549632/L-Nz2YgP_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "ロッテリア",
@@ -2254,6 +2621,11 @@
   "amenity/fast_food|吉野家": {
     "count": 545,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FYoshinoya-Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/tw.yoshinoya/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1048014265104232448/RefxUA4v_bigger.jpg"
+    },
     "match": ["amenity/restaurant|吉野家"],
     "tags": {
       "amenity": "fast_food",
@@ -2270,6 +2642,10 @@
   "amenity/fast_food|富士そば": {
     "count": 61,
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/fujisoba/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/671156564/100202_105415_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "富士そば",
@@ -2286,6 +2662,10 @@
   "amenity/fast_food|幸楽苑": {
     "count": 87,
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/Kourakuen/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/945588521678520320/JdTybpQO_bigger.jpg"
+    },
     "match": ["amenity/restaurant|幸楽苑"],
     "tags": {
       "amenity": "fast_food",
@@ -2306,6 +2686,10 @@
       "sg",
       "tw"
     ],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMOS-Burger-Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/712033394109124608/kVGTqBLR_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "摩斯漢堡",
@@ -2367,6 +2751,11 @@
       "sg",
       "tw"
     ],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKFC%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/KFC/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/882415249164349443/Kt9XxCbA_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "肯德基",
@@ -2380,6 +2769,11 @@
   "amenity/fast_food|麥當勞": {
     "count": 255,
     "countryCodes": ["hk", "mo", "tw"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMcDonald's%20Golden%20Arches.svg&width=100",
+      "facebook": "https://graph.facebook.com/mcdonalds/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1062729780032872448/UDkaj5UU_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "麥當勞",
@@ -2394,6 +2788,11 @@
   "amenity/fast_food|麦当劳": {
     "count": 199,
     "countryCodes": ["cn", "sg"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMcDonald's%20Golden%20Arches.svg&width=100",
+      "facebook": "https://graph.facebook.com/mcdonalds/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1062729780032872448/UDkaj5UU_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "麦当劳",
@@ -2408,6 +2807,10 @@
   "amenity/fast_food|롯데리아": {
     "count": 139,
     "countryCodes": ["kr"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLottria%20Sanyo-Himeji%20Eki.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/867982456468549632/L-Nz2YgP_bigger.jpg"
+    },
     "tags": {
       "amenity": "fast_food",
       "brand": "롯데리아",

--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -11,6 +11,11 @@
   },
   "amenity/fuel|7-Eleven": {
     "count": 1048,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F7-eleven%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/7ElevenMexico/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/875639017512906752/qMa3uhuo_bigger.jpg"
+    },
     "match": [
       "amenity/fuel|7 Eleven",
       "amenity/fuel|7-11"
@@ -37,6 +42,9 @@
     }
   },
   "amenity/fuel|ADNOC": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAbu%20Dhabi%20National%20Oil%20Company%20logo.png&width=100"
+    },
     "nocount": true,
     "tags": {
       "amenity": "fuel",
@@ -85,6 +93,9 @@
   },
   "amenity/fuel|Agrola": {
     "count": 111,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAgrola%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Agrola",
@@ -138,6 +149,9 @@
   },
   "amenity/fuel|Arco": {
     "count": 500,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FARCO.svg&width=100"
+    },
     "match": ["amenity/fuel|ARCO"],
     "tags": {
       "amenity": "fuel",
@@ -149,6 +163,11 @@
   },
   "amenity/fuel|Asda": {
     "count": 66,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FASDA%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/Asda/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/843786547736592385/-8MMVMa7_bigger.jpg"
+    },
     "nomatch": [
       "shop/fuel|Asda",
       "shop/supermarket|ASDA"
@@ -163,6 +182,9 @@
   },
   "amenity/fuel|Auchan": {
     "count": 101,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/877095334316576768/bhQDPUWZ_bigger.jpg"
+    },
     "nomatch": ["shop/supermarket|Auchan"],
     "tags": {
       "amenity": "fuel",
@@ -175,6 +197,9 @@
   "amenity/fuel|Avanti": {
     "count": 105,
     "countryCodes": ["at"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOmv%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Avanti",
@@ -185,6 +210,9 @@
   },
   "amenity/fuel|Avia": {
     "count": 806,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAVIA%20International%20logo.svg&width=100"
+    },
     "match": [
       "amenity/fuel|AVIA",
       "amenity/fuel|Station Avia"
@@ -241,6 +269,10 @@
   },
   "amenity/fuel|BP": {
     "count": 4849,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBP%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/879386367276482560/2quhYJn1_bigger.jpg"
+    },
     "match": [
       "amenity/fuel|Bp",
       "amenity/fuel|bp"
@@ -326,6 +358,9 @@
   },
   "amenity/fuel|CEPSA": {
     "count": 760,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCepsa%20Logo.png&width=100"
+    },
     "match": ["amenity/fuel|Cepsa"],
     "tags": {
       "amenity": "fuel",
@@ -372,6 +407,11 @@
   },
   "amenity/fuel|Carrefour Market": {
     "count": 132,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCarrefour%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/carrefouritalia/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1065247142086881280/nvIHOW4d_bigger.jpg"
+    },
     "nomatch": [
       "shop/supermarket|Carrefour Market"
     ],
@@ -427,6 +467,9 @@
   },
   "amenity/fuel|Chevron": {
     "count": 2139,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChevron%20Logo.svg&width=100"
+    },
     "nomatch": ["shop/convenience|Chevron"],
     "tags": {
       "amenity": "fuel",
@@ -438,6 +481,9 @@
   },
   "amenity/fuel|Circle K": {
     "count": 1180,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCircle%20k%20logo%20detail.png&width=100"
+    },
     "nomatch": ["shop/convenience|Circle K"],
     "tags": {
       "amenity": "fuel",
@@ -449,6 +495,9 @@
   },
   "amenity/fuel|Citgo": {
     "count": 941,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCitgo%20logo.svg&width=100"
+    },
     "nomatch": ["shop/convenience|Citgo"],
     "tags": {
       "amenity": "fuel",
@@ -478,6 +527,9 @@
   },
   "amenity/fuel|Co-op": {
     "count": 293,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSaskatoon%20Co-op%20Logo.svg&width=100"
+    },
     "match": [
       "amenity/fuel|Co-Op",
       "amenity/fuel|Coop"
@@ -508,6 +560,9 @@
   },
   "amenity/fuel|Conoco": {
     "count": 518,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FConoco%20Inc.%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Conoco",
@@ -538,6 +593,9 @@
   "amenity/fuel|Cosmo": {
     "count": 85,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCosmo%20Oil%20company%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Cosmo",
@@ -548,6 +606,10 @@
   },
   "amenity/fuel|Costco Gasoline": {
     "count": 228,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCostco%20Wholesale%20logo%202010-10-26.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/654811081630584832/tBIHLgT1_bigger.jpg"
+    },
     "match": [
       "amenity/fuel|Costco",
       "amenity/fuel|Costco Gas",
@@ -636,6 +698,9 @@
   "amenity/fuel|Domo": {
     "count": 59,
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDOMO%20Gasoline%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Domo",
@@ -685,6 +750,9 @@
   },
   "amenity/fuel|ENEOS": {
     "count": 2070,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJXTG%20Nippon%20Oil%20%26%20Energy%20logo.svg&width=100"
+    },
     "match": ["amenity/fuel|Eneos"],
     "tags": {
       "amenity": "fuel",
@@ -716,6 +784,9 @@
   },
   "amenity/fuel|Eni": {
     "count": 885,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/875644564459012097/fsDlSI7T_bigger.jpg"
+    },
     "match": [
       "amenity/fuel|ENI",
       "amenity/fuel|eni"
@@ -730,6 +801,9 @@
   },
   "amenity/fuel|Erg": {
     "count": 422,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FERG%20logo2018.jpg&width=100"
+    },
     "match": ["amenity/fuel|ERG"],
     "tags": {
       "amenity": "fuel",
@@ -741,6 +815,10 @@
   },
   "amenity/fuel|Esso": {
     "count": 5173,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEsso%20textlogo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/595503093447598080/4ooH4R98_bigger.png"
+    },
     "match": [
       "amenity/fuel|ESSO",
       "amenity/fuel|Station Esso"
@@ -770,6 +848,9 @@
   },
   "amenity/fuel|Exxon": {
     "count": 1504,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FExxon%20logo%202016.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Exxon",
@@ -809,6 +890,9 @@
   },
   "amenity/fuel|Flying J": {
     "count": 74,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFlying%20J%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Flying J",
@@ -838,6 +922,9 @@
   },
   "amenity/fuel|GALP": {
     "count": 487,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGalp.png&width=100"
+    },
     "match": ["amenity/fuel|Galp"],
     "tags": {
       "amenity": "fuel",
@@ -865,6 +952,9 @@
   },
   "amenity/fuel|Gazprom": {
     "count": 67,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGazprom%20Avia%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Gazprom",
@@ -903,6 +993,9 @@
   },
   "amenity/fuel|Gulf": {
     "count": 561,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGulf%20logo.png&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Gulf",
@@ -923,6 +1016,9 @@
   },
   "amenity/fuel|H-E-B Fuel": {
     "count": 232,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20the%20HEB%20Grocery%20Company%2C%20LP.png&width=100"
+    },
     "match": ["amenity/fuel|H-E-B Gas"],
     "nomatch": ["shop/supermarket|H-E-B"],
     "tags": {
@@ -936,6 +1032,9 @@
   "amenity/fuel|HEM": {
     "count": 285,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTamoil.svg&width=100"
+    },
     "match": ["amenity/fuel|Hem"],
     "tags": {
       "amenity": "fuel",
@@ -980,6 +1079,9 @@
   },
   "amenity/fuel|Hess": {
     "count": 158,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHess%20Corporation%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Hess",
@@ -991,6 +1093,9 @@
   "amenity/fuel|Hofer": {
     "count": 72,
     "countryCodes": ["at", "si"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Hofer.svg&width=100"
+    },
     "nomatch": ["shop/supermarket|Hofer"],
     "tags": {
       "amenity": "fuel",
@@ -1042,6 +1147,9 @@
   },
   "amenity/fuel|Indian Oil": {
     "count": 578,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FIndian%20Oil%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Indian Oil",
@@ -1094,6 +1202,9 @@
   },
   "amenity/fuel|Irving": {
     "count": 439,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FIrving%20Oil%20Logo.svg&width=100"
+    },
     "nomatch": ["shop/convenience|Irving"],
     "tags": {
       "amenity": "fuel",
@@ -1162,6 +1273,11 @@
   },
   "amenity/fuel|Kroger": {
     "count": 83,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCurrent%20Kroger%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/Kroger/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/829112544921006082/rfcZbBI5_bigger.jpg"
+    },
     "match": ["amenity/fuel|Kroger Fuel"],
     "nomatch": ["shop/supermarket|Kroger"],
     "tags": {
@@ -1232,6 +1348,9 @@
   },
   "amenity/fuel|Love's": {
     "count": 90,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLove%E2%80%99s%20Travel%20Stops%20%26%20Country%20Stores%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Love's",
@@ -1242,6 +1361,9 @@
   },
   "amenity/fuel|Lukoil": {
     "count": 925,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLUK%20OIL%20Logo%20kyr.svg&width=100"
+    },
     "match": [
       "amenity/fuel|LUKOIL",
       "amenity/fuel|LukOil"
@@ -1264,6 +1386,11 @@
   },
   "amenity/fuel|MOL": {
     "count": 502,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMOL%20Group.svg&width=100",
+      "facebook": "https://graph.facebook.com/mymolo/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/378800000474004977/cf7c3082d7151bad59c596ac0def6604_bigger.png"
+    },
     "match": ["amenity/fuel|Mol"],
     "tags": {
       "amenity": "fuel",
@@ -1307,6 +1434,9 @@
   },
   "amenity/fuel|Marathon": {
     "count": 1034,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMarathon%20Oil%20Logo.svg&width=100"
+    },
     "nomatch": ["shop/convenience|Marathon"],
     "tags": {
       "amenity": "fuel",
@@ -1348,6 +1478,9 @@
   "amenity/fuel|Migrol": {
     "count": 86,
     "countryCodes": ["ch"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Migrol.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Migrol",
@@ -1358,6 +1491,9 @@
   },
   "amenity/fuel|Mobil": {
     "count": 1850,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMobil%20logo.svg&width=100"
+    },
     "nomatch": ["shop/convenience|Mobil Mart"],
     "tags": {
       "amenity": "fuel",
@@ -1405,6 +1541,9 @@
   },
   "amenity/fuel|Murphy USA": {
     "count": 294,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMurphylogo3d2.jpg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Murphy USA",
@@ -1433,6 +1572,10 @@
   },
   "amenity/fuel|Neste": {
     "count": 191,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNeste%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1015138866095906816/Va1aA79Z_bigger.jpg"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Neste",
@@ -1443,6 +1586,9 @@
   },
   "amenity/fuel|OIL!": {
     "count": 134,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20OIL!.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "OIL!",
@@ -1474,6 +1620,9 @@
   },
   "amenity/fuel|OMV": {
     "count": 961,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOmv%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "OMV",
@@ -1508,6 +1657,9 @@
   },
   "amenity/fuel|Opet": {
     "count": 119,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20Opet.jpg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Opet",
@@ -1528,6 +1680,9 @@
     }
   },
   "amenity/fuel|Oxxo": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOxxo%20Logo.svg&width=100"
+    },
     "match": ["amenity/fuel|OXXO"],
     "nocount": true,
     "nomatch": ["shop/convenience|Oxxo"],
@@ -1600,6 +1755,9 @@
   },
   "amenity/fuel|Pemex": {
     "count": 1923,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Petr%C3%B3leos%20Mexicanos.svg&width=100"
+    },
     "match": ["amenity/fuel|PEMEX"],
     "tags": {
       "amenity": "fuel",
@@ -1611,6 +1769,9 @@
   },
   "amenity/fuel|Pertamina": {
     "count": 315,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPertamina%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Pertamina",
@@ -1630,6 +1791,9 @@
   "amenity/fuel|Petro-Canada": {
     "count": 1222,
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPetro%20canada%20logo.jpg&width=100"
+    },
     "match": ["amenity/fuel|Petro Canada"],
     "nomatch": ["shop/convenience|Petro-Canada"],
     "tags": {
@@ -1651,6 +1815,9 @@
   },
   "amenity/fuel|PetroPerú": {
     "count": 61,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Petroperu%20vertical%20negativo.jpg&width=100"
+    },
     "match": ["amenity/fuel|Petroperu"],
     "tags": {
       "amenity": "fuel",
@@ -1723,6 +1890,11 @@
   "amenity/fuel|Petron": {
     "count": 1642,
     "countryCodes": ["ph"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20Petron.svg&width=100",
+      "facebook": "https://graph.facebook.com/PetronCorporation/picture?type=square",
+      "twitter": "https://abs.twimg.com/sticky/default_profile_images/default_profile_bigger.png"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Petron",
@@ -1733,6 +1905,9 @@
   },
   "amenity/fuel|Petronas": {
     "count": 441,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPetronas%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Petronas",
@@ -1754,6 +1929,9 @@
   },
   "amenity/fuel|Phillips 66": {
     "count": 534,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPhillips%2066%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Phillips 66",
@@ -1828,6 +2006,9 @@
   },
   "amenity/fuel|Puma": {
     "count": 652,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPuma%20Energy%20Logo.jpg&width=100"
+    },
     "nomatch": ["shop/clothes|Puma"],
     "tags": {
       "amenity": "fuel",
@@ -1867,6 +2048,10 @@
   },
   "amenity/fuel|QT": {
     "count": 52,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FQuikTrip%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/978987077554581504/R7x8NTvv_bigger.jpg"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "QT",
@@ -1888,6 +2073,10 @@
   },
   "amenity/fuel|QuikTrip": {
     "count": 326,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FQuikTrip%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/978987077554581504/R7x8NTvv_bigger.jpg"
+    },
     "nomatch": ["shop/convenience|QuikTrip"],
     "tags": {
       "amenity": "fuel",
@@ -1899,6 +2088,11 @@
   },
   "amenity/fuel|Race Trac": {
     "count": 62,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRaceTrac%2C%204544%20Atlantic%20Blvd%2C%20Jacksonville.JPG&width=100",
+      "facebook": "https://graph.facebook.com/RaceTrac/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/861578724134748160/BSNLDbfS_bigger.jpg"
+    },
     "match": ["amenity/fuel|RaceTrac"],
     "tags": {
       "amenity": "fuel",
@@ -1919,6 +2113,9 @@
   },
   "amenity/fuel|Repsol": {
     "count": 1523,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20de%20Repsol.jpg&width=100"
+    },
     "match": ["amenity/fuel|REPSOL"],
     "tags": {
       "amenity": "fuel",
@@ -1938,6 +2135,9 @@
   },
   "amenity/fuel|Rompetrol": {
     "count": 257,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo-Rompetrol%20KMG%20colored%20approved.jpg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Rompetrol",
@@ -2005,6 +2205,10 @@
   },
   "amenity/fuel|Safeway": {
     "count": 96,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSafeway%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/813782141259497472/inQrmCRf_bigger.jpg"
+    },
     "nomatch": ["shop/supermarket|Safeway"],
     "tags": {
       "amenity": "fuel",
@@ -2017,6 +2221,10 @@
   "amenity/fuel|Sainsbury's": {
     "count": 86,
     "countryCodes": ["gb"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSainsbury's%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1101419025421225984/xsPc8EfW_bigger.jpg"
+    },
     "match": ["amenity/fuel|Sainsburys"],
     "nomatch": ["shop/supermarket|Sainsbury's"],
     "tags": {
@@ -2029,6 +2237,10 @@
   },
   "amenity/fuel|Sam's Club": {
     "count": 71,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSams%20Club.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/378800000538177464/45249044ab8659e5c9079129bba5233b_bigger.jpeg"
+    },
     "nomatch": ["shop/wholesale|Sam's Club"],
     "tags": {
       "amenity": "fuel",
@@ -2075,6 +2287,11 @@
   },
   "amenity/fuel|Shell": {
     "count": 14287,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRoyal%20Dutch%20Shell.png&width=100",
+      "facebook": "https://graph.facebook.com/Shell/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/934717921816993793/H1vB6P7o_bigger.jpg"
+    },
     "match": [
       "amenity/fuel|Posto Shell",
       "amenity/fuel|SHELL",
@@ -2122,6 +2339,9 @@
   },
   "amenity/fuel|Sinopec": {
     "count": 130,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/833927267038294016/e-a35RhV_bigger.jpg"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Sinopec",
@@ -2140,6 +2360,9 @@
   },
   "amenity/fuel|Slovnaft": {
     "count": 242,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F%D0%A1%D0%BB%D0%BE%D0%B2%D0%BD%D0%B0%D1%84%D1%82.jpg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Slovnaft",
@@ -2150,6 +2373,9 @@
   },
   "amenity/fuel|Socar": {
     "count": 113,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FState%20Oil%20Company%20of%20Azerbaijan%20Republic%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Socar",
@@ -2201,6 +2427,9 @@
   },
   "amenity/fuel|St1": {
     "count": 221,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSt1%20Logo.png&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "St1",
@@ -2242,6 +2471,9 @@
   },
   "amenity/fuel|Statoil": {
     "count": 211,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEquinor.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Statoil",
@@ -2300,6 +2532,9 @@
   },
   "amenity/fuel|Tamoil": {
     "count": 967,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTamoil.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Tamoil",
@@ -2331,6 +2566,9 @@
   },
   "amenity/fuel|Teboil": {
     "count": 94,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTeboil%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Teboil",
@@ -2380,6 +2618,9 @@
   },
   "amenity/fuel|Texaco": {
     "count": 1344,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTexaco%20textlogo.svg&width=100"
+    },
     "nomatch": ["shop/convenience|Texaco"],
     "tags": {
       "amenity": "fuel",
@@ -2413,6 +2654,10 @@
   },
   "amenity/fuel|Total": {
     "count": 3640,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Total%20Delft.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/876776431543615489/1QCXAxs1_bigger.jpg"
+    },
     "match": [
       "amenity/fuel|Station Total",
       "amenity/fuel|TOTAL"
@@ -2436,6 +2681,9 @@
   },
   "amenity/fuel|TotalErg": {
     "count": 355,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTotalerg%20logo.png&width=100"
+    },
     "match": ["amenity/fuel|Total Erg"],
     "tags": {
       "amenity": "fuel",
@@ -2459,6 +2707,9 @@
   },
   "amenity/fuel|Turmöl": {
     "count": 86,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20turmoel%20hoch.png&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Turmöl",
@@ -2468,6 +2719,9 @@
     }
   },
   "amenity/fuel|UDF Fuel": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUnited%20Dairy%20Farmers%20logo.png&width=100"
+    },
     "match": [
       "amenity/fuel|UDF",
       "amenity/fuel|UDF Fuels",
@@ -2519,6 +2773,9 @@
   },
   "amenity/fuel|Uno-X": {
     "count": 114,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUno-X%20logo.png&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Uno-X",
@@ -2529,6 +2786,10 @@
   },
   "amenity/fuel|Valero": {
     "count": 1050,
+    "logos": {
+      "facebook": "https://graph.facebook.com/valeroenergy/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/986631405122732033/AqhNDA1z_bigger.jpg"
+    },
     "nomatch": ["shop/convenience|Valero"],
     "tags": {
       "amenity": "fuel",
@@ -2558,6 +2819,9 @@
   },
   "amenity/fuel|WOG": {
     "count": 346,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWOG%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "WOG",
@@ -2568,6 +2832,10 @@
   },
   "amenity/fuel|Wawa": {
     "count": 256,
+    "logos": {
+      "facebook": "https://graph.facebook.com/wawa/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/948254909677359104/lpvtnJzZ_bigger.jpg"
+    },
     "nomatch": ["shop/convenience|Wawa"],
     "tags": {
       "amenity": "fuel",
@@ -2611,6 +2879,9 @@
   },
   "amenity/fuel|YPF": {
     "count": 321,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FYpf%20logo13.png&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "YPF",
@@ -2622,6 +2893,9 @@
   "amenity/fuel|Z": {
     "count": 100,
     "countryCodes": ["nz"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FZEnergylogo.png&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Z",
@@ -2701,6 +2975,9 @@
   },
   "amenity/fuel|Башнефть": {
     "count": 294,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBashneft%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Башнефть",
@@ -2778,6 +3055,9 @@
   },
   "amenity/fuel|Лукойл": {
     "count": 2361,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLUK%20OIL%20Logo%20kyr.svg&width=100"
+    },
     "match": ["amenity/fuel|Лукоил"],
     "nomatch": ["shop/convenience|Лукойл"],
     "tags": {
@@ -2827,6 +3107,9 @@
   },
   "amenity/fuel|ОККО": {
     "count": 328,
+    "logos": {
+      "facebook": "https://graph.facebook.com/okkoua/picture?type=square"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "ОККО",
@@ -2855,6 +3138,9 @@
   },
   "amenity/fuel|ПТК": {
     "count": 115,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F%D0%9B%D0%BE%D0%B3%D0%BE%D1%82%D0%B8%D0%BF%20%D0%9F%D0%B5%D1%82%D0%B5%D1%80%D0%B1%D1%83%D1%80%D0%B3%D1%81%D0%BA%D0%BE%D0%B9%20%D1%82%D0%BE%D0%BF%D0%BB%D0%B8%D0%B2%D0%BD%D0%BE%D0%B9%20%D0%BA%D0%BE%D0%BC%D0%BF%D0%B0%D0%BD%D0%B8%D0%B8.jpg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "ПТК",
@@ -2886,6 +3172,9 @@
   },
   "amenity/fuel|Роснефть": {
     "count": 1129,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRosneft%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Роснефть",
@@ -2906,6 +3195,9 @@
   },
   "amenity/fuel|Сургутнефтегаз": {
     "count": 107,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSng2.gif&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Сургутнефтегаз",
@@ -2939,6 +3231,9 @@
   },
   "amenity/fuel|Татнефть": {
     "count": 352,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTatneft%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Татнефть",
@@ -2951,6 +3246,9 @@
   },
   "amenity/fuel|Укрнафта": {
     "count": 254,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUkrnafta.png&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "Укрнафта",
@@ -3058,6 +3356,10 @@
   "amenity/fuel|เอสโซ่": {
     "count": 80,
     "countryCodes": ["th"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEsso%20textlogo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/595503093447598080/4ooH4R98_bigger.png"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "เอสโซ่",
@@ -3073,6 +3375,10 @@
   "amenity/fuel|エッソ": {
     "count": 129,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEsso%20textlogo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/595503093447598080/4ooH4R98_bigger.png"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "エッソ",
@@ -3099,6 +3405,9 @@
   "amenity/fuel|エネオス": {
     "count": 634,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJXTG%20Nippon%20Oil%20%26%20Energy%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "エネオス",
@@ -3114,6 +3423,9 @@
   "amenity/fuel|コスモ石油": {
     "count": 599,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCosmo%20Oil%20company%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "コスモ石油",
@@ -3129,6 +3441,9 @@
   "amenity/fuel|ゼネラル": {
     "count": 93,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTonenGeneral.svg&width=100"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "ゼネラル",
@@ -3143,6 +3458,9 @@
   },
   "amenity/fuel|中国石化": {
     "count": 185,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/833927267038294016/e-a35RhV_bigger.jpg"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "中国石化",
@@ -3155,6 +3473,9 @@
   },
   "amenity/fuel|中国石化 Sinopec": {
     "count": 130,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/833927267038294016/e-a35RhV_bigger.jpg"
+    },
     "tags": {
       "amenity": "fuel",
       "brand": "中国石化 Sinopec",

--- a/brands/amenity/ice_cream.json
+++ b/brands/amenity/ice_cream.json
@@ -1,6 +1,9 @@
 {
   "amenity/ice_cream|Baskin-Robbins": {
     "count": 161,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBaskin%20Robbins%20logo%202013.png&width=100"
+    },
     "match": [
       "amenity/fast_food|Baskin Robbins",
       "amenity/fast_food|Baskin-Robbins",
@@ -17,6 +20,10 @@
   },
   "amenity/ice_cream|Ben & Jerry's": {
     "count": 61,
+    "logos": {
+      "facebook": "https://graph.facebook.com/benandjerrysUS/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/887388366832107521/k1qJVVve_bigger.jpg"
+    },
     "match": [
       "amenity/ice_cream|Ben & Jerrys",
       "amenity/ice_cream|Ben and Jerry's",
@@ -61,6 +68,9 @@
   },
   "amenity/ice_cream|Freddo": {
     "count": 54,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo-freddo.jpg&width=100"
+    },
     "tags": {
       "amenity": "ice_cream",
       "brand": "Freddo",
@@ -73,6 +83,9 @@
   "amenity/ice_cream|Grido": {
     "count": 272,
     "countryCodes": ["ar"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGrido%20logo.svg&width=100"
+    },
     "match": ["amenity/ice_cream|Grido Helado"],
     "tags": {
       "amenity": "ice_cream",

--- a/brands/amenity/money_transfer.json
+++ b/brands/amenity/money_transfer.json
@@ -24,6 +24,9 @@
   },
   "amenity/money_transfer|Western Union": {
     "count": 128,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWestern%20Union%20logo.svg&width=100"
+    },
     "match": [
       "amenity/bureau_de_change|Western Union"
     ],

--- a/brands/amenity/payment_centre.json
+++ b/brands/amenity/payment_centre.json
@@ -2,6 +2,9 @@
   "amenity/payment_centre|Abitab": {
     "count": 107,
     "countryCodes": ["uy"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSocios-logo-abitab.jpg&width=100"
+    },
     "tags": {
       "amenity": "payment_centre",
       "brand": "Abitab",

--- a/brands/amenity/payment_terminal.json
+++ b/brands/amenity/payment_terminal.json
@@ -12,6 +12,9 @@
   "amenity/payment_terminal|ПриватБанк": {
     "count": 218,
     "countryCodes": ["ua"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F%D0%9F%D1%80%D0%B8%D0%B2%D0%B0%D1%82%D0%91%D0%B0%D0%BD%D0%BA.png&width=100"
+    },
     "tags": {
       "amenity": "payment_terminal",
       "brand": "ПриватБанк",

--- a/brands/amenity/pharmacy.json
+++ b/brands/amenity/pharmacy.json
@@ -50,6 +50,9 @@
   },
   "amenity/pharmacy|Bartell Drugs": {
     "count": 60,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBartell%20Drugs%20(logo).gif&width=100"
+    },
     "tags": {
       "amenity": "pharmacy",
       "brand": "Bartell Drugs",
@@ -83,6 +86,10 @@
   "amenity/pharmacy|Boots": {
     "count": 1351,
     "countryCodes": ["gb"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/bootsuk/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1008610499792179200/Cfi9QCoK_bigger.jpg"
+    },
     "match": ["amenity/pharmacy|Boots Pharmacy"],
     "nomatch": ["shop/chemist|Boots"],
     "tags": {
@@ -135,6 +142,11 @@
   },
   "amenity/pharmacy|CVS": {
     "count": 3066,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCVSPharmacyLogo2014.png&width=100",
+      "facebook": "https://graph.facebook.com/CVS/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1088838575884550146/ApAxqFLl_bigger.jpg"
+    },
     "match": [
       "amenity/pharmacy|CVS Pharmacy",
       "amenity/pharmacy|CVS/Pharmacy",
@@ -202,6 +214,10 @@
     }
   },
   "amenity/pharmacy|Costco Pharmacy": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCostco%20Wholesale%20logo%202010-10-26.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/654811081630584832/tBIHLgT1_bigger.jpg"
+    },
     "nocount": true,
     "nomatch": [
       "amenity/fuel|Costco Gasoline",
@@ -282,6 +298,9 @@
   "amenity/pharmacy|Drogaria São Paulo": {
     "count": 159,
     "countryCodes": ["br"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/drogariasaoapaulo/picture?type=square"
+    },
     "tags": {
       "amenity": "pharmacy",
       "brand": "Drogaria São Paulo",
@@ -327,6 +346,9 @@
   "amenity/pharmacy|Familiprix": {
     "count": 97,
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFamiliprix.jpg&width=100"
+    },
     "tags": {
       "amenity": "pharmacy",
       "brand": "Familiprix",
@@ -409,6 +431,9 @@
   },
   "amenity/pharmacy|Farmacias Ahumada": {
     "count": 183,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFarmacias%20ahumada.jpg&width=100"
+    },
     "tags": {
       "amenity": "pharmacy",
       "brand": "Farmacias Ahumada",
@@ -499,6 +524,10 @@
   "amenity/pharmacy|Farmacity": {
     "count": 230,
     "countryCodes": ["ra"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFarmacity%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/903599963556470785/a-teZnyt_bigger.jpg"
+    },
     "tags": {
       "amenity": "pharmacy",
       "brand": "Farmacity",
@@ -609,6 +638,9 @@
   },
   "amenity/pharmacy|H-E-B Pharmacy": {
     "count": 265,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20the%20HEB%20Grocery%20Company%2C%20LP.png&width=100"
+    },
     "tags": {
       "amenity": "pharmacy",
       "brand": "H-E-B Pharmacy",
@@ -620,6 +652,10 @@
   },
   "amenity/pharmacy|Hy-Vee Pharmacy": {
     "count": 140,
+    "logos": {
+      "facebook": "https://graph.facebook.com/HyVee/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/684132881187250177/WEaq3BAp_bigger.png"
+    },
     "tags": {
       "amenity": "pharmacy",
       "brand": "Hy-Vee Pharmacy",
@@ -631,6 +667,9 @@
   },
   "amenity/pharmacy|Inkafarma": {
     "count": 378,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20de%20Inkafarma.png&width=100"
+    },
     "tags": {
       "amenity": "pharmacy",
       "brand": "Inkafarma",
@@ -693,6 +732,9 @@
   },
   "amenity/pharmacy|Lloyds Pharmacy": {
     "count": 631,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/3785151714/bacbe389277bb2f5477016a7fde79bcd_bigger.jpeg"
+    },
     "match": ["amenity/pharmacy|Lloyds"],
     "tags": {
       "amenity": "pharmacy",
@@ -705,6 +747,9 @@
   },
   "amenity/pharmacy|London Drugs": {
     "count": 52,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLondon%20Drugs%20Logo%20-%20with%20border.png&width=100"
+    },
     "tags": {
       "amenity": "pharmacy",
       "brand": "London Drugs",
@@ -745,6 +790,9 @@
   },
   "amenity/pharmacy|Mēness aptieka": {
     "count": 79,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/854306359071961089/tyVjOiXp_bigger.jpg"
+    },
     "tags": {
       "amenity": "pharmacy",
       "brand": "Mēness aptieka",
@@ -861,6 +909,9 @@
   },
   "amenity/pharmacy|Pharmaprix": {
     "count": 116,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FShoppers-Drug-Mart-Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "pharmacy",
       "brand": "Pharmaprix",
@@ -904,6 +955,10 @@
   "amenity/pharmacy|Rite Aid": {
     "count": 1590,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRite%20Aid.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1096082254231613441/2lYTJj1d_bigger.png"
+    },
     "match": [
       "amenity/pharmacy|Rite Aid Pharmacy",
       "amenity/pharmacy|Rite-Aid"
@@ -974,6 +1029,9 @@
   "amenity/pharmacy|Shoppers Drug Mart": {
     "count": 785,
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FShoppers-Drug-Mart-Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "pharmacy",
       "brand": "Shoppers Drug Mart",
@@ -1007,6 +1065,9 @@
   "amenity/pharmacy|Superdrug": {
     "count": 229,
     "countryCodes": ["gb"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1010086590536929280/Dy5TpFig_bigger.jpg"
+    },
     "nomatch": ["shop/chemist|Superdrug"],
     "tags": {
       "amenity": "pharmacy",
@@ -1065,6 +1126,10 @@
   "amenity/pharmacy|Walgreens": {
     "count": 3848,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWalgreens%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/875789275668918273/7l9RDOnl_bigger.jpg"
+    },
     "match": [
       "amenity/pharmacy|Walgreen's",
       "amenity/pharmacy|Walgreens Pharmacy",
@@ -1082,6 +1147,11 @@
   },
   "amenity/pharmacy|Walmart Pharmacy": {
     "count": 143,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWalmart%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/walmart/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1087396420141731840/c18XRlag_bigger.jpg"
+    },
     "tags": {
       "amenity": "pharmacy",
       "brand": "Walmart",
@@ -1096,6 +1166,9 @@
   },
   "amenity/pharmacy|Watsons": {
     "count": 133,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWatsons%20logo.png&width=100"
+    },
     "nomatch": ["shop/chemist|Watsons"],
     "tags": {
       "amenity": "pharmacy",
@@ -1632,6 +1705,9 @@
   "amenity/pharmacy|ココカラファイン": {
     "count": 96,
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1050257672753229825/lhBcsYat_bigger.jpg"
+    },
     "tags": {
       "amenity": "pharmacy",
       "brand": "ココカラファイン",

--- a/brands/amenity/post_box.json
+++ b/brands/amenity/post_box.json
@@ -10,6 +10,9 @@
   "amenity/post_box|Deutsche Post": {
     "count": 180,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Deutsche%20Post%20DHL.svg&width=100"
+    },
     "match": [
       "amenity/post_box|Deutsche Post AG"
     ],
@@ -26,6 +29,10 @@
   },
   "amenity/post_box|USPS": {
     "count": 158,
+    "logos": {
+      "facebook": "https://graph.facebook.com/USPS/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/864100712883597313/a1fN6W7g_bigger.jpg"
+    },
     "nomatch": ["amenity/post_office|USPS"],
     "tags": {
       "amenity": "post_box",

--- a/brands/amenity/post_office.json
+++ b/brands/amenity/post_office.json
@@ -2,6 +2,10 @@
   "amenity/post_office|Australia Post": {
     "count": 160,
     "countryCodes": ["au"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAustralia%20Post.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1050581738009718785/uXnrUC3X_bigger.jpg"
+    },
     "tags": {
       "amenity": "post_office",
       "brand": "Australia Post",
@@ -13,6 +17,9 @@
   "amenity/post_office|CTT": {
     "count": 131,
     "countryCodes": ["mo"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMacau%20DSC.png&width=100"
+    },
     "tags": {
       "amenity": "post_office",
       "brand": "CTT",
@@ -43,6 +50,10 @@
   "amenity/post_office|Correios": {
     "count": 734,
     "countryCodes": ["br"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCorreios%20(2014).svg&width=100",
+      "facebook": "https://graph.facebook.com/correiosoficial/picture?type=square"
+    },
     "tags": {
       "amenity": "post_office",
       "brand": "Correios",
@@ -54,6 +65,9 @@
   "amenity/post_office|Correo Argentino": {
     "count": 489,
     "countryCodes": ["ar"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCorreo%20arg%20logo.png&width=100"
+    },
     "tags": {
       "amenity": "post_office",
       "brand": "Correo Argentino",
@@ -86,6 +100,11 @@
   },
   "amenity/post_office|DHL": {
     "count": 383,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDHL%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/dhl/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/565097171377086464/sw0nS-B6_bigger.jpeg"
+    },
     "match": [
       "amenity/post_office|DHL Paketshop"
     ],
@@ -100,6 +119,11 @@
   },
   "amenity/post_office|DPD Paketshop": {
     "count": 55,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDPD%20logo%20(2015).svg&width=100",
+      "facebook": "https://graph.facebook.com/350375105088695/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1026391882773999617/4L8W5gAK_bigger.jpg"
+    },
     "tags": {
       "amenity": "post_office",
       "brand": "DPD Paketshop",
@@ -111,6 +135,9 @@
   "amenity/post_office|Deutsche Post": {
     "count": 616,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Deutsche%20Post%20DHL.svg&width=100"
+    },
     "match": [
       "amenity/post_office|Deutsche Post AG",
       "amenity/post_office|Deutsche Post Filiale"
@@ -136,6 +163,10 @@
   },
   "amenity/post_office|FedEx": {
     "count": 122,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFedEx%20Corporation%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1080508748810973184/XDOvWBz0_bigger.jpg"
+    },
     "tags": {
       "amenity": "post_office",
       "brand": "FedEx",
@@ -161,6 +192,10 @@
   "amenity/post_office|LBC": {
     "count": 148,
     "countryCodes": ["ph"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/LBCexpress/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/378800000750854395/994d80332a83588369120b06940a801e_bigger.png"
+    },
     "match": ["amenity/post_office|LBC Express"],
     "tags": {
       "amenity": "post_office",
@@ -172,6 +207,9 @@
   },
   "amenity/post_office|La Poste": {
     "count": 684,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLaurent%20Vincenti%20La%20Poste.JPG&width=100"
+    },
     "tags": {
       "amenity": "post_office",
       "brand": "La Poste",
@@ -200,6 +238,9 @@
   },
   "amenity/post_office|Oficina de Correos": {
     "count": 492,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCorreos%20logo.svg&width=100"
+    },
     "match": ["amenity/post_office|Correos"],
     "tags": {
       "amenity": "post_office",
@@ -220,6 +261,9 @@
   "amenity/post_office|Poczta Polska": {
     "count": 442,
     "countryCodes": ["pl"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPoczta%20Polska.svg&width=100"
+    },
     "tags": {
       "amenity": "post_office",
       "brand": "Poczta Polska",
@@ -231,6 +275,9 @@
   "amenity/post_office|Poste Italiane": {
     "count": 681,
     "countryCodes": ["it"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPoste-Italiane-Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "post_office",
       "brand": "Poste Italiane",
@@ -264,6 +311,9 @@
   "amenity/post_office|Slovenská pošta": {
     "count": 74,
     "countryCodes": ["sk"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogoSlovakPost.gif&width=100"
+    },
     "tags": {
       "amenity": "post_office",
       "brand": "Slovenská pošta",
@@ -274,6 +324,9 @@
   },
   "amenity/post_office|The UPS Store": {
     "count": 563,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1080841709934780417/MTIJnZHk_bigger.jpg"
+    },
     "match": [
       "amenity/post_office|UPS",
       "amenity/post_office|UPS Store",
@@ -291,6 +344,10 @@
   "amenity/post_office|US Post Office": {
     "count": 606,
     "countryCodes": ["us"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/USPS/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/864100712883597313/a1fN6W7g_bigger.jpg"
+    },
     "match": [
       "amenity/post_office|U.S. Post Office",
       "amenity/post_office|USPS",
@@ -339,6 +396,10 @@
   "amenity/post_office|Казпочта": {
     "count": 91,
     "countryCodes": ["kz"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/Kazpost/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/790482285342691328/zsdvDB1k_bigger.jpg"
+    },
     "tags": {
       "amenity": "post_office",
       "brand": "Казпочта",
@@ -350,6 +411,9 @@
   "amenity/post_office|Нова Пошта №1": {
     "count": 1051,
     "countryCodes": ["ua"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNova%20Poshta%202014%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "post_office",
       "brand": "Нова Пошта №1",
@@ -385,6 +449,11 @@
   "amenity/post_office|Почта России": {
     "count": 494,
     "countryCodes": ["ru"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRussian%20Post.svg&width=100",
+      "facebook": "https://graph.facebook.com/ruspost/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1101408827734405121/rdkWoQic_bigger.png"
+    },
     "tags": {
       "amenity": "post_office",
       "brand": "Почта России",
@@ -396,6 +465,9 @@
   "amenity/post_office|Укрпошта": {
     "count": 260,
     "countryCodes": ["ua"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUkrposhta.svg&width=100"
+    },
     "tags": {
       "amenity": "post_office",
       "brand": "Укрпошта",

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -1,6 +1,9 @@
 {
   "amenity/restaurant|100 Montaditos": {
     "count": 59,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20100%20montaditos.jpg&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "100 Montaditos",
@@ -11,6 +14,10 @@
   },
   "amenity/restaurant|ASK Italian": {
     "countryCodes": ["gb"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FASK%20Italian%20Logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/785503531876880385/IIG7xkte_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "amenity": "restaurant",
@@ -23,6 +30,10 @@
   },
   "amenity/restaurant|Applebee's": {
     "count": 99,
+    "logos": {
+      "facebook": "https://graph.facebook.com/Applebeesmundoe/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/836660132951941121/nY1FWtCw_bigger.jpg"
+    },
     "match": [
       "amenity/restaurant|Applebee's Bar & Grill",
       "amenity/restaurant|Applebee's Bar + Grill",
@@ -49,6 +60,9 @@
   },
   "amenity/restaurant|Autogrill": {
     "count": 69,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAutogrill-Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Autogrill",
@@ -60,6 +74,7 @@
   "amenity/restaurant|Bella Italia": {
     "count": 215,
     "countryCodes": ["gb"],
+    "logos": {},
     "tags": {
       "amenity": "restaurant",
       "brand": "Bella Italia",
@@ -70,6 +85,9 @@
   },
   "amenity/restaurant|Big Boy": {
     "count": 73,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/966539777955610625/ymNlD8HL_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Big Boy",
@@ -100,6 +118,9 @@
       "sa",
       "us"
     ],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1012884477591162881/taWyvfmG_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Blaze Pizza",
@@ -124,6 +145,9 @@
   "amenity/restaurant|Bonefish Grill": {
     "count": 95,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBonefish%20Grill%20sign.jpg&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Bonefish Grill",
@@ -135,6 +159,9 @@
   },
   "amenity/restaurant|Boston Pizza": {
     "count": 322,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBostonPizzaLondon.JPG&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Boston Pizza",
@@ -146,6 +173,9 @@
   },
   "amenity/restaurant|Buffalo Grill": {
     "count": 312,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Buffalo%20Grill.png&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Buffalo Grill",
@@ -157,6 +187,9 @@
   },
   "amenity/restaurant|Buffalo Wild Wings": {
     "count": 652,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1088483105994870785/JSNfvCYl_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Buffalo Wild Wings",
@@ -180,6 +213,9 @@
   },
   "amenity/restaurant|California Pizza Kitchen": {
     "count": 126,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/979156010525863936/x4gsiEZK_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "California Pizza Kitchen",
@@ -199,6 +235,10 @@
   },
   "amenity/restaurant|Carluccio's": {
     "count": 62,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCarluccio's%20Logo.jpeg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/553567478693908481/BWWI_wgN_bigger.jpeg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Carluccio's",
@@ -229,6 +269,9 @@
     }
   },
   "amenity/restaurant|Chevys": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20Chevys%20Fresh%20Mex.png&width=100"
+    },
     "match": ["amenity/fast_food|Chevys"],
     "nocount": true,
     "tags": {
@@ -251,6 +294,10 @@
   },
   "amenity/restaurant|Chili's": {
     "count": 780,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChili's%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/895676609167937538/-1o6Yg8f_bigger.jpg"
+    },
     "match": [
       "amenity/restaurant|Chili's Grill & Bar"
     ],
@@ -266,6 +313,9 @@
   "amenity/restaurant|Chiquito": {
     "count": 61,
     "countryCodes": ["gb"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/474868712101527552/t7hL9NFu_bigger.jpeg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Chiquito",
@@ -277,6 +327,9 @@
   },
   "amenity/restaurant|Chuck E. Cheese's": {
     "count": 106,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1082685748028026880/pPcUFDue_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Chuck E. Cheese's",
@@ -289,6 +342,10 @@
   "amenity/restaurant|Cici's Pizza": {
     "count": 75,
     "countryCodes": ["us"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/Cicis/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/661938239926763520/oixs5-Oj_bigger.png"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Cici's Pizza",
@@ -354,6 +411,9 @@
   },
   "amenity/restaurant|Denny's": {
     "count": 1008,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1082632150879555584/STcwZIcj_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Denny's",
@@ -417,6 +477,9 @@
   "amenity/restaurant|Flunch": {
     "count": 178,
     "countryCodes": ["fr"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Restaurant%20Flunch.jpg&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Flunch",
@@ -440,6 +503,10 @@
   "amenity/restaurant|Frankie & Benny's": {
     "count": 164,
     "countryCodes": ["gb"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/frankiebennys/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1051767146148220929/f2Qe39Xj_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Frankie & Benny's",
@@ -450,6 +517,9 @@
     }
   },
   "amenity/restaurant|Freshii": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFreshii%20logo.svg&width=100"
+    },
     "match": ["amenity/fast_food|Freshii"],
     "nocount": true,
     "tags": {
@@ -511,6 +581,9 @@
   "amenity/restaurant|Golden Corral": {
     "count": 267,
     "countryCodes": ["us"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1026542672092246016/YCTjiKhP_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Golden Corral",
@@ -522,6 +595,9 @@
   },
   "amenity/restaurant|Gourmet Burger Kitchen": {
     "count": 57,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1010163506501636103/zhWth6eO_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Gourmet Burger Kitchen",
@@ -541,6 +617,10 @@
   },
   "amenity/restaurant|Hard Rock Cafe": {
     "count": 101,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHard%20Rock%20Paris.jpg&width=100",
+      "facebook": "https://graph.facebook.com/hardrockcafejapan/picture?type=square"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Hard Rock Cafe",
@@ -553,6 +633,9 @@
   "amenity/restaurant|Harvester": {
     "count": 78,
     "countryCodes": ["gb"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/814845405271912448/0HrN6nVa_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Harvester",
@@ -599,6 +682,11 @@
   },
   "amenity/restaurant|IHOP": {
     "count": 937,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FIHOP%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/IHOP/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1016368420969799680/zxWgFYZ7_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "IHOP",
@@ -610,6 +698,9 @@
   },
   "amenity/restaurant|IL Патио": {
     "count": 118,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRosInter.png&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "IL Патио",
@@ -630,6 +721,10 @@
   "amenity/restaurant|Jason's Deli": {
     "count": 88,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJason's%20Deli%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1037021897634996224/8PKBGgkg_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Jason's Deli",
@@ -654,6 +749,9 @@
   "amenity/restaurant|Joe's Crab Shack": {
     "count": 72,
     "countryCodes": ["us"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/770636048028176385/9c66gT6y_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Joe's Crab Shack",
@@ -665,6 +763,9 @@
   },
   "amenity/restaurant|Johnny Carino’s": {
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCarino's.png&width=100"
+    },
     "match": ["amenity/restaurant|Carinio's"],
     "nocount": true,
     "tags": {
@@ -677,6 +778,9 @@
     }
   },
   "amenity/restaurant|Johnny Rockets": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJohnny%20Rockets%20logo.png&width=100"
+    },
     "nocount": true,
     "tags": {
       "amenity": "restaurant",
@@ -709,6 +813,11 @@
   "amenity/restaurant|Kudu": {
     "count": 169,
     "countryCodes": ["sa"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKudu%20in%20Unaizah.JPG&width=100",
+      "facebook": "https://graph.facebook.com/kudu.restaurants/picture?type=square",
+      "twitter": "https://abs.twimg.com/sticky/default_profile_images/default_profile_bigger.png"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Kudu",
@@ -753,6 +862,9 @@
   "amenity/restaurant|Logan's Roadhouse": {
     "count": 114,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogan's%20Roadhouse.svg&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Logan's Roadhouse",
@@ -889,6 +1001,10 @@
   },
   "amenity/restaurant|Nando's": {
     "count": 425,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNandosmerryhill.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/691977669920038912/748UCJdK_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Nando's",
       "amenity/fast_food|Nandos",
@@ -1005,6 +1121,9 @@
   },
   "amenity/restaurant|Outback Steakhouse": {
     "count": 484,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/778575984958267392/MGtDYhwg_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Outback Steakhouse",
@@ -1016,6 +1135,9 @@
   },
   "amenity/restaurant|P.F. Chang's": {
     "count": 80,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FP%20F%20Chang's%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "P.F. Chang's",
@@ -1026,6 +1148,9 @@
     }
   },
   "amenity/restaurant|Pardos Chicken": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Pardos.jpg&width=100"
+    },
     "match": [
       "amenity/fast_food|Pardo's Chicken",
       "amenity/fast_food|Pardos chicken",
@@ -1066,6 +1191,9 @@
   "amenity/restaurant|Perkins": {
     "count": 191,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPerkins%20Logo.gif&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Perkins",
@@ -1105,6 +1233,11 @@
   },
   "amenity/restaurant|Pizza Hut": {
     "count": 3317,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPizza%20Hut%201967-1999%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/pizzahut.japan/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/930129320730804224/Hp-ga-Kp_bigger.jpg"
+    },
     "nomatch": [
       "amenity/fast_food|Pizza Hut Express"
     ],
@@ -1138,6 +1271,9 @@
     }
   },
   "amenity/restaurant|PizzaExpress": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPizzaExpress%20Logo.jpg&width=100"
+    },
     "match": [
       "amenity/fast_food|Pizza Express",
       "amenity/restaurant|Pizza Express"
@@ -1155,6 +1291,9 @@
   "amenity/restaurant|Poivre Rouge": {
     "count": 62,
     "countryCodes": ["fr"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Restaumarch%C3%A9.jpg&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Poivre Rouge",
@@ -1166,6 +1305,9 @@
   },
   "amenity/restaurant|Prezzo": {
     "count": 152,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/876732602664800256/RsaacUWN_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Prezzo",
@@ -1177,6 +1319,9 @@
   },
   "amenity/restaurant|Red Lobster": {
     "count": 490,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1097886281470824454/u6CQm-sN_bigger.png"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Red Lobster",
@@ -1219,6 +1364,10 @@
   },
   "amenity/restaurant|Ruby Tuesday": {
     "count": 359,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRubytuesday.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/793177949990158336/NfMm_YiN_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Ruby Tuesday",
@@ -1262,6 +1411,9 @@
   "amenity/restaurant|Shoney's": {
     "count": 60,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FShoney's%20Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Shoney's",
@@ -1284,6 +1436,9 @@
   "amenity/restaurant|Skyline Chili": {
     "count": 57,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCincinnati-skyline-chili-exterior.jpg&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Skyline Chili",
@@ -1320,6 +1475,10 @@
   },
   "amenity/restaurant|Steak 'n Shake": {
     "count": 165,
+    "logos": {
+      "facebook": "https://graph.facebook.com/steaknshake/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1057974269630652416/xus0P6S2_bigger.jpg"
+    },
     "match": ["amenity/fast_food|Steak 'n Shake"],
     "tags": {
       "amenity": "restaurant",
@@ -1343,6 +1502,9 @@
   "amenity/restaurant|Swiss Chalet": {
     "count": 175,
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSwiss-Chalet-Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Swiss Chalet",
@@ -1354,6 +1516,11 @@
   },
   "amenity/restaurant|TGI Friday's": {
     "count": 287,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTgi%20fridays%20logo13.svg&width=100",
+      "facebook": "https://graph.facebook.com/officialtgifridays/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1092919919090397184/r6DbSmVL_bigger.jpg"
+    },
     "match": [
       "amenity/restaurant|T.G.I. Friday's",
       "amenity/restaurant|TGI Fridays"
@@ -1380,6 +1547,11 @@
   },
   "amenity/restaurant|The Cheesecake Factory": {
     "count": 71,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCheesecakeFactoryLogo1.png&width=100",
+      "facebook": "https://graph.facebook.com/thecheesecakefactory/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/973252460528599040/CsjOOA0W_bigger.jpg"
+    },
     "match": [
       "amenity/restaurant|Cheesecake Factory"
     ],
@@ -1418,6 +1590,9 @@
   },
   "amenity/restaurant|Toby Carvery": {
     "count": 56,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1091279321795309573/A5J8Nhws_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Toby Carvery",
@@ -1440,6 +1615,9 @@
   },
   "amenity/restaurant|Tony Roma's": {
     "count": 69,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTony%20Romas%20Logo.jpg&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Tony Roma's",
@@ -1459,6 +1637,9 @@
   },
   "amenity/restaurant|Vapiano": {
     "count": 162,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F160831%20VAPIANO%20Logo.png&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Vapiano",
@@ -1493,6 +1674,11 @@
   "amenity/restaurant|Waffle House": {
     "count": 748,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWaffle%20House%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/WaffleHouse/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1101161068079009795/A3gLOPut_bigger.png"
+    },
     "match": ["amenity/fast_food|Waffle House"],
     "tags": {
       "amenity": "restaurant",
@@ -1505,6 +1691,9 @@
   },
   "amenity/restaurant|Wagamama": {
     "count": 129,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWagamama-Logo.svg&width=100"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Wagamama",
@@ -1538,6 +1727,9 @@
   },
   "amenity/restaurant|Wingstop": {
     "count": 137,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/987744144729649152/uG_lOCgM_bigger.jpg"
+    },
     "match": [
       "amenity/fast_food|Wing Stop",
       "amenity/fast_food|Wingstop",
@@ -1553,6 +1745,9 @@
     }
   },
   "amenity/restaurant|YO! Sushi": {
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1016267884174159875/oe4SQ-ns_bigger.jpg"
+    },
     "match": ["amenity/restaurant|Yo! Sushi"],
     "nocount": true,
     "tags": {
@@ -1566,6 +1761,9 @@
   },
   "amenity/restaurant|Zizzi": {
     "count": 117,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1019143213616193537/NONqnbFg_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "Zizzi",
@@ -1612,6 +1810,9 @@
   },
   "amenity/restaurant|いきなり！ステーキ": {
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/ikinari.steak/picture?type=square"
+    },
     "match": ["amenity/restaurant|いきなりステーキ"],
     "nocount": true,
     "tags": {
@@ -1704,6 +1905,9 @@
   "amenity/restaurant|ココス": {
     "count": 184,
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/875584429069959169/5l38DoS7_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "ココス",
@@ -1749,6 +1953,9 @@
   "amenity/restaurant|ジョナサン": {
     "count": 174,
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1098912743497711618/uM80VkgK_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "ジョナサン",
@@ -1805,6 +2012,9 @@
   "amenity/restaurant|バーミヤン": {
     "count": 176,
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1098907474789163010/uXiRaQ9S_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "バーミヤン",
@@ -1820,6 +2030,9 @@
   "amenity/restaurant|ビッグボーイ": {
     "count": 61,
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/966539777955610625/ymNlD8HL_bigger.jpg"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "ビッグボーイ",
@@ -1865,6 +2078,10 @@
   "amenity/restaurant|丸亀製麺": {
     "count": 153,
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/marugame/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/577073917258522624/LU5iUB6a_bigger.jpeg"
+    },
     "match": ["amenity/fast_food|丸亀製麺"],
     "tags": {
       "amenity": "restaurant",
@@ -1891,6 +2108,9 @@
   "amenity/restaurant|和食さと": {
     "count": 55,
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/satorsgroup/picture?type=square"
+    },
     "match": ["amenity/restaurant|さと"],
     "tags": {
       "amenity": "restaurant",
@@ -2024,6 +2244,9 @@
   "amenity/restaurant|餃子の王将": {
     "count": 269,
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/ohshosaiyo/picture?type=square"
+    },
     "tags": {
       "amenity": "restaurant",
       "brand": "餃子の王将",

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -17,6 +17,11 @@
   },
   "amenity/vending_machine|DHL Packstation": {
     "count": 77,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDHL%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/dhl/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/565097171377086464/sw0nS-B6_bigger.jpeg"
+    },
     "match": [
       "amenity/vending_machine|Packstation"
     ],
@@ -51,6 +56,9 @@
   },
   "amenity/vending_machine|Paczkomat InPost": {
     "count": 237,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FInPost%20logo.svg&width=100"
+    },
     "tags": {
       "amenity": "vending_machine",
       "brand": "InPost",
@@ -78,6 +86,10 @@
   },
   "amenity/vending_machine|Redbox": {
     "count": 172,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRedbox%20logo16.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1034645214764453888/g48C6W9j_bigger.jpg"
+    },
     "tags": {
       "amenity": "vending_machine",
       "brand": "Redbox",

--- a/brands/leisure/fitness_centre.json
+++ b/brands/leisure/fitness_centre.json
@@ -1,6 +1,10 @@
 {
   "leisure/fitness_centre|24 Hour Fitness": {
     "count": 81,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F24%20Hour%20Fitness%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1032411070000816128/4PDonjr6_bigger.jpg"
+    },
     "tags": {
       "brand": "24 Hour Fitness",
       "brand:wikidata": "Q4631849",
@@ -56,6 +60,9 @@
   },
   "leisure/fitness_centre|Gold's Gym": {
     "count": 95,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGold's%20Gym%20Weight%20Plate%20Logo%20Primary%20150x150.png&width=100"
+    },
     "tags": {
       "brand": "Gold's Gym",
       "brand:wikidata": "Q1536234",
@@ -66,6 +73,9 @@
   },
   "leisure/fitness_centre|LA Fitness": {
     "count": 226,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1051847982247624705/XHGdH17U_bigger.jpg"
+    },
     "tags": {
       "brand": "LA Fitness",
       "brand:wikidata": "Q6457180",
@@ -84,6 +94,10 @@
   },
   "leisure/fitness_centre|Planet Fitness": {
     "count": 288,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPlanet%20Fitness%20Ypsilanti%20Twp.JPG&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/854416626296512514/DUlDe74c_bigger.jpg"
+    },
     "tags": {
       "brand": "Planet Fitness",
       "brand:wikidata": "Q7201095",
@@ -94,6 +108,9 @@
   },
   "leisure/fitness_centre|PureGym": {
     "countryCodes": ["gb"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/724551608932114432/yt3g43on_bigger.jpg"
+    },
     "match": [
       "leisure/fitness_centre|Pure Gym",
       "leisure/fitness_centre|Puregym",
@@ -131,6 +148,10 @@
   },
   "leisure/fitness_centre|YMCA": {
     "count": 85,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FYMCA-SVG-Common%20International.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/541909790255898624/b5xsDNl5_bigger.jpeg"
+    },
     "tags": {
       "brand": "YMCA",
       "brand:wikidata": "Q157169",

--- a/brands/shop/alcohol.json
+++ b/brands/shop/alcohol.json
@@ -1,6 +1,9 @@
 {
   "shop/alcohol|Alko": {
     "count": 186,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAlko.svg&width=100"
+    },
     "tags": {
       "brand": "Alko",
       "brand:wikidata": "Q1849187",
@@ -31,6 +34,9 @@
   },
   "shop/alcohol|Bargain Booze": {
     "count": 165,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/998956835796205568/21tNi907_bigger.jpg"
+    },
     "tags": {
       "brand": "Bargain Booze",
       "brand:wikidata": "Q16971315",
@@ -88,6 +94,9 @@
   },
   "shop/alcohol|LCBO": {
     "count": 458,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLiquor%20Control%20Board%20of%20Ontario%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "LCBO",
       "brand:wikidata": "Q845263",
@@ -124,6 +133,10 @@
   },
   "shop/alcohol|Nicolas": {
     "count": 279,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNICOLAS%20LOGO.PNG&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/842779196082573314/AtkEMQlh_bigger.jpg"
+    },
     "tags": {
       "brand": "Nicolas",
       "brand:wikidata": "Q3340012",
@@ -162,6 +175,9 @@
   },
   "shop/alcohol|Systembolaget": {
     "count": 295,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSystembolaget%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Systembolaget",
       "brand:wikidata": "Q1476113",
@@ -172,6 +188,9 @@
   },
   "shop/alcohol|The Beer Store": {
     "count": 256,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FThe%20Beer%20Store%20logo.png&width=100"
+    },
     "tags": {
       "brand": "The Beer Store",
       "brand:wikidata": "Q16243674",
@@ -181,6 +200,9 @@
     }
   },
   "shop/alcohol|Total Wine": {
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/3095579292/69f5115c869a3b0f73bfb7ad25ba2a37_bigger.png"
+    },
     "nocount": true,
     "tags": {
       "brand": "Total Wine",
@@ -268,6 +290,9 @@
   },
   "shop/alcohol|Красное & Белое": {
     "count": 451,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKrasnoe%26Beloe.%20Logotip.jpg&width=100"
+    },
     "match": [
       "shop/alcohol|Красное и Белое",
       "shop/alcohol|Красное и белое",

--- a/brands/shop/baby_goods.json
+++ b/brands/shop/baby_goods.json
@@ -9,6 +9,11 @@
   },
   "shop/baby_goods|Babies R Us": {
     "count": 67,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FToys%20%22R%22%20Us%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/toysяusjp/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/945565173309251584/2S7le7sp_bigger.jpg"
+    },
     "tags": {
       "brand": "Babies R Us",
       "brand:wikidata": "Q696334",
@@ -28,6 +33,11 @@
   },
   "shop/baby_goods|Mothercare": {
     "count": 60,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMothercare.svg&width=100",
+      "facebook": "https://graph.facebook.com/mothercareuk/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1019611689103306752/TeFb7zCC_bigger.jpg"
+    },
     "tags": {
       "brand": "Mothercare",
       "brand:wikidata": "Q136738",

--- a/brands/shop/bakery.json
+++ b/brands/shop/bakery.json
@@ -35,6 +35,10 @@
   },
   "shop/bakery|Backwerk": {
     "count": 174,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBackwerk%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/155997891116938/picture?type=square"
+    },
     "match": ["shop/bakery|BackWerk"],
     "tags": {
       "brand": "BackWerk",
@@ -128,6 +132,9 @@
   },
   "shop/bakery|Der Beck": {
     "count": 115,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDer%20Beck.svg&width=100"
+    },
     "tags": {
       "brand": "Der Beck",
       "brand:wikidata": "Q1192443",
@@ -147,6 +154,9 @@
   "shop/bakery|Ditsch": {
     "count": 83,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDitsch-B%C3%A4ckerei%20Wiesbaden.JPG&width=100"
+    },
     "match": ["amenity/fast_food|Ditsch"],
     "tags": {
       "brand": "Ditsch",
@@ -202,6 +212,9 @@
   },
   "shop/bakery|Greggs": {
     "count": 773,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1001837345728016385/86hcMlm8_bigger.jpg"
+    },
     "match": ["amenity/fast_food|Greggs"],
     "tags": {
       "brand": "Greggs",
@@ -229,6 +242,9 @@
   },
   "shop/bakery|Hofpfisterei": {
     "count": 136,
+    "logos": {
+      "facebook": "https://graph.facebook.com/hofpfisterei/picture?type=square"
+    },
     "tags": {
       "brand": "Hofpfisterei",
       "brand:wikidata": "Q1623217",
@@ -257,6 +273,9 @@
   },
   "shop/bakery|K&U Bäckerei": {
     "count": 79,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKuU-Logo.png&width=100"
+    },
     "match": ["shop/bakery|K&U"],
     "tags": {
       "brand": "K&U Bäckerei",
@@ -269,6 +288,10 @@
   "shop/bakery|Kamps": {
     "count": 274,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKamps-Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/417008548362119/picture?type=square"
+    },
     "tags": {
       "brand": "Kamps",
       "brand:wikidata": "Q1723381",
@@ -385,6 +408,10 @@
   },
   "shop/bakery|Paul": {
     "count": 231,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Paul.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1104154254699364353/69J1OrZ1_bigger.png"
+    },
     "tags": {
       "brand": "Paul",
       "brand:wikidata": "Q3370417",
@@ -432,6 +459,9 @@
   },
   "shop/bakery|Sehne": {
     "count": 98,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSehne%20Backwaren%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Sehne",
       "brand:wikidata": "Q1314761",
@@ -443,6 +473,9 @@
   "shop/bakery|Steinecke": {
     "count": 288,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSteinecke%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Steinecke",
       "brand:wikidata": "Q57516278",
@@ -460,6 +493,9 @@
   },
   "shop/bakery|Ströck": {
     "count": 63,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%204C.png&width=100"
+    },
     "tags": {
       "brand": "Ströck",
       "brand:wikidata": "Q2357607",
@@ -514,6 +550,9 @@
   },
   "shop/bakery|뚜레쥬르": {
     "countryCodes": ["kr"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/TousLesJoursUSA/picture?type=square"
+    },
     "match": ["shop/bakery|뚜레주르"],
     "nocount": true,
     "tags": {

--- a/brands/shop/beauty.json
+++ b/brands/shop/beauty.json
@@ -1,6 +1,10 @@
 {
   "shop/beauty|Bath & Body Works": {
     "count": 85,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBbw%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1077920705352777733/OtRwUUoo_bigger.jpg"
+    },
     "tags": {
       "brand": "Bath & Body Works",
       "brand:wikidata": "Q810773",
@@ -53,6 +57,9 @@
   },
   "shop/beauty|Ulta Beauty": {
     "count": 135,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FULTA%20Beauty%20Logo.png&width=100"
+    },
     "match": ["shop/beauty|Ulta"],
     "tags": {
       "brand": "Ulta Beauty",

--- a/brands/shop/bed.json
+++ b/brands/shop/bed.json
@@ -1,6 +1,10 @@
 {
   "shop/bed|Dreams": {
     "count": 70,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNEW-DREAMS-LOGO.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1081135964695810048/-hO3gHMP_bigger.jpg"
+    },
     "tags": {
       "brand": "Dreams",
       "brand:wikidata": "Q5306688",
@@ -12,6 +16,9 @@
   "shop/bed|Matratzen Concord": {
     "count": 419,
     "countryCodes": ["at", "ch", "de"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/MatratzenConcord/picture?type=square"
+    },
     "tags": {
       "brand": "Matratzen Concord",
       "brand:wikidata": "Q18629057",

--- a/brands/shop/beverages.json
+++ b/brands/shop/beverages.json
@@ -9,6 +9,9 @@
   },
   "shop/beverages|Dursty": {
     "count": 69,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDursty%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Dursty",
       "brand:wikidata": "Q1267518",
@@ -49,6 +52,9 @@
   },
   "shop/beverages|Getränke Hoffmann": {
     "count": 217,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGetr%C3%A4nke%20Hoffmann%20Logo.tif&width=100"
+    },
     "tags": {
       "brand": "Getränke Hoffmann",
       "brand:wikidata": "Q19284021",
@@ -67,6 +73,9 @@
   },
   "shop/beverages|Hol'ab": {
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20hol%20ab.svg&width=100"
+    },
     "match": [
       "shop/beverages|Hol Ab",
       "shop/beverages|Hol ab",
@@ -108,6 +117,9 @@
   "shop/beverages|Trinkgut": {
     "count": 70,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTrinkgut%20Logo.svg&width=100"
+    },
     "match": ["shop/beverages|trinkgut"],
     "tags": {
       "brand": "Trinkgut",

--- a/brands/shop/bicycle.json
+++ b/brands/shop/bicycle.json
@@ -1,6 +1,10 @@
 {
   "shop/bicycle|Evans Cycles": {
     "count": 51,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Evans%20Cycles.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/872443417208528897/FMBaLG01_bigger.jpg"
+    },
     "tags": {
       "brand": "Evans Cycles",
       "brand:wikidata": "Q5415901",

--- a/brands/shop/bookmaker.json
+++ b/brands/shop/bookmaker.json
@@ -1,6 +1,10 @@
 {
   "shop/bookmaker|Betfred": {
     "count": 454,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNew-betfred-logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1034363254758359041/dxetDfNN_bigger.jpg"
+    },
     "tags": {
       "brand": "Betfred",
       "brand:wikidata": "Q4897425",
@@ -32,6 +36,10 @@
   },
   "shop/bookmaker|Ladbrokes": {
     "count": 757,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLadbrokes%20Logo2.gif&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1037325155310161921/6E9Rvy3Y_bigger.jpg"
+    },
     "tags": {
       "brand": "Ladbrokes",
       "brand:wikidata": "Q1799875",
@@ -42,6 +50,10 @@
   },
   "shop/bookmaker|Paddy Power": {
     "count": 181,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPaddypowerplc.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/964533060942299136/XCPfJNxf_bigger.jpg"
+    },
     "tags": {
       "brand": "Paddy Power",
       "brand:wikidata": "Q3888718",
@@ -52,6 +64,9 @@
   },
   "shop/bookmaker|Tipico": {
     "count": 59,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTipico%20Unternehmenslogo.jpg&width=100"
+    },
     "tags": {
       "brand": "Tipico",
       "brand:wikidata": "Q15851003",
@@ -62,6 +77,9 @@
   },
   "shop/bookmaker|William Hill": {
     "count": 799,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/797028677733253120/bW9oFXT-_bigger.jpg"
+    },
     "tags": {
       "brand": "William Hill",
       "brand:wikidata": "Q4053147",
@@ -92,6 +110,9 @@
   },
   "shop/bookmaker|Фонбет": {
     "count": 70,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFonbet%20logo.jpg&width=100"
+    },
     "tags": {
       "brand": "Фонбет",
       "brand:wikidata": "Q49137910",

--- a/brands/shop/books.json
+++ b/brands/shop/books.json
@@ -12,6 +12,10 @@
   },
   "shop/books|Barnes & Noble": {
     "count": 517,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBarnes%20and%20Noble%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1093981584842207232/tlsafBnB_bigger.jpg"
+    },
     "tags": {
       "brand": "Barnes & Noble",
       "brand:wikidata": "Q795454",
@@ -31,6 +35,9 @@
     }
   },
   "shop/books|Chapters": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChapters%20Logo.svg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Chapters",
@@ -50,6 +57,9 @@
   },
   "shop/books|Empik": {
     "count": 154,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogoEmpik.png&width=100"
+    },
     "tags": {
       "brand": "Empik",
       "brand:wikidata": "Q3045978",
@@ -60,6 +70,10 @@
   },
   "shop/books|Fnac": {
     "count": 86,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFnac%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1020280617630674944/ZhhGv6rx_bigger.jpg"
+    },
     "tags": {
       "brand": "Fnac",
       "brand:wikidata": "Q676585",
@@ -80,6 +94,11 @@
   },
   "shop/books|Hugendubel": {
     "count": 60,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHugendubel-Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/hugendubelbuchhandlungen/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/737556831283728384/Y4NgJN2n_bigger.jpg"
+    },
     "tags": {
       "brand": "Hugendubel",
       "brand:wikidata": "Q1634142",
@@ -106,6 +125,10 @@
   },
   "shop/books|National Book Store": {
     "count": 90,
+    "logos": {
+      "facebook": "https://graph.facebook.com/nbsalert/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/683840702296363008/6zGFzezE_bigger.jpg"
+    },
     "tags": {
       "brand": "National Book Store",
       "brand:wikidata": "Q6971094",
@@ -127,6 +150,9 @@
   "shop/books|TSUTAYA": {
     "count": 78,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCulture%20Convenience%20Club%20(CCC)%20logo.svg&width=100"
+    },
     "nomatch": [
       "shop/music|TSUTAYA",
       "shop/video|TSUTAYA"
@@ -142,6 +168,9 @@
   "shop/books|Thalia": {
     "count": 195,
     "countryCodes": ["at", "ch", "de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20thalia%20rgb%2004%2009%202018.jpg&width=100"
+    },
     "tags": {
       "brand": "Thalia",
       "brand:wikidata": "Q2408854",
@@ -152,6 +181,9 @@
   },
   "shop/books|The Works": {
     "count": 95,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1066979738982461440/rTCTlJHQ_bigger.jpg"
+    },
     "tags": {
       "brand": "The Works",
       "brand:wikidata": "Q7775853",
@@ -170,6 +202,10 @@
   },
   "shop/books|Waterstones": {
     "count": 193,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWaterstone's.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1079909723644837888/HfOKyVNn_bigger.jpg"
+    },
     "tags": {
       "brand": "Waterstones",
       "brand:wikidata": "Q151779",
@@ -180,6 +216,11 @@
   },
   "shop/books|Weltbild": {
     "count": 73,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20weltbild%20de.gif&width=100",
+      "facebook": "https://graph.facebook.com/weltbild/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1056848916845617152/yOTu3Smi_bigger.jpg"
+    },
     "tags": {
       "brand": "Weltbild",
       "brand:wikidata": "Q883522",
@@ -234,6 +275,10 @@
   "shop/books|ブックオフ": {
     "count": 167,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBookoff%20Corporation%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/bookoffcorporation/picture?type=square"
+    },
     "tags": {
       "brand": "ブックオフ",
       "brand:en": "Book Off",
@@ -248,6 +293,9 @@
   },
   "shop/books|メロンブックス": {
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/877364475304714240/Ael4G2BP_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "brand": "メロンブックス",

--- a/brands/shop/butcher.json
+++ b/brands/shop/butcher.json
@@ -39,6 +39,9 @@
   },
   "shop/butcher|Vinzenzmurr": {
     "count": 59,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FVinzenzmurr%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Vinzenzmurr",
       "brand:wikidata": "Q2527361",
@@ -57,6 +60,9 @@
   },
   "shop/butcher|Великолукский мясокомбинат": {
     "count": 193,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F%D0%92%D0%B5%D0%BB%D0%B8%D0%BA%D0%BE%D0%BB%D1%83%D0%BA%D1%81%D0%BA%D0%B8%D0%B9%20%D0%BC%D1%8F%D1%81%D0%BE%D0%BA%D0%BE%D0%BC%D0%B1%D0%B8%D0%BD%D0%B0%D1%82.png&width=100"
+    },
     "tags": {
       "brand": "Великолукский мясокомбинат",
       "brand:wikidata": "Q18401767",

--- a/brands/shop/car.json
+++ b/brands/shop/car.json
@@ -1,6 +1,11 @@
 {
   "shop/car|Audi": {
     "count": 235,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAudi-Logo%202016.svg&width=100",
+      "facebook": "https://graph.facebook.com/audi.jp/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1091205397837303813/IEY4-H-m_bigger.jpg"
+    },
     "tags": {
       "brand": "Audi",
       "brand:wikidata": "Q23317",
@@ -11,6 +16,11 @@
   },
   "shop/car|BMW": {
     "count": 247,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBMW.svg&width=100",
+      "facebook": "https://graph.facebook.com/BMWGroup/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/862231725421858816/0h7EJOSr_bigger.jpg"
+    },
     "tags": {
       "brand": "BMW",
       "brand:wikidata": "Q26678",
@@ -21,6 +31,9 @@
   },
   "shop/car|Chevrolet": {
     "count": 305,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1058000376866136064/GWdNyYFl_bigger.jpg"
+    },
     "tags": {
       "brand": "Chevrolet",
       "brand:wikidata": "Q29570",
@@ -41,6 +54,9 @@
   },
   "shop/car|Dacia": {
     "count": 75,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDacia%20Logo%20new.jpg&width=100"
+    },
     "tags": {
       "brand": "Dacia",
       "brand:wikidata": "Q27460",
@@ -51,6 +67,9 @@
   },
   "shop/car|Fiat": {
     "count": 198,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFiat%20Automobiles%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Fiat",
       "brand:wikidata": "Q27597",
@@ -61,6 +80,11 @@
   },
   "shop/car|Ford": {
     "count": 544,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFord%20Motor%20Company%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/ford/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/839910514289426433/BxTIsgFj_bigger.jpg"
+    },
     "nomatch": ["shop/car_repair|Ford"],
     "tags": {
       "brand": "Ford",
@@ -72,6 +96,11 @@
   },
   "shop/car|Honda": {
     "count": 449,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHonda-logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/HondaJP/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/848740737189527552/wTZC89a1_bigger.jpg"
+    },
     "match": ["shop/car|Honda Cars"],
     "nomatch": ["shop/motorcycle|Honda"],
     "tags": {
@@ -84,6 +113,10 @@
   },
   "shop/car|Hyundai": {
     "count": 528,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHyundai%20Motor%20Company%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/821433960639008768/_M06NaeP_bigger.jpg"
+    },
     "tags": {
       "brand": "Hyundai",
       "brand:wikidata": "Q55931",
@@ -94,6 +127,9 @@
   },
   "shop/car|Isuzu": {
     "count": 80,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FIsuzu.svg&width=100"
+    },
     "tags": {
       "brand": "Isuzu",
       "brand:wikidata": "Q29803",
@@ -104,6 +140,9 @@
   },
   "shop/car|Kia": {
     "count": 188,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKIA%20logo2.svg&width=100"
+    },
     "match": [
       "shop/car|KIA",
       "shop/car|KIA Motors",
@@ -119,6 +158,9 @@
   },
   "shop/car|Land Rover": {
     "count": 70,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20Land%20Rover%2C%20a%20British%20marque.svg&width=100"
+    },
     "tags": {
       "brand": "Land Rover",
       "brand:wikidata": "Q35907",
@@ -129,6 +171,11 @@
   },
   "shop/car|Lexus": {
     "count": 94,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLexus%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/lexus/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/950827317076504576/rloLQKsS_bigger.jpg"
+    },
     "tags": {
       "brand": "Lexus",
       "brand:wikidata": "Q35919",
@@ -139,6 +186,11 @@
   },
   "shop/car|Mazda": {
     "count": 241,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMazda%20Motor%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/Mazda.Japan/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1067610043980238849/VRGAbAHM_bigger.jpg"
+    },
     "tags": {
       "brand": "Mazda",
       "brand:wikidata": "Q35996",
@@ -149,6 +201,11 @@
   },
   "shop/car|Mercedes-Benz": {
     "count": 380,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMercedes%20benz%20logo1989.png&width=100",
+      "facebook": "https://graph.facebook.com/MercedesBenz/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/378800000224166791/b8d346a6b66796687a649763d6b91936_bigger.jpeg"
+    },
     "match": [
       "shop/car|Mercedes",
       "shop/car|Mercedes Benz"
@@ -163,6 +220,10 @@
   },
   "shop/car|Mitsubishi": {
     "count": 213,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMitsubishi%20Motors%20SVG%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1062754932770521088/tA0yYfCq_bigger.jpg"
+    },
     "match": ["shop/car|Mitsubishi Motors"],
     "tags": {
       "brand": "Mitsubishi",
@@ -185,6 +246,11 @@
   },
   "shop/car|Nissan": {
     "count": 504,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCL70277LOGO-b%20Cropped.jpg&width=100",
+      "facebook": "https://graph.facebook.com/NissanJP/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/878142380301352967/Re_r5Mxs_bigger.jpg"
+    },
     "match": ["shop/car|NISSAN"],
     "tags": {
       "brand": "Nissan",
@@ -196,6 +262,9 @@
   },
   "shop/car|Opel": {
     "count": 235,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOpel-Logo-2011-Vector.svg&width=100"
+    },
     "tags": {
       "brand": "Opel",
       "brand:wikidata": "Q40966",
@@ -206,6 +275,11 @@
   },
   "shop/car|Peugeot": {
     "count": 596,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPeugeot%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/Peugeot/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/875713244580786182/OGYlk4GK_bigger.jpg"
+    },
     "nomatch": ["shop/car_repair|Peugeot"],
     "tags": {
       "brand": "Peugeot",
@@ -217,6 +291,10 @@
   },
   "shop/car|Porsche": {
     "count": 112,
+    "logos": {
+      "facebook": "https://graph.facebook.com/porsche/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/520154210327728128/XPlGCcKQ_bigger.jpeg"
+    },
     "tags": {
       "brand": "Porsche",
       "brand:wikidata": "Q40993",
@@ -227,6 +305,10 @@
   },
   "shop/car|Renault": {
     "count": 806,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRenault%202009%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/841673482903670784/cwyLm740_bigger.jpg"
+    },
     "nomatch": ["shop/car_repair|Renault"],
     "tags": {
       "brand": "Renault",
@@ -238,6 +320,9 @@
   },
   "shop/car|Seat": {
     "count": 115,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSEAT%20Logo%20from%202017.svg&width=100"
+    },
     "tags": {
       "brand": "Seat",
       "brand:wikidata": "Q188217",
@@ -248,6 +333,10 @@
   },
   "shop/car|Skoda": {
     "count": 167,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNew%20%C5%A0koda%20logo-2.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/378800000228830971/885ed1fec2184f97ba1c9a1fb12b6ae1_bigger.jpeg"
+    },
     "tags": {
       "brand": "Skoda",
       "brand:wikidata": "Q29637",
@@ -258,6 +347,11 @@
   },
   "shop/car|Subaru": {
     "count": 150,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSubaru%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/SUBARU.jp/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1874214260/logo_subaru_bigger.JPG"
+    },
     "tags": {
       "brand": "Subaru",
       "brand:wikidata": "Q172741",
@@ -268,6 +362,10 @@
   },
   "shop/car|Suzuki": {
     "count": 222,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSuzuki%20logo%202.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/923402474454630403/gB5--AII_bigger.jpg"
+    },
     "nomatch": ["shop/motorcycle|Suzuki"],
     "tags": {
       "brand": "Suzuki",
@@ -279,6 +377,10 @@
   },
   "shop/car|Tesla": {
     "count": 74,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTesla%20Motors.svg&width=100",
+      "facebook": "https://graph.facebook.com/tesla/picture?type=square"
+    },
     "tags": {
       "brand": "Tesla",
       "brand:wikidata": "Q478214",
@@ -289,6 +391,11 @@
   },
   "shop/car|Toyota": {
     "count": 758,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FToyota%20carlogo.svg&width=100",
+      "facebook": "https://graph.facebook.com/ToyotaSpecialShowroom/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1019836793716273153/Pl0xS5IC_bigger.jpg"
+    },
     "nomatch": ["shop/car_repair|Toyota"],
     "tags": {
       "brand": "Toyota",
@@ -300,6 +407,10 @@
   },
   "shop/car|Volkswagen": {
     "count": 385,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FVolkswagen%20Logo%20till%201995.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/918741546735824896/stA-WNRI_bigger.jpg"
+    },
     "match": ["shop/car|VW"],
     "tags": {
       "brand": "Volkswagen",
@@ -311,6 +422,9 @@
   },
   "shop/car|Volvo": {
     "count": 208,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FVolvo%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Volvo",
       "brand:wikidata": "Q215293",
@@ -322,6 +436,11 @@
   "shop/car|ホンダ": {
     "count": 57,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHonda-logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/HondaJP/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/848740737189527552/wTZC89a1_bigger.jpg"
+    },
     "tags": {
       "brand": "ホンダ",
       "brand:en": "Honda",

--- a/brands/shop/car_parts.json
+++ b/brands/shop/car_parts.json
@@ -1,6 +1,9 @@
 {
   "shop/car_parts|Advance Auto Parts": {
     "count": 669,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20Advance%20Auto%20Parts.svg&width=100"
+    },
     "match": [
       "shop/car_repair|Advance Auto Parts"
     ],
@@ -14,6 +17,9 @@
   },
   "shop/car_parts|AutoZone": {
     "count": 909,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20AutoZone.png&width=100"
+    },
     "match": [
       "shop/car_parts|Auto Zone",
       "shop/car_parts|Autozone",
@@ -39,6 +45,9 @@
   },
   "shop/car_parts|Halfords": {
     "count": 128,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/894829428764704768/XprrrJyW_bigger.jpg"
+    },
     "match": ["shop/bicycle|Halfords"],
     "nomatch": [
       "shop/car_repair|Halfords Autocentre"
@@ -62,6 +71,10 @@
   },
   "shop/car_parts|NAPA Auto Parts": {
     "count": 460,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20the%20National%20Automotive%20Parts%20Association.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/877735026703519744/4gppscV7_bigger.jpg"
+    },
     "match": [
       "shop/car_parts|NAPA",
       "shop/car_parts|Napa Auto Parts",
@@ -153,6 +166,10 @@
   "shop/car_parts|オートバックス": {
     "count": 120,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAutobacs%20Seven%20%E3%82%AA%E3%83%BC%E3%83%88%E3%83%90%E3%83%83%E3%82%AF%E3%82%B9%E7%9C%8B%E6%9D%BF.JPG&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/898398595002417154/CgR8Rgjd_bigger.jpg"
+    },
     "tags": {
       "brand": "オートバックス",
       "brand:en": "Autobacs",

--- a/brands/shop/car_repair.json
+++ b/brands/shop/car_repair.json
@@ -2,6 +2,9 @@
   "shop/car_repair|A.T.U": {
     "count": 457,
     "countryCodes": ["at", "de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAuto-Teile-Unger%20Logo.svg&width=100"
+    },
     "match": [
       "shop/car_repair|ATU",
       "shop/car_repair|Auto-Teile-Unger"
@@ -16,6 +19,9 @@
   },
   "shop/car_repair|ATS Euromaster": {
     "count": 57,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/572348690115751936/8zWGjm2u_bigger.jpeg"
+    },
     "tags": {
       "brand": "ATS Euromaster",
       "brand:wikidata": "Q4654920",
@@ -26,6 +32,11 @@
   },
   "shop/car_repair|Bosch Car Service": {
     "count": 104,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBosch-Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/BoschGlobal/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/908326929614426113/ffrjkfbT_bigger.jpg"
+    },
     "match": ["shop/car_repair|Bosch Service"],
     "tags": {
       "brand": "Bosch Car Service",
@@ -45,6 +56,9 @@
   },
   "shop/car_repair|Carglass": {
     "count": 305,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCarglass-Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Carglass",
       "brand:wikidata": "Q1035997",
@@ -93,6 +107,9 @@
   },
   "shop/car_repair|Firestone": {
     "count": 295,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFirestone.svg&width=100"
+    },
     "match": [
       "shop/car_repair|Firestone Complete Auto Care",
       "shop/tyres|Firestone"
@@ -107,6 +124,11 @@
   },
   "shop/car_repair|Ford": {
     "count": 71,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFord%20Motor%20Company%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/ford/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/839910514289426433/BxTIsgFj_bigger.jpg"
+    },
     "nomatch": ["shop/car|Ford"],
     "tags": {
       "brand": "Ford",
@@ -129,6 +151,9 @@
   },
   "shop/car_repair|Grease Monkey": {
     "count": 82,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGMI%202c%20Logo%20BlackTag%20May2011.jpg&width=100"
+    },
     "tags": {
       "brand": "Grease Monkey",
       "brand:wikidata": "Q5598563",
@@ -139,6 +164,9 @@
   },
   "shop/car_repair|Halfords Autocentre": {
     "count": 52,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/763666491522879488/IDO6pgKh_bigger.jpg"
+    },
     "match": ["shop/car_repair|Halfords"],
     "nomatch": ["shop/car_parts|Halfords"],
     "tags": {
@@ -161,6 +189,9 @@
   },
   "shop/car_repair|Kwik Fit": {
     "count": 202,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/725269358449152000/1BFagDRC_bigger.jpg"
+    },
     "match": ["shop/car_repair|Kwik-Fit"],
     "tags": {
       "brand": "Kwik Fit",
@@ -222,6 +253,9 @@
   },
   "shop/car_repair|Pep Boys": {
     "count": 134,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/704718154627289088/T2VfGc_0_bigger.jpg"
+    },
     "tags": {
       "brand": "Pep Boys",
       "brand:wikidata": "Q3375007",
@@ -232,6 +266,11 @@
   },
   "shop/car_repair|Peugeot": {
     "count": 175,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPeugeot%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/Peugeot/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/875713244580786182/OGYlk4GK_bigger.jpg"
+    },
     "nomatch": ["shop/car|Peugeot"],
     "tags": {
       "brand": "Peugeot",
@@ -251,6 +290,9 @@
   },
   "shop/car_repair|Point S": {
     "count": 87,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPointS%204c%20klein.svg&width=100"
+    },
     "tags": {
       "brand": "Point S",
       "brand:wikidata": "Q3393358",
@@ -261,6 +303,10 @@
   },
   "shop/car_repair|Renault": {
     "count": 324,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRenault%202009%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/841673482903670784/cwyLm740_bigger.jpg"
+    },
     "match": ["shop/car_repair|Garage Renault"],
     "nomatch": ["shop/car|Renault"],
     "tags": {
@@ -283,6 +329,9 @@
   },
   "shop/car_repair|Safelite AutoGlass": {
     "countryCodes": ["us"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/941319713149333505/oSj6thH6_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "brand": "Safelite AutoGlass",
@@ -305,6 +354,9 @@
   },
   "shop/car_repair|Speedy": {
     "count": 224,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSpeedy%20France%20logo%20officiel.png&width=100"
+    },
     "nomatch": [
       "shop/car_repair|Speedy Auto Service"
     ],
@@ -318,6 +370,10 @@
   },
   "shop/car_repair|Speedy Auto Service": {
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSpeedy-logo-onblue.jpg&width=100",
+      "facebook": "https://graph.facebook.com/SpeedyAutoServiceCanada/picture?type=square"
+    },
     "nocount": true,
     "nomatch": ["shop/car_repair|Speedy"],
     "tags": {
@@ -329,6 +385,11 @@
   },
   "shop/car_repair|Toyota": {
     "count": 77,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FToyota%20carlogo.svg&width=100",
+      "facebook": "https://graph.facebook.com/ToyotaSpecialShowroom/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1019836793716273153/Pl0xS5IC_bigger.jpg"
+    },
     "nomatch": ["shop/car|Toyota"],
     "tags": {
       "brand": "Toyota",

--- a/brands/shop/carpet.json
+++ b/brands/shop/carpet.json
@@ -1,6 +1,10 @@
 {
   "shop/carpet|Carpetright": {
     "count": 80,
+    "logos": {
+      "facebook": "https://graph.facebook.com/carpetright/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/793378131000385536/rNGVxi7M_bigger.jpg"
+    },
     "match": ["shop/carpet|Carpet Right"],
     "tags": {
       "brand": "Carpetright",

--- a/brands/shop/catalogue.json
+++ b/brands/shop/catalogue.json
@@ -1,6 +1,11 @@
 {
   "shop/catalogue|Argos": {
     "count": 155,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FArgos%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/argos/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1034719429433741312/9TpSQISk_bigger.jpg"
+    },
     "tags": {
       "brand": "Argos",
       "brand:wikidata": "Q4789707",

--- a/brands/shop/charity.json
+++ b/brands/shop/charity.json
@@ -1,6 +1,9 @@
 {
   "shop/charity|Age UK": {
     "count": 162,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1062640403890012160/sKLJr0LV_bigger.jpg"
+    },
     "tags": {
       "brand": "Age UK",
       "brand:wikidata": "Q4691850",
@@ -11,6 +14,9 @@
   },
   "shop/charity|Barnardo's": {
     "count": 95,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/773811120717062144/-LlJgkGP_bigger.jpg"
+    },
     "tags": {
       "brand": "Barnardo's",
       "brand:wikidata": "Q2884670",
@@ -21,6 +27,9 @@
   },
   "shop/charity|British Heart Foundation": {
     "count": 250,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1018581043832672256/pFxu3S-U_bigger.jpg"
+    },
     "tags": {
       "brand": "British Heart Foundation",
       "brand:wikidata": "Q4970039",
@@ -31,6 +40,10 @@
   },
   "shop/charity|British Red Cross": {
     "count": 72,
+    "logos": {
+      "facebook": "https://graph.facebook.com/britishredcross/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1026395468983623680/4sW7GSwd_bigger.jpg"
+    },
     "tags": {
       "brand": "British Red Cross",
       "brand:wikidata": "Q4970966",
@@ -41,6 +54,9 @@
   },
   "shop/charity|Cancer Research UK": {
     "count": 175,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/948495800971259904/YTVv7Ma9_bigger.jpg"
+    },
     "tags": {
       "brand": "Cancer Research UK",
       "brand:wikidata": "Q326079",
@@ -65,6 +81,9 @@
   },
   "shop/charity|Mind": {
     "count": 62,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/700296365285310464/nxkGt-oH_bigger.jpg"
+    },
     "tags": {
       "brand": "Mind",
       "brand:wikidata": "Q3314763",
@@ -90,6 +109,10 @@
   },
   "shop/charity|Oxfam": {
     "count": 289,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOxfam%20logo%2C%202016%20(cropped).jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1047149379910606849/PYdTCugb_bigger.jpg"
+    },
     "tags": {
       "brand": "Oxfam",
       "brand:wikidata": "Q267941",
@@ -100,6 +123,9 @@
   },
   "shop/charity|RSPCA": {
     "count": 65,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/798101205729808384/d2QZlyR3_bigger.jpg"
+    },
     "tags": {
       "brand": "RSPCA",
       "brand:wikidata": "Q584819",
@@ -110,6 +136,10 @@
   },
   "shop/charity|Salvation Army": {
     "count": 156,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSalvationArmy.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/877163494491262976/MDatx4PJ_bigger.jpg"
+    },
     "tags": {
       "brand": "Salvation Army",
       "brand:wikidata": "Q188307",
@@ -120,6 +150,9 @@
   },
   "shop/charity|Scope": {
     "count": 86,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1098320113835610113/WisJatSW_bigger.png"
+    },
     "tags": {
       "brand": "Scope",
       "brand:wikidata": "Q7434435",
@@ -130,6 +163,9 @@
   },
   "shop/charity|Sue Ryder": {
     "count": 129,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1103043966751133698/BJk80NfX_bigger.jpg"
+    },
     "tags": {
       "brand": "Sue Ryder",
       "brand:wikidata": "Q7634271",
@@ -140,6 +176,10 @@
   },
   "shop/charity|The Salvation Army": {
     "count": 62,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSalvationArmy.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/877163494491262976/MDatx4PJ_bigger.jpg"
+    },
     "tags": {
       "brand": "The Salvation Army",
       "brand:wikidata": "Q188307",

--- a/brands/shop/chemist.json
+++ b/brands/shop/chemist.json
@@ -26,6 +26,9 @@
   "shop/chemist|Bipa": {
     "count": 475,
     "countryCodes": ["at", "hr"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBipa%20Logo.svg&width=100"
+    },
     "match": ["shop/chemist|BIPA"],
     "tags": {
       "brand": "Bipa",
@@ -77,6 +80,9 @@
   },
   "shop/chemist|Etos": {
     "count": 497,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEtos%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Etos",
       "brand:wikidata": "Q2609459",
@@ -103,6 +109,9 @@
   },
   "shop/chemist|Kruidvat": {
     "count": 1218,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKruidvat%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Kruidvat",
       "brand:wikidata": "Q2226366",
@@ -140,6 +149,11 @@
   },
   "shop/chemist|Rossmann": {
     "count": 2956,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRossmann%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/rossmann.gmbh/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/663683721657208832/OpZzT8dd_bigger.jpg"
+    },
     "tags": {
       "brand": "Rossmann",
       "brand:wikidata": "Q316004",
@@ -177,6 +191,9 @@
   },
   "shop/chemist|Trekpleister": {
     "count": 203,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTrekpleister%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Trekpleister",
       "brand:wikidata": "Q2551576",
@@ -230,6 +247,10 @@
       "si",
       "sk"
     ],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDm-drogerie-Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/dm.Deutschland/picture?type=square"
+    },
     "match": [
       "shop/chemist|DM",
       "shop/chemist|DM Drogeriemarkt",

--- a/brands/shop/chocolate.json
+++ b/brands/shop/chocolate.json
@@ -19,6 +19,9 @@
   },
   "shop/chocolate|Leonidas": {
     "count": 128,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLeonidas%20shop%2C%20Downtown%20Manhattan.JPG&width=100"
+    },
     "tags": {
       "brand": "Leonidas",
       "brand:wikidata": "Q80335",

--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -24,6 +24,11 @@
   },
   "shop/clothes|Abercrombie & Fitch": {
     "count": 69,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAbercrombie%20%26%20Fitch%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/abercrombie/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1090830222302298112/W60h63qk_bigger.jpg"
+    },
     "tags": {
       "brand": "Abercrombie & Fitch",
       "brand:wikidata": "Q319344",
@@ -34,6 +39,10 @@
   },
   "shop/clothes|Accessorize": {
     "count": 57,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMonsoon%20accessorize%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1014248943121813505/qNRJq7zh_bigger.jpg"
+    },
     "tags": {
       "brand": "Accessorize",
       "brand:wikidata": "Q3069980",
@@ -44,6 +53,9 @@
   },
   "shop/clothes|Ackermans": {
     "count": 106,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAckermans-Logo.jpg&width=100"
+    },
     "tags": {
       "brand": "Ackermans",
       "brand:wikidata": "Q4674255",
@@ -62,6 +74,10 @@
   },
   "shop/clothes|Aeropostale": {
     "count": 65,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAeropostale%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1022567836043173895/8EvkF14a_bigger.jpg"
+    },
     "tags": {
       "brand": "Aeropostale",
       "brand:wikidata": "Q794565",
@@ -72,6 +88,10 @@
   },
   "shop/clothes|American Apparel": {
     "count": 53,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAmerican%20Apparel%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/2439473817/athb5wxi0s8t4a9qze3d_bigger.jpeg"
+    },
     "tags": {
       "brand": "American Apparel",
       "brand:wikidata": "Q463378",
@@ -82,6 +102,10 @@
   },
   "shop/clothes|American Eagle Outfitters": {
     "count": 153,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAmerican%20Eagle%20Outfitters%20text%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/926225107445366786/HNAMY-nG_bigger.jpg"
+    },
     "tags": {
       "brand": "American Eagle Outfitters",
       "brand:wikidata": "Q2842931",
@@ -91,6 +115,9 @@
     }
   },
   "shop/clothes|Ann Taylor": {
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/632020433571676162/jq9ErOl5_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "brand": "Ann Taylor",
@@ -102,6 +129,10 @@
   },
   "shop/clothes|Anthropologie": {
     "count": 74,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAnthropologieLogo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1013829328205991938/mMkaMqhL_bigger.jpg"
+    },
     "tags": {
       "brand": "Anthropologie",
       "brand:wikidata": "Q4773903",
@@ -112,6 +143,9 @@
   },
   "shop/clothes|Ardene": {
     "count": 70,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FArdene%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Ardene",
       "brand:wikidata": "Q2860764",
@@ -143,6 +177,11 @@
   },
   "shop/clothes|Banana Republic": {
     "count": 164,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBanana%20Republic%20logo.png&width=100",
+      "facebook": "https://graph.facebook.com/BananaRepublic/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1088122926740647936/UjE5aobK_bigger.jpg"
+    },
     "tags": {
       "brand": "Banana Republic",
       "brand:wikidata": "Q806085",
@@ -161,6 +200,11 @@
   },
   "shop/clothes|Bershka": {
     "count": 225,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBershka%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/bershka/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1091263653419061249/N3D29PsI_bigger.jpg"
+    },
     "tags": {
       "brand": "Bershka",
       "brand:wikidata": "Q827258",
@@ -181,6 +225,9 @@
   },
   "shop/clothes|Big Star": {
     "count": 62,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBig%20Star%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Big Star",
       "brand:wikidata": "Q9171569",
@@ -201,6 +248,9 @@
   },
   "shop/clothes|Bonobo": {
     "count": 85,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBonobos%20LogoGrey%20April13.jpg&width=100"
+    },
     "tags": {
       "brand": "Bonobo",
       "brand:wikidata": "Q4942546",
@@ -211,6 +261,9 @@
   },
   "shop/clothes|Brice": {
     "count": 62,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLOGO%20BRICE%20Noir.png&width=100"
+    },
     "tags": {
       "brand": "Brice",
       "brand:wikidata": "Q2925067",
@@ -229,6 +282,10 @@
   },
   "shop/clothes|Brooks Brothers": {
     "count": 76,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBrooks%20Brothers%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1085664744818860032/1GmuBSB0_bigger.jpg"
+    },
     "tags": {
       "brand": "Brooks Brothers",
       "brand:wikidata": "Q929722",
@@ -239,6 +296,10 @@
   },
   "shop/clothes|Burberry": {
     "count": 82,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBurberry%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1024960867845197824/40BZozPb_bigger.jpg"
+    },
     "tags": {
       "brand": "Burberry",
       "brand:wikidata": "Q390107",
@@ -249,6 +310,10 @@
   },
   "shop/clothes|Burlington Coat Factory": {
     "count": 158,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBurlington%20Coat%20Factory%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/851496565118205953/l8vJaRWh_bigger.jpg"
+    },
     "tags": {
       "brand": "Burlington Coat Factory",
       "brand:wikidata": "Q4999220",
@@ -260,6 +325,9 @@
   "shop/clothes|Burton": {
     "count": 110,
     "countryCodes": ["fr", "gb"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/966321347923271680/THD9mE6x_bigger.jpg"
+    },
     "tags": {
       "brand": "Burton",
       "brand:wikidata": "Q5000795",
@@ -270,6 +338,9 @@
   },
   "shop/clothes|C&A": {
     "count": 966,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FC-und-A-Logo-2011.svg&width=100"
+    },
     "tags": {
       "brand": "C&A",
       "brand:wikidata": "Q701338",
@@ -301,6 +372,10 @@
   },
   "shop/clothes|Calvin Klein": {
     "count": 109,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCalvin%20klein%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/889490770687905792/N8mVqffO_bigger.jpg"
+    },
     "tags": {
       "brand": "Calvin Klein",
       "brand:wikidata": "Q1068628",
@@ -311,6 +386,11 @@
   },
   "shop/clothes|Calzedonia": {
     "count": 386,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCalzedonia%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/calzedonia/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/734767482116923392/nJRu-xpK_bigger.jpg"
+    },
     "tags": {
       "brand": "Calzedonia",
       "brand:wikidata": "Q1027874",
@@ -385,6 +465,9 @@
   },
   "shop/clothes|Celio": {
     "count": 286,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20celio%20RVB.jpg&width=100"
+    },
     "tags": {
       "brand": "Celio",
       "brand:wikidata": "Q2672003",
@@ -395,6 +478,9 @@
   },
   "shop/clothes|Charles Vögele": {
     "count": 88,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCharles%20Voegele%20Logo.svg&width=100"
+    },
     "match": ["shop/clothes|Vögele"],
     "tags": {
       "brand": "Charles Vögele",
@@ -406,6 +492,9 @@
   },
   "shop/clothes|Charlotte Russe": {
     "count": 65,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCharlotte%20russe.png&width=100"
+    },
     "tags": {
       "brand": "Charlotte Russe",
       "brand:wikidata": "Q5086126",
@@ -416,6 +505,9 @@
   },
   "shop/clothes|Chico's": {
     "count": 134,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChico's%20FAS%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Chico's",
       "brand:wikidata": "Q5096393",
@@ -426,6 +518,9 @@
   },
   "shop/clothes|Christopher & Banks": {
     "count": 56,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChristopher%20%26%20Banks%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Christopher & Banks",
       "brand:wikidata": "Q5111816",
@@ -453,6 +548,9 @@
   },
   "shop/clothes|Columbia": {
     "count": 66,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/378800000507623403/444cd8e60cf59b6fab58ba06c80c2a6c_bigger.png"
+    },
     "nomatch": ["amenity/bank|Columbia Bank"],
     "tags": {
       "brand": "Columbia",
@@ -515,6 +613,9 @@
   },
   "shop/clothes|David's Bridal": {
     "count": 65,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/899743614934421505/tuKy4f_-_bigger.jpg"
+    },
     "tags": {
       "brand": "David's Bridal",
       "brand:wikidata": "Q5230388",
@@ -525,6 +626,11 @@
   },
   "shop/clothes|Desigual": {
     "count": 216,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDesigual%20logo.jpg&width=100",
+      "facebook": "https://graph.facebook.com/desigual/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1105077887680548864/MXN9rGjm_bigger.png"
+    },
     "tags": {
       "brand": "Desigual",
       "brand:wikidata": "Q83750",
@@ -535,6 +641,9 @@
   },
   "shop/clothes|Devred": {
     "count": 85,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20DEVRED%201902.jpg&width=100"
+    },
     "tags": {
       "brand": "Devred",
       "brand:wikidata": "Q3025542",
@@ -553,6 +662,10 @@
   },
   "shop/clothes|Diesel": {
     "count": 104,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDiesel%20Logo%202015.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1059404541618253824/3amvryNj_bigger.jpg"
+    },
     "tags": {
       "brand": "Diesel",
       "brand:wikidata": "Q158285",
@@ -573,6 +686,9 @@
   },
   "shop/clothes|Dorothy Perkins": {
     "count": 98,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1017023323711115264/qftZ4OL7_bigger.jpg"
+    },
     "tags": {
       "brand": "Dorothy Perkins",
       "brand:wikidata": "Q5298588",
@@ -583,6 +699,9 @@
   },
   "shop/clothes|Dress Barn": {
     "count": 178,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDressBarn%20new%20logo.gif&width=100"
+    },
     "tags": {
       "brand": "Dress Barn",
       "brand:wikidata": "Q5307031",
@@ -625,6 +744,9 @@
   "shop/clothes|Engbers": {
     "count": 86,
     "countryCodes": ["at", "de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEngbers%20(Unternehmen)%20logo.svg&width=100"
+    },
     "match": ["shop/clothes|engbers"],
     "tags": {
       "brand": "Engbers",
@@ -637,6 +759,11 @@
   "shop/clothes|Ernsting's family": {
     "count": 646,
     "countryCodes": ["at", "de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FErnstings%20family.svg&width=100",
+      "facebook": "https://graph.facebook.com/Ernstingsfamily/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/973861075769810944/vMuI_clb_bigger.jpg"
+    },
     "match": [
       "shop/clothes|Ernsting's Family",
       "shop/clothes|Ernstings Family"
@@ -651,6 +778,10 @@
   },
   "shop/clothes|Esprit": {
     "count": 479,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEsprit%20Logo%20neu.svg&width=100",
+      "facebook": "https://graph.facebook.com/esprit/picture?type=square"
+    },
     "tags": {
       "brand": "Esprit",
       "brand:wikidata": "Q532746",
@@ -671,6 +802,9 @@
   },
   "shop/clothes|Express": {
     "count": 96,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FExpress%2C%20Inc.%20logo.svg&width=100"
+    },
     "nomatch": ["shop/convenience|Express"],
     "tags": {
       "brand": "Express",
@@ -682,6 +816,9 @@
   },
   "shop/clothes|Fat Face": {
     "count": 106,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1055013284485779458/dtR2OyFc_bigger.jpg"
+    },
     "tags": {
       "brand": "Fat Face",
       "brand:wikidata": "Q5437186",
@@ -692,6 +829,9 @@
   },
   "shop/clothes|Forever 21": {
     "count": 189,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FForever%2021%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Forever 21",
       "brand:wikidata": "Q1060537",
@@ -702,6 +842,11 @@
   },
   "shop/clothes|GU": {
     "count": 54,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGU%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/g.u.japan/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/662735261940355074/rT_LKLPE_bigger.jpg"
+    },
     "tags": {
       "brand": "GU",
       "brand:wikidata": "Q5512642",
@@ -712,6 +857,11 @@
   },
   "shop/clothes|Gant": {
     "count": 95,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGant%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/gant/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/639327987708596224/qFUiCX_t_bigger.jpg"
+    },
     "tags": {
       "brand": "Gant",
       "brand:wikidata": "Q1493667",
@@ -722,6 +872,11 @@
   },
   "shop/clothes|Gap": {
     "count": 247,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGap%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/GapJapan/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1082116452868448256/iNWOuH66_bigger.jpg"
+    },
     "match": ["shop/clothes|GAP"],
     "tags": {
       "brand": "Gap",
@@ -733,6 +888,9 @@
   },
   "shop/clothes|Gerry Weber": {
     "count": 262,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGerry%20Weber%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Gerry Weber",
       "brand:wikidata": "Q873447",
@@ -744,6 +902,9 @@
   "shop/clothes|Gina Laura": {
     "count": 102,
     "countryCodes": ["at", "de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGina%20Laura%20Logo.jpg&width=100"
+    },
     "tags": {
       "brand": "Gina Laura",
       "brand:wikidata": "Q2700576",
@@ -754,6 +915,9 @@
   },
   "shop/clothes|Gloria Jeans": {
     "count": 51,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGloria%20Jeans.jpg&width=100"
+    },
     "tags": {
       "brand": "Gloria Jeans",
       "brand:wikidata": "Q4139985",
@@ -764,6 +928,11 @@
   },
   "shop/clothes|Gucci": {
     "count": 66,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGucci.png&width=100",
+      "facebook": "https://graph.facebook.com/GUCCI/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1101437643290742784/XkwupsME_bigger.png"
+    },
     "tags": {
       "brand": "Gucci",
       "brand:wikidata": "Q178516",
@@ -774,6 +943,9 @@
   },
   "shop/clothes|Guess": {
     "count": 200,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Guess.jpg&width=100"
+    },
     "tags": {
       "brand": "Guess",
       "brand:wikidata": "Q2470307",
@@ -784,6 +956,10 @@
   },
   "shop/clothes|Gymboree": {
     "count": 97,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGymboree%20logo.gif&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1018723545122131968/mBlwxTN2_bigger.jpg"
+    },
     "tags": {
       "brand": "Gymboree",
       "brand:wikidata": "Q4039771",
@@ -804,6 +980,11 @@
   },
   "shop/clothes|H&M": {
     "count": 1727,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FH%26M-Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/hmhongkong/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/790839927378419712/XjyjXvQJ_bigger.jpg"
+    },
     "match": ["shop/clothes|H & M"],
     "tags": {
       "brand": "H&M",
@@ -815,6 +996,9 @@
   },
   "shop/clothes|Hallhuber": {
     "count": 81,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHH%20LOGO%202013.svg&width=100"
+    },
     "tags": {
       "brand": "Hallhuber",
       "brand:wikidata": "Q1571714",
@@ -837,6 +1021,9 @@
   },
   "shop/clothes|Hollister": {
     "count": 75,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1080115653288304641/XgzGGBc9_bigger.jpg"
+    },
     "tags": {
       "brand": "Hollister",
       "brand:wikidata": "Q1257477",
@@ -847,6 +1034,11 @@
   },
   "shop/clothes|Hot Topic": {
     "count": 71,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHot%20Topic%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/hottopic/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/890313667379580928/83hx0rNu_bigger.jpg"
+    },
     "tags": {
       "brand": "Hot Topic",
       "brand:wikidata": "Q9294032",
@@ -865,6 +1057,10 @@
   },
   "shop/clothes|Hugo Boss": {
     "count": 147,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHugo-Boss-Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/981463273836089344/mZoBl9wy_bigger.jpg"
+    },
     "match": ["shop/clothes|Boss"],
     "tags": {
       "brand": "Hugo Boss",
@@ -884,6 +1080,9 @@
   },
   "shop/clothes|Hunkemöller": {
     "count": 307,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHunkemoeller%20Logo.png&width=100"
+    },
     "tags": {
       "brand": "Hunkemöller",
       "brand:wikidata": "Q2604175",
@@ -894,6 +1093,11 @@
   },
   "shop/clothes|Intimissimi": {
     "count": 250,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FIntimissimi%20vector%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/intimissimi/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/954025520349569024/favurwps_bigger.jpg"
+    },
     "tags": {
       "brand": "Intimissimi",
       "brand:wikidata": "Q305404",
@@ -915,6 +1119,9 @@
   },
   "shop/clothes|Jack & Jones": {
     "count": 230,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/2735852177/8e4633c7fe64dadc067689fa0064c9c6_bigger.jpeg"
+    },
     "tags": {
       "brand": "Jack & Jones",
       "brand:wikidata": "Q6077665",
@@ -935,6 +1142,9 @@
       "sg",
       "us"
     ],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/661519780046897152/vjDrJiE5_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "brand": "Jack Wills",
@@ -954,6 +1164,9 @@
   },
   "shop/clothes|Jeans Fritz": {
     "count": 150,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJeans-Fritz-Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Jeans Fritz",
       "brand:wikidata": "Q1686071",
@@ -985,6 +1198,9 @@
   },
   "shop/clothes|Jigsaw": {
     "count": 63,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/728543220158836736/01mbnkez_bigger.jpg"
+    },
     "tags": {
       "brand": "Jigsaw",
       "brand:wikidata": "Q6192383",
@@ -995,6 +1211,9 @@
   },
   "shop/clothes|Jos. A. Bank": {
     "count": 52,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1001953978790313984/rZx5Eh6N_bigger.jpg"
+    },
     "tags": {
       "brand": "Jos. A. Bank",
       "brand:wikidata": "Q6204078",
@@ -1005,6 +1224,10 @@
   },
   "shop/clothes|Joules": {
     "count": 61,
+    "logos": {
+      "facebook": "https://graph.facebook.com/Joules/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1101150179636449281/YKJYSzG8_bigger.png"
+    },
     "tags": {
       "brand": "Joules",
       "brand:wikidata": "Q25351738",
@@ -1033,6 +1256,10 @@
   },
   "shop/clothes|KappAhl": {
     "count": 85,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKappAhl%20wordmark.svg&width=100",
+      "facebook": "https://graph.facebook.com/kappahl/picture?type=square"
+    },
     "tags": {
       "brand": "KappAhl",
       "brand:wikidata": "Q4349016",
@@ -1043,6 +1270,9 @@
   },
   "shop/clothes|KiK": {
     "count": 1105,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKiK-Logo.svg&width=100"
+    },
     "match": [
       "shop/clothes|KIK",
       "shop/clothes|Kik",
@@ -1068,6 +1298,11 @@
   },
   "shop/clothes|LC Waikiki": {
     "count": 89,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLC%20Waikiki%20logo.PNG&width=100",
+      "facebook": "https://graph.facebook.com/lcwaikiki/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/946265766751555584/81kl_de0_bigger.jpg"
+    },
     "tags": {
       "brand": "LC Waikiki",
       "brand:wikidata": "Q3205965",
@@ -1085,6 +1320,10 @@
     }
   },
   "shop/clothes|La Senza": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLa%20Senza%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1096482433711685632/7mAHBXSB_bigger.png"
+    },
     "nocount": true,
     "tags": {
       "brand": "La Senza",
@@ -1096,6 +1335,10 @@
   },
   "shop/clothes|Lacoste": {
     "count": 254,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogoL.png&width=100",
+      "facebook": "https://graph.facebook.com/LacosteFrance/picture?type=square"
+    },
     "tags": {
       "brand": "Lacoste",
       "brand:wikidata": "Q309031",
@@ -1117,6 +1360,9 @@
   },
   "shop/clothes|Levi's": {
     "count": 296,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLevi's%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Levi's",
       "brand:wikidata": "Q127962",
@@ -1129,6 +1375,10 @@
   "shop/clothes|Lids": {
     "count": 55,
     "countryCodes": ["ca", "us"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/Lids/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/883075707248627712/mJGRc7_e_bigger.jpg"
+    },
     "tags": {
       "brand": "Lids",
       "brand:wikidata": "Q19841609",
@@ -1140,6 +1390,10 @@
   },
   "shop/clothes|Lindex": {
     "count": 148,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLindex%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/lindex/picture?type=square"
+    },
     "tags": {
       "brand": "Lindex",
       "brand:wikidata": "Q1786717",
@@ -1150,6 +1404,9 @@
   },
   "shop/clothes|Loft": {
     "count": 96,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/632020433571676162/jq9ErOl5_bigger.jpg"
+    },
     "tags": {
       "brand": "Loft",
       "brand:wikidata": "Q4766699",
@@ -1161,6 +1418,11 @@
   },
   "shop/clothes|Louis Vuitton": {
     "count": 58,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLouis%20Vuitton%20logo%20and%20wordmark.svg&width=100",
+      "facebook": "https://graph.facebook.com/LouisVuitton/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/744891970380767232/jum1SDsC_bigger.jpg"
+    },
     "tags": {
       "brand": "Louis Vuitton",
       "brand:wikidata": "Q191485",
@@ -1171,6 +1433,9 @@
   },
   "shop/clothes|M&Co": {
     "count": 51,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/3060281697/0cf4741ed2fcb2ab442637e226a3d538_bigger.jpeg"
+    },
     "tags": {
       "brand": "M&Co",
       "brand:wikidata": "Q6711808",
@@ -1189,6 +1454,9 @@
   },
   "shop/clothes|Mango": {
     "count": 438,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMango-logo.jpg&width=100"
+    },
     "tags": {
       "brand": "Mango",
       "brand:wikidata": "Q136503",
@@ -1199,6 +1467,9 @@
   },
   "shop/clothes|Marc O'Polo": {
     "count": 99,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMarc%20O%E2%80%99Polo%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Marc O'Polo",
       "brand:wikidata": "Q1892752",
@@ -1217,6 +1488,9 @@
   },
   "shop/clothes|Mark's": {
     "count": 120,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMark's%20Work%20Wearhouse%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Mark's",
       "brand:wikidata": "Q6766373",
@@ -1227,6 +1501,10 @@
   },
   "shop/clothes|Marks & Spencer": {
     "count": 59,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMarksAndSpencer1884%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1096328339030196224/qI38Qkt9_bigger.png"
+    },
     "tags": {
       "brand": "Marks & Spencer",
       "brand:wikidata": "Q714491",
@@ -1237,6 +1515,11 @@
   },
   "shop/clothes|Massimo Dutti": {
     "count": 144,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMassimo%20Dutti%20a%20Cal%20Franquesa%2002.jpg&width=100",
+      "facebook": "https://graph.facebook.com/massimodutti/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/926094006626521089/9u2a2J92_bigger.jpg"
+    },
     "tags": {
       "brand": "Massimo Dutti",
       "brand:wikidata": "Q788231",
@@ -1247,6 +1530,9 @@
   },
   "shop/clothes|Matalan": {
     "count": 158,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1059530620374867970/wCJvqGG5_bigger.jpg"
+    },
     "tags": {
       "brand": "Matalan",
       "brand:wikidata": "Q12061509",
@@ -1257,6 +1543,9 @@
   },
   "shop/clothes|Maurices": {
     "count": 135,
+    "logos": {
+      "facebook": "https://graph.facebook.com/maurices/picture?type=square"
+    },
     "tags": {
       "brand": "Maurices",
       "brand:wikidata": "Q6793571",
@@ -1292,6 +1581,9 @@
   },
   "shop/clothes|Mexx": {
     "count": 58,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMexx%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Mexx",
       "brand:wikidata": "Q1837290",
@@ -1302,6 +1594,9 @@
   },
   "shop/clothes|Michael Kors": {
     "count": 85,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMichael%20Kors%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Michael Kors",
       "brand:wikidata": "Q19572998",
@@ -1336,6 +1631,10 @@
   },
   "shop/clothes|Monsoon": {
     "count": 84,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMonsoon%20accessorize%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1014248943121813505/qNRJq7zh_bigger.jpg"
+    },
     "tags": {
       "brand": "Monsoon",
       "brand:wikidata": "Q3069980",
@@ -1372,6 +1671,9 @@
   },
   "shop/clothes|NKD": {
     "count": 934,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F150707%20NKD%20Logog%20Wikipedia.svg&width=100"
+    },
     "tags": {
       "brand": "NKD",
       "brand:wikidata": "Q927272",
@@ -1392,6 +1694,10 @@
   },
   "shop/clothes|New Look": {
     "count": 335,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNew%20Look%20(clothing%20retailer)%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1057923508460761088/9Gem24tH_bigger.jpg"
+    },
     "tags": {
       "brand": "New Look",
       "brand:wikidata": "Q12063852",
@@ -1402,6 +1708,9 @@
   },
   "shop/clothes|New Yorker": {
     "count": 428,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNew%20Yorker.svg&width=100"
+    },
     "match": ["shop/clothes|NewYorker"],
     "tags": {
       "brand": "New Yorker",
@@ -1413,6 +1722,9 @@
   },
   "shop/clothes|Next": {
     "count": 370,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1047405356635344896/fbsYbE_N_bigger.jpg"
+    },
     "tags": {
       "brand": "Next",
       "brand:wikidata": "Q246655",
@@ -1423,6 +1735,11 @@
   },
   "shop/clothes|Nike": {
     "count": 199,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20NIKE.svg&width=100",
+      "facebook": "https://graph.facebook.com/nike/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/953320896101412864/UdE5mfkP_bigger.jpg"
+    },
     "match": [
       "shop/shoes|Nike",
       "shop/sports|Nike"
@@ -1437,6 +1754,9 @@
   },
   "shop/clothes|Nordstrom Rack": {
     "count": 96,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCurrent%20Nordstrom%20Rack%20Logo.jpg&width=100"
+    },
     "tags": {
       "brand": "Nordstrom Rack",
       "brand:wikidata": "Q21463374",
@@ -1447,6 +1767,9 @@
   },
   "shop/clothes|OVS": {
     "count": 155,
+    "logos": {
+      "facebook": "https://graph.facebook.com/OVS/picture?type=square"
+    },
     "tags": {
       "brand": "OVS",
       "brand:wikidata": "Q2042514",
@@ -1475,6 +1798,9 @@
   },
   "shop/clothes|Old Navy": {
     "count": 475,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOld%20Navy%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Old Navy",
       "brand:wikidata": "Q2735242",
@@ -1514,6 +1840,9 @@
   },
   "shop/clothes|Orsay": {
     "count": 210,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FORSAY.svg&width=100"
+    },
     "tags": {
       "brand": "Orsay",
       "brand:wikidata": "Q883245",
@@ -1534,6 +1863,9 @@
   },
   "shop/clothes|Oysho": {
     "count": 69,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLOGO%20oysho%20wikipedia.png&width=100"
+    },
     "tags": {
       "brand": "Oysho",
       "brand:wikidata": "Q3327046",
@@ -1543,6 +1875,10 @@
     }
   },
   "shop/clothes|PacSun": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPacSun%20Logo.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/763503514890842112/oY_iKSnB_bigger.jpg"
+    },
     "match": ["shop/clothes|Pac Sun"],
     "nocount": true,
     "tags": {
@@ -1555,6 +1891,9 @@
   },
   "shop/clothes|Palmers": {
     "count": 88,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPalmerslogo.jpg&width=100"
+    },
     "tags": {
       "brand": "Palmers",
       "brand:wikidata": "Q1509985",
@@ -1565,6 +1904,9 @@
   },
   "shop/clothes|Peacocks": {
     "count": 228,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/665232157699350532/RFhB9Sqy_bigger.jpg"
+    },
     "tags": {
       "brand": "Peacocks",
       "brand:wikidata": "Q7157762",
@@ -1575,6 +1917,9 @@
   },
   "shop/clothes|Peek & Cloppenburg": {
     "count": 84,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Peek%20%26%20Cloppenburg.svg&width=100"
+    },
     "tags": {
       "brand": "Peek & Cloppenburg",
       "brand:wikidata": "Q2066959",
@@ -1617,6 +1962,10 @@
   },
   "shop/clothes|Phase Eight": {
     "count": 55,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPhase%20Eight%20Logo.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/826031206961647617/L_YJKtfM_bigger.jpg"
+    },
     "tags": {
       "brand": "Phase Eight",
       "brand:wikidata": "Q17020730",
@@ -1666,6 +2015,11 @@
   },
   "shop/clothes|Primark": {
     "count": 229,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPrimark%20Stores%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/Primark/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/998127801600430082/h0ka8wAA_bigger.jpg"
+    },
     "tags": {
       "brand": "Primark",
       "brand:wikidata": "Q137023",
@@ -1676,6 +2030,9 @@
   },
   "shop/clothes|Promod": {
     "count": 221,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPromod-Boutique%20Francaise.jpg&width=100"
+    },
     "tags": {
       "brand": "Promod",
       "brand:wikidata": "Q3407429",
@@ -1686,6 +2043,10 @@
   },
   "shop/clothes|Pull & Bear": {
     "count": 97,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPull%26Bear%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1065168584450674690/8NL1vlQR_bigger.jpg"
+    },
     "tags": {
       "brand": "Pull & Bear",
       "brand:wikidata": "Q691029",
@@ -1716,6 +2077,9 @@
   },
   "shop/clothes|Rainbow": {
     "count": 82,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRainbow-logo.jpg&width=100"
+    },
     "tags": {
       "brand": "Rainbow",
       "brand:wikidata": "Q7284708",
@@ -1725,6 +2089,11 @@
     }
   },
   "shop/clothes|Reebok": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FReebok%20delta%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/ReebokUS/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/542438975974019073/Yzm6Gwv8_bigger.jpeg"
+    },
     "match": [
       "shop/shoes|Reebok",
       "shop/sports|Reebok"
@@ -1750,6 +2119,11 @@
   },
   "shop/clothes|Reserved": {
     "count": 193,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGda%C5%84sk%20Alfa%20Centrum%20sklep%20Reserved.JPG&width=100",
+      "facebook": "https://graph.facebook.com/Reserved/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/819070741752774656/LzABgA0C_bigger.jpg"
+    },
     "tags": {
       "brand": "Reserved",
       "brand:wikidata": "Q21809354",
@@ -1760,6 +2134,9 @@
   },
   "shop/clothes|River Island": {
     "count": 162,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1072101180791287814/Y0vBqxNn_bigger.jpg"
+    },
     "tags": {
       "brand": "River Island",
       "brand:wikidata": "Q2670328",
@@ -1770,6 +2147,10 @@
   },
   "shop/clothes|Ross": {
     "count": 418,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRoss%20Stores%20logo.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/666413791169503233/rCEE7G_S_bigger.jpg"
+    },
     "match": ["shop/clothes|Ross Dress for Less"],
     "tags": {
       "brand": "Ross",
@@ -1829,6 +2210,9 @@
   },
   "shop/clothes|Sisley": {
     "count": 95,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSisley%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Sisley",
       "brand:wikidata": "Q12054325",
@@ -1842,6 +2226,9 @@
   },
   "shop/clothes|Springfield": {
     "count": 116,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMarca-springfield.png&width=100"
+    },
     "tags": {
       "brand": "Springfield",
       "brand:wikidata": "Q958209",
@@ -1852,6 +2239,10 @@
   },
   "shop/clothes|Stefanel": {
     "count": 71,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FStefanel-logo2016.png&width=100",
+      "facebook": "https://graph.facebook.com/Stefanel.Official/picture?type=square"
+    },
     "tags": {
       "brand": "Stefanel",
       "brand:wikidata": "Q2338087",
@@ -1873,6 +2264,9 @@
   },
   "shop/clothes|Stradivarius": {
     "count": 158,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/971352713517821952/SvetxMXi_bigger.jpg"
+    },
     "tags": {
       "brand": "Stradivarius",
       "brand:wikidata": "Q3322945",
@@ -1931,6 +2325,10 @@
   },
   "shop/clothes|Superdry": {
     "count": 139,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSupergrouplogo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1021773831546056704/C5cZqYeP_bigger.jpg"
+    },
     "tags": {
       "brand": "Superdry",
       "brand:wikidata": "Q1684445",
@@ -1941,6 +2339,10 @@
   },
   "shop/clothes|TJ Maxx": {
     "count": 317,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTJ%20Maxx%20Logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/578229320994295808/nAHcV1yx_bigger.png"
+    },
     "match": ["shop/clothes|T.J. Maxx"],
     "tags": {
       "brand": "TJ Maxx",
@@ -1952,6 +2354,10 @@
   },
   "shop/clothes|TK Maxx": {
     "count": 276,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTK%20Maxx%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1078275977426468866/QgWrQjee_bigger.jpg"
+    },
     "tags": {
       "brand": "TK Maxx",
       "brand:wikidata": "Q23823668",
@@ -1969,6 +2375,9 @@
       "hu",
       "nl"
     ],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTakkoLogo.svg&width=100"
+    },
     "match": ["shop/clothes|Takko Fashion"],
     "tags": {
       "brand": "Takko",
@@ -1980,6 +2389,10 @@
   },
   "shop/clothes|Talbots": {
     "count": 90,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTalbots%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/648526811479961600/EcfZDBkl_bigger.png"
+    },
     "tags": {
       "brand": "Talbots",
       "brand:wikidata": "Q7679064",
@@ -1990,6 +2403,9 @@
   },
   "shop/clothes|Tally Weijl": {
     "count": 208,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTALLY%20WEiJL%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Tally Weijl",
       "brand:wikidata": "Q689695",
@@ -2018,6 +2434,11 @@
   },
   "shop/clothes|Tezenis": {
     "count": 134,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTezenis%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/tezenis/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/926074804901425153/ZRR849vv_bigger.jpg"
+    },
     "tags": {
       "brand": "Tezenis",
       "brand:wikidata": "Q28056374",
@@ -2027,6 +2448,9 @@
   },
   "shop/clothes|The Children's Place": {
     "count": 127,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/200694312/Twitter_Logo_TCP_lockup_2995_bigger.jpg"
+    },
     "tags": {
       "brand": "The Children's Place",
       "brand:wikidata": "Q3520257",
@@ -2037,6 +2461,11 @@
   },
   "shop/clothes|The North Face": {
     "count": 85,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTheNorthFace%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/thenorthface/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1042076860023275523/9qahAU7A_bigger.jpg"
+    },
     "tags": {
       "brand": "The North Face",
       "brand:wikidata": "Q152784",
@@ -2076,6 +2505,11 @@
   },
   "shop/clothes|Tom Tailor": {
     "count": 146,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTOM%20TAILOR%20Logo.png&width=100",
+      "facebook": "https://graph.facebook.com/tomtailor/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/683959899139796992/hvCObo0H_bigger.png"
+    },
     "tags": {
       "brand": "Tom Tailor",
       "brand:wikidata": "Q571206",
@@ -2086,6 +2520,10 @@
   },
   "shop/clothes|Tommy Hilfiger": {
     "count": 270,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTommy%20hilfig%20vectorlogo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1029280250331627520/VUFItzJv_bigger.jpg"
+    },
     "tags": {
       "brand": "Tommy Hilfiger",
       "brand:wikidata": "Q634881",
@@ -2104,6 +2542,10 @@
   },
   "shop/clothes|Topshop": {
     "count": 78,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTopshoplogo.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1093467767557292032/bck-649i_bigger.jpg"
+    },
     "tags": {
       "brand": "Topshop",
       "brand:wikidata": "Q1893576",
@@ -2124,6 +2566,9 @@
   },
   "shop/clothes|Triumph": {
     "count": 175,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTriumph%20International%20Logo%202008.svg&width=100"
+    },
     "tags": {
       "brand": "Triumph",
       "brand:wikidata": "Q671216",
@@ -2144,6 +2589,9 @@
   },
   "shop/clothes|Ulla Popken": {
     "count": 143,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUlla%20Popken%20neu.png&width=100"
+    },
     "tags": {
       "brand": "Ulla Popken",
       "brand:wikidata": "Q2475146",
@@ -2154,6 +2602,11 @@
   },
   "shop/clothes|Uniqlo": {
     "count": 127,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUNIQLO%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/uniqlo/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/874794943566323712/B9wQNv90_bigger.jpg"
+    },
     "tags": {
       "brand": "Uniqlo",
       "brand:wikidata": "Q26070",
@@ -2164,6 +2617,10 @@
   },
   "shop/clothes|United Colors of Benetton": {
     "count": 273,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBenetton%20Group%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/BenettonItalia/picture?type=square"
+    },
     "match": ["shop/clothes|Benetton"],
     "tags": {
       "brand": "United Colors of Benetton",
@@ -2175,6 +2632,9 @@
   },
   "shop/clothes|Urban Outfitters": {
     "count": 150,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/770320292040376320/mMgRkcES_bigger.jpg"
+    },
     "tags": {
       "brand": "Urban Outfitters",
       "brand:wikidata": "Q3552193",
@@ -2185,6 +2645,9 @@
   },
   "shop/clothes|Vero Moda": {
     "count": 267,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBS%20DK.JPG&width=100"
+    },
     "tags": {
       "brand": "Vero Moda",
       "brand:wikidata": "Q594721",
@@ -2195,6 +2658,11 @@
   },
   "shop/clothes|Victoria's Secret": {
     "count": 234,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FVictoria%E2%80%99s-Secret-Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/victoriassecret/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/542675764026429440/gPXHFroZ_bigger.png"
+    },
     "tags": {
       "brand": "Victoria's Secret",
       "brand:wikidata": "Q332477",
@@ -2216,6 +2684,9 @@
   },
   "shop/clothes|White House Black Market": {
     "count": 63,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWHBM%20Logo.png&width=100"
+    },
     "tags": {
       "brand": "White House Black Market",
       "brand:wikidata": "Q7994858",
@@ -2226,6 +2697,10 @@
   },
   "shop/clothes|White Stuff": {
     "count": 65,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWhite-stuff-logo.gif&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/633617979469524993/ydbUTjT3_bigger.jpg"
+    },
     "tags": {
       "brand": "White Stuff",
       "brand:wikidata": "Q7995442",
@@ -2236,6 +2711,9 @@
   },
   "shop/clothes|Wibra": {
     "count": 128,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWibra%20Wallonie%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Wibra",
       "brand:wikidata": "Q943405",
@@ -2254,6 +2732,9 @@
   },
   "shop/clothes|Winners": {
     "count": 132,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWinners%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Winners",
       "brand:wikidata": "Q845257",
@@ -2284,6 +2765,9 @@
   },
   "shop/clothes|Yamamay": {
     "count": 95,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FYamamay%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Yamamay",
       "brand:wikidata": "Q2599214",
@@ -2302,6 +2786,11 @@
   },
   "shop/clothes|Zara": {
     "count": 678,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FZara%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/zara/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1088788926834319361/3xCQPSpG_bigger.jpg"
+    },
     "tags": {
       "brand": "Zara",
       "brand:wikidata": "Q147662",
@@ -2312,6 +2801,10 @@
   },
   "shop/clothes|Zeeman": {
     "count": 484,
+    "logos": {
+      "facebook": "https://graph.facebook.com/zeemantextielsupers/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/590535419659362306/C05BHfKZ_bigger.jpg"
+    },
     "tags": {
       "brand": "Zeeman",
       "brand:wikidata": "Q184399",
@@ -2332,6 +2825,9 @@
   },
   "shop/clothes|mister*lady": {
     "count": 112,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Mister*lady.jpg&width=100"
+    },
     "tags": {
       "brand": "mister*lady",
       "brand:wikidata": "Q18640136",
@@ -2342,6 +2838,9 @@
   },
   "shop/clothes|rue21": {
     "count": 66,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/793801428380835840/XsjVskJq_bigger.jpg"
+    },
     "match": [
       "shop/clothes|Rue 21",
       "shop/clothes|Rue21"
@@ -2356,6 +2855,9 @@
   },
   "shop/clothes|s.Oliver": {
     "count": 132,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FS.Oliver.svg&width=100"
+    },
     "tags": {
       "brand": "s.Oliver",
       "brand:wikidata": "Q265056",
@@ -2399,6 +2901,9 @@
   "shop/clothes|しまむら": {
     "count": 320,
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/grshimamura/picture?type=square"
+    },
     "tags": {
       "brand": "しまむら",
       "brand:en": "Shimamura",
@@ -2440,6 +2945,11 @@
   "shop/clothes|ユニクロ": {
     "count": 271,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUNIQLO%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/uniqlo/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/874794943566323712/B9wQNv90_bigger.jpg"
+    },
     "tags": {
       "brand": "ユニクロ",
       "brand:en": "UNIQLO",
@@ -2454,6 +2964,10 @@
   },
   "shop/clothes|ライトオン": {
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/righton.co.jp/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/778400122572972032/qWkHGwx6_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "brand": "ライトオン",
@@ -2483,6 +2997,10 @@
   "shop/clothes|洋服の青山": {
     "count": 322,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F%E6%B4%8B%E6%9C%8D%E3%81%AE%E9%9D%92%E5%B1%B1.jpg&width=100",
+      "facebook": "https://graph.facebook.com/AoyamaOfficial/picture?type=square"
+    },
     "tags": {
       "brand": "洋服の青山",
       "brand:en": "Aoyama Tailor",

--- a/brands/shop/coffee.json
+++ b/brands/shop/coffee.json
@@ -1,6 +1,9 @@
 {
   "shop/coffee|Nespresso": {
     "count": 126,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMonogramme%20Nespresso.png&width=100"
+    },
     "tags": {
       "brand": "Nespresso",
       "brand:wikidata": "Q301301",
@@ -11,6 +14,9 @@
   },
   "shop/coffee|Tchibo": {
     "count": 259,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTchibo%20Logo%20Kachel%20Ohne%20Schutzzone%202017.svg&width=100"
+    },
     "match": [
       "amenity/cafe|Tchibo",
       "shop/convenience|Tchibo"

--- a/brands/shop/confectionery.json
+++ b/brands/shop/confectionery.json
@@ -76,6 +76,9 @@
   },
   "shop/confectionery|Thorntons": {
     "count": 77,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/796370840753410050/w5tkzrmR_bigger.jpg"
+    },
     "tags": {
       "brand": "Thorntons",
       "brand:wikidata": "Q683102",
@@ -97,6 +100,9 @@
   "shop/confectionery|シャトレーゼ": {
     "count": 71,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChatraise%20logo.png&width=100"
+    },
     "tags": {
       "brand": "シャトレーゼ",
       "brand:en": "Chateraise",

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -9,6 +9,11 @@
   },
   "shop/convenience|7-Eleven": {
     "count": 11479,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F7-eleven%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/7ElevenMexico/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/875639017512906752/qMa3uhuo_bigger.jpg"
+    },
     "match": [
       "shop/convenience|7 Eleven",
       "shop/convenience|7 eleven",
@@ -73,6 +78,9 @@
   },
   "shop/convenience|Albert Heijn to go": {
     "count": 59,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAlbert%20heijn.svg&width=100"
+    },
     "tags": {
       "brand": "Albert Heijn to go",
       "brand:wikidata": "Q1653985",
@@ -158,6 +166,10 @@
   },
   "shop/convenience|BP Shop": {
     "count": 108,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBP%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/879386367276482560/2quhYJn1_bigger.jpg"
+    },
     "nomatch": ["amenity/fuel|BP"],
     "tags": {
       "brand": "BP Shop",
@@ -340,6 +352,9 @@
   },
   "shop/convenience|Circle K": {
     "count": 1375,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCircle%20k%20logo%20detail.png&width=100"
+    },
     "match": [
       "shop/convenience|OK",
       "shop/convenience|OK-Mart"
@@ -364,6 +379,9 @@
   },
   "shop/convenience|Co-op": {
     "count": 272,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSaskatoon%20Co-op%20Logo.svg&width=100"
+    },
     "match": [
       "shop/convenience|COOP",
       "shop/convenience|Co-Op",
@@ -517,6 +535,10 @@
   },
   "shop/convenience|FamilyMart": {
     "count": 834,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFamilyMart%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/880365539968798721/yNVr_BFn_bigger.jpg"
+    },
     "match": ["shop/convenience|Family Mart"],
     "tags": {
       "brand": "FamilyMart",
@@ -746,6 +768,11 @@
   },
   "shop/convenience|Lawson": {
     "count": 253,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLawson%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/lawson.fanpage/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/875517108884455426/q3HMm7hU_bigger.jpg"
+    },
     "match": ["shop/convenience|LAWSON"],
     "tags": {
       "brand": "Lawson",
@@ -810,6 +837,9 @@
   },
   "shop/convenience|Marathon": {
     "count": 93,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMarathon%20Oil%20Logo.svg&width=100"
+    },
     "nomatch": ["amenity/fuel|Marathon"],
     "tags": {
       "brand": "Marathon",
@@ -845,6 +875,9 @@
     }
   },
   "shop/convenience|Małpka Express": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSklep%20Ma%C5%82pka%20Express.jpg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Małpka Express",
@@ -875,6 +908,9 @@
   },
   "shop/convenience|Migrolino": {
     "count": 80,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMlino%20logo%204c%20co.jpg&width=100"
+    },
     "tags": {
       "brand": "Migrolino",
       "brand:wikidata": "Q56745088",
@@ -893,6 +929,9 @@
   },
   "shop/convenience|Ministop": {
     "count": 375,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMINISTOP%20logo.svg&width=100"
+    },
     "match": ["shop/convenience|Mini Stop"],
     "tags": {
       "brand": "Ministop",
@@ -912,6 +951,9 @@
   },
   "shop/convenience|Mobil Mart": {
     "count": 67,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMobil%20logo.svg&width=100"
+    },
     "nomatch": ["amenity/fuel|Mobil"],
     "tags": {
       "brand": "Mobil Mart",
@@ -931,6 +973,9 @@
   },
   "shop/convenience|Nisa": {
     "count": 85,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1091320703633248257/cj3S7Oqu_bigger.jpg"
+    },
     "tags": {
       "brand": "Nisa",
       "brand:wikidata": "Q16999069",
@@ -941,6 +986,9 @@
   },
   "shop/convenience|Nisa Local": {
     "count": 198,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1091320703633248257/cj3S7Oqu_bigger.jpg"
+    },
     "tags": {
       "brand": "Nisa Local",
       "brand:wikidata": "Q16999069",
@@ -959,6 +1007,9 @@
   },
   "shop/convenience|OK便利商店": {
     "count": 164,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCircle%20k%20logo%20detail.png&width=100"
+    },
     "match": ["shop/convenience|OK便利店 Circle K"],
     "tags": {
       "brand": "OK便利商店",
@@ -1009,6 +1060,9 @@
   },
   "shop/convenience|Oxxo": {
     "count": 2694,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOxxo%20Logo.svg&width=100"
+    },
     "match": [
       "shop/convenience|OXXO",
       "shop/supermarket|OXXO",
@@ -1033,6 +1087,9 @@
   },
   "shop/convenience|Petro-Canada": {
     "count": 133,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPetro%20canada%20logo.jpg&width=100"
+    },
     "nomatch": ["amenity/fuel|Petro-Canada"],
     "tags": {
       "brand": "Petro-Canada",
@@ -1054,6 +1111,9 @@
   },
   "shop/convenience|Premier": {
     "count": 368,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/552086468839997441/Ok2vWsQl_bigger.jpeg"
+    },
     "tags": {
       "brand": "Premier",
       "brand:wikidata": "Q7240340",
@@ -1165,6 +1225,11 @@
   },
   "shop/convenience|Shell Select": {
     "count": 123,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRoyal%20Dutch%20Shell.png&width=100",
+      "facebook": "https://graph.facebook.com/Shell/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/934717921816993793/H1vB6P7o_bigger.jpg"
+    },
     "nomatch": [
       "amenity/fuel|Shell",
       "amenity/fuel|Shell Express"
@@ -1196,6 +1261,10 @@
   },
   "shop/convenience|Spar": {
     "count": 1316,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSpar-logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/639011130107633664/nLN6cXfa_bigger.png"
+    },
     "match": ["shop/convenience|SPAR"],
     "nomatch": [
       "shop/convenience|Spar Express",
@@ -1211,6 +1280,10 @@
   },
   "shop/convenience|Spar Express": {
     "count": 62,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSpar-logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/639011130107633664/nLN6cXfa_bigger.png"
+    },
     "match": [
       "shop/convenience|SPAR Express",
       "shop/supermarket|Spar Express"
@@ -1357,6 +1430,9 @@
   },
   "shop/convenience|The Co-operative Food": {
     "count": 328,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1034360565127409665/V4fCWHgw_bigger.jpg"
+    },
     "nomatch": [
       "shop/supermarket|The Co-operative Food"
     ],
@@ -1414,6 +1490,9 @@
   },
   "shop/convenience|United Dairy Farmers": {
     "count": 86,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUnited%20Dairy%20Farmers%20logo.png&width=100"
+    },
     "match": [
       "amenity/ice_cream|UDF",
       "amenity/ice_cream|United Dairy Farmers",
@@ -1490,6 +1569,10 @@
   },
   "shop/convenience|Wawa": {
     "count": 400,
+    "logos": {
+      "facebook": "https://graph.facebook.com/wawa/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/948254909677359104/lpvtnJzZ_bigger.jpg"
+    },
     "nomatch": ["amenity/fuel|Wawa"],
     "tags": {
       "brand": "Wawa",
@@ -1754,6 +1837,9 @@
   },
   "shop/convenience|ВкусВилл": {
     "count": 325,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FVkusVill%20textlogo.png&width=100"
+    },
     "tags": {
       "brand": "ВкусВилл",
       "brand:wikidata": "Q57271676",
@@ -2068,6 +2154,10 @@
   },
   "shop/convenience|Магнит": {
     "count": 2287,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMagnit%20Logo.gif&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1098477357390856192/wILY9KdL_bigger.png"
+    },
     "match": ["shop/supermarket|Магнит у дома"],
     "nomatch": [
       "shop/cosmetics|Магнит Косметик",
@@ -2317,6 +2407,9 @@
   },
   "shop/convenience|Сельпо": {
     "count": 57,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSilpo.png&width=100"
+    },
     "tags": {
       "brand": "Сельпо",
       "brand:wikidata": "Q4419434",
@@ -2517,6 +2610,9 @@
   "shop/convenience|サンクス": {
     "count": 703,
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/875617750923616257/dCryLWcX_bigger.jpg"
+    },
     "tags": {
       "brand": "サンクス",
       "brand:en": "Sunkus",
@@ -2532,6 +2628,9 @@
   "shop/convenience|サークルK": {
     "count": 859,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCircle%20k%20logo%20detail.png&width=100"
+    },
     "tags": {
       "brand": "サークルK",
       "brand:en": "Circle K",
@@ -2547,6 +2646,10 @@
   "shop/convenience|スリーエフ": {
     "count": 162,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FThree-f.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/875645560073539585/X1oFVQef_bigger.jpg"
+    },
     "tags": {
       "brand": "スリーエフ",
       "brand:en": "Three F",
@@ -2577,6 +2680,11 @@
   "shop/convenience|セブン-イレブン": {
     "count": 6783,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F7-eleven%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/7ElevenMexico/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/875639017512906752/qMa3uhuo_bigger.jpg"
+    },
     "match": [
       "shop/convenience|セブン−イレブン",
       "shop/convenience|セブンイレブン",
@@ -2647,6 +2755,10 @@
   "shop/convenience|ファミリーマート": {
     "count": 6059,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFamilyMart%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/880365539968798721/yNVr_BFn_bigger.jpg"
+    },
     "tags": {
       "brand": "ファミリーマート",
       "brand:en": "FamilyMart",
@@ -2662,6 +2774,9 @@
   "shop/convenience|ポプラ": {
     "count": 106,
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/826586791058644992/chXkmxnQ_bigger.jpg"
+    },
     "tags": {
       "brand": "ポプラ",
       "brand:en": "Poplar",
@@ -2677,6 +2792,9 @@
   "shop/convenience|ミニストップ": {
     "count": 919,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMINISTOP%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "ミニストップ",
       "brand:en": "Ministop",
@@ -2706,6 +2824,11 @@
   "shop/convenience|ローソン": {
     "count": 5360,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLawson%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/lawson.fanpage/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/875517108884455426/q3HMm7hU_bigger.jpg"
+    },
     "match": ["shop/convenience|ﾛｰｿﾝ"],
     "tags": {
       "brand": "ローソン",
@@ -2756,6 +2879,10 @@
   },
   "shop/convenience|全家": {
     "count": 608,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFamilyMart%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/880365539968798721/yNVr_BFn_bigger.jpg"
+    },
     "tags": {
       "brand": "全家",
       "brand:en": "FamilyMart",
@@ -2800,6 +2927,11 @@
   "shop/convenience|세븐일레븐": {
     "count": 291,
     "countryCodes": ["kr"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F7-eleven%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/7ElevenMexico/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/875639017512906752/qMa3uhuo_bigger.jpg"
+    },
     "tags": {
       "brand": "세븐일레븐",
       "brand:en": "7-Eleven",

--- a/brands/shop/cosmetics.json
+++ b/brands/shop/cosmetics.json
@@ -8,6 +8,9 @@
     }
   },
   "shop/cosmetics|KIKO Milano": {
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/952897224551346176/E2KWgQTi_bigger.jpg"
+    },
     "match": [
       "shop/cosmetics|KIKO",
       "shop/cosmetics|Kiko",
@@ -32,6 +35,11 @@
   },
   "shop/cosmetics|Lush": {
     "count": 138,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLush%20(Unternehmen)%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/LUSHJAPAN/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/840483871674179585/zDsW_ehT_bigger.jpg"
+    },
     "tags": {
       "brand": "Lush",
       "brand:wikidata": "Q1585448",
@@ -50,6 +58,9 @@
   },
   "shop/cosmetics|Nocibé": {
     "count": 63,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Nocib%C3%A9.png&width=100"
+    },
     "tags": {
       "brand": "Nocibé",
       "brand:wikidata": "Q3342592",
@@ -59,6 +70,9 @@
     }
   },
   "shop/cosmetics|Origins": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDFS%20Galleria%20Customhouse%20Auckland%20Origins%20counter%202013.jpg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Origins",
@@ -78,6 +92,9 @@
   },
   "shop/cosmetics|Sephora": {
     "count": 274,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSephora%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Sephora",
       "brand:wikidata": "Q2408041",
@@ -88,6 +105,11 @@
   },
   "shop/cosmetics|The Body Shop": {
     "count": 206,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FThe-Body-Shop-Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/thebodyshoptaiwan/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/997798602809532417/NNF6_rus_bigger.jpg"
+    },
     "match": [
       "shop/beauty|The Body Shop",
       "shop/chemist|The Body Shop"
@@ -138,6 +160,10 @@
   "shop/cosmetics|Магнит Косметик": {
     "count": 176,
     "countryCodes": ["ru"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMagnit%20Logo.gif&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1098477357390856192/wILY9KdL_bigger.png"
+    },
     "match": [
       "shop/chemist|Магнит Косметик",
       "shop/cosmetics|Магнит косметик",

--- a/brands/shop/craft.json
+++ b/brands/shop/craft.json
@@ -1,6 +1,11 @@
 {
   "shop/craft|Hobby Lobby": {
     "count": 222,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHobby%20lobby%20logo15.png&width=100",
+      "facebook": "https://graph.facebook.com/HobbyLobby/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/630563733656350720/tDOhLnsW_bigger.jpg"
+    },
     "tags": {
       "brand": "Hobby Lobby",
       "brand:wikidata": "Q5874938",
@@ -11,6 +16,9 @@
   },
   "shop/craft|Hobbycraft": {
     "countryCodes": ["gb"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/378800000761890482/065a1af2468ff8f210a01ee62f7ec226_bigger.jpeg"
+    },
     "match": ["shop/art|Hobbycraft"],
     "nocount": true,
     "tags": {
@@ -22,6 +30,10 @@
     }
   },
   "shop/craft|Jo-Ann": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJASinc%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/895011226534776833/PwBI2ol0_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "brand": "Jo-Ann",
@@ -33,6 +45,9 @@
   },
   "shop/craft|Michaels": {
     "count": 299,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/796386226450239488/4rxYpY0E_bigger.jpg"
+    },
     "match": ["shop/craft|Michael's"],
     "tags": {
       "brand": "Michaels",

--- a/brands/shop/deli.json
+++ b/brands/shop/deli.json
@@ -2,6 +2,9 @@
   "shop/deli|ほっともっと": {
     "count": 74,
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1099849032661315585/e5zgKssc_bigger.png"
+    },
     "nomatch": ["shop/fast_food|ほっともっと"],
     "tags": {
       "brand": "ほっともっと",

--- a/brands/shop/department_store.json
+++ b/brands/shop/department_store.json
@@ -19,6 +19,9 @@
   },
   "shop/department_store|Bi-Mart": {
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBi-Mart.svg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Bi-Mart",
@@ -31,6 +34,9 @@
   "shop/department_store|Big Lots": {
     "count": 260,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBig%20Lots%20logo.jpeg&width=100"
+    },
     "match": ["shop/variety_store|Big Lots"],
     "tags": {
       "brand": "Big Lots",
@@ -43,6 +49,9 @@
   "shop/department_store|Big W": {
     "count": 130,
     "countryCodes": ["au"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBIGW%20Logo.png&width=100"
+    },
     "tags": {
       "brand": "Big W",
       "brand:wikidata": "Q4906646",
@@ -67,6 +76,11 @@
   "shop/department_store|Casas Bahia": {
     "count": 55,
     "countryCodes": ["br"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCasas%20Bahia%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/CasasBahia/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1082372755050414080/862MhHQ1_bigger.jpg"
+    },
     "tags": {
       "brand": "Casas Bahia",
       "brand:wikidata": "Q5048048",
@@ -87,6 +101,10 @@
   },
   "shop/department_store|Debenhams": {
     "count": 135,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDebenhams%20logo%202018.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1036496105167626241/fVgF0iJx_bigger.jpg"
+    },
     "tags": {
       "brand": "Debenhams",
       "brand:wikidata": "Q1181484",
@@ -97,6 +115,10 @@
   },
   "shop/department_store|Dillard's": {
     "count": 122,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDillard's%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/638796789571801088/p4X10HEZ_bigger.png"
+    },
     "tags": {
       "brand": "Dillard's",
       "brand:wikidata": "Q844805",
@@ -107,6 +129,10 @@
   },
   "shop/department_store|El Corte Inglés": {
     "count": 67,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Corte%20Ingl%C3%A9s.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1081875226118578177/nS9FEHzn_bigger.jpg"
+    },
     "tags": {
       "brand": "El Corte Inglés",
       "brand:wikidata": "Q623133",
@@ -117,6 +143,9 @@
   },
   "shop/department_store|Falabella": {
     "count": 56,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFalabella.svg&width=100"
+    },
     "match": [
       "shop/department_store|Saga Falabella"
     ],
@@ -131,6 +160,9 @@
   },
   "shop/department_store|Galeria Kaufhof": {
     "count": 63,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Galeria%20Kaufhof%20Einzeilig.svg&width=100"
+    },
     "tags": {
       "brand": "Galeria Kaufhof",
       "brand:wikidata": "Q322598",
@@ -151,6 +183,9 @@
   },
   "shop/department_store|HEMA": {
     "count": 304,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHEMA%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "HEMA",
       "brand:wikidata": "Q903805",
@@ -161,6 +196,9 @@
   },
   "shop/department_store|Harvey Norman": {
     "count": 72,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBroadway-on-the-Mal%20Harvey-Norman%20sign.jpg&width=100"
+    },
     "tags": {
       "brand": "Harvey Norman",
       "brand:wikidata": "Q4040441",
@@ -182,6 +220,10 @@
   "shop/department_store|JCPenney": {
     "count": 425,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJCPenney%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/522418664184631296/s1YYLIt4_bigger.jpeg"
+    },
     "tags": {
       "brand": "JCPenney",
       "brand:wikidata": "Q920037",
@@ -193,6 +235,9 @@
   "shop/department_store|Karstadt": {
     "count": 68,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20KARSTADT%20mit%20Claim.svg&width=100"
+    },
     "tags": {
       "brand": "Karstadt",
       "brand:wikidata": "Q182910",
@@ -203,6 +248,9 @@
   },
   "shop/department_store|Kmart~(Australia)": {
     "countryCodes": ["au"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKmart%20Australia%20logo.svg&width=100"
+    },
     "match": [
       "shop/supermarket|Kmart~(Australia)"
     ],
@@ -220,6 +268,9 @@
   },
   "shop/department_store|Kmart~(USA)": {
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKmart%20logo.svg&width=100"
+    },
     "match": ["shop/supermarket|Kmart~(USA)"],
     "nocount": true,
     "nomatch": [
@@ -236,6 +287,10 @@
   "shop/department_store|Kohl's": {
     "count": 511,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKohl's%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1102627749838155776/hWfrvm2j_bigger.png"
+    },
     "match": ["shop/clothes|Kohl's"],
     "tags": {
       "brand": "Kohl's",
@@ -247,6 +302,11 @@
   },
   "shop/department_store|Lojas Americanas": {
     "count": 113,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLojas%20Americanas%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/lojasamericanas/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/755034518520754176/EEBwUNXV_bigger.jpg"
+    },
     "tags": {
       "brand": "Lojas Americanas",
       "brand:wikidata": "Q3064093",
@@ -257,6 +317,10 @@
   },
   "shop/department_store|Macy's": {
     "count": 342,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMacys%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1071177977822613506/7ELCddNH_bigger.jpg"
+    },
     "tags": {
       "brand": "Macy's",
       "brand:wikidata": "Q629269",
@@ -267,6 +331,10 @@
   },
   "shop/department_store|Marks & Spencer": {
     "count": 154,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMarksAndSpencer1884%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1096328339030196224/qI38Qkt9_bigger.png"
+    },
     "tags": {
       "brand": "Marks & Spencer",
       "brand:wikidata": "Q714491",
@@ -277,6 +345,9 @@
   },
   "shop/department_store|Marshalls": {
     "count": 152,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMarshalls%20Logo.svg&width=100"
+    },
     "match": ["shop/clothes|Marshalls"],
     "tags": {
       "brand": "Marshalls",
@@ -288,6 +359,9 @@
   },
   "shop/department_store|Myer": {
     "count": 51,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMyer%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Myer",
       "brand:wikidata": "Q1110323",
@@ -297,6 +371,10 @@
     }
   },
   "shop/department_store|Neiman Marcus": {
+    "logos": {
+      "facebook": "https://graph.facebook.com/neimanmarcus/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1091722306181836800/JFkyVN3P_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "brand": "Neiman Marcus",
@@ -308,6 +386,9 @@
   },
   "shop/department_store|Nordstrom": {
     "count": 70,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNordstrom%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Nordstrom",
       "brand:wikidata": "Q174310",
@@ -317,6 +398,10 @@
     }
   },
   "shop/department_store|Oechsle": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20de%20Oechsle.png&width=100",
+      "facebook": "https://graph.facebook.com/tiendasoechsle/picture?type=square"
+    },
     "nocount": true,
     "tags": {
       "brand": "Oechsle",
@@ -346,6 +431,9 @@
   },
   "shop/department_store|Ripley": {
     "count": 55,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRipley%20Logo.png&width=100"
+    },
     "tags": {
       "brand": "Ripley",
       "brand:wikidata": "Q3433040",
@@ -355,6 +443,10 @@
     }
   },
   "shop/department_store|Saks Fifth Avenue": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSaksFifthAvenueA.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/3033823660/5bd71ffa7e4d514212dc3ac2d63c5d0c_bigger.jpeg"
+    },
     "nocount": true,
     "tags": {
       "brand": "Saks Fifth Avenue",
@@ -365,6 +457,10 @@
     }
   },
   "shop/department_store|Saks Off 5th": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSaksFifthAvenueA.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/3033823660/5bd71ffa7e4d514212dc3ac2d63c5d0c_bigger.jpeg"
+    },
     "nocount": true,
     "tags": {
       "brand": "Saks Off 5th",
@@ -376,6 +472,10 @@
   },
   "shop/department_store|Sears": {
     "count": 412,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSears%20logo%202010-present.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/775708940487299072/RFWLUqW4_bigger.jpg"
+    },
     "tags": {
       "brand": "Sears",
       "brand:wikidata": "Q6499202",
@@ -396,6 +496,9 @@
   },
   "shop/department_store|Target~(Australia)": {
     "countryCodes": ["au"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTarget%20Logo.svg&width=100"
+    },
     "match": [
       "shop/supermarket|Target~(Australia)"
     ],
@@ -413,6 +516,11 @@
   },
   "shop/department_store|Target~(USA)": {
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTarget%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/target/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/960896975737622528/-5k32D4t_bigger.jpg"
+    },
     "match": ["shop/supermarket|Target~(USA)"],
     "nocount": true,
     "nomatch": [
@@ -439,6 +547,11 @@
   },
   "shop/department_store|Walmart": {
     "count": 214,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWalmart%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/walmart/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1087396420141731840/c18XRlag_bigger.jpg"
+    },
     "tags": {
       "brand": "Walmart",
       "brand:wikidata": "Q483551",
@@ -453,6 +566,9 @@
   "shop/department_store|Woolworth": {
     "count": 198,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWoolworth%20DE.svg&width=100"
+    },
     "tags": {
       "brand": "Woolworth",
       "brand:wikidata": "Q183538",

--- a/brands/shop/doityourself.json
+++ b/brands/shop/doityourself.json
@@ -1,6 +1,9 @@
 {
   "shop/doityourself|Ace Hardware": {
     "count": 439,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/461877115663552513/uGdYfwOo_bigger.png"
+    },
     "match": ["shop/hardware|Ace Hardware"],
     "tags": {
       "brand": "Ace Hardware",
@@ -12,6 +15,10 @@
   },
   "shop/doityourself|B&Q": {
     "count": 232,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FB%26Q%20company%20logo%20(2).png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/821677485687500801/WHJQ3YtP_bigger.jpg"
+    },
     "tags": {
       "brand": "B&Q",
       "brand:wikidata": "Q707602",
@@ -22,6 +29,11 @@
   },
   "shop/doityourself|Bauhaus": {
     "count": 231,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWuppertal%20-%20Bauhaus%2004%20ies.jpg&width=100",
+      "facebook": "https://graph.facebook.com/137379942944322/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/664750253200011264/siRSK-69_bigger.png"
+    },
     "tags": {
       "brand": "Bauhaus",
       "brand:wikidata": "Q672043",
@@ -33,6 +45,9 @@
   "shop/doityourself|Biltema": {
     "count": 68,
     "countryCodes": ["dk", "fi", "no", "se"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBiltema%203.jpg&width=100"
+    },
     "tags": {
       "brand": "Biltema",
       "brand:wikidata": "Q3355552",
@@ -43,6 +58,9 @@
   },
   "shop/doityourself|Brico": {
     "count": 139,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBrico%20logo.jpg&width=100"
+    },
     "tags": {
       "brand": "Brico",
       "brand:wikidata": "Q2510786",
@@ -53,6 +71,9 @@
   },
   "shop/doityourself|Brico Dépôt": {
     "count": 83,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBricodepot.png&width=100"
+    },
     "tags": {
       "brand": "Brico Dépôt",
       "brand:wikidata": "Q2889702",
@@ -63,6 +84,9 @@
   },
   "shop/doityourself|Bricoman": {
     "count": 58,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBricoman%20Logo.png&width=100"
+    },
     "tags": {
       "brand": "Bricoman",
       "brand:wikidata": "Q2925142",
@@ -94,6 +118,9 @@
   "shop/doityourself|Bunnings Warehouse": {
     "count": 217,
     "countryCodes": ["au", "nz"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBunnings%202005%20SeanMcClean.jpg&width=100"
+    },
     "tags": {
       "brand": "Bunnings Warehouse",
       "brand:wikidata": "Q4997829",
@@ -114,6 +141,9 @@
   },
   "shop/doityourself|Clas Ohlson": {
     "count": 69,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FClas%20Ohlson.svg&width=100"
+    },
     "tags": {
       "brand": "Clas Ohlson",
       "brand:wikidata": "Q3356220",
@@ -124,6 +154,9 @@
   },
   "shop/doityourself|Easy": {
     "count": 54,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Easy%20Cencosud.jpg&width=100"
+    },
     "tags": {
       "brand": "Easy",
       "brand:wikidata": "Q5331091",
@@ -134,6 +167,9 @@
   },
   "shop/doityourself|Gamma": {
     "count": 68,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGamma%20logo%202010.png&width=100"
+    },
     "match": ["shop/doityourself|GAMMA"],
     "tags": {
       "brand": "Gamma",
@@ -154,6 +190,9 @@
   "shop/doityourself|Globus Baumarkt": {
     "count": 62,
     "countryCodes": ["de", "lu"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGlobus%20SB-Warenhaus%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Globus Baumarkt",
       "brand:wikidata": "Q457503",
@@ -174,6 +213,9 @@
       "lu",
       "nl"
     ],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F8Eck%203D%204c%2005cm.tif&width=100"
+    },
     "match": ["shop/doityourself|Hagebau"],
     "tags": {
       "brand": "Hagebaumarkt",
@@ -197,6 +239,9 @@
   "shop/doityourself|Hellweg": {
     "count": 68,
     "countryCodes": ["at", "de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHELLWEG%20Logo%202017.svg&width=100"
+    },
     "tags": {
       "brand": "Hellweg",
       "brand:wikidata": "Q1603084",
@@ -207,6 +252,9 @@
   },
   "shop/doityourself|Home Building Centre": {
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHome%20Hardware%20Logo.svg&width=100"
+    },
     "nocount": true,
     "nomatch": [
       "shop/hardware|Home Hardware Building Centre"
@@ -221,6 +269,11 @@
   },
   "shop/doityourself|Home Depot": {
     "count": 1253,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTheHomeDepot%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/homedepot/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/907958185394184192/TakPZDxd_bigger.jpg"
+    },
     "match": [
       "shop/doityourself|The Home Depot",
       "shop/hardware|Home Depot"
@@ -235,6 +288,9 @@
   },
   "shop/doityourself|Home Hardware Building Centre": {
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHome%20Hardware%20Logo.svg&width=100"
+    },
     "match": ["shop/doityourself|Home Hardware"],
     "nocount": true,
     "nomatch": ["shop/hardware|Home Hardware"],
@@ -248,6 +304,10 @@
   },
   "shop/doityourself|Homebase": {
     "count": 187,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHomebase.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1064463197271412736/s2AywY2R_bigger.jpg"
+    },
     "tags": {
       "brand": "Homebase",
       "brand:wikidata": "Q9293447",
@@ -258,6 +318,9 @@
   },
   "shop/doityourself|Hornbach": {
     "count": 136,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHornbach%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Hornbach",
       "brand:wikidata": "Q685926",
@@ -268,6 +331,9 @@
   },
   "shop/doityourself|Hubo": {
     "count": 121,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHubo%20Belgique%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Hubo",
       "brand:wikidata": "Q3142153",
@@ -278,6 +344,9 @@
   },
   "shop/doityourself|Jewson": {
     "count": 57,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/458888840157995008/QRQLxYuE_bigger.jpeg"
+    },
     "tags": {
       "brand": "Jewson",
       "brand:wikidata": "Q6190226",
@@ -308,6 +377,9 @@
   },
   "shop/doityourself|Leroy Merlin": {
     "count": 338,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLeroy%20Merlin.svg&width=100"
+    },
     "tags": {
       "brand": "Leroy Merlin",
       "brand:wikidata": "Q889624",
@@ -318,6 +390,11 @@
   },
   "shop/doityourself|Lowe's": {
     "count": 1322,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLowes%20Companies%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/lowes/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/729776009231380480/Dozl6Ihw_bigger.jpg"
+    },
     "match": [
       "shop/doityourself|Lowes",
       "shop/hardware|Lowe's"
@@ -332,6 +409,10 @@
   },
   "shop/doityourself|Menards": {
     "count": 184,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMenards%20Stripe%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1080511499578290176/Bt6aub6Y_bigger.jpg"
+    },
     "tags": {
       "brand": "Menards",
       "brand:wikidata": "Q1639897",
@@ -342,6 +423,9 @@
   },
   "shop/doityourself|Mr.Bricolage": {
     "count": 292,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMr%20Bricolage%20logo.png&width=100"
+    },
     "match": ["shop/doityourself|Mr Bricolage"],
     "tags": {
       "brand": "Mr.Bricolage",
@@ -353,6 +437,9 @@
   },
   "shop/doityourself|OBI": {
     "count": 456,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FObi.svg&width=100"
+    },
     "match": ["shop/doityourself|Obi"],
     "tags": {
       "brand": "OBI",
@@ -373,6 +460,9 @@
     }
   },
   "shop/doityourself|Praktiker": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPraktiker%20Logo.svg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Praktiker",
@@ -385,6 +475,9 @@
   "shop/doityourself|Praxis": {
     "count": 77,
     "countryCodes": ["nl"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPraxis%20Amsterdam-Zuidoost.PNG&width=100"
+    },
     "match": ["shop/hardware|Praxis"],
     "tags": {
       "brand": "Praxis",
@@ -396,6 +489,9 @@
   },
   "shop/doityourself|Promart": {
     "countryCodes": ["pe"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20de%20Promart.png&width=100"
+    },
     "match": ["shop/hardware|Promart"],
     "nocount": true,
     "tags": {
@@ -418,6 +514,9 @@
   },
   "shop/doityourself|Screwfix": {
     "count": 109,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/874568511359778816/DtUvUAY6_bigger.jpg"
+    },
     "tags": {
       "brand": "Screwfix",
       "brand:wikidata": "Q7439115",
@@ -463,6 +562,11 @@
   "shop/doityourself|Toom Baumarkt": {
     "count": 106,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FToom%20Baumarkt.svg&width=100",
+      "facebook": "https://graph.facebook.com/192246064148765/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1915129467/tt_Logo_Schatten_bigger.jpg"
+    },
     "match": ["shop/doityourself|Toom"],
     "tags": {
       "brand": "Toom Baumarkt",
@@ -474,6 +578,9 @@
   },
   "shop/doityourself|Travis Perkins": {
     "count": 56,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTravis-Perkins-Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Travis Perkins",
       "brand:wikidata": "Q2450664",
@@ -494,6 +601,9 @@
   },
   "shop/doityourself|Wickes": {
     "count": 173,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1034485397030612992/QbzJLMs8_bigger.jpg"
+    },
     "tags": {
       "brand": "Wickes",
       "brand:wikidata": "Q7998350",
@@ -522,6 +632,9 @@
   },
   "shop/doityourself|Леруа Мерлен": {
     "count": 77,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLeroy%20Merlin.svg&width=100"
+    },
     "tags": {
       "brand": "Леруа Мерлен",
       "brand:en": "Leroy Merlin",
@@ -551,6 +664,10 @@
   "shop/doityourself|カインズホーム": {
     "count": 72,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCAINZ%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/cainzfun/picture?type=square"
+    },
     "tags": {
       "brand": "カインズホーム",
       "brand:en": "Cainz Home",
@@ -566,6 +683,9 @@
   "shop/doityourself|コメリ": {
     "count": 189,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKOMERI%20LOGO.svg&width=100"
+    },
     "tags": {
       "brand": "コメリ",
       "brand:ja": "コメリ",

--- a/brands/shop/electronics.json
+++ b/brands/shop/electronics.json
@@ -9,6 +9,9 @@
   },
   "shop/electronics|Apple Store": {
     "count": 90,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FApple%20Store.png&width=100"
+    },
     "match": ["shop/computer|Apple Store"],
     "tags": {
       "brand": "Apple Store",
@@ -28,6 +31,9 @@
   },
   "shop/electronics|Batteries Plus Bulbs": {
     "count": 94,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBatteries%20Plus%20Bulbs%20logo.png&width=100"
+    },
     "match": ["shop/electronics|Batteries Plus"],
     "tags": {
       "brand": "Batteries Plus Bulbs",
@@ -38,6 +44,9 @@
   },
   "shop/electronics|Best Buy": {
     "count": 815,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBest%20Buy%20logo%202018.svg&width=100"
+    },
     "match": ["shop/hifi|Best Buy"],
     "tags": {
       "brand": "Best Buy",
@@ -50,6 +59,9 @@
   "shop/electronics|Boulanger": {
     "count": 80,
     "countryCodes": ["fr"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/995934742775255040/Golp0sMi_bigger.jpg"
+    },
     "tags": {
       "brand": "Boulanger",
       "brand:wikidata": "Q2921695",
@@ -71,6 +83,9 @@
       "pl",
       "pt"
     ],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/919907430158479362/BEbGhbXs_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "brand": "CeX",
@@ -83,6 +98,10 @@
   "shop/electronics|Currys": {
     "count": 80,
     "countryCodes": ["gb", "ie"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/curryspcworld/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/585799551455522817/SuqRlREo_bigger.jpg"
+    },
     "tags": {
       "brand": "Currys",
       "brand:wikidata": "Q3246464",
@@ -112,6 +131,9 @@
   },
   "shop/electronics|Darty": {
     "count": 204,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Fnac%20Darty.svg&width=100"
+    },
     "tags": {
       "brand": "Darty",
       "brand:wikidata": "Q3117381",
@@ -130,6 +152,9 @@
   },
   "shop/electronics|Elgiganten": {
     "count": 82,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FElgiganten.PNG&width=100"
+    },
     "tags": {
       "brand": "Elgiganten",
       "brand:wikidata": "Q17050121",
@@ -140,6 +165,10 @@
   },
   "shop/electronics|Euronics": {
     "count": 303,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Euronics.svg&width=100",
+      "facebook": "https://graph.facebook.com/EuronicsItalia/picture?type=square"
+    },
     "tags": {
       "brand": "Euronics",
       "brand:wikidata": "Q184860",
@@ -172,6 +201,9 @@
   "shop/electronics|Interdiscount": {
     "count": 66,
     "countryCodes": ["ch"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Interdiscount.svg&width=100"
+    },
     "tags": {
       "brand": "Interdiscount",
       "brand:wikidata": "Q1665980",
@@ -182,6 +214,9 @@
   },
   "shop/electronics|JB Hi-Fi": {
     "countryCodes": ["au", "nz"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJB%20Hi-Fi%20Wagga%20Wagga.jpg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "JB Hi-Fi",
@@ -229,6 +264,10 @@
   },
   "shop/electronics|Maplin": {
     "count": 59,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMaplin%20Electronics%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/814044033483948032/IozUMsvp_bigger.jpg"
+    },
     "tags": {
       "brand": "Maplin",
       "brand:wikidata": "Q6754124",
@@ -249,6 +288,11 @@
   },
   "shop/electronics|Media Markt": {
     "count": 398,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMedia%20Markt%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/MediaMarkt.ES/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/694569853663903744/nMQY5qc4_bigger.png"
+    },
     "match": [
       "shop/electronics|MediaMarkt",
       "shop/electronics|Mediamarkt"
@@ -275,6 +319,9 @@
   "shop/electronics|Musimundo": {
     "count": 61,
     "countryCodes": ["ar"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1098565316609748992/J7JMYhTN_bigger.png"
+    },
     "tags": {
       "brand": "Musimundo",
       "brand:wikidata": "Q6034719",
@@ -303,6 +350,9 @@
   },
   "shop/electronics|RTV Euro AGD": {
     "count": 103,
+    "logos": {
+      "facebook": "https://graph.facebook.com/rtveuroagd/picture?type=square"
+    },
     "tags": {
       "brand": "RTV Euro AGD",
       "brand:wikidata": "Q7277895",
@@ -313,6 +363,9 @@
   },
   "shop/electronics|RadioShack": {
     "count": 169,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRadioShack%20logo.svg&width=100"
+    },
     "match": ["shop/electronics|Radio Shack"],
     "tags": {
       "brand": "RadioShack",
@@ -324,6 +377,11 @@
   },
   "shop/electronics|Samsung": {
     "count": 240,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSamsung%20wordmark.svg&width=100",
+      "facebook": "https://graph.facebook.com/SamsungNewsroom/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/773340588154380288/2ZTg4WC-_bigger.jpg"
+    },
     "match": [
       "shop/computer|Samsung",
       "shop/mobile_phone|Samsung"
@@ -339,6 +397,11 @@
   "shop/electronics|Saturn": {
     "count": 164,
     "countryCodes": ["at", "de", "lu", "pl"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSaturn-Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/SaturnDE/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1075752779350769664/c2nygxRU_bigger.jpg"
+    },
     "tags": {
       "brand": "Saturn",
       "brand:wikidata": "Q2543504",
@@ -349,6 +412,11 @@
   },
   "shop/electronics|Sony": {
     "count": 61,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSony%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/sony.jpn/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/419987824717213696/jDu1T8do_bigger.jpeg"
+    },
     "tags": {
       "brand": "Sony",
       "brand:wikidata": "Q41187",
@@ -371,6 +439,9 @@
   "shop/electronics|The Source": {
     "count": 111,
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FThe%20Source%20logo%20en-fr.svg&width=100"
+    },
     "tags": {
       "brand": "The Source",
       "brand:wikidata": "Q3212934",
@@ -400,6 +471,10 @@
   "shop/electronics|Worten": {
     "count": 51,
     "countryCodes": ["es", "pt"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%202x.png&width=100",
+      "facebook": "https://graph.facebook.com/WortenES/picture?type=square"
+    },
     "tags": {
       "brand": "Worten",
       "brand:wikidata": "Q10394039",
@@ -410,6 +485,9 @@
   },
   "shop/electronics|М.Видео": {
     "count": 152,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMvideo.svg&width=100"
+    },
     "tags": {
       "brand": "М.Видео",
       "brand:en": "M.video",
@@ -440,6 +518,10 @@
   },
   "shop/electronics|Эльдорадо": {
     "count": 341,
+    "logos": {
+      "facebook": "https://graph.facebook.com/Eldorado.Stores/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1057267580447133696/37MhSbcc_bigger.jpg"
+    },
     "tags": {
       "brand": "Эльдорадо",
       "brand:wikidata": "Q4531492",
@@ -451,6 +533,10 @@
   "shop/electronics|エディオン": {
     "count": 110,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEdion%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/edion.jp/picture?type=square"
+    },
     "tags": {
       "brand": "エディオン",
       "brand:en": "EDION",
@@ -481,6 +567,9 @@
   "shop/electronics|コジマ": {
     "count": 55,
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/kojima.official/picture?type=square"
+    },
     "tags": {
       "brand": "コジマ",
       "brand:en": "Kojima",
@@ -495,6 +584,9 @@
   },
   "shop/electronics|ソフマップ": {
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSofmap%20Logo.svg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "ソフマップ",
@@ -508,6 +600,10 @@
   },
   "shop/electronics|ビックカメラ": {
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBICCAMERA%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/biccamera.page/picture?type=square"
+    },
     "nocount": true,
     "tags": {
       "brand": "ビックカメラ",

--- a/brands/shop/erotic.json
+++ b/brands/shop/erotic.json
@@ -2,6 +2,9 @@
   "shop/erotic|Orion": {
     "count": 95,
     "countryCodes": ["at", "de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNoimage%20pr.gif&width=100"
+    },
     "tags": {
       "brand": "Orion",
       "brand:wikidata": "Q1609577",

--- a/brands/shop/florist.json
+++ b/brands/shop/florist.json
@@ -2,6 +2,9 @@
   "shop/florist|Blume 2000": {
     "count": 111,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBLUME%202000%20Unternehmenslogo.jpg&width=100"
+    },
     "tags": {
       "brand": "Blume 2000",
       "brand:wikidata": "Q886166",
@@ -13,6 +16,9 @@
   "shop/florist|Blumen Risse": {
     "count": 77,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Blumen%20Risse.jpg&width=100"
+    },
     "tags": {
       "brand": "Blumen Risse",
       "brand:wikidata": "Q886177",
@@ -23,6 +29,9 @@
   },
   "shop/florist|Interflora": {
     "count": 89,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFleurop%202017%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Interflora",
       "brand:wikidata": "Q692179",

--- a/brands/shop/funeral_directors.json
+++ b/brands/shop/funeral_directors.json
@@ -1,6 +1,10 @@
 {
   "shop/funeral_directors|The Co-operative Funeralcare": {
     "count": 121,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FThe%20Co-Operative%20clover%20leaf%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1034361261193134080/1PfqKyVV_bigger.jpg"
+    },
     "tags": {
       "brand": "The Co-operative Funeralcare",
       "brand:wikidata": "Q7726521",

--- a/brands/shop/furniture.json
+++ b/brands/shop/furniture.json
@@ -2,6 +2,10 @@
   "shop/furniture|Aaron's": {
     "count": 133,
     "countryCodes": ["ca", "us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAarons%20Logo%20Blue%20CMYK.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1102999101665406977/a0ukKtqR_bigger.jpg"
+    },
     "tags": {
       "brand": "Aaron's",
       "brand:wikidata": "Q10397787",
@@ -12,6 +16,9 @@
   },
   "shop/furniture|Ashley HomeStore": {
     "countryCodes": ["ca", "us"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/793453568288325636/UiWzv4oc_bigger.jpg"
+    },
     "match": [
       "shop/furniture|Ashley Furniture",
       "shop/furniture|Ashley Furniture HomeStore"
@@ -73,6 +80,10 @@
   },
   "shop/furniture|Conforama": {
     "count": 195,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FConforama%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1021365064388022273/bE7G0Hfg_bigger.jpg"
+    },
     "tags": {
       "brand": "Conforama",
       "brand:wikidata": "Q541134",
@@ -82,6 +93,9 @@
     }
   },
   "shop/furniture|Crate & Barrel": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCrateandBarrelLogo.svg&width=100"
+    },
     "match": ["shop/furniture|Crate and Barrel"],
     "nocount": true,
     "tags": {
@@ -94,6 +108,9 @@
   },
   "shop/furniture|DFS": {
     "count": 66,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/676402722946621440/S5P4YZXG_bigger.jpg"
+    },
     "tags": {
       "brand": "DFS",
       "brand:wikidata": "Q5204927",
@@ -105,6 +122,9 @@
   "shop/furniture|Dänisches Bettenlager": {
     "count": 611,
     "countryCodes": ["at", "de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLOGO%20JYSK.jpg&width=100"
+    },
     "match": ["shop/bed|Dänisches Bettenlager"],
     "tags": {
       "brand": "Dänisches Bettenlager",
@@ -116,6 +136,9 @@
   },
   "shop/furniture|Ethan Allen": {
     "count": 60,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEthan%20Allen%20Logo.JPG&width=100"
+    },
     "tags": {
       "brand": "Ethan Allen",
       "brand:wikidata": "Q5402870",
@@ -125,6 +148,9 @@
     }
   },
   "shop/furniture|Fly": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFly-Logo.svg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Fly",
@@ -136,6 +162,9 @@
   },
   "shop/furniture|Harveys": {
     "count": 73,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/644090357416873984/nuqIAG7O_bigger.jpg"
+    },
     "tags": {
       "brand": "Harveys",
       "brand:wikidata": "Q5677754",
@@ -146,6 +175,9 @@
   },
   "shop/furniture|Havertys": {
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHavertys-logo-new.jpg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Havertys",
@@ -157,6 +189,11 @@
   },
   "shop/furniture|IKEA": {
     "count": 266,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FIkea%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/IKEA/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/848820350867714048/e9NaLJUC_bigger.jpg"
+    },
     "tags": {
       "brand": "IKEA",
       "brand:wikidata": "Q54078",
@@ -167,6 +204,9 @@
   },
   "shop/furniture|JYSK": {
     "count": 246,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLOGO%20JYSK.jpg&width=100"
+    },
     "match": ["shop/furniture|Jysk"],
     "tags": {
       "brand": "JYSK",
@@ -185,6 +225,9 @@
     }
   },
   "shop/furniture|La-Z-Boy": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLa-Z-Boy%20Logo.svg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "La-Z-Boy",
@@ -240,6 +283,9 @@
     }
   },
   "shop/furniture|Restoration Hardware": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20RH.gif&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Restoration Hardware",
@@ -259,6 +305,9 @@
   },
   "shop/furniture|Roller": {
     "count": 104,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FROLLER%20Logo.jpg&width=100"
+    },
     "tags": {
       "brand": "Roller",
       "brand:wikidata": "Q1621286",
@@ -280,6 +329,10 @@
   },
   "shop/furniture|ScS": {
     "countryCodes": ["gb"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FScslogoUK.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/791189440429432832/x3LQSxxn_bigger.jpg"
+    },
     "match": ["shop/furniture|SCS"],
     "nocount": true,
     "tags": {
@@ -302,6 +355,10 @@
   },
   "shop/furniture|Williams-Sonoma": {
     "countryCodes": ["ca", "us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWilliams-Sonoma%2C%20Inc.%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/811867470206214144/p1nrNSEb_bigger.jpg"
+    },
     "match": [
       "shop/furniture|William Sonoma",
       "shop/furniture|Williams Sonoma"
@@ -326,6 +383,10 @@
   "shop/furniture|ニトリ": {
     "count": 136,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNITORI%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/911049695601991682/HCnF523x_bigger.jpg"
+    },
     "tags": {
       "brand": "ニトリ",
       "brand:en": "Nitori",

--- a/brands/shop/garden_centre.json
+++ b/brands/shop/garden_centre.json
@@ -1,6 +1,10 @@
 {
   "shop/garden_centre|Dehner": {
     "count": 61,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDehner.svg&width=100",
+      "facebook": "https://graph.facebook.com/840717512606415/picture?type=square"
+    },
     "tags": {
       "brand": "Dehner",
       "brand:wikidata": "Q1183029",
@@ -23,6 +27,9 @@
   "shop/garden_centre|Jardiland": {
     "count": 135,
     "countryCodes": ["fr"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1082572992457121793/rwRCyllh_bigger.jpg"
+    },
     "tags": {
       "brand": "Jardiland",
       "brand:wikidata": "Q3162276",

--- a/brands/shop/gift.json
+++ b/brands/shop/gift.json
@@ -1,6 +1,9 @@
 {
   "shop/gift|Card Factory": {
     "count": 202,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCardfactorylogo.jpg&width=100"
+    },
     "tags": {
       "brand": "Card Factory",
       "brand:wikidata": "Q5038192",
@@ -19,6 +22,9 @@
   },
   "shop/gift|Hallmark": {
     "count": 227,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHallmark%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Hallmark",
       "brand:wikidata": "Q1521910",
@@ -30,6 +36,9 @@
   "shop/gift|Nanu-Nana": {
     "count": 79,
     "countryCodes": ["at", "de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNanu-Nana%20Logo.svg&width=100"
+    },
     "match": ["shop/gift/Nanu Nana"],
     "tags": {
       "brand": "Nanu-Nana",

--- a/brands/shop/greengrocer.json
+++ b/brands/shop/greengrocer.json
@@ -1,6 +1,10 @@
 {
   "shop/greengrocer|Produce Junction": {
     "countryCodes": ["us"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/ProduceJunction/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/3761319227/72e5bb95c213583ee21383b21b5b00d0_bigger.png"
+    },
     "nocount": true,
     "tags": {
       "brand": "Produce Junction",

--- a/brands/shop/hairdresser.json
+++ b/brands/shop/hairdresser.json
@@ -69,6 +69,10 @@
   },
   "shop/hairdresser|Great Clips": {
     "count": 829,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGreat%20Clips%20Logo.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/819560305579597824/2iEN9-ii_bigger.jpg"
+    },
     "tags": {
       "brand": "Great Clips",
       "brand:wikidata": "Q5598967",
@@ -172,6 +176,10 @@
   },
   "shop/hairdresser|Supercuts": {
     "count": 483,
+    "logos": {
+      "facebook": "https://graph.facebook.com/Supercuts/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1068895472671019008/uUnBNmoS_bigger.jpg"
+    },
     "match": ["shop/hairdresser|Super Cuts"],
     "tags": {
       "brand": "Supercuts",
@@ -191,6 +199,10 @@
   },
   "shop/hairdresser|Toni & Guy": {
     "count": 103,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTony%26Guy%20logo.gif&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/940543926141964288/jQR8J2az_bigger.jpg"
+    },
     "tags": {
       "brand": "Toni & Guy",
       "brand:wikidata": "Q324784",

--- a/brands/shop/hardware.json
+++ b/brands/shop/hardware.json
@@ -17,6 +17,9 @@
   },
   "shop/hardware|Harbor Freight Tools": {
     "count": 192,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/459004871165747200/5VM_h-H4_bigger.jpeg"
+    },
     "tags": {
       "brand": "Harbor Freight Tools",
       "brand:wikidata": "Q5654601",
@@ -28,6 +31,9 @@
   "shop/hardware|Home Hardware": {
     "count": 142,
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHome%20Hardware%20Logo.svg&width=100"
+    },
     "nomatch": [
       "shop/doityourself|Home Hardware Building Centre"
     ],

--- a/brands/shop/health_food.json
+++ b/brands/shop/health_food.json
@@ -1,6 +1,9 @@
 {
   "shop/health_food|Holland & Barrett": {
     "count": 159,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1019883451934298112/TxU5ZErp_bigger.jpg"
+    },
     "tags": {
       "brand": "Holland & Barrett",
       "brand:wikidata": "Q5880870",

--- a/brands/shop/hearing_aids.json
+++ b/brands/shop/hearing_aids.json
@@ -1,6 +1,9 @@
 {
   "shop/hearing_aids|Amplifon": {
     "count": 222,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAmplifon.tif&width=100"
+    },
     "match": ["shop/hearing_aids|amplifon"],
     "tags": {
       "brand": "Amplifon",
@@ -30,6 +33,10 @@
   },
   "shop/hearing_aids|Geers": {
     "count": 98,
+    "logos": {
+      "facebook": "https://graph.facebook.com/geers.hoerakustik/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/483891860432109569/gJ-LCsd1_bigger.jpeg"
+    },
     "tags": {
       "brand": "Geers",
       "brand:wikidata": "Q1497707",
@@ -57,6 +64,9 @@
   "shop/hearing_aids|Kind Hörgeräte": {
     "count": 104,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKIND%20H%C3%B6rger%C3%A4te%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Kind Hörgeräte",
       "brand:wikidata": "Q43598590",
@@ -68,6 +78,9 @@
   "shop/hearing_aids|Neuroth": {
     "count": 62,
     "countryCodes": ["at", "de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Neuroth%20AG.jpg&width=100"
+    },
     "tags": {
       "brand": "Neuroth",
       "brand:wikidata": "Q15836645",

--- a/brands/shop/hifi.json
+++ b/brands/shop/hifi.json
@@ -1,6 +1,10 @@
 {
   "shop/hifi|Bang & Olufsen": {
     "count": 65,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBang%20and%20Olufsen%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1034733828005355520/rcwjmcLO_bigger.jpg"
+    },
     "tags": {
       "brand": "Bang & Olufsen",
       "brand:wikidata": "Q790020",

--- a/brands/shop/houseware.json
+++ b/brands/shop/houseware.json
@@ -1,6 +1,9 @@
 {
   "shop/houseware|Bed Bath & Beyond": {
     "count": 208,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBedbath%26beyond.svg&width=100"
+    },
     "match": [
       "shop/department_store|Bed Bath & Beyond"
     ],
@@ -35,6 +38,10 @@
   },
   "shop/houseware|HomeGoods": {
     "count": 62,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHomegoods%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/636583431346999296/lvg1N1fS_bigger.jpg"
+    },
     "match": [
       "shop/houseware|Home Goods",
       "shop/interior_decoration|Home Goods",
@@ -81,6 +88,10 @@
   },
   "shop/houseware|The Container Store": {
     "countryCodes": ["us"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/containerstore/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/813394428496728064/yRUL-KJF_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "brand": "The Container Store",
@@ -109,6 +120,9 @@
   "shop/houseware|WMF": {
     "count": 57,
     "countryCodes": ["at", "de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWMF%20Group%20Logo%20Silber%20RGB.png&width=100"
+    },
     "tags": {
       "brand": "WMF",
       "brand:wikidata": "Q451423",
@@ -119,6 +133,11 @@
   },
   "shop/houseware|Xenos": {
     "count": 112,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo-Xenos-Rubin-Red.png&width=100",
+      "facebook": "https://graph.facebook.com/XenosNL/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1053240246622666753/t17rjHWr_bigger.jpg"
+    },
     "tags": {
       "brand": "Xenos",
       "brand:wikidata": "Q16547960",

--- a/brands/shop/interior_decoration.json
+++ b/brands/shop/interior_decoration.json
@@ -10,6 +10,9 @@
   "shop/interior_decoration|Depot": {
     "count": 158,
     "countryCodes": ["at", "ch", "de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDepot%20(Unternehmen)%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Depot",
       "brand:wikidata": "Q1191740",
@@ -31,6 +34,9 @@
   },
   "shop/interior_decoration|Pier 1 Imports": {
     "count": 109,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPier%201%20Imports%20Logo%20NEW.png&width=100"
+    },
     "match": ["shop/furniture|Pier 1 Imports"],
     "tags": {
       "brand": "Pier 1 Imports",

--- a/brands/shop/jewelry.json
+++ b/brands/shop/jewelry.json
@@ -12,6 +12,9 @@
   },
   "shop/jewelry|Bijou Brigitte": {
     "count": 240,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBijouBrigitte-logo.png&width=100"
+    },
     "tags": {
       "brand": "Bijou Brigitte",
       "brand:wikidata": "Q599545",
@@ -30,6 +33,11 @@
   },
   "shop/jewelry|Cartier": {
     "count": 56,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCartier%20logo.png&width=100",
+      "facebook": "https://graph.facebook.com/cartier/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1069613895952814082/1g7XABSC_bigger.jpg"
+    },
     "tags": {
       "brand": "Cartier",
       "brand:wikidata": "Q538587",
@@ -48,6 +56,10 @@
   },
   "shop/jewelry|Claire's": {
     "count": 163,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FClairs%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/957986069219282944/hRGvL96i_bigger.jpg"
+    },
     "match": ["shop/clothes|Claire's"],
     "tags": {
       "brand": "Claire's",
@@ -59,6 +71,9 @@
   },
   "shop/jewelry|Ernest Jones": {
     "count": 72,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/786588875812659200/xIr7E161_bigger.jpg"
+    },
     "tags": {
       "brand": "Ernest Jones",
       "brand:wikidata": "Q5393358",
@@ -98,6 +113,10 @@
   },
   "shop/jewelry|James Avery Jewelry": {
     "count": 98,
+    "logos": {
+      "facebook": "https://graph.facebook.com/JamesAvery/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/897452488588013571/YqRau9rn_bigger.jpg"
+    },
     "tags": {
       "brand": "James Avery Jewelry",
       "brand:wikidata": "Q6129024",
@@ -144,6 +163,10 @@
   },
   "shop/jewelry|Pandora": {
     "count": 442,
+    "logos": {
+      "facebook": "https://graph.facebook.com/PANDORA.Japan/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1083351600654155776/jUbb09zX_bigger.jpg"
+    },
     "tags": {
       "brand": "Pandora",
       "brand:wikidata": "Q2241604",
@@ -154,6 +177,10 @@
   },
   "shop/jewelry|Swarovski": {
     "count": 339,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSwarovski%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/swarovski/picture?type=square"
+    },
     "tags": {
       "brand": "Swarovski",
       "brand:wikidata": "Q611115",

--- a/brands/shop/kiosk.json
+++ b/brands/shop/kiosk.json
@@ -31,6 +31,10 @@
   },
   "shop/kiosk|R-Kioski": {
     "count": 209,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FR-kioski-logo%20yellow%20background%20December%2027%202014.svg&width=100",
+      "facebook": "https://graph.facebook.com/rkioski/picture?type=square"
+    },
     "match": ["shop/kiosk|R-kioski"],
     "tags": {
       "brand": "R-Kioski",
@@ -51,6 +55,9 @@
   "shop/kiosk|Ruch": {
     "count": 234,
     "countryCodes": ["pl"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLOGO%20RUCH%20g%C5%82%C3%B3wne.jpg&width=100"
+    },
     "tags": {
       "brand": "Ruch",
       "brand:wikidata": "Q1260314",
@@ -61,6 +68,9 @@
   },
   "shop/kiosk|Tisak": {
     "count": 271,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTisak%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Tisak",
       "brand:wikidata": "Q12643627",

--- a/brands/shop/massage.json
+++ b/brands/shop/massage.json
@@ -1,6 +1,9 @@
 {
   "shop/massage|Massage Envy": {
     "count": 161,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMassage%20Envy%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Massage Envy",
       "brand:wikidata": "Q22922899",

--- a/brands/shop/mobile_phone.json
+++ b/brands/shop/mobile_phone.json
@@ -1,6 +1,10 @@
 {
   "shop/mobile_phone|3 Store": {
     "count": 115,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F3logo.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/967985753027362816/2jPkroPW_bigger.jpg"
+    },
     "tags": {
       "brand": "3 Store",
       "brand:wikidata": "Q407009",
@@ -11,6 +15,10 @@
   },
   "shop/mobile_phone|AT&T": {
     "count": 906,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAT%26T%20logo%202016.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1062348760670339073/egM1bS-c_bigger.jpg"
+    },
     "match": [
       "shop/electronics|AT&T",
       "shop/electronics|ATT"
@@ -26,6 +34,9 @@
   "shop/mobile_phone|Bell": {
     "count": 149,
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBell%20Mobility%20logo.svg&width=100"
+    },
     "match": ["shop/electronics|Bell"],
     "tags": {
       "brand": "Bell",
@@ -63,6 +74,9 @@
   },
   "shop/mobile_phone|Carphone Warehouse": {
     "count": 360,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCarphone%20Warehouse%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Carphone Warehouse",
       "brand:wikidata": "Q118046",
@@ -73,6 +87,9 @@
   },
   "shop/mobile_phone|Claro": {
     "count": 596,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogoClaro2017.png&width=100"
+    },
     "tags": {
       "brand": "Claro",
       "brand:wikidata": "Q1770208",
@@ -83,6 +100,11 @@
   },
   "shop/mobile_phone|Cricket Wireless": {
     "count": 202,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCricket%20Wireless%20Logo.png&width=100",
+      "facebook": "https://graph.facebook.com/Cricketnation/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1004849541151985664/zx_5vL5O_bigger.jpg"
+    },
     "match": ["shop/mobile_phone|Cricket"],
     "tags": {
       "brand": "Cricket Wireless",
@@ -94,6 +116,10 @@
   },
   "shop/mobile_phone|Digicel": {
     "count": 155,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDigicel.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/889845742998872066/-5EbELrp_bigger.jpg"
+    },
     "tags": {
       "brand": "Digicel",
       "brand:wikidata": "Q2117506",
@@ -104,6 +130,10 @@
   },
   "shop/mobile_phone|EE": {
     "count": 237,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEE%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/948161522362126336/Gh7TJbt3_bigger.jpg"
+    },
     "tags": {
       "brand": "EE",
       "brand:wikidata": "Q5322942",
@@ -114,6 +144,9 @@
   },
   "shop/mobile_phone|Entel": {
     "count": 73,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FENTel%20Argentina%20-%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Entel",
       "brand:wikidata": "Q5323742",
@@ -133,6 +166,9 @@
   "shop/mobile_phone|Freedom Mobile": {
     "count": 51,
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWind%20Italia.svg&width=100"
+    },
     "match": ["shop/mobile_phone|Wind Mobile"],
     "tags": {
       "brand": "Freedom Mobile",
@@ -144,6 +180,9 @@
   },
   "shop/mobile_phone|MTN": {
     "count": 56,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMTN%20logo.png&width=100"
+    },
     "match": [
       "office/telecommunication|Agence MTN",
       "office/telecommunication|MTN",
@@ -159,6 +198,10 @@
   },
   "shop/mobile_phone|MetroPCS": {
     "count": 309,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMetroByT-Mobile.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1059487459292016644/jtMoU5Ql_bigger.jpg"
+    },
     "match": ["shop/mobile_phone|Metro PCS"],
     "tags": {
       "brand": "MetroPCS",
@@ -199,6 +242,9 @@
   },
   "shop/mobile_phone|Movistar": {
     "count": 519,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Movistar.svg&width=100"
+    },
     "tags": {
       "brand": "Movistar",
       "brand:wikidata": "Q967735",
@@ -209,6 +255,9 @@
   },
   "shop/mobile_phone|O2": {
     "count": 631,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FO2.svg&width=100"
+    },
     "tags": {
       "brand": "O2",
       "brand:wikidata": "Q7072246",
@@ -230,6 +279,11 @@
   },
   "shop/mobile_phone|Orange": {
     "count": 866,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOrange%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/orange/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1082294413852901376/jW3OtU-R_bigger.jpg"
+    },
     "match": [
       "office/telecommunication|Agence Orange",
       "office/telecommunication|Orange",
@@ -253,6 +307,9 @@
   },
   "shop/mobile_phone|Phone House": {
     "count": 58,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCarphone%20Warehouse%20logo.svg&width=100"
+    },
     "match": [
       "shop/mobile_phone|The Phone House"
     ],
@@ -266,6 +323,9 @@
   },
   "shop/mobile_phone|Play": {
     "count": 192,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPlay%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Play",
       "brand:wikidata": "Q7202998",
@@ -277,6 +337,9 @@
   "shop/mobile_phone|Plus": {
     "count": 158,
     "countryCodes": ["pl"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPlus%20logo.svg&width=100"
+    },
     "nomatch": ["shop/supermarket|PLUS"],
     "tags": {
       "brand": "Plus",
@@ -289,6 +352,9 @@
   "shop/mobile_phone|Rogers": {
     "count": 77,
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRogers%20logo.svg&width=100"
+    },
     "match": ["shop/electronics|Rogers"],
     "tags": {
       "brand": "Rogers",
@@ -300,6 +366,10 @@
   },
   "shop/mobile_phone|SFR": {
     "count": 204,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20SFR%202014.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/755318544796119040/NG06ZJNQ_bigger.jpg"
+    },
     "tags": {
       "brand": "SFR",
       "brand:wikidata": "Q218765",
@@ -310,6 +380,10 @@
   },
   "shop/mobile_phone|Sprint": {
     "count": 651,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20Sprint%20Nextel.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1017724895210295296/LeEVTlNv_bigger.jpg"
+    },
     "nomatch": ["amenity/fuel|Sprint"],
     "tags": {
       "brand": "Sprint",
@@ -321,6 +395,10 @@
   },
   "shop/mobile_phone|T-Mobile": {
     "count": 1034,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FT-Mobile%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/981976280504516608/t6UPf6ru_bigger.jpg"
+    },
     "match": ["shop/mobile_phone|T Mobile"],
     "tags": {
       "brand": "T-Mobile",
@@ -332,6 +410,9 @@
   },
   "shop/mobile_phone|TIM": {
     "count": 109,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTelecom%20italia%202016.png&width=100"
+    },
     "match": ["shop/mobile_phone|Tim"],
     "tags": {
       "brand": "TIM",
@@ -343,6 +424,10 @@
   },
   "shop/mobile_phone|Telcel": {
     "count": 88,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTelcel%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/767798417678405632/hP_WoWZi_bigger.jpg"
+    },
     "tags": {
       "brand": "Telcel",
       "brand:wikidata": "Q3517255",
@@ -353,6 +438,9 @@
   },
   "shop/mobile_phone|Tele2": {
     "count": 282,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTele2%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Tele2",
       "brand:wikidata": "Q309865",
@@ -363,6 +451,9 @@
   },
   "shop/mobile_phone|Telekom": {
     "count": 220,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTelekom%20Logo%202013.svg&width=100"
+    },
     "match": ["shop/mobile_phone|Telekom Shop"],
     "tags": {
       "brand": "Telekom",
@@ -374,6 +465,9 @@
   },
   "shop/mobile_phone|Telenor": {
     "count": 117,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTelenor%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Telenor",
       "brand:wikidata": "Q845632",
@@ -392,6 +486,9 @@
   },
   "shop/mobile_phone|Telstra": {
     "countryCodes": ["au"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTelstra%20logo.svg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Telstra",
@@ -403,6 +500,9 @@
   },
   "shop/mobile_phone|Telus": {
     "count": 91,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTelus-Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Telus",
       "brand:wikidata": "Q165858",
@@ -421,6 +521,10 @@
   },
   "shop/mobile_phone|Turkcell": {
     "count": 164,
+    "logos": {
+      "facebook": "https://graph.facebook.com/Turkcell/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/997370208531746816/kmS7w0vf_bigger.jpg"
+    },
     "tags": {
       "brand": "Turkcell",
       "brand:wikidata": "Q283852",
@@ -452,6 +556,10 @@
   },
   "shop/mobile_phone|Verizon Wireless": {
     "count": 907,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FVerizon%202015%20logo%20-vector.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1032361834085408768/UTSm_MOD_bigger.jpg"
+    },
     "match": ["shop/mobile_phone|Verizon"],
     "tags": {
       "brand": "Verizon Wireless",
@@ -463,6 +571,10 @@
   },
   "shop/mobile_phone|Vodafone": {
     "count": 1508,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FVodafone%20icon.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/915700782531522560/XJP2ZISI_bigger.jpg"
+    },
     "match": [
       "shop/mobile_phone|Vodafone Shop",
       "shop/mobile_phone|vodafone"
@@ -489,6 +601,9 @@
   "shop/mobile_phone|Wind": {
     "count": 200,
     "countryCodes": ["it"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWind%20Logo.png&width=100"
+    },
     "tags": {
       "brand": "Wind",
       "brand:wikidata": "Q650467",
@@ -499,6 +614,9 @@
   },
   "shop/mobile_phone|Yoigo": {
     "count": 84,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FYoigo%20morado.svg&width=100"
+    },
     "tags": {
       "brand": "Yoigo",
       "brand:wikidata": "Q2630989",
@@ -535,6 +653,9 @@
   },
   "shop/mobile_phone|Билайн": {
     "count": 607,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F%D0%91%D0%B8%D0%BB%D0%B0%D0%B9%D0%BD%202.jpg&width=100"
+    },
     "tags": {
       "brand": "Билайн",
       "brand:en": "Beeline",
@@ -547,6 +668,9 @@
   },
   "shop/mobile_phone|Евросеть": {
     "count": 1037,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEuroset.png&width=100"
+    },
     "tags": {
       "brand": "Евросеть",
       "brand:en": "Euroset",
@@ -559,6 +683,10 @@
   },
   "shop/mobile_phone|Київстар": {
     "count": 75,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKyivstar%20logo15.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1076409804229353472/KN2XlbP8_bigger.jpg"
+    },
     "tags": {
       "brand": "Київстар",
       "brand:en": "Kyivstar",
@@ -571,6 +699,11 @@
   },
   "shop/mobile_phone|МТС": {
     "count": 1208,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMTS-2010.gif&width=100",
+      "facebook": "https://graph.facebook.com/mts/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1083672144515616768/ocUrD2fk_bigger.jpg"
+    },
     "tags": {
       "brand": "МТС",
       "brand:en": "MTS",
@@ -583,6 +716,11 @@
   },
   "shop/mobile_phone|Мегафон": {
     "count": 549,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMegaFon%20sign%2Blogo%20horiz%20green%20RU%20(RGB).svg&width=100",
+      "facebook": "https://graph.facebook.com/MegaFon.ru/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1053918653719236613/88aW-PKu_bigger.jpg"
+    },
     "match": ["shop/mobile_phone|МегаФон"],
     "tags": {
       "brand": "Мегафон",
@@ -596,6 +734,9 @@
   },
   "shop/mobile_phone|Связной": {
     "count": 985,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSvyaznoyLogo.png&width=100"
+    },
     "tags": {
       "brand": "Связной",
       "brand:en": "Svyaznoy",
@@ -608,6 +749,9 @@
   },
   "shop/mobile_phone|Теле2": {
     "count": 93,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTele2%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Теле2",
       "brand:en": "Tele2",
@@ -621,6 +765,9 @@
   "shop/mobile_phone|ソフトバンク": {
     "count": 75,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSoftbank%20mobile%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "ソフトバンク",
       "brand:en": "SoftBank Telecom",
@@ -651,6 +798,11 @@
   "shop/mobile_phone|ドコモショップ": {
     "count": 513,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNTT%20docomo%20company%20logos.svg&width=100",
+      "facebook": "https://graph.facebook.com/docomo.official/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1036466325781078016/FP3uSOts_bigger.jpg"
+    },
     "tags": {
       "brand": "ドコモショップ",
       "brand:en": "DoCoMo Shop",

--- a/brands/shop/money_lender.json
+++ b/brands/shop/money_lender.json
@@ -20,6 +20,9 @@
   },
   "shop/money_lender|Money Mart": {
     "count": 131,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMoney%20Mart%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Money Mart",
       "brand:wikidata": "Q6899166",

--- a/brands/shop/motorcycle.json
+++ b/brands/shop/motorcycle.json
@@ -1,6 +1,9 @@
 {
   "shop/motorcycle|Harley-Davidson": {
     "count": 57,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHarley-Davidson%20logo.svg&width=100"
+    },
     "match": ["shop/motorcycle|Harley Davidson"],
     "tags": {
       "brand": "Harley-Davidson",
@@ -12,6 +15,11 @@
   },
   "shop/motorcycle|Honda": {
     "count": 289,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHonda-logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/HondaJP/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/848740737189527552/wTZC89a1_bigger.jpg"
+    },
     "nomatch": ["shop/car|Honda"],
     "tags": {
       "brand": "Honda",
@@ -43,6 +51,10 @@
   },
   "shop/motorcycle|Suzuki": {
     "count": 107,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSuzuki%20logo%202.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/923402474454630403/gB5--AII_bigger.jpg"
+    },
     "nomatch": ["shop/car|Suzuki"],
     "tags": {
       "brand": "Suzuki",
@@ -54,6 +66,10 @@
   },
   "shop/motorcycle|Yamaha": {
     "count": 298,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FYamaha%20Motor%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/875751770063908864/cj8_odoI_bigger.jpg"
+    },
     "tags": {
       "brand": "Yamaha",
       "brand:wikidata": "Q158888",

--- a/brands/shop/music.json
+++ b/brands/shop/music.json
@@ -1,6 +1,9 @@
 {
   "shop/music|HMV": {
     "count": 86,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHMV%20record.JPG&width=100"
+    },
     "tags": {
       "brand": "HMV",
       "brand:wikidata": "Q10854572",
@@ -11,6 +14,9 @@
   },
   "shop/music|TSUTAYA": {
     "count": 62,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCulture%20Convenience%20Club%20(CCC)%20logo.svg&width=100"
+    },
     "nomatch": [
       "shop/books|TSUTAYA",
       "shop/video|TSUTAYA"

--- a/brands/shop/musical_instrument.json
+++ b/brands/shop/musical_instrument.json
@@ -1,6 +1,9 @@
 {
   "shop/musical_instrument|Guitar Center": {
     "count": 71,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1104624675982794754/Kc2eCD4L_bigger.png"
+    },
     "tags": {
       "brand": "Guitar Center",
       "brand:wikidata": "Q3622794",

--- a/brands/shop/newsagent.json
+++ b/brands/shop/newsagent.json
@@ -109,6 +109,10 @@
   },
   "shop/newsagent|読売新聞": {
     "count": 93,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FYomiuri-Shimbun-Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1091035339232227328/elp0X_L6_bigger.jpg"
+    },
     "tags": {
       "brand": "読売新聞",
       "brand:en": "Yomiuri Shimbun",

--- a/brands/shop/nutrition_supplements.json
+++ b/brands/shop/nutrition_supplements.json
@@ -1,6 +1,9 @@
 {
   "shop/nutrition_supplements|GNC": {
     "count": 331,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGNC%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "GNC",
       "brand:wikidata": "Q4808595",
@@ -11,6 +14,10 @@
   },
   "shop/nutrition_supplements|The Vitamin Shoppe": {
     "count": 67,
+    "logos": {
+      "facebook": "https://graph.facebook.com/THEVITAMINSHOPPE/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1067124204682838016/yxn-mqME_bigger.jpg"
+    },
     "tags": {
       "brand": "The Vitamin Shoppe",
       "brand:wikidata": "Q7772938",

--- a/brands/shop/optician.json
+++ b/brands/shop/optician.json
@@ -11,6 +11,10 @@
   },
   "shop/optician|Apollo": {
     "count": 164,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FApollo-Optik%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/254579254900837/picture?type=square"
+    },
     "match": [
       "shop/optician|Apollo Optik",
       "shop/optician|Apollo-Optik"
@@ -65,6 +69,9 @@
   },
   "shop/optician|Fielmann": {
     "count": 526,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F160506%20Fielmann%20LogoNEU%20pos%20wiki.svg&width=100"
+    },
     "tags": {
       "brand": "Fielmann",
       "brand:wikidata": "Q457822",
@@ -121,6 +128,9 @@
   },
   "shop/optician|Hans Anders": {
     "count": 157,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHans%20Anders%20Logo.png&width=100"
+    },
     "tags": {
       "brand": "Hans Anders",
       "brand:wikidata": "Q1884976",
@@ -140,6 +150,9 @@
   "shop/optician|Krys": {
     "count": 244,
     "countryCodes": ["fr"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20KRYS%20GROUP.png&width=100"
+    },
     "tags": {
       "brand": "Krys",
       "brand:wikidata": "Q3119538",
@@ -232,6 +245,9 @@
   },
   "shop/optician|Specsavers": {
     "count": 499,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/767730339166973952/S-xwXTCc_bigger.jpg"
+    },
     "tags": {
       "brand": "Specsavers",
       "brand:wikidata": "Q2000610",
@@ -242,6 +258,11 @@
   },
   "shop/optician|Sunglass Hut": {
     "count": 128,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSunglasshutnew.jpg&width=100",
+      "facebook": "https://graph.facebook.com/SunglassHut/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/704779291171692546/LXVOe22V_bigger.jpg"
+    },
     "tags": {
       "brand": "Sunglass Hut",
       "brand:wikidata": "Q136311",
@@ -274,6 +295,9 @@
   },
   "shop/optician|Vision Express": {
     "count": 249,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/997108586147995648/2e-jycg6_bigger.jpg"
+    },
     "tags": {
       "brand": "Vision Express",
       "brand:wikidata": "Q7936150",
@@ -314,6 +338,10 @@
   "shop/optician|メガネスーパー": {
     "count": 90,
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/meganesuper/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1077773116535754753/wtCSwVyq_bigger.jpg"
+    },
     "tags": {
       "brand": "メガネスーパー",
       "brand:ja": "メガネスーパー",

--- a/brands/shop/outdoor.json
+++ b/brands/shop/outdoor.json
@@ -1,5 +1,9 @@
 {
   "shop/outdoor|Bass Pro Shops": {
+    "logos": {
+      "facebook": "https://graph.facebook.com/bassproshops/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/550161695050457090/PI31akEj_bigger.jpeg"
+    },
     "match": ["shop/sports|Bass Pro Shops"],
     "nocount": true,
     "tags": {
@@ -27,6 +31,9 @@
   },
   "shop/outdoor|Jack Wolfskin": {
     "count": 53,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOutdoorjacke%20von%20Jack%20Wolfskin%2020100104%20003.JPG&width=100"
+    },
     "match": ["shop/clothes|Jack Wolfskin"],
     "tags": {
       "brand": "Jack Wolfskin",
@@ -49,6 +56,10 @@
   },
   "shop/outdoor|Mountain Warehouse": {
     "count": 106,
+    "logos": {
+      "facebook": "https://graph.facebook.com/MountainWarehouse/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/486874549670006787/vRjtGsMQ_bigger.jpeg"
+    },
     "tags": {
       "brand": "Mountain Warehouse",
       "brand:wikidata": "Q6925414",
@@ -59,6 +70,10 @@
   },
   "shop/outdoor|REI": {
     "count": 95,
+    "logos": {
+      "facebook": "https://graph.facebook.com/9062006483/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/941769225005236224/r5et5wgk_bigger.jpg"
+    },
     "tags": {
       "brand": "REI",
       "brand:wikidata": "Q3414933",
@@ -68,6 +83,9 @@
     }
   },
   "shop/outdoor|Sportsman's Warehouse": {
+    "logos": {
+      "facebook": "https://graph.facebook.com/sportsmanswarehouse05/picture?type=square"
+    },
     "match": [
       "shop/outdoor|Sportsmans Warehouse",
       "shop/sports|Sportsman's Warehouse",

--- a/brands/shop/paint.json
+++ b/brands/shop/paint.json
@@ -11,6 +11,9 @@
   },
   "shop/paint|Comex": {
     "count": 107,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FComex.png&width=100"
+    },
     "tags": {
       "brand": "Comex",
       "brand:wikidata": "Q5151654",

--- a/brands/shop/party.json
+++ b/brands/shop/party.json
@@ -1,6 +1,9 @@
 {
   "shop/party|Party City": {
     "count": 118,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPartyCity%20Logo.jpg&width=100"
+    },
     "tags": {
       "brand": "Party City",
       "brand:wikidata": "Q7140896",

--- a/brands/shop/pawnbroker.json
+++ b/brands/shop/pawnbroker.json
@@ -1,6 +1,9 @@
 {
   "shop/pawnbroker|Cash Converters": {
     "count": 107,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1080851674749640704/GLO4H-z8_bigger.jpg"
+    },
     "tags": {
       "brand": "Cash Converters",
       "brand:wikidata": "Q5048645",

--- a/brands/shop/perfumery.json
+++ b/brands/shop/perfumery.json
@@ -1,6 +1,10 @@
 {
   "shop/perfumery|Douglas": {
     "count": 238,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDouglas%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/DouglasDeutschland/picture?type=square"
+    },
     "match": [
       "shop/beauty|Douglas",
       "shop/chemist|Douglas",
@@ -34,6 +38,9 @@
   },
   "shop/perfumery|Marionnaud": {
     "count": 106,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Marionnaud.svg&width=100"
+    },
     "tags": {
       "brand": "Marionnaud",
       "brand:wikidata": "Q1129073",
@@ -44,6 +51,10 @@
   },
   "shop/perfumery|O Boticário": {
     "count": 72,
+    "logos": {
+      "facebook": "https://graph.facebook.com/oboticario/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1105042791317557248/5u0WlLMc_bigger.png"
+    },
     "tags": {
       "brand": "O Boticário",
       "brand:wikidata": "Q7073219",

--- a/brands/shop/pet.json
+++ b/brands/shop/pet.json
@@ -96,6 +96,10 @@
   "shop/pet|PetSmart": {
     "count": 617,
     "countryCodes": ["ca", "us"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/PetSmart/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1098635129541472256/i2m2Oc0N_bigger.png"
+    },
     "match": ["shop/pet|Petsmart"],
     "tags": {
       "brand": "PetSmart",
@@ -140,6 +144,9 @@
   },
   "shop/pet|Pets at Home": {
     "count": 215,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1219801082/PAH_Logo_bigger.jpg"
+    },
     "match": ["shop/pet|Pets At Home"],
     "tags": {
       "brand": "Pets at Home",

--- a/brands/shop/second_hand.json
+++ b/brands/shop/second_hand.json
@@ -1,6 +1,9 @@
 {
   "shop/second_hand|Value Village": {
     "count": 78,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSavers-logo.png&width=100"
+    },
     "tags": {
       "brand": "Value Village",
       "brand:wikidata": "Q7428188",

--- a/brands/shop/shoes.json
+++ b/brands/shop/shoes.json
@@ -12,6 +12,10 @@
   },
   "shop/shoes|Aldo": {
     "count": 116,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAldo%20Group%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/903333253662228480/mJUkUOzW_bigger.jpg"
+    },
     "tags": {
       "brand": "Aldo",
       "brand:wikidata": "Q2832297",
@@ -33,6 +37,9 @@
   },
   "shop/shoes|Bata": {
     "count": 381,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBata.svg&width=100"
+    },
     "tags": {
       "brand": "Bata",
       "brand:wikidata": "Q688082",
@@ -53,6 +60,9 @@
   },
   "shop/shoes|Birkenstock": {
     "count": 63,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBIRKENSTOCK%20Logo.jpg&width=100"
+    },
     "tags": {
       "brand": "Birkenstock",
       "brand:wikidata": "Q648458",
@@ -83,6 +93,9 @@
   },
   "shop/shoes|Camper": {
     "count": 55,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCamper%20shoes%20Logo.png&width=100"
+    },
     "tags": {
       "brand": "Camper",
       "brand:wikidata": "Q1030922",
@@ -101,6 +114,10 @@
   },
   "shop/shoes|Clarks": {
     "count": 343,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FC%20%26%20J%20Clarks%20International%20company%20logo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1088383035807096832/UCHk9AIP_bigger.jpg"
+    },
     "tags": {
       "brand": "Clarks",
       "brand:wikidata": "Q1095857",
@@ -111,6 +128,11 @@
   },
   "shop/shoes|Converse": {
     "count": 70,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FConverse%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/converse/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/875776501446094848/L7gmYdCS_bigger.jpg"
+    },
     "tags": {
       "brand": "Converse",
       "brand:wikidata": "Q319515",
@@ -131,6 +153,9 @@
   },
   "shop/shoes|DSW": {
     "count": 109,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDSW%20Official%20Logo.png&width=100"
+    },
     "tags": {
       "brand": "DSW",
       "brand:wikidata": "Q5206207",
@@ -141,6 +166,9 @@
   },
   "shop/shoes|Deichmann": {
     "count": 1479,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDeichmann%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Deichmann",
       "brand:wikidata": "Q664543",
@@ -172,6 +200,11 @@
   },
   "shop/shoes|Ecco": {
     "count": 240,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogoBW.jpg&width=100",
+      "facebook": "https://graph.facebook.com/Ecco/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/496384752891346944/fSM-Xk3O_bigger.jpeg"
+    },
     "tags": {
       "brand": "Ecco",
       "brand:wikidata": "Q1280255",
@@ -218,6 +251,10 @@
   },
   "shop/shoes|Geox": {
     "count": 193,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGeox.svg&width=100",
+      "facebook": "https://graph.facebook.com/GEOX/picture?type=square"
+    },
     "tags": {
       "brand": "Geox",
       "brand:wikidata": "Q588001",
@@ -228,6 +265,9 @@
   },
   "shop/shoes|Humanic": {
     "count": 58,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHumanic%202013.jpg&width=100"
+    },
     "tags": {
       "brand": "Humanic",
       "brand:wikidata": "Q1636668",
@@ -248,6 +288,9 @@
   },
   "shop/shoes|Journeys": {
     "count": 57,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1083717041/jy_twitterB_W_bigger.jpg"
+    },
     "tags": {
       "brand": "Journeys",
       "brand:wikidata": "Q61994838",
@@ -291,6 +334,9 @@
   },
   "shop/shoes|Minelli": {
     "count": 61,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/910799985096216576/oHDV91QT_bigger.jpg"
+    },
     "tags": {
       "brand": "Minelli",
       "brand:wikidata": "Q61994831",
@@ -303,6 +349,11 @@
   },
   "shop/shoes|New Balance": {
     "count": 82,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNew%20Balance%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/newbalance/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/616215717273206784/ZXT8iOW0_bigger.jpg"
+    },
     "tags": {
       "brand": "New Balance",
       "brand:wikidata": "Q742988",
@@ -313,6 +364,9 @@
   },
   "shop/shoes|Office": {
     "count": 55,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/560809669027835905/jU4yaJG2_bigger.jpeg"
+    },
     "tags": {
       "brand": "Office",
       "brand:wikidata": "Q7079121",
@@ -323,6 +377,10 @@
   },
   "shop/shoes|Payless ShoeSource": {
     "count": 271,
+    "logos": {
+      "facebook": "https://graph.facebook.com/payless/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/811990880173199360/q4TUcugi_bigger.jpg"
+    },
     "match": [
       "shop/shoes|Payless",
       "shop/shoes|Payless Shoe Source",
@@ -338,6 +396,9 @@
   },
   "shop/shoes|Quick Schuh": {
     "count": 122,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FQS%20Logo%204c%20gruene%20Flaeche.jpg&width=100"
+    },
     "tags": {
       "brand": "Quick Schuh",
       "brand:wikidata": "Q2123069",
@@ -365,6 +426,9 @@
       "hu",
       "sk"
     ],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Reno.svg&width=100"
+    },
     "tags": {
       "brand": "Reno",
       "brand:wikidata": "Q2144204",
@@ -375,6 +439,9 @@
   },
   "shop/shoes|Rieker": {
     "count": 108,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRieker%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Rieker",
       "brand:wikidata": "Q2152193",
@@ -396,6 +463,9 @@
   "shop/shoes|San Marina": {
     "count": 67,
     "countryCodes": ["fr"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSan%20marina%20logo.png&width=100"
+    },
     "tags": {
       "brand": "San Marina",
       "brand:wikidata": "Q3471558",
@@ -417,6 +487,9 @@
   },
   "shop/shoes|Schuh": {
     "count": 62,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1062037586242355200/x2uyvsW-_bigger.jpg"
+    },
     "tags": {
       "brand": "Schuh",
       "brand:wikidata": "Q7432952",
@@ -427,6 +500,9 @@
   },
   "shop/shoes|Shoe Carnival": {
     "count": 106,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FShoecarnival.png&width=100"
+    },
     "tags": {
       "brand": "Shoe Carnival",
       "brand:wikidata": "Q7500007",
@@ -437,6 +513,10 @@
   },
   "shop/shoes|Shoe Zone": {
     "count": 189,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FShoeZone%20logo.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/849991111309479938/--OVVUq7_bigger.jpg"
+    },
     "tags": {
       "brand": "Shoe Zone",
       "brand:wikidata": "Q7500016",
@@ -448,6 +528,9 @@
   "shop/shoes|Siemes Schuhcenter": {
     "count": 81,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSchuhcenter.gif&width=100"
+    },
     "tags": {
       "brand": "Siemes Schuhcenter",
       "brand:wikidata": "Q2800720",
@@ -458,6 +541,10 @@
   },
   "shop/shoes|Skechers": {
     "count": 148,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F2000px%20SkechersLogo.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1103071990129123328/yRRui0V1_bigger.png"
+    },
     "tags": {
       "brand": "Skechers",
       "brand:wikidata": "Q2945643",
@@ -480,6 +567,9 @@
   },
   "shop/shoes|The Shoe Company": {
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTHE%20SHOE%20COMPANY%20LOGO.jpg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "The Shoe Company",
@@ -491,6 +581,10 @@
   },
   "shop/shoes|Vans": {
     "count": 84,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FVans-logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/709974008276652032/DdO7jzyU_bigger.jpg"
+    },
     "match": ["shop/clothes|Vans"],
     "tags": {
       "brand": "Vans",
@@ -547,6 +641,10 @@
   "shop/shoes|東京靴流通センター": {
     "count": 116,
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/chiyodafanpage/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/953894782618689536/sAL4bE21_bigger.jpg"
+    },
     "tags": {
       "brand": "東京靴流通センター",
       "brand:en": "Tokyo Shoes Retailing Center",

--- a/brands/shop/sports.json
+++ b/brands/shop/sports.json
@@ -1,6 +1,11 @@
 {
   "shop/sports|Adidas": {
     "count": 200,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAdidas%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/adidas/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1022906761492099072/fH9_Vtru_bigger.jpg"
+    },
     "match": [
       "shop/clothes|Adidas",
       "shop/shoes|Adidas"
@@ -25,6 +30,9 @@
   },
   "shop/sports|Big 5 Sporting Goods": {
     "count": 134,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/922575451729440768/nECkGozo_bigger.jpg"
+    },
     "tags": {
       "brand": "Big 5 Sporting Goods",
       "brand:wikidata": "Q4904902",
@@ -35,6 +43,11 @@
   },
   "shop/sports|Decathlon": {
     "count": 609,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDecathlon%20Logo.png&width=100",
+      "facebook": "https://graph.facebook.com/decathlon/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/927502592044826624/uV77GmrK_bigger.jpg"
+    },
     "tags": {
       "brand": "Decathlon",
       "brand:wikidata": "Q509349",
@@ -45,6 +58,9 @@
   },
   "shop/sports|Dick's Sporting Goods": {
     "count": 327,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/984093123964846083/srBT0TEj_bigger.jpg"
+    },
     "tags": {
       "brand": "Dick's Sporting Goods",
       "brand:wikidata": "Q5272601",
@@ -98,6 +114,9 @@
   },
   "shop/sports|JD Sports": {
     "count": 109,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/501662442229755905/symF-ozG_bigger.jpeg"
+    },
     "tags": {
       "brand": "JD Sports",
       "brand:wikidata": "Q6108019",
@@ -137,6 +156,9 @@
   },
   "shop/sports|Sport 2000": {
     "count": 260,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20SDM.png&width=100"
+    },
     "tags": {
       "brand": "Sport 2000",
       "brand:wikidata": "Q262394",
@@ -157,6 +179,9 @@
   },
   "shop/sports|Sports Authority": {
     "count": 84,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSports%20Authority%20logo2011.jpg&width=100"
+    },
     "tags": {
       "brand": "Sports Authority",
       "brand:wikidata": "Q7579688",
@@ -167,6 +192,9 @@
   },
   "shop/sports|Sports Direct": {
     "count": 272,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1093476002901168128/0JeA5eGF_bigger.jpg"
+    },
     "tags": {
       "brand": "Sports Direct",
       "brand:wikidata": "Q2913554",
@@ -177,6 +205,9 @@
   },
   "shop/sports|Спортмастер": {
     "count": 392,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSportmaster.png&width=100"
+    },
     "tags": {
       "brand": "Спортмастер",
       "brand:wikidata": "Q4438176",
@@ -187,6 +218,9 @@
   },
   "shop/sports|Спортмастер Гипер": {
     "count": 54,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSportmaster.png&width=100"
+    },
     "tags": {
       "brand": "Спортмастер Гипер",
       "brand:wikidata": "Q4438176",

--- a/brands/shop/stationery.json
+++ b/brands/shop/stationery.json
@@ -30,6 +30,10 @@
   },
   "shop/stationery|Office Depot": {
     "count": 514,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FOffice-Depot-Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1018152775564320768/kH7WpGKV_bigger.jpg"
+    },
     "match": ["shop/stationery|OfficeDepot"],
     "tags": {
       "brand": "Office Depot",
@@ -72,6 +76,9 @@
     }
   },
   "shop/stationery|Paper Source": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPaper-source-logo.png&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Paper Source",
@@ -83,6 +90,9 @@
   },
   "shop/stationery|Paperchase": {
     "count": 80,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1083057103563038721/dI5eeQme_bigger.jpg"
+    },
     "tags": {
       "brand": "Paperchase",
       "brand:wikidata": "Q7132739",
@@ -93,6 +103,9 @@
   },
   "shop/stationery|Ryman": {
     "count": 95,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/946036886988083200/_2puYaT9_bigger.jpg"
+    },
     "tags": {
       "brand": "Ryman",
       "brand:wikidata": "Q7385188",
@@ -103,6 +116,10 @@
   },
   "shop/stationery|Staples": {
     "count": 787,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FStaples.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/705406434494836736/Qx_PL9SD_bigger.jpg"
+    },
     "match": ["shop/office_supplies|Staples"],
     "tags": {
       "brand": "Staples",
@@ -114,6 +131,9 @@
   },
   "shop/stationery|Комус": {
     "count": 60,
+    "logos": {
+      "facebook": "https://graph.facebook.com/komusclub/picture?type=square"
+    },
     "tags": {
       "brand": "Комус",
       "brand:en": "Komus",

--- a/brands/shop/storage_rental.json
+++ b/brands/shop/storage_rental.json
@@ -12,6 +12,9 @@
   },
   "shop/storage_rental|Public Storage": {
     "count": 204,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPublic%20Storage%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Public Storage",
       "brand:wikidata": "Q1156045",

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -40,6 +40,9 @@
   "shop/supermarket|ADEG": {
     "count": 86,
     "countryCodes": ["at"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAdeg%20logo%20gruen%202015.jpg&width=100"
+    },
     "match": ["shop/supermarket|Adeg"],
     "tags": {
       "brand": "ADEG",
@@ -71,6 +74,9 @@
   "shop/supermarket|Albert": {
     "count": 253,
     "countryCodes": ["cz"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAlbert%20Logo.png&width=100"
+    },
     "tags": {
       "brand": "Albert",
       "brand:wikidata": "Q9144241",
@@ -81,6 +87,9 @@
   },
   "shop/supermarket|Albert Heijn": {
     "count": 849,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAlbert%20heijn.svg&width=100"
+    },
     "tags": {
       "brand": "Albert Heijn",
       "brand:wikidata": "Q1653985",
@@ -91,6 +100,9 @@
   },
   "shop/supermarket|Albertsons": {
     "count": 307,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAlbertsons%20logo.svg&width=100"
+    },
     "match": ["shop/supermarket|Albertson's"],
     "tags": {
       "brand": "Albertsons",
@@ -110,6 +122,9 @@
   },
   "shop/supermarket|Aldi": {
     "count": 4844,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FALDI%20Nord%20Logo%202015.png&width=100"
+    },
     "match": ["shop/supermarket|ALDI"],
     "tags": {
       "brand": "Aldi",
@@ -122,6 +137,9 @@
   "shop/supermarket|Aldi Nord": {
     "count": 273,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FALDI%20Nord%20Logo%202015.png&width=100"
+    },
     "match": [
       "shop/supermarket|ALDI NORD",
       "shop/supermarket|ALDI Nord"
@@ -137,6 +155,9 @@
   "shop/supermarket|Aldi Süd": {
     "count": 777,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAldi%20S%C3%BCd%202017%20logo.svg&width=100"
+    },
     "match": [
       "shop/supermarket|ALDI SÜD",
       "shop/supermarket|ALDI Süd"
@@ -160,6 +181,10 @@
   "shop/supermarket|Alimerka": {
     "count": 111,
     "countryCodes": ["es"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/supermercados_alimerka/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/659793335503204352/7J6NiZzm_bigger.jpg"
+    },
     "tags": {
       "brand": "Alimerka",
       "brand:wikidata": "Q16482738",
@@ -170,6 +195,9 @@
   },
   "shop/supermarket|Alnatura": {
     "count": 111,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAlnatura-Logo-2017.png&width=100"
+    },
     "tags": {
       "brand": "Alnatura",
       "brand:wikidata": "Q876811",
@@ -208,6 +236,9 @@
   },
   "shop/supermarket|Auchan": {
     "count": 332,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/877095334316576768/bhQDPUWZ_bigger.jpg"
+    },
     "nomatch": ["amenity/fuel|Auchan"],
     "tags": {
       "brand": "Auchan",
@@ -243,6 +274,9 @@
   },
   "shop/supermarket|Bi-Lo": {
     "count": 67,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBI%E2%80%A2LO-brand.svg&width=100"
+    },
     "tags": {
       "brand": "Bi-Lo",
       "brand:wikidata": "Q4835622",
@@ -254,6 +288,9 @@
   "shop/supermarket|Biedronka": {
     "count": 2731,
     "countryCodes": ["pl"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGda%C5%84sk%20ulica%20Pomorska%2024%20(Biedronka).JPG&width=100"
+    },
     "tags": {
       "brand": "Biedronka",
       "brand:wikidata": "Q857182",
@@ -282,6 +319,9 @@
   },
   "shop/supermarket|Billa": {
     "count": 1560,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBilla-Logo.svg&width=100"
+    },
     "match": ["shop/supermarket|BILLA"],
     "tags": {
       "brand": "Billa",
@@ -375,6 +415,9 @@
   },
   "shop/supermarket|Budgens": {
     "count": 62,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/796001828966203392/69ZeL67f_bigger.jpg"
+    },
     "tags": {
       "brand": "Budgens",
       "brand:wikidata": "Q4985016",
@@ -386,6 +429,9 @@
   "shop/supermarket|Bulk Barn": {
     "count": 81,
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBulk%20Barn%20Logo.jpg&width=100"
+    },
     "tags": {
       "brand": "Bulk Barn",
       "brand:wikidata": "Q4996466",
@@ -467,6 +513,11 @@
   },
   "shop/supermarket|Carrefour": {
     "count": 1316,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCarrefour%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/carrefouritalia/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1065247142086881280/nvIHOW4d_bigger.jpg"
+    },
     "nomatch": [
       "amenity/fuel|Carrefour",
       "shop/convenience|Carrefour Express",
@@ -543,6 +594,9 @@
   },
   "shop/supermarket|Carulla": {
     "count": 52,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCarulla%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Carulla",
       "brand:wikidata": "Q5047480",
@@ -619,6 +673,9 @@
   },
   "shop/supermarket|Co-op": {
     "count": 490,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSaskatoon%20Co-op%20Logo.svg&width=100"
+    },
     "match": [
       "shop/supermarket|COOP",
       "shop/supermarket|Co-Op",
@@ -639,6 +696,9 @@
   },
   "shop/supermarket|Coles": {
     "count": 633,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FColes%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Coles",
       "brand:wikidata": "Q1108172",
@@ -649,6 +709,9 @@
   },
   "shop/supermarket|Colruyt": {
     "count": 238,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FColruyt%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Colruyt",
       "brand:wikidata": "Q2363991",
@@ -660,6 +723,9 @@
   "shop/supermarket|Combi": {
     "count": 118,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCombi.png&width=100"
+    },
     "tags": {
       "brand": "Combi",
       "brand:wikidata": "Q1113618",
@@ -712,6 +778,9 @@
   "shop/supermarket|Consum": {
     "count": 279,
     "countryCodes": ["es"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FConsum%20Cooperativa.jpg&width=100"
+    },
     "tags": {
       "brand": "Consum",
       "brand:wikidata": "Q8350308",
@@ -722,6 +791,9 @@
   },
   "shop/supermarket|Continente": {
     "count": 131,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogocontinente.jpg&width=100"
+    },
     "tags": {
       "brand": "Continente",
       "brand:wikidata": "Q2995683",
@@ -740,6 +812,9 @@
   },
   "shop/supermarket|Coop Prix": {
     "countryCodes": ["no"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCoop%20Prix.png&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Coop Prix",
@@ -751,6 +826,9 @@
   },
   "shop/supermarket|Cora": {
     "count": 54,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCora%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Cora",
       "brand:wikidata": "Q686643",
@@ -761,6 +839,10 @@
   },
   "shop/supermarket|Costcutter": {
     "count": 99,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCostcutter.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/799170592163397632/wyr6kFNA_bigger.jpg"
+    },
     "tags": {
       "brand": "Costcutter",
       "brand:wikidata": "Q5175072",
@@ -772,6 +854,9 @@
   "shop/supermarket|Coto": {
     "count": 72,
     "countryCodes": ["ar"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCoto%20superm%20logo.png&width=100"
+    },
     "match": ["shop/supermarket|COTO"],
     "tags": {
       "brand": "Coto",
@@ -818,6 +903,9 @@
   },
   "shop/supermarket|Cub Foods": {
     "count": 59,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCub%20Foods.png&width=100"
+    },
     "tags": {
       "brand": "Cub Foods",
       "brand:wikidata": "Q5191916",
@@ -881,6 +969,9 @@
   },
   "shop/supermarket|Denner": {
     "count": 443,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDenner%20Logo%202014.jpg&width=100"
+    },
     "tags": {
       "brand": "Denner",
       "brand:wikidata": "Q379911",
@@ -892,6 +983,10 @@
   "shop/supermarket|Despar": {
     "count": 228,
     "countryCodes": ["it"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSpar-logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/639011130107633664/nLN6cXfa_bigger.png"
+    },
     "match": [
       "shop/supermarket|DESPAR",
       "shop/supermarket|deSPAR"
@@ -915,6 +1010,10 @@
   },
   "shop/supermarket|Dia": {
     "count": 955,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDia%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/800711981225410560/cuzfS3Pk_bigger.jpg"
+    },
     "match": [
       "shop/supermarket|DIA",
       "shop/supermarket|Dia %",
@@ -933,6 +1032,10 @@
   },
   "shop/supermarket|Dia Market": {
     "count": 119,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDia%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/800711981225410560/cuzfS3Pk_bigger.jpg"
+    },
     "tags": {
       "brand": "Dia Market",
       "brand:wikidata": "Q925132",
@@ -954,6 +1057,9 @@
   },
   "shop/supermarket|Dirk van den Broek": {
     "count": 68,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDirk%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Dirk van den Broek",
       "brand:wikidata": "Q17502722",
@@ -983,6 +1089,10 @@
   },
   "shop/supermarket|Dunnes Stores": {
     "count": 77,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20Dunnes%20Stores.png&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/839449686054432768/Udhd8DjK_bigger.jpg"
+    },
     "tags": {
       "brand": "Dunnes Stores",
       "brand:wikidata": "Q1266203",
@@ -1001,6 +1111,9 @@
   },
   "shop/supermarket|E. Leclerc": {
     "count": 228,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FE.Leclerc%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "E. Leclerc",
       "brand:wikidata": "Q1273376",
@@ -1011,6 +1124,9 @@
   },
   "shop/supermarket|E. Leclerc Drive": {
     "count": 122,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FE.Leclerc%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "E. Leclerc Drive",
       "brand:wikidata": "Q1273376",
@@ -1024,6 +1140,9 @@
   },
   "shop/supermarket|EMTÉ": {
     "count": 57,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FEmte%20logo.jpg&width=100"
+    },
     "tags": {
       "brand": "EMTÉ",
       "brand:wikidata": "Q3119122",
@@ -1035,6 +1154,9 @@
   "shop/supermarket|Edeka": {
     "count": 1827,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Edeka.svg&width=100"
+    },
     "match": [
       "shop/supermarket|EDEKA",
       "shop/supermarket|Edeka Neukauf"
@@ -1074,6 +1196,9 @@
   "shop/supermarket|Ekono": {
     "count": 80,
     "countryCodes": ["cl"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogotipo%20Ekono.svg&width=100"
+    },
     "tags": {
       "brand": "Ekono",
       "brand:wikidata": "Q2842729",
@@ -1098,6 +1223,9 @@
   },
   "shop/supermarket|Esselunga": {
     "count": 112,
+    "logos": {
+      "facebook": "https://graph.facebook.com/Esselunga/picture?type=square"
+    },
     "tags": {
       "brand": "Esselunga",
       "brand:wikidata": "Q1059636",
@@ -1109,6 +1237,9 @@
   "shop/supermarket|EuroSpin": {
     "count": 162,
     "countryCodes": ["it", "si"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/EurospinItaliaSpa/picture?type=square"
+    },
     "match": ["shop/supermarket|Eurospin"],
     "tags": {
       "brand": "EuroSpin",
@@ -1130,6 +1261,9 @@
   },
   "shop/supermarket|Extra": {
     "count": 167,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FExtra%20mobillogo.png&width=100"
+    },
     "match": [
       "shop/convenience|Coop Extra",
       "shop/convenience|Extra",
@@ -1164,6 +1298,9 @@
   },
   "shop/supermarket|Fareway": {
     "count": 57,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFareway%20Food%20Stores%2C%20Inc-%20company%20logo-%202014-04-03%2017-22.jpg&width=100"
+    },
     "tags": {
       "brand": "Fareway",
       "brand:wikidata": "Q5434998",
@@ -1186,6 +1323,9 @@
   },
   "shop/supermarket|Farmfoods": {
     "count": 164,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFarmfoods%20Limited%20Logo.jpg&width=100"
+    },
     "tags": {
       "brand": "Farmfoods",
       "brand:wikidata": "Q5435841",
@@ -1207,6 +1347,9 @@
   },
   "shop/supermarket|Food 4 Less": {
     "count": 60,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFood4Less%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Food 4 Less",
       "brand:wikidata": "Q5465282",
@@ -1323,6 +1466,9 @@
   },
   "shop/supermarket|Foodworks": {
     "count": 102,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFoodworks-Logo.jpg&width=100"
+    },
     "tags": {
       "brand": "Foodworks",
       "brand:wikidata": "Q5465579",
@@ -1342,6 +1488,9 @@
   "shop/supermarket|Fred Meyer": {
     "count": 75,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFred%20Meyer%20logo.svg&width=100"
+    },
     "match": ["shop/department_store|Fred Meyer"],
     "tags": {
       "brand": "Fred Meyer",
@@ -1361,6 +1510,9 @@
   },
   "shop/supermarket|FreshCo": {
     "count": 54,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFreshCo%20logo.png&width=100"
+    },
     "tags": {
       "brand": "FreshCo",
       "brand:wikidata": "Q5502915",
@@ -1371,6 +1523,10 @@
   },
   "shop/supermarket|Froiz": {
     "count": 131,
+    "logos": {
+      "facebook": "https://graph.facebook.com/158051157541336/picture?type=square",
+      "twitter": "https://abs.twimg.com/sticky/default_profile_images/default_profile_bigger.png"
+    },
     "tags": {
       "brand": "Froiz",
       "brand:wikidata": "Q17070775",
@@ -1381,6 +1537,9 @@
   },
   "shop/supermarket|Føtex": {
     "count": 83,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FF%C3%B8tex%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Føtex",
       "brand:wikidata": "Q1480395",
@@ -1429,6 +1588,9 @@
   },
   "shop/supermarket|Giant Eagle": {
     "count": 157,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGiantEagle.svg&width=100"
+    },
     "tags": {
       "brand": "Giant Eagle",
       "brand:wikidata": "Q1522721",
@@ -1439,6 +1601,9 @@
   },
   "shop/supermarket|Globus": {
     "count": 57,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGlobus%20SB-Warenhaus%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Globus",
       "brand:wikidata": "Q457503",
@@ -1459,6 +1624,9 @@
   },
   "shop/supermarket|Grocery Outlet": {
     "count": 235,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGroceryoutlet%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Grocery Outlet",
       "brand:wikidata": "Q5609934",
@@ -1477,6 +1645,9 @@
   },
   "shop/supermarket|Géant Casino": {
     "count": 82,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20geant%202015%20rvb.png&width=100"
+    },
     "tags": {
       "brand": "Géant Casino",
       "brand:wikidata": "Q1380537",
@@ -1487,6 +1658,9 @@
   },
   "shop/supermarket|H-E-B": {
     "count": 282,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20the%20HEB%20Grocery%20Company%2C%20LP.png&width=100"
+    },
     "tags": {
       "brand": "H-E-B",
       "brand:wikidata": "Q830621",
@@ -1538,6 +1712,9 @@
   },
   "shop/supermarket|Heron Foods": {
     "count": 82,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/589070024230440960/ZBf4EE6m_bigger.png"
+    },
     "tags": {
       "brand": "Heron Foods",
       "brand:wikidata": "Q5743472",
@@ -1549,6 +1726,9 @@
   "shop/supermarket|Hofer": {
     "count": 509,
     "countryCodes": ["at", "si"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Hofer.svg&width=100"
+    },
     "nomatch": ["amenity/fuel|Hofer"],
     "tags": {
       "brand": "Hofer",
@@ -1579,6 +1759,10 @@
   },
   "shop/supermarket|Hy-Vee": {
     "count": 188,
+    "logos": {
+      "facebook": "https://graph.facebook.com/HyVee/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/684132881187250177/WEaq3BAp_bigger.png"
+    },
     "tags": {
       "brand": "Hy-Vee",
       "brand:wikidata": "Q1639719",
@@ -1664,6 +1848,9 @@
   },
   "shop/supermarket|IGA": {
     "count": 642,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FIGA%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "IGA",
       "brand:wikidata": "Q3146662",
@@ -1674,6 +1861,10 @@
   },
   "shop/supermarket|Iceland": {
     "count": 600,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FIceland%20supermarket%20front.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/998234843736457216/AqtyY1Rc_bigger.jpg"
+    },
     "tags": {
       "brand": "Iceland",
       "brand:wikidata": "Q721810",
@@ -1692,6 +1883,9 @@
   },
   "shop/supermarket|Ingles": {
     "count": 80,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FIngles%20Markets%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Ingles",
       "brand:wikidata": "Q6032595",
@@ -1759,6 +1953,9 @@
   "shop/supermarket|Jewel-Osco": {
     "count": 87,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJewel%20Osco%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Jewel-Osco",
       "brand:wikidata": "Q3178470",
@@ -1769,6 +1966,9 @@
   },
   "shop/supermarket|Joker": {
     "countryCodes": ["no"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJoker%20butikkjede%20norgesgruppen%20joker.jpg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Joker",
@@ -1780,6 +1980,9 @@
   },
   "shop/supermarket|Jumbo": {
     "count": 514,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FJumbo%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Jumbo",
       "brand:wikidata": "Q2262314",
@@ -1798,6 +2001,11 @@
   },
   "shop/supermarket|Kaufland": {
     "count": 1177,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FKaufland%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/132476996783723/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/887226332324691969/tV8aZpR0_bigger.jpg"
+    },
     "tags": {
       "brand": "Kaufland",
       "brand:wikidata": "Q685967",
@@ -1845,6 +2053,11 @@
   },
   "shop/supermarket|Kroger": {
     "count": 759,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCurrent%20Kroger%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/Kroger/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/829112544921006082/rfcZbBI5_bigger.jpg"
+    },
     "nomatch": ["amenity/fuel|Kroger"],
     "tags": {
       "brand": "Kroger",
@@ -1866,6 +2079,9 @@
   },
   "shop/supermarket|La Anónima": {
     "count": 54,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSupermercados%20La%20anonima%20logo.jpg&width=100"
+    },
     "tags": {
       "brand": "La Anónima",
       "brand:wikidata": "Q6135985",
@@ -1898,6 +2114,9 @@
   "shop/supermarket|Landi": {
     "count": 58,
     "countryCodes": ["ch"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLandi.svg&width=100"
+    },
     "tags": {
       "brand": "Landi",
       "brand:wikidata": "Q1803010",
@@ -1908,6 +2127,9 @@
   },
   "shop/supermarket|Leader Price": {
     "count": 589,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLeader%20Price%202010%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Leader Price",
       "brand:wikidata": "Q2181426",
@@ -1936,6 +2158,9 @@
   "shop/supermarket|Lider": {
     "count": 72,
     "countryCodes": ["cl"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FL%C3%ADder%20logo.svg&width=100"
+    },
     "match": ["shop/supermarket|Líder"],
     "nomatch": ["shop/supermarket|Lider Express"],
     "tags": {
@@ -1948,6 +2173,9 @@
   },
   "shop/supermarket|Lider Express": {
     "countryCodes": ["cl"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FL%C3%ADder%20logo.svg&width=100"
+    },
     "match": ["shop/supermarket|Líder Express"],
     "nocount": true,
     "nomatch": ["shop/supermarket|Lider"],
@@ -1961,6 +2189,11 @@
   },
   "shop/supermarket|Lidl": {
     "count": 8798,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLidl-Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/lidl/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/964075341051580416/x8dSwwod_bigger.jpg"
+    },
     "match": ["shop/supermarket|LIDL"],
     "tags": {
       "brand": "Lidl",
@@ -2049,6 +2282,9 @@
   "shop/supermarket|Lupa": {
     "count": 101,
     "countryCodes": ["es"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/LupaSupermercados/picture?type=square"
+    },
     "tags": {
       "brand": "Lupa",
       "brand:wikidata": "Q58044048",
@@ -2079,6 +2315,9 @@
   "shop/supermarket|MPREIS": {
     "count": 198,
     "countryCodes": ["at", "it"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMPreis%20Logo.svg&width=100"
+    },
     "match": ["shop/supermarket|M-Preis"],
     "tags": {
       "brand": "MPREIS",
@@ -2100,6 +2339,9 @@
   },
   "shop/supermarket|Market Basket": {
     "count": 67,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMarket%20Basket%20Logo.png&width=100"
+    },
     "tags": {
       "brand": "Market Basket",
       "brand:wikidata": "Q2079198",
@@ -2111,6 +2353,9 @@
   "shop/supermarket|Marktkauf": {
     "count": 103,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMarktkauf.svg&width=100"
+    },
     "tags": {
       "brand": "Marktkauf",
       "brand:wikidata": "Q1533254",
@@ -2141,6 +2386,10 @@
   },
   "shop/supermarket|Maxi Dia": {
     "count": 73,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDia%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/800711981225410560/cuzfS3Pk_bigger.jpg"
+    },
     "tags": {
       "brand": "Maxi Dia",
       "brand:wikidata": "Q925132",
@@ -2158,6 +2407,9 @@
       "lv",
       "pl"
     ],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMaxima%20logo.svg&width=100"
+    },
     "nomatch": [
       "shop/supermarket|Maxima XX",
       "shop/supermarket|Maxima XXX"
@@ -2179,6 +2431,9 @@
       "lv",
       "pl"
     ],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMaxima%20logo.svg&width=100"
+    },
     "nomatch": [
       "shop/supermarket|Maxima X",
       "shop/supermarket|Maxima XXX"
@@ -2199,6 +2454,9 @@
       "lv",
       "pl"
     ],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMaxima%20logo.svg&width=100"
+    },
     "match": ["shop/supermarket|Maxima"],
     "nocount": true,
     "nomatch": [
@@ -2250,6 +2508,9 @@
   "shop/supermarket|Mego": {
     "count": 56,
     "countryCodes": ["lv"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/mego.lv/picture?type=square"
+    },
     "tags": {
       "brand": "Mego",
       "brand:wikidata": "Q16363314",
@@ -2260,6 +2521,9 @@
   },
   "shop/supermarket|Meijer": {
     "count": 170,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMeijer%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Meijer",
       "brand:wikidata": "Q1917753",
@@ -2270,6 +2534,9 @@
   },
   "shop/supermarket|Meny": {
     "count": 82,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMeny%20butikkjede%20norgesgruppen%20logo.jpg&width=100"
+    },
     "tags": {
       "brand": "Meny",
       "brand:wikidata": "Q10581720",
@@ -2299,6 +2566,9 @@
   "shop/supermarket|Merkur": {
     "count": 134,
     "countryCodes": ["at"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Merkur.svg&width=100"
+    },
     "tags": {
       "brand": "Merkur",
       "brand:wikidata": "Q1921857",
@@ -2309,6 +2579,9 @@
   },
   "shop/supermarket|Metro~(Canada)": {
     "countryCodes": ["ca"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMetro%20Inc.%20logo.svg&width=100"
+    },
     "nocount": true,
     "nomatch": ["shop/wholesale|Metro"],
     "tags": {
@@ -2321,6 +2594,9 @@
   },
   "shop/supermarket|Metro~(Peru)": {
     "countryCodes": ["pe"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Metro%20Cencosud.png&width=100"
+    },
     "nocount": true,
     "nomatch": ["shop/wholesale|Metro"],
     "tags": {
@@ -2336,6 +2612,9 @@
   },
   "shop/supermarket|Migros": {
     "count": 746,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMigros.svg&width=100"
+    },
     "tags": {
       "brand": "Migros",
       "brand:wikidata": "Q680727",
@@ -2367,6 +2646,9 @@
   },
   "shop/supermarket|Mix Markt": {
     "count": 70,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMIX%20Markt%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Mix Markt",
       "brand:wikidata": "Q327854",
@@ -2377,6 +2659,9 @@
   },
   "shop/supermarket|Monoprix": {
     "count": 283,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMonoprix%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Monoprix",
       "brand:wikidata": "Q3321241",
@@ -2443,6 +2728,9 @@
   },
   "shop/supermarket|Naturalia": {
     "count": 68,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNaturalia%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Naturalia",
       "brand:wikidata": "Q3337081",
@@ -2453,6 +2741,9 @@
   },
   "shop/supermarket|Netto": {
     "count": 4178,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGda%C5%84sk%20ulica%20D%C4%85browszczak%C3%B3w%2020%20(logo%20Netto).JPG&width=100"
+    },
     "match": [
       "shop/supermarket|NETTO",
       "shop/supermarket|netto"
@@ -2467,6 +2758,9 @@
   },
   "shop/supermarket|Netto Marken-Discount": {
     "count": 909,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNetto%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Netto Marken-Discount",
       "brand:wikidata": "Q879858",
@@ -2499,6 +2793,9 @@
   "shop/supermarket|Norfa XL": {
     "count": 73,
     "countryCodes": ["lt"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNorfa%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Norfa XL",
       "brand:wikidata": "Q1998983",
@@ -2509,6 +2806,9 @@
   },
   "shop/supermarket|Norma": {
     "count": 1206,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FNorma%20Logo.svg&width=100"
+    },
     "match": ["shop/supermarket|NORMA"],
     "tags": {
       "brand": "Norma",
@@ -2566,6 +2866,9 @@
   },
   "shop/supermarket|Palí": {
     "count": 56,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20de%20Walmart%20Mexico%20y%20Centroamerica.jpg&width=100"
+    },
     "tags": {
       "brand": "Palí",
       "brand:wikidata": "Q1064887",
@@ -2604,6 +2907,10 @@
       "it",
       "ro"
     ],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPenny%20Market%20logo%202014.png&width=100",
+      "facebook": "https://graph.facebook.com/PennyDeutschland/picture?type=square"
+    },
     "match": [
       "shop/supermarket|PENNY",
       "shop/supermarket|Penny Market",
@@ -2660,6 +2967,9 @@
   },
   "shop/supermarket|Pingo Doce": {
     "count": 334,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPingo%20Doce%20Santana%20(Sesimbra).jpg&width=100"
+    },
     "tags": {
       "brand": "Pingo Doce",
       "brand:wikidata": "Q1575057",
@@ -2795,6 +3105,11 @@
   },
   "shop/supermarket|Publix": {
     "count": 776,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPublix%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/publix/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/530470667448107008/PvF_G2_c_bigger.jpeg"
+    },
     "tags": {
       "brand": "Publix",
       "brand:wikidata": "Q672170",
@@ -2857,6 +3172,10 @@
   },
   "shop/supermarket|Ralphs": {
     "count": 98,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRalphs.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/829113387929972737/Ve6U9Jd9_bigger.jpg"
+    },
     "tags": {
       "brand": "Ralphs",
       "brand:wikidata": "Q3929820",
@@ -2867,6 +3186,11 @@
   },
   "shop/supermarket|Real": {
     "count": 143,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FReal%2C-Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/real/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/930088669628850176/fUTDH88G_bigger.jpg"
+    },
     "match": [
       "shop/supermarket|real",
       "shop/supermarket|real,-"
@@ -2912,6 +3236,9 @@
   "shop/supermarket|Rema 1000": {
     "count": 281,
     "countryCodes": ["dk", "no"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FREMA1000.jpg&width=100"
+    },
     "match": ["shop/supermarket|REMA 1000"],
     "tags": {
       "brand": "Rema 1000",
@@ -2923,6 +3250,11 @@
   },
   "shop/supermarket|Rewe": {
     "count": 1490,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20REWE.svg&width=100",
+      "facebook": "https://graph.facebook.com/Rewe/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/922436311574892546/miFnb6vo_bigger.jpg"
+    },
     "match": ["shop/supermarket|REWE"],
     "nomatch": ["shop/supermarket|Rewe City"],
     "tags": {
@@ -2935,6 +3267,11 @@
   },
   "shop/supermarket|Rewe City": {
     "count": 73,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20REWE.svg&width=100",
+      "facebook": "https://graph.facebook.com/Rewe/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/922436311574892546/miFnb6vo_bigger.jpg"
+    },
     "match": ["shop/supermarket|REWE City"],
     "nomatch": ["shop/supermarket|Rewe"],
     "tags": {
@@ -2947,6 +3284,9 @@
   },
   "shop/supermarket|Rimi": {
     "count": 92,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRimi%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Rimi",
       "brand:wikidata": "Q7334456",
@@ -2968,6 +3308,10 @@
   },
   "shop/supermarket|Safeway": {
     "count": 655,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSafeway%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/813782141259497472/inQrmCRf_bigger.jpg"
+    },
     "nomatch": ["amenity/fuel|Safeway"],
     "tags": {
       "brand": "Safeway",
@@ -2980,6 +3324,10 @@
   "shop/supermarket|Sainsbury's": {
     "count": 529,
     "countryCodes": ["gb"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSainsbury's%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1101419025421225984/xsPc8EfW_bigger.jpg"
+    },
     "match": ["shop/supermarket|Sainsburys"],
     "nomatch": ["amenity/fuel|Sainsbury's"],
     "tags": {
@@ -3013,6 +3361,9 @@
   },
   "shop/supermarket|Save-On-Foods": {
     "count": 51,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSave%20On%20Foods%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Save-On-Foods",
       "brand:wikidata": "Q7427974",
@@ -3045,6 +3396,9 @@
   "shop/supermarket|ShopRite": {
     "count": 108,
     "countryCodes": ["us"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/466948326969987072/F66s5ItP_bigger.png"
+    },
     "nomatch": ["shop/supermarket|Shoprite"],
     "tags": {
       "brand": "ShopRite",
@@ -3105,6 +3459,9 @@
     }
   },
   "shop/supermarket|Sky": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCoop%20Deutschland%20Logo.svg&width=100"
+    },
     "match": ["shop/supermarket|sky"],
     "nocount": true,
     "tags": {
@@ -3117,6 +3474,9 @@
   },
   "shop/supermarket|Smith's": {
     "count": 65,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSmithsFoodDrug-logo.png&width=100"
+    },
     "nomatch": ["amenity/fuel|Smith's"],
     "tags": {
       "brand": "Smith's",
@@ -3138,6 +3498,9 @@
   },
   "shop/supermarket|Soriana": {
     "count": 246,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogoSoriana.PNG&width=100"
+    },
     "tags": {
       "brand": "Soriana",
       "brand:wikidata": "Q735562",
@@ -3148,6 +3511,10 @@
   },
   "shop/supermarket|Spar": {
     "count": 2986,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSpar-logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/639011130107633664/nLN6cXfa_bigger.png"
+    },
     "match": ["shop/supermarket|SPAR"],
     "nomatch": [
       "shop/convenience|Spar",
@@ -3174,6 +3541,10 @@
   },
   "shop/supermarket|Sprouts Farmers Market": {
     "count": 121,
+    "logos": {
+      "facebook": "https://graph.facebook.com/SproutsFarmersMarket/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1068641003324694528/_h9Do1-N_bigger.jpg"
+    },
     "tags": {
       "brand": "Sprouts Farmers Market",
       "brand:wikidata": "Q7581369",
@@ -3282,6 +3653,9 @@
   "shop/supermarket|SuperBrugsen": {
     "count": 215,
     "countryCodes": ["dk"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSB%20logo%20rektangel%20RGB%20standard.jpg&width=100"
+    },
     "tags": {
       "brand": "SuperBrugsen",
       "brand:wikidata": "Q12337746",
@@ -3333,6 +3707,10 @@
   "shop/supermarket|Superspar": {
     "count": 54,
     "countryCodes": ["es", "za"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSpar-logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/639011130107633664/nLN6cXfa_bigger.png"
+    },
     "tags": {
       "brand": "Superspar",
       "brand:wikidata": "Q610492",
@@ -3344,6 +3722,9 @@
   "shop/supermarket|Tegut": {
     "count": 93,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTegut%E2%80%A6.svg&width=100"
+    },
     "match": ["shop/supermarket|tegut"],
     "tags": {
       "brand": "Tegut",
@@ -3355,6 +3736,10 @@
   },
   "shop/supermarket|Tesco": {
     "count": 1318,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTescologo.svg&width=100",
+      "twitter": "https://abs.twimg.com/sticky/default_profile_images/default_profile_bigger.png"
+    },
     "match": ["shop/supermarket|TESCO"],
     "nomatch": [
       "shop/convenience|Tesco Express",
@@ -3370,6 +3755,10 @@
   },
   "shop/supermarket|Tesco Express": {
     "count": 612,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTescologo.svg&width=100",
+      "twitter": "https://abs.twimg.com/sticky/default_profile_images/default_profile_bigger.png"
+    },
     "tags": {
       "brand": "Tesco Express",
       "brand:wikidata": "Q487494",
@@ -3412,6 +3801,9 @@
   "shop/supermarket|The Co-operative Food": {
     "count": 1173,
     "countryCodes": ["gb"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1034360565127409665/V4fCWHgw_bigger.jpg"
+    },
     "match": [
       "shop/supermarket|Co-operative Food",
       "shop/supermarket|The Co-operative"
@@ -3430,6 +3822,10 @@
   "shop/supermarket|The Fresh Market": {
     "count": 61,
     "countryCodes": ["us"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/thefreshmarket/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/791251254337036288/0VUcaeIf_bigger.jpg"
+    },
     "tags": {
       "brand": "The Fresh Market",
       "brand:wikidata": "Q7735265",
@@ -3441,6 +3837,9 @@
   "shop/supermarket|Todis": {
     "count": 65,
     "countryCodes": ["it"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Todis%20lungo%20verde.jpg&width=100"
+    },
     "tags": {
       "brand": "Todis",
       "brand:wikidata": "Q3992174",
@@ -3485,6 +3884,9 @@
   "shop/supermarket|Tottus": {
     "count": 101,
     "countryCodes": ["cl", "pe"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogotipo%20Tottus.svg&width=100"
+    },
     "tags": {
       "brand": "Tottus",
       "brand:wikidata": "Q7828510",
@@ -3496,6 +3898,9 @@
   "shop/supermarket|Trader Joe's": {
     "count": 406,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTrader%20Joes%20Logo.svg&width=100"
+    },
     "tags": {
       "brand": "Trader Joe's",
       "brand:wikidata": "Q688825",
@@ -3507,6 +3912,9 @@
   "shop/supermarket|Treff 3000": {
     "count": 89,
     "countryCodes": ["de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Edeka.svg&width=100"
+    },
     "tags": {
       "brand": "Treff 3000",
       "brand:wikidata": "Q701755",
@@ -3518,6 +3926,9 @@
   "shop/supermarket|Tuodì": {
     "count": 51,
     "countryCodes": ["it"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Dico.png&width=100"
+    },
     "tags": {
       "brand": "Tuodì",
       "brand:wikidata": "Q3706995",
@@ -3546,6 +3957,9 @@
   "shop/supermarket|Unimarc": {
     "count": 261,
     "countryCodes": ["cl"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUnimarc%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Unimarc",
       "brand:wikidata": "Q6156244",
@@ -3557,6 +3971,9 @@
   "shop/supermarket|Unimarkt": {
     "count": 104,
     "countryCodes": ["at"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FUnimarktLogoNeu.jpg&width=100"
+    },
     "tags": {
       "brand": "Unimarkt",
       "brand:wikidata": "Q1169599",
@@ -3599,6 +4016,9 @@
   "shop/supermarket|Volg": {
     "count": 248,
     "countryCodes": ["ch", "li"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FVolg.svg&width=100"
+    },
     "tags": {
       "brand": "Volg",
       "brand:wikidata": "Q2530746",
@@ -3620,6 +4040,9 @@
   },
   "shop/supermarket|Vons": {
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FVons%20logo.svg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Vons",
@@ -3631,6 +4054,10 @@
   },
   "shop/supermarket|Waitrose": {
     "count": 303,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWaitrose%20Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1036753874512687104/1ef8sudl_bigger.jpg"
+    },
     "tags": {
       "brand": "Waitrose",
       "brand:wikidata": "Q771734",
@@ -3641,6 +4068,11 @@
   },
   "shop/supermarket|Walmart Neighborhood Market": {
     "count": 723,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWalmart%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/walmart/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1087396420141731840/c18XRlag_bigger.jpg"
+    },
     "tags": {
       "brand": "Walmart",
       "brand:wikidata": "Q483551",
@@ -3654,6 +4086,11 @@
   },
   "shop/supermarket|Walmart Supercenter": {
     "count": 3449,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWalmart%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/walmart/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1087396420141731840/c18XRlag_bigger.jpg"
+    },
     "match": [
       "shop/department_store|Walmart Supercenter",
       "shop/supermarket|Walmart"
@@ -3683,6 +4120,9 @@
   "shop/supermarket|Wegmans": {
     "count": 94,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWegmansLogo.svg&width=100"
+    },
     "tags": {
       "brand": "Wegmans",
       "brand:wikidata": "Q11288478",
@@ -3705,6 +4145,11 @@
   "shop/supermarket|Whole Foods Market": {
     "count": 362,
     "countryCodes": ["ca", "gb", "us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWhole%20Foods%20Market%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/WholeFoods/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1037450039553978368/iuMg_L3Q_bigger.jpg"
+    },
     "match": ["shop/supermarket|Whole Foods"],
     "tags": {
       "brand": "Whole Foods Market",
@@ -3739,6 +4184,9 @@
   "shop/supermarket|Winn Dixie": {
     "count": 113,
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWinn%20Dixie%20Logo.svg&width=100"
+    },
     "match": ["shop/supermarket|Winn-Dixie"],
     "tags": {
       "brand": "Winn Dixie",
@@ -3775,6 +4223,9 @@
   "shop/supermarket|denn's Biomarkt": {
     "count": 190,
     "countryCodes": ["at", "de"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDenns%20Biomarkt%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "denn's Biomarkt",
       "brand:wikidata": "Q48883773",
@@ -3797,6 +4248,9 @@
   "shop/supermarket|Şok": {
     "count": 583,
     "countryCodes": ["tr"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/831881850201194496/HxDzAV5x_bigger.jpg"
+    },
     "tags": {
       "brand": "Şok",
       "brand:wikidata": "Q19613992",
@@ -3907,6 +4361,9 @@
   },
   "shop/supermarket|Ашан": {
     "count": 123,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/877095334316576768/bhQDPUWZ_bigger.jpg"
+    },
     "tags": {
       "brand": "Ашан",
       "brand:en": "Auchan",
@@ -4004,6 +4461,9 @@
   "shop/supermarket|Гулливер": {
     "count": 67,
     "countryCodes": ["ru"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/gulliver_supermarket/picture?type=square"
+    },
     "tags": {
       "brand": "Гулливер",
       "brand:wikidata": "Q58003470",
@@ -4125,6 +4585,10 @@
   },
   "shop/supermarket|Магнит": {
     "count": 5325,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMagnit%20Logo.gif&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1098477357390856192/wILY9KdL_bigger.png"
+    },
     "match": ["shop/department_store|Магнит"],
     "nomatch": [
       "shop/convenience|Магнит",
@@ -4179,6 +4643,9 @@
   },
   "shop/supermarket|Народная 7Я семьЯ": {
     "count": 198,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F7Family.png&width=100"
+    },
     "match": ["shop/supermarket|Семья"],
     "tags": {
       "brand": "Народная 7Я семьЯ",
@@ -4251,6 +4718,9 @@
   "shop/supermarket|Радеж": {
     "count": 68,
     "countryCodes": ["ru"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRadezh%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Радеж",
       "brand:en": "Radezh",
@@ -4306,6 +4776,9 @@
   "shop/supermarket|Сільпо": {
     "count": 214,
     "countryCodes": ["ua"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSilpo.png&width=100"
+    },
     "tags": {
       "brand": "Сільпо",
       "brand:en": "Silpo",
@@ -4363,6 +4836,9 @@
   "shop/supermarket|Эдельвейс": {
     "count": 59,
     "countryCodes": ["ru"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/edelveis_supermarket/picture?type=square"
+    },
     "tags": {
       "brand": "Эдельвейс",
       "brand:en": "Edelveis",
@@ -4383,6 +4859,9 @@
   "shop/supermarket|いなげや": {
     "count": 78,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FInageya%20Co.%20logo.png&width=100"
+    },
     "tags": {
       "brand": "いなげや",
       "brand:en": "Inageya",
@@ -4428,6 +4907,10 @@
   "shop/supermarket|イトーヨーカドー": {
     "count": 73,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FIto-Yokado%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/itoyokado/picture?type=square"
+    },
     "match": ["shop/supermarket|イトーヨーカ堂"],
     "tags": {
       "brand": "イトーヨーカドー",
@@ -4444,6 +4927,9 @@
   "shop/supermarket|カスミ": {
     "count": 65,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHead%20office%20of%20Kasumi%20Co.%2C%20Ltd.jpg&width=100"
+    },
     "tags": {
       "brand": "カスミ",
       "brand:en": "Kasumi",
@@ -4485,6 +4971,9 @@
   "shop/supermarket|マックスバリュ": {
     "count": 196,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMaxValu.JPG&width=100"
+    },
     "tags": {
       "brand": "マックスバリュ",
       "brand:en": "Maxvalu Tokai",
@@ -4515,6 +5004,9 @@
   "shop/supermarket|ヤオコー": {
     "count": 59,
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/yaokococoro/picture?type=square"
+    },
     "tags": {
       "brand": "ヤオコー",
       "brand:en": "Yaoko",
@@ -4529,6 +5021,9 @@
   },
   "shop/supermarket|ヨークベニマル": {
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FYork%20benimaru%20logo.svg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "ヨークベニマル",
@@ -4560,6 +5055,9 @@
   "shop/supermarket|ライフ": {
     "count": 149,
     "countryCodes": ["jp"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/lifecorp428/picture?type=square"
+    },
     "tags": {
       "brand": "ライフ",
       "brand:en": "Life",
@@ -4574,6 +5072,9 @@
   },
   "shop/supermarket|全聯": {
     "count": 100,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPxmart%20Building%2020131012.jpg&width=100"
+    },
     "tags": {
       "brand": "全聯",
       "brand:en": "Pxmart",
@@ -4586,6 +5087,9 @@
   },
   "shop/supermarket|全聯福利中心": {
     "count": 367,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FPxmart%20Building%2020131012.jpg&width=100"
+    },
     "tags": {
       "brand": "全聯福利中心",
       "brand:en": "Pxmart",
@@ -4598,6 +5102,11 @@
   },
   "shop/supermarket|家乐福": {
     "count": 51,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCarrefour%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/carrefouritalia/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1065247142086881280/nvIHOW4d_bigger.jpg"
+    },
     "tags": {
       "brand": "家乐福",
       "brand:wikidata": "Q217599",
@@ -4609,6 +5118,9 @@
   "shop/supermarket|惠康 Wellcome": {
     "count": 66,
     "countryCodes": ["hk"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWellcome%20Supermarket.svg&width=100"
+    },
     "tags": {
       "brand": "惠康 Wellcome",
       "brand:en": "Wellcome",
@@ -4636,6 +5148,11 @@
   },
   "shop/supermarket|沃尔玛": {
     "count": 51,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWalmart%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/walmart/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1087396420141731840/c18XRlag_bigger.jpg"
+    },
     "tags": {
       "brand": "沃尔玛",
       "brand:en": "Walmart",
@@ -4661,6 +5178,9 @@
   },
   "shop/supermarket|西友": {
     "count": 152,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSEIYU%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "西友",
       "brand:en": "Seiyu Group",
@@ -4673,6 +5193,9 @@
   },
   "shop/supermarket|頂好": {
     "count": 55,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWellcome%20Supermarket.svg&width=100"
+    },
     "tags": {
       "brand": "頂好",
       "brand:en": "Wellcome",
@@ -4685,6 +5208,9 @@
   },
   "shop/supermarket|頂好超市": {
     "count": 61,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FWellcome%20Supermarket.svg&width=100"
+    },
     "tags": {
       "brand": "頂好超市",
       "brand:en": "Wellcome",

--- a/brands/shop/ticket.json
+++ b/brands/shop/ticket.json
@@ -1,6 +1,11 @@
 {
   "shop/ticket|Boutique Grandes Lignes": {
     "countryCodes": ["fr"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20SNCF%202011.svg&width=100",
+      "facebook": "https://graph.facebook.com/SNCFOFFICIEL/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/829331568082690048/we6jTkGG_bigger.jpg"
+    },
     "nocount": true,
     "tags": {
       "brand": "Boutique Grandes Lignes",
@@ -21,6 +26,9 @@
   "shop/ticket|Guichet Transilien": {
     "count": 253,
     "countryCodes": ["fr"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/776102546045865984/-NPGF3eG_bigger.jpg"
+    },
     "tags": {
       "brand": "Guichet Transilien",
       "brand:wikidata": "Q389554",

--- a/brands/shop/toys.json
+++ b/brands/shop/toys.json
@@ -70,6 +70,11 @@
   },
   "shop/toys|Lego": {
     "count": 140,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLEGO%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/lego/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/940608855125487618/-W2tTgtk_bigger.jpg"
+    },
     "tags": {
       "brand": "Lego",
       "brand:wikidata": "Q1063455",
@@ -101,6 +106,9 @@
   },
   "shop/toys|The Entertainer": {
     "count": 57,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1065176417300881409/BR5S2nYI_bigger.jpg"
+    },
     "tags": {
       "brand": "The Entertainer",
       "brand:wikidata": "Q7732289",
@@ -111,6 +119,11 @@
   },
   "shop/toys|Toys R Us": {
     "count": 269,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FToys%20%22R%22%20Us%20logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/toysяusjp/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/945565173309251584/2S7le7sp_bigger.jpg"
+    },
     "tags": {
       "brand": "Toys R Us",
       "brand:wikidata": "Q696334",
@@ -150,6 +163,9 @@
   "shop/toys|Кораблик": {
     "count": 60,
     "countryCodes": ["ru"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/korablik.shop/picture?type=square"
+    },
     "tags": {
       "brand": "Кораблик",
       "brand:wikidata": "Q57653416",

--- a/brands/shop/travel_agency.json
+++ b/brands/shop/travel_agency.json
@@ -2,6 +2,9 @@
   "shop/travel_agency|Coral Travel": {
     "count": 62,
     "countryCodes": ["pl", "ru", "ua"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/coraltravelofficial/picture?type=square"
+    },
     "tags": {
       "brand": "Coral Travel",
       "brand:wikidata": "Q58011479",
@@ -12,6 +15,9 @@
   "shop/travel_agency|D-reizen": {
     "count": 85,
     "countryCodes": ["nl"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FD-reizen%20logo.jpg&width=100"
+    },
     "tags": {
       "brand": "D-reizen",
       "brand:wikidata": "Q2445498",
@@ -64,6 +70,9 @@
   "shop/travel_agency|Havas Voyages": {
     "count": 57,
     "countryCodes": ["fr"],
+    "logos": {
+      "facebook": "https://graph.facebook.com/havas.voyages/picture?type=square"
+    },
     "tags": {
       "brand": "Havas Voyages",
       "brand:wikidata": "Q57628091",
@@ -109,6 +118,10 @@
   },
   "shop/travel_agency|Thomas Cook": {
     "count": 365,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FThomas%20Cook%20Group%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/916310260612239360/hX-k5rRE_bigger.jpg"
+    },
     "tags": {
       "brand": "Thomas Cook",
       "brand:wikidata": "Q2141800",
@@ -119,6 +132,10 @@
   },
   "shop/travel_agency|Thomson": {
     "count": 87,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTUI-Travel-Logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1050055186444681216/2uTIGX7F_bigger.jpg"
+    },
     "tags": {
       "brand": "Thomson",
       "brand:wikidata": "Q7795876",

--- a/brands/shop/tyres.json
+++ b/brands/shop/tyres.json
@@ -12,6 +12,9 @@
   },
   "shop/tyres|Bridgestone": {
     "count": 105,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBridgestone%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Bridgestone",
       "brand:wikidata": "Q179433",
@@ -56,6 +59,10 @@
   },
   "shop/tyres|Michelin": {
     "count": 66,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMichelin%20Wordmark.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1031457567963312128/I7Vnou9B_bigger.jpg"
+    },
     "tags": {
       "brand": "Michelin",
       "brand:wikidata": "Q151107",

--- a/brands/shop/variety_store.json
+++ b/brands/shop/variety_store.json
@@ -1,6 +1,10 @@
 {
   "shop/variety_store|99 Cents Only Stores": {
     "countryCodes": ["us"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2F99%20CENTS%20ONLY%20STORES%20LOGO.jpg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1032698085896404992/x224SLqh_bigger.jpg"
+    },
     "match": [
       "shop/convenience|99 Cents Only",
       "shop/convenience|99 Cents Only Stores",
@@ -20,6 +24,10 @@
   },
   "shop/variety_store|Action": {
     "count": 582,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FAction%20Logo.png&width=100",
+      "facebook": "https://graph.facebook.com/action.nederland/picture?type=square"
+    },
     "match": ["shop/supermarket|Action"],
     "tags": {
       "brand": "Action",
@@ -60,6 +68,10 @@
   },
   "shop/variety_store|Dollar General": {
     "count": 685,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FDollar%20General%20logo.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/459772606040641536/__566KGj_bigger.jpeg"
+    },
     "match": [
       "shop/convenience|Dollar General",
       "shop/department_store|Dollar General",
@@ -75,6 +87,9 @@
   },
   "shop/variety_store|Dollar Tree": {
     "count": 1323,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/509405558898561024/27hmihjq_bigger.png"
+    },
     "match": [
       "shop/convenience|Dollar Tree",
       "shop/department_store|Dollar Tree",
@@ -100,6 +115,9 @@
   },
   "shop/variety_store|Family Dollar": {
     "count": 1028,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/458699553458241536/evZeMwhE_bigger.jpeg"
+    },
     "match": [
       "shop/convenience|Family Dollar",
       "shop/department_store|Family Dollar",
@@ -115,6 +133,9 @@
   },
   "shop/variety_store|Five Below": {
     "count": 113,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FFive%20below%20logo.png&width=100"
+    },
     "tags": {
       "brand": "Five Below",
       "brand:wikidata": "Q5455836",
@@ -139,6 +160,9 @@
   },
   "shop/variety_store|GiFi": {
     "count": 285,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGifi%20logo%202012.png&width=100"
+    },
     "tags": {
       "brand": "GiFi",
       "brand:wikidata": "Q3105439",
@@ -149,6 +173,9 @@
   },
   "shop/variety_store|Home Bargains": {
     "count": 111,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1017147039434633217/vjWMjrOZ_bigger.jpg"
+    },
     "match": ["shop/supermarket|Home Bargains"],
     "tags": {
       "brand": "Home Bargains",
@@ -160,6 +187,9 @@
   },
   "shop/variety_store|Mäc-Geiz": {
     "count": 87,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMac-Geiz.svg&width=100"
+    },
     "tags": {
       "brand": "Mäc-Geiz",
       "brand:wikidata": "Q1957126",
@@ -170,6 +200,9 @@
   },
   "shop/variety_store|NOZ": {
     "count": 131,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20Noz.svg&width=100"
+    },
     "tags": {
       "brand": "NOZ",
       "brand:wikidata": "Q3345688",
@@ -180,6 +213,9 @@
   },
   "shop/variety_store|Poundland": {
     "count": 281,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/933016190104096769/24M4_8NQ_bigger.jpg"
+    },
     "tags": {
       "brand": "Poundland",
       "brand:wikidata": "Q1434528",
@@ -190,6 +226,9 @@
   },
   "shop/variety_store|Poundstretcher": {
     "count": 73,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/948143325160329216/rGVPFlFZ_bigger.jpg"
+    },
     "tags": {
       "brand": "Poundstretcher",
       "brand:wikidata": "Q7235675",
@@ -218,6 +257,9 @@
       "si",
       "sk"
     ],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTEDi-Logo.svg&width=100"
+    },
     "match": ["shop/variety_store|Tedi"],
     "tags": {
       "brand": "TEDi",
@@ -239,6 +281,9 @@
   },
   "shop/variety_store|Wilko": {
     "count": 80,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1018756618635431936/9rRo7jvO_bigger.jpg"
+    },
     "tags": {
       "brand": "Wilko",
       "brand:wikidata": "Q8002536",
@@ -265,6 +310,9 @@
   "shop/variety_store|セリア": {
     "count": 143,
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSeria%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "セリア",
       "brand:en": "Seria",
@@ -280,6 +328,9 @@
   "shop/variety_store|ダイソー": {
     "count": 463,
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1102749621086875648/YGTdOo9__bigger.png"
+    },
     "match": ["shop/variety_store|ザ・ダイソー"],
     "tags": {
       "brand": "ダイソー",
@@ -295,6 +346,9 @@
   },
   "shop/variety_store|ドン・キホーテ": {
     "countryCodes": ["jp"],
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1098907826305421312/KCKaI33I_bigger.png"
+    },
     "match": [
       "shop/supermarket|ドン キホーテ",
       "shop/supermarket|ドン・キホーテ",

--- a/brands/shop/video.json
+++ b/brands/shop/video.json
@@ -1,6 +1,9 @@
 {
   "shop/video|Blockbuster": {
     "count": 59,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBlockbuster%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Blockbuster",
       "brand:wikidata": "Q884711",
@@ -21,6 +24,9 @@
   },
   "shop/video|TSUTAYA": {
     "count": 165,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCulture%20Convenience%20Club%20(CCC)%20logo.svg&width=100"
+    },
     "nomatch": [
       "shop/books|TSUTAYA",
       "shop/music|TSUTAYA"

--- a/brands/shop/video_games.json
+++ b/brands/shop/video_games.json
@@ -1,6 +1,9 @@
 {
   "shop/video_games|EB Games": {
     "count": 127,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20EB%20Games.png&width=100"
+    },
     "tags": {
       "brand": "EB Games",
       "brand:wikidata": "Q4993686",
@@ -11,6 +14,10 @@
   },
   "shop/video_games|GameStop": {
     "count": 928,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FGameStop.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/1034554730691743744/rei9Hx_U_bigger.jpg"
+    },
     "match": [
       "shop/video_games|Game Stop",
       "shop/video_games|Gamestop"

--- a/brands/shop/watches.json
+++ b/brands/shop/watches.json
@@ -1,6 +1,11 @@
 {
   "shop/watches|Swatch": {
     "count": 81,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSwatch%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/swatch/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1211853364/swatch_logo_bigger.jpg"
+    },
     "tags": {
       "brand": "Swatch",
       "brand:wikidata": "Q573422",

--- a/brands/shop/wholesale.json
+++ b/brands/shop/wholesale.json
@@ -1,5 +1,8 @@
 {
   "shop/wholesale|BJ's Wholesale Club": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBJs%20Wholesale%20Club%20Logo.svg&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "BJ's Wholesale Club",
@@ -12,6 +15,10 @@
   },
   "shop/wholesale|Costco": {
     "count": 312,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCostco%20Wholesale%20logo%202010-10-26.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/654811081630584832/tBIHLgT1_bigger.jpg"
+    },
     "match": [
       "shop/department_store|Costco",
       "shop/department_store|Costco Wholesale",
@@ -32,6 +39,9 @@
     }
   },
   "shop/wholesale|Makro": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMakro%20logo.svg&width=100"
+    },
     "match": ["shop/supermarket|Makro"],
     "nocount": true,
     "tags": {
@@ -43,6 +53,9 @@
     }
   },
   "shop/wholesale|Metro": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMetroC%2BC-Logo.svg&width=100"
+    },
     "match": ["shop/supermarket|Metro"],
     "nocount": true,
     "nomatch": [
@@ -59,6 +72,10 @@
   },
   "shop/wholesale|Sam's Club": {
     "count": 66,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FSams%20Club.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/378800000538177464/45249044ab8659e5c9079129bba5233b_bigger.jpeg"
+    },
     "match": [
       "shop/department_store|Sam's Club",
       "shop/supermarket|Sam's Club"
@@ -77,6 +94,10 @@
   },
   "shop/wholesale|コストコ": {
     "countryCodes": ["jp"],
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCostco%20Wholesale%20logo%202010-10-26.svg&width=100",
+      "twitter": "https://pbs.twimg.com/profile_images/654811081630584832/tBIHLgT1_bigger.jpg"
+    },
     "match": [
       "shop/department_store|コストコ",
       "shop/supermarket|コストコ"

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -1,6 +1,9 @@
 {
   "tourism/hotel|B&B Hôtel": {
     "count": 115,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20B%26B%20Hotels.png&width=100"
+    },
     "match": ["tourism/hotel|B&b Hôtel"],
     "tags": {
       "brand": "B&B Hôtel",
@@ -12,6 +15,9 @@
   },
   "tourism/hotel|Best Western": {
     "count": 313,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBW%20Master%20Brand%20Logo%20RGB%20300%20DPI.jpg&width=100"
+    },
     "match": ["tourism/motel|Best Western"],
     "nomatch": [
       "tourism/hotel|Best Western Plus"
@@ -26,6 +32,9 @@
   },
   "tourism/hotel|Best Western Plus": {
     "count": 63,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FBW%20Master%20Brand%20Logo%20RGB%20300%20DPI.jpg&width=100"
+    },
     "nomatch": ["tourism/hotel|Best Western"],
     "tags": {
       "brand": "Best Western",
@@ -58,6 +67,9 @@
   },
   "tourism/hotel|Comfort Inn": {
     "count": 339,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChoicehotels%20logo15.png&width=100"
+    },
     "match": ["tourism/motel|Comfort Inn"],
     "nomatch": ["tourism/hotel|Comfort Suites"],
     "tags": {
@@ -70,6 +82,9 @@
   },
   "tourism/hotel|Comfort Inn & Suites": {
     "count": 94,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChoicehotels%20logo15.png&width=100"
+    },
     "tags": {
       "brand": "Comfort Inn & Suites",
       "brand:wikidata": "Q1075788",
@@ -80,6 +95,9 @@
   },
   "tourism/hotel|Comfort Suites": {
     "count": 174,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChoicehotels%20logo15.png&width=100"
+    },
     "nomatch": ["tourism/hotel|Comfort Inn"],
     "tags": {
       "brand": "Comfort Suites",
@@ -112,6 +130,9 @@
   },
   "tourism/hotel|Crowne Plaza": {
     "count": 86,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FCrowne%20Plaza%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Crowne Plaza",
       "brand:wikidata": "Q2746220",
@@ -136,6 +157,9 @@
   },
   "tourism/hotel|Embassy Suites": {
     "count": 83,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/1100115322592550914/7d8AToeH_bigger.png"
+    },
     "tags": {
       "brand": "Embassy Suites",
       "brand:wikidata": "Q5369524",
@@ -169,6 +193,9 @@
   },
   "tourism/hotel|Formule 1": {
     "count": 71,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHotel%20F1%20Logo%202007.png&width=100"
+    },
     "tags": {
       "brand": "Formule 1",
       "brand:wikidata": "Q1630895",
@@ -178,6 +205,9 @@
     }
   },
   "tourism/hotel|Grand Hyatt": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHyatt%20Logo.png&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Grand Hyatt",
@@ -203,6 +233,9 @@
   },
   "tourism/hotel|Hilton": {
     "count": 56,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHI%20mk%20logo%20hiltonbrandlogo.jpg&width=100"
+    },
     "tags": {
       "brand": "Hilton",
       "brand:wikidata": "Q598884",
@@ -223,6 +256,9 @@
   },
   "tourism/hotel|Holiday Inn": {
     "count": 446,
+    "logos": {
+      "twitter": "https://pbs.twimg.com/profile_images/926089732181782528/P85q5zmy_bigger.jpg"
+    },
     "nomatch": [
       "tourism/hotel|Holiday Inn Express"
     ],
@@ -236,6 +272,10 @@
   },
   "tourism/hotel|Holiday Inn Express": {
     "count": 573,
+    "logos": {
+      "facebook": "https://graph.facebook.com/holidayinnexpress/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/877546729587048448/4Ce2CMr1_bigger.jpg"
+    },
     "nomatch": ["tourism/hotel|Holiday Inn"],
     "tags": {
       "brand": "Holiday Inn Express",
@@ -247,6 +287,10 @@
   },
   "tourism/hotel|Holiday Inn Express & Suites": {
     "count": 150,
+    "logos": {
+      "facebook": "https://graph.facebook.com/holidayinnexpress/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/877546729587048448/4Ce2CMr1_bigger.jpg"
+    },
     "tags": {
       "brand": "Holiday Inn Express & Suites",
       "brand:wikidata": "Q5880423",
@@ -266,6 +310,9 @@
     }
   },
   "tourism/hotel|Hyatt": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHyatt%20Logo.png&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Hyatt",
@@ -277,6 +324,9 @@
     }
   },
   "tourism/hotel|Hyatt Centric": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHyatt%20Logo.png&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Hyatt Centric",
@@ -288,6 +338,9 @@
     }
   },
   "tourism/hotel|Hyatt House": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHyatt%20Logo.png&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Hyatt House",
@@ -300,6 +353,9 @@
   },
   "tourism/hotel|Hyatt Place": {
     "count": 56,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHyatt%20Logo.png&width=100"
+    },
     "tags": {
       "brand": "Hyatt",
       "brand:wikidata": "Q1425063",
@@ -309,6 +365,9 @@
     }
   },
   "tourism/hotel|Hyatt Regency": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHyatt%20Logo.png&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Hyatt Regency",
@@ -321,6 +380,9 @@
   },
   "tourism/hotel|Ibis": {
     "count": 226,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FIbis%20Hotel%20Logo%202016.png&width=100"
+    },
     "match": [
       "tourism/hotel|Hotel Ibis",
       "tourism/hotel|Hôtel Ibis",
@@ -384,6 +446,10 @@
   },
   "tourism/hotel|Marriott": {
     "count": 71,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMarriott%20Logo.svg&width=100",
+      "facebook": "https://graph.facebook.com/marriottinternational/picture?type=square"
+    },
     "tags": {
       "brand": "Marriott",
       "brand:wikidata": "Q1141173",
@@ -394,6 +460,10 @@
   },
   "tourism/hotel|Mercure": {
     "count": 119,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMercure%20Hotels%20Logo%202013.svg&width=100",
+      "facebook": "https://graph.facebook.com/MercureHotels/picture?type=square"
+    },
     "tags": {
       "brand": "Mercure",
       "brand:wikidata": "Q1709809",
@@ -404,6 +474,9 @@
   },
   "tourism/hotel|Novotel": {
     "count": 174,
+    "logos": {
+      "facebook": "https://graph.facebook.com/Novotelhotels/picture?type=square"
+    },
     "tags": {
       "brand": "Novotel",
       "brand:wikidata": "Q420545",
@@ -413,6 +486,9 @@
     }
   },
   "tourism/hotel|Park Hyatt": {
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHyatt%20Logo.png&width=100"
+    },
     "nocount": true,
     "tags": {
       "brand": "Park Hyatt",
@@ -425,6 +501,10 @@
   },
   "tourism/hotel|Premier Inn": {
     "count": 424,
+    "logos": {
+      "facebook": "https://graph.facebook.com/premierinn/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1016272684890689536/H6wgWWkn_bigger.jpg"
+    },
     "tags": {
       "brand": "Premier Inn",
       "brand:wikidata": "Q2108626",
@@ -445,6 +525,9 @@
   },
   "tourism/hotel|Quality Inn": {
     "count": 253,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChoicehotels%20logo15.png&width=100"
+    },
     "match": ["tourism/motel|Quality Inn"],
     "tags": {
       "brand": "Quality Inn",
@@ -456,6 +539,9 @@
   },
   "tourism/hotel|Quality Inn & Suites": {
     "count": 108,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChoicehotels%20logo15.png&width=100"
+    },
     "tags": {
       "brand": "Quality Inn & Suites",
       "brand:wikidata": "Q1075788",
@@ -466,6 +552,9 @@
   },
   "tourism/hotel|Ramada": {
     "count": 116,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRamada%20Worldwide%20logo.svg&width=100"
+    },
     "tags": {
       "brand": "Ramada",
       "brand:wikidata": "Q1502859",
@@ -479,6 +568,9 @@
   },
   "tourism/hotel|Red Roof Inn": {
     "count": 67,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FRed%20Roof%20Inn%20logo.svg&width=100"
+    },
     "match": ["tourism/motel|Red Roof Inn"],
     "tags": {
       "brand": "Red Roof Inn",
@@ -513,6 +605,10 @@
   },
   "tourism/hotel|Sheraton": {
     "count": 63,
+    "logos": {
+      "facebook": "https://graph.facebook.com/sheratonhotels/picture?type=square",
+      "twitter": "https://pbs.twimg.com/profile_images/1002217498857521153/KwmEKPGZ_bigger.jpg"
+    },
     "tags": {
       "brand": "Sheraton",
       "brand:wikidata": "Q634831",
@@ -523,6 +619,9 @@
   },
   "tourism/hotel|Sleep Inn": {
     "count": 94,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FChoicehotels%20logo15.png&width=100"
+    },
     "tags": {
       "brand": "Sleep Inn",
       "brand:wikidata": "Q1075788",
@@ -543,6 +642,9 @@
   },
   "tourism/hotel|Travelodge": {
     "count": 316,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FTravelodge.svg&width=100"
+    },
     "match": ["tourism/motel|Travelodge"],
     "tags": {
       "brand": "Travelodge",

--- a/brands/tourism/motel.json
+++ b/brands/tourism/motel.json
@@ -12,6 +12,9 @@
   },
   "tourism/motel|Motel 6": {
     "count": 297,
+    "logos": {
+      "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FMotel-6-logo.svg&width=100"
+    },
     "match": ["tourism/hotel|Motel 6"],
     "tags": {
       "brand": "Motel 6",

--- a/fetch_logos.js
+++ b/fetch_logos.js
@@ -1,0 +1,167 @@
+const colors = require('colors/safe');
+const fetch = require('node-fetch');
+const fileTree = require('./lib/file_tree');
+const wdk = require('wikidata-sdk');
+
+// If you want to fetch Twitter logos, sign up for
+// API credentials at https://apps.twitter.com/
+// and put them into `config/secrets.json`
+let twitterAPI;
+try {
+    // `config/secrets.json` should contain:
+    // {
+    //   "twitter_consumer_key": "",
+    //   "twitter_consumer_secret": "",
+    //   "twitter_access_token_key": "",
+    //   "twitter_access_token_secret": ""
+    // }
+    const Twitter = require('twitter');
+    const secrets = require('./config/secrets.json');
+    twitterAPI = new Twitter({
+        consumer_key: secrets.twitter_consumer_key,
+        consumer_secret: secrets.twitter_consumer_secret,
+        access_token_key: secrets.twitter_access_token_key,
+        access_token_secret: secrets.twitter_access_token_secret
+    });
+} catch(err) { /* ignore */ }
+
+
+// what to fetch
+let _brands = fileTree.read('brands');
+let _toFetch = gatherQIDs(_brands);
+let _qids = Object.keys(_toFetch);
+let _total = _qids.length;
+if (!_total) {
+    console.log('Nothing to fetch');
+    process.exit();
+}
+
+// split into several wikidata requests
+let _urls = wdk.getManyEntities({
+    ids: _qids, languages: ['en'], props: ['info', 'claims'], format: 'json'
+});
+
+let _logos = {};
+doFetch(0);
+
+
+function gatherQIDs(brands) {
+    let toFetch = {};
+    Object.keys(brands).forEach(k => {
+        const qid = brands[k].tags['brand:wikidata'];
+        if (qid && /^Q\d+$/.test(qid)) {
+            toFetch[qid] = toFetch[qid] || [];
+            toFetch[qid].push(k);
+        }
+    });
+
+    return toFetch;
+}
+
+
+function doFetch(index) {
+    if (index >= _urls.length) {
+        return finish();
+    }
+
+    let currURL = _urls[index];
+
+    console.log(colors.yellow.bold(`batch ${index+1}/${_urls.length}`));
+
+    fetch(currURL)
+        .then(response => response.json())
+        .then(processEntities)
+        .catch(e => console.error(colors.red(e)))
+        .then(delay(500))
+        .then(() => { doFetch(++index); });
+}
+
+
+function processEntities(result) {
+    let queue = [];
+
+    Object.keys(result.entities).forEach(qid => {
+        let entity = result.entities[qid];
+        if (!entity.claims) return;
+
+        let claim, value;
+
+        // P154 - Commons Logo  (often not square)
+        if (entity.claims.P154) {
+            claim = entity.claims.P154[0];
+            value = claim.mainsnak.datavalue.value;
+            if (value) {
+                _logos[qid] = _logos[qid] || {};
+                _logos[qid].wikidata = 'https://commons.wikimedia.org/w/index.php?' +
+                    utilQsString({ title: `Special:Redirect/file/${value}`, width: 100 });
+            }
+        }
+
+        // P2002 - Twitter username
+        if (entity.claims.P2002) {
+            // https://developer.twitter.com/en/docs/accounts-and-users/user-profile-images-and-banners.html
+            // https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-show
+            // rate limit: 900calls / 15min
+            claim = entity.claims.P2002[0];
+            value = claim.mainsnak.datavalue.value;
+            if (value && twitterAPI) {
+                _logos[qid] = _logos[qid] || {};
+                queue.push(
+                    twitterAPI.get('users/show', { screen_name: value })
+                        .then(user => {
+                            _logos[qid].twitter = user.profile_image_url_https.replace('_normal', '_bigger');
+                        })
+                        .catch(e => {
+                            console.error(colors.red(`Error: Twitter username @${value} for ${qid}: ` + JSON.stringify(e)))
+                        })
+                        .then(delay(500))
+                );
+            }
+        }
+
+        // P2013 - Facebook ID
+        // P2003 - Instagram ID
+        if (entity.claims.P2013 || entity.claims.P2003) {
+            // https://developers.facebook.com/docs/graph-api/reference/user/picture/
+            claim = (entity.claims.P2013 || entity.claims.P2003)[0];
+            value = claim.mainsnak.datavalue.value;
+            if (value) {
+                _logos[qid] = _logos[qid] || {};
+                _logos[qid].facebook = `https://graph.facebook.com/${value}/picture?type=square`;
+            }
+        }
+
+        // others we may want to add someday
+        // P2397 - YouTube ID
+        // P2677 - LinkedIn ID
+        // P3267 - Flickr ID
+        // P3836 - Pintrest ID
+    });
+
+    return Promise.all(queue);
+}
+
+
+function finish() {
+    // merge in the latest logos that were collected..
+    Object.keys(_logos).forEach(qid => {
+        _toFetch[qid].forEach(k => {
+            _brands[k].logos = Object.assign((_brands[k].logos || {}), _logos[qid]);
+        });
+    });
+
+    fileTree.write('brands', _brands);  // save updates
+}
+
+
+function delay(msec) {
+    return new Promise((resolve) => setTimeout(resolve, msec));
+}
+
+
+function utilQsString(obj) {
+    return Object.keys(obj).sort().map(function(key) {
+        return encodeURIComponent(key) + '=' + encodeURIComponent(obj[key]);
+    }).join('&');
+}
+

--- a/lib/file_tree.js
+++ b/lib/file_tree.js
@@ -40,6 +40,7 @@ exports.write = (tree, obj) => {
     console.time(colors.green(tree + ' updated'));
     let dict = {};
 
+
     // populate K-V dictionary
     Object.keys(obj).forEach(k => {
         let parts = k.split('|', 2);
@@ -49,7 +50,7 @@ exports.write = (tree, obj) => {
 
         dict[key] = dict[key] || {};
         dict[key][value] = dict[key][value] || {};
-        dict[key][value][k] = obj[k];
+        dict[key][value][k] = sort(obj[k]);
 
         if (dict[key][value][k].tags) {
             dict[key][value][k].tags = sort(obj[k].tags);

--- a/match_wikiTags.js
+++ b/match_wikiTags.js
@@ -2,7 +2,6 @@ const clearConsole = require('clear');
 const colors = require('colors/safe');
 const fetch = require('node-fetch');
 const fileTree = require('./lib/file_tree');
-const sort = require('./lib/sort');
 const stemmer = require('./lib/stemmer');
 const wdk = require('wikidata-sdk');
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "dist": "node build_nameSuggestions.js && rollup -c",
     "build": "node build_filterNames",
+    "logos": "node fetch_logos",
     "wikimatch": "node match_wikiTags",
     "test": "node validate"
   },
@@ -38,6 +39,7 @@
   },
   "optionalDependencies": {
     "osmium": "^0.5.7",
+    "twitter": "^1.7.1",
     "wikidata-sdk": "^5.15.0"
   },
   "engines": {

--- a/schema/entries.json
+++ b/schema/entries.json
@@ -24,6 +24,10 @@
                         "pattern": "^[a-z]{2}$"
                     }
                 },
+                "logos": {
+                    "description": "(generated) Logos fetched from Wikidata or brand social media pages.",
+                    "type": "object"
+                },
                 "match": {
                     "description": "(optional) Array of alternate keys that are the same as this entry.",
                     "type": "array",
@@ -53,6 +57,7 @@
                     "properties": {
                         "count":        { "not" : {} },
                         "countryCodes": { "not" : {} },
+                        "logos":        { "not" : {} },
                         "match":        { "not" : {} },
                         "nomatch":      { "not" : {} },
                         "nocount":      { "not" : {} },


### PR DESCRIPTION
This PR adds the ability to fetch logos for all the Wikidata-tagged brands..
see #2116 

- `npm run logos` to run it
- stores api secrets in `config/secrets.json` (this file is .gitignore'd)
- uses `brand:wikidata` tag to lookup the following properties from Wikidata:
  - _P154 - Brand logo from wikicommons._  This works, but unfortunately the logos are often not square enough to make them suitable for what I want.  But we can fetch them anyway.
  - _P2002 - Twitter username_  -> then we use the Twitter API to fetch a square logo for that brand
  - _P2003 - Facebook username_ -> construct Facebook Graph API url to fetch square logo
  - _P2013 - Instagram username,_ -> (It's actually same Graph API as Facebook now, so we just save it as `facebook`)
- The fetched logos are stored in a `"logos": {}` object on each brand entry.

This is kind of great too because: the way to add more logos is to just update Wikidata with the brand social media account, and run the script again. We are making Wikidata better!

I'd really like to merge this and make the logos available in iD, so that the users see them as they are assigning a brand preset.

Would love to hear people's thoughts!