### PR TITLE
Add wiki data to BoConcept A/S

### DIFF
--- a/brands/shop/furniture.json
+++ b/brands/shop/furniture.json
@@ -46,6 +46,7 @@
     "count": 52,
     "tags": {
       "brand": "BoConcept",
+      "brand:wikidata": "Q11338915",
       "name": "BoConcept",
       "shop": "furniture"
     }


### PR DESCRIPTION
I also added to social media profiles to https://www.wikidata.org/wiki/Q11338915

I did not add the wikipedia page, since it seems to to be well written https://en.wikipedia.org/wiki/BoConcept "This article contains content that is written like an advertisement."