### PR TITLE
Add Buca di Beppo Italian restaurant

### DIFF
--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -171,6 +171,18 @@
       "name": "Boston Pizza"
     }
   },
+  "amenity/restaurant|Buca di Beppo": {
+    "countryCodes": ["us"],
+    "nocount": true,
+    "tags": {
+      "amenity": "restaurant",
+      "brand": "Buca di Beppo",
+      "brand:wikidata": "Q4982340",
+      "brand:wikipedia": "en:Buca di Beppo",
+      "cuisine": "italian",
+      "name": "Buca di Beppo"
+    }
+  },
   "amenity/restaurant|Buffalo Grill": {
     "count": 312,
     "logos": {


### PR DESCRIPTION
Italian chain restaurant in the US.  Wikipedia says there's 92 locations in the US.

Signed-off-by: Tim Smith <tsmith@chef.io>