### PR TITLE
Fold CVS / Rite Aid and Walgreens all into Pharamacy

### DIFF
--- a/brands/amenity/pharmacy.json
+++ b/brands/amenity/pharmacy.json
@@ -153,9 +153,9 @@
       "amenity/pharmacy|CVS Pharmacy",
       "amenity/pharmacy|CVS/Pharmacy",
       "amenity/pharmacy|CVS/pharmacy",
+      "shop/chemist|CVS",
       "shop/convenience|CVS"
     ],
-    "nomatch": ["shop/chemist|CVS"],
     "tags": {
       "amenity": "pharmacy",
       "brand": "CVS",
@@ -971,9 +971,10 @@
     },
     "match": [
       "amenity/pharmacy|Rite Aid Pharmacy",
-      "amenity/pharmacy|Rite-Aid"
+      "amenity/pharmacy|Rite-Aid",
+      "shop/chemist|Rite Aid",
+      "shop/convenience|Rite Aid"
     ],
-    "nomatch": ["shop/chemist|Rite Aid"],
     "tags": {
       "amenity": "pharmacy",
       "brand": "Rite Aid",
@@ -1143,9 +1144,9 @@
     "match": [
       "amenity/pharmacy|Walgreen's",
       "amenity/pharmacy|Walgreens Pharmacy",
+      "shop/chemist|Walgreens",
       "shop/convenience|Walgreens"
     ],
-    "nomatch": ["shop/chemist|Walgreens"],
     "tags": {
       "amenity": "pharmacy",
       "brand": "Walgreens",

--- a/brands/shop/chemist.json
+++ b/brands/shop/chemist.json
@@ -58,15 +58,6 @@
       "shop": "chemist"
     }
   },
-  "shop/chemist|CVS": {
-    "count": 131,
-    "nomatch": ["amenity/pharmacy|CVS"],
-    "tags": {
-      "brand": "CVS",
-      "name": "CVS",
-      "shop": "chemist"
-    }
-  },
   "shop/chemist|Drogeria Natura": {
     "count": 66,
     "countryCodes": ["pl"],
@@ -139,15 +130,6 @@
       "shop": "chemist"
     }
   },
-  "shop/chemist|Rite Aid": {
-    "count": 76,
-    "nomatch": ["amenity/pharmacy|Rite Aid"],
-    "tags": {
-      "brand": "Rite Aid",
-      "name": "Rite Aid",
-      "shop": "chemist"
-    }
-  },
   "shop/chemist|Rossmann": {
     "count": 2956,
     "logos": {
@@ -201,16 +183,6 @@
       "brand:wikidata": "Q2551576",
       "brand:wikipedia": "nl:Trekpleister (drogisterij)",
       "name": "Trekpleister",
-      "shop": "chemist"
-    }
-  },
-  "shop/chemist|Walgreens": {
-    "count": 213,
-    "nomatch": ["amenity/pharmacy|Walgreens"],
-    "tags": {
-      "brand": "Walgreens",
-      "brand:wikipedia": "en:Walgreens",
-      "name": "Walgreens",
       "shop": "chemist"
     }
   },

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -1182,14 +1182,6 @@
       "shop": "convenience"
     }
   },
-  "shop/convenience|Rite Aid": {
-    "count": 83,
-    "tags": {
-      "brand": "Rite Aid",
-      "name": "Rite Aid",
-      "shop": "convenience"
-    }
-  },
   "shop/convenience|Royal Farms": {
     "count": 115,
     "nomatch": ["amenity/fuel|Royal Farms"],


### PR DESCRIPTION
This might be a bit controversial, but I'm fairly certain this is the right change and we never had wikidata on these old entries so they were never in the dist file.

These stores are all locations where you can buy random toiletries as well as prescription drugs as they run a full drug counter. In a lot of places like Target they're just the pharmacy counter without any of the convenience store like items. Since these stores dispense prescription drugs they can't be a chemist per the OSM wiki entry for chemist:

"A shop typically selling a similar range of articles to a dispensing [W] community pharmacy: [W] over-the-counter drugs, personal hygiene (toothpastes, shampoos, soaps etc.), cosmetics (usually cheaper ones), and household cleaning products. The exact product mix will vary from country to country. "

Signed-off-by: Tim Smith <tsmith@chef.io>