### PR TITLE
Add Jared and fix Kay

### DIFF
--- a/brands/shop/jewelry.json
+++ b/brands/shop/jewelry.json
@@ -127,9 +127,13 @@
   },
   "shop/jewelry|Jared": {
     "count": 53,
+    "countryCodes": ["us"],
     "tags": {
       "brand": "Jared",
+      "brand:wikidata": "Q62029282",
       "name": "Jared",
+      "operator": "Sterling Jewelers",
+      "operator:wikidata": "Q7611434",
       "shop": "jewelry"
     }
   },
@@ -146,9 +150,10 @@
     "countryCodes": ["us"],
     "tags": {
       "brand": "Kay Jewelers",
-      "brand:wikidata": "Q7611434",
-      "brand:wikipedia": "en:Sterling Jewelers",
+      "brand:wikidata": "Q62029290",
       "name": "Kay Jewelers",
+      "operator": "Sterling Jewelers",
+      "operator:wikidata": "Q7611434",
       "shop": "jewelry"
     }
   },


### PR DESCRIPTION
Kay and Jared are both brands run by Sterling. I created brand wikidata pages for those and moved Sterling over to the operator since they run these and independent brands that give the illusion of false choice.

Signed-off-by: Tim Smith <tsmith@chef.io>