### PR TITLE
Add official_names for restaurants and fix Popeyes

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -155,7 +155,8 @@
       "brand:wikidata": "Q891163",
       "brand:wikipedia": "en:Bojangles' Famous Chicken 'n Biscuits",
       "cuisine": "chicken",
-      "name": "Bojangles'"
+      "name": "Bojangles'",
+      "official_name": "Bojangles' Famous Chicken 'n Biscuits"
     }
   },
   "amenity/fast_food|Booster Juice": {
@@ -359,7 +360,8 @@
       "brand:wikidata": "Q465751",
       "brand:wikipedia": "en:Chipotle Mexican Grill",
       "cuisine": "mexican",
-      "name": "Chipotle"
+      "name": "Chipotle",
+      "official_name": "Chipotle Mexican Grill"
     }
   },
   "amenity/fast_food|Chowking": {
@@ -673,7 +675,8 @@
       "brand:wikidata": "Q1131810",
       "brand:wikipedia": "en:Five Guys",
       "cuisine": "burger",
-      "name": "Five Guys"
+      "name": "Five Guys",
+      "official_name": "Five Guys Burgers and Fries"
     }
   },
   "amenity/fast_food|Freddy's": {
@@ -1271,7 +1274,8 @@
       "brand:wikidata": "Q7132349",
       "brand:wikipedia": "en:Papa Murphy's",
       "cuisine": "pizza",
-      "name": "Papa Murphy's"
+      "name": "Papa Murphy's",
+      "official_name": "Papa Murphy's Take 'N' Bake Pizza"
     }
   },
   "amenity/fast_food|Philly Pretzel Factory": {
@@ -1424,22 +1428,23 @@
       "name": "Pollo Tropical"
     }
   },
-  "amenity/fast_food|Popeye's": {
+  "amenity/fast_food|Popeyes": {
     "count": 511,
     "logos": {
       "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20Popeyes%20Chicken%20and%20Biscuits.png&width=100"
     },
     "match": [
-      "amenity/fast_food|Popeyes",
+      "amenity/fast_food|Popeye's",
       "amenity/fast_food|Popeyes Louisiana Kitchen"
     ],
     "tags": {
       "amenity": "fast_food",
-      "brand": "Popeye's",
+      "brand": "Popeyes",
       "brand:wikidata": "Q1330910",
       "brand:wikipedia": "en:Popeyes",
       "cuisine": "chicken",
-      "name": "Popeye's"
+      "name": "Popeyes",
+      "official_name": "Popeyes Louisiana Kitchen"
     }
   },
   "amenity/fast_food|Potbelly": {
@@ -1491,7 +1496,8 @@
       "brand:wikidata": "Q1363885",
       "brand:wikipedia": "en:Qdoba",
       "cuisine": "mexican",
-      "name": "Qdoba"
+      "name": "Qdoba",
+      "official_name": "Qdoba Mexican Grill"
     }
   },
   "amenity/fast_food|Quick": {

--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -1429,7 +1429,7 @@
     }
   },
   "amenity/fast_food|Popeyes": {
-    "count": 511,
+    "count": 194,
     "logos": {
       "wikidata": "https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FLogo%20of%20Popeyes%20Chicken%20and%20Biscuits.png&width=100"
     },

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -94,7 +94,8 @@
       "brand:wikidata": "Q4386779",
       "brand:wikipedia": "en:Big Boy Restaurants",
       "cuisine": "burger",
-      "name": "Big Boy"
+      "name": "Big Boy",
+      "official_name": "Big Boy Restaurant & Bakery"
     }
   },
   "amenity/restaurant|Black Bear Diner": {
@@ -420,7 +421,8 @@
       "brand:wikipedia": "en:Cracker Barrel",
       "cuisine": "american",
       "name": "Cracker Barrel",
-      "shop": "gift"
+      "shop": "gift",
+      "official_name": "Cracker Barrel Old Country Store"
     }
   },
   "amenity/restaurant|Denny's": {
@@ -1202,7 +1204,8 @@
       "brand:wikidata": "Q7169056",
       "brand:wikipedia": "en:Perkins Restaurant and Bakery",
       "cuisine": "american",
-      "name": "Perkins"
+      "name": "Perkins",
+      "official_name": "Perkins Restaurant and Bakery"
     }
   },
   "amenity/restaurant|Pieology Pizzeria": {
@@ -1342,7 +1345,8 @@
       "brand:wikidata": "Q7304886",
       "brand:wikipedia": "en:Red Robin",
       "cuisine": "burger",
-      "name": "Red Robin"
+      "name": "Red Robin",
+      "official_name": "Red Robin Gourmet Burgers and Brews"
     }
   },
   "amenity/restaurant|Restaurant Universitaire": {


### PR DESCRIPTION
I added the full names for various american fast food and restaurant chains to aid in searches. These are based off of their official websites and wikipedia pages.

I also corrected the name of Popeyes. It's not Popeye's despite how people often spell it. Check the website: https://popeyes.com/

Signed-off-by: Tim Smith <tsmith@chef.io>