### PR TITLE
Add Sleep Country

### DIFF
--- a/brands/shop/bed.json
+++ b/brands/shop/bed.json
@@ -49,6 +49,17 @@
       "shop": "bed"
     }
   },
+  "shop/bed|Sleep Country": {
+    "countryCodes": ["ca"],
+    "nocount": true,
+    "tags": {
+      "brand": "Sleep Country",
+      "brand:wikidata": "Q7539684",
+      "brand:wikipedia": "en:Sleep Country Canada",
+      "name": "Sleep Country",
+      "shop": "bed"
+    }
+  },
   "shop/bed|Sleep Number": {
     "count": 59,
     "countryCodes": ["us"],


### PR DESCRIPTION
It's listed as Sleep Country Canada only because there was once a Sleep Country USA in the pacific northwest that was acquired by sleep train that was acquired by MattressFirm. I've learned way too much about the mattress industry tonight.

Signed-off-by: Tim Smith <tsmith@chef.io>