### PR TITLE
Vending machines in Germany: Add details

### DIFF
--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -31,15 +31,18 @@
       "twitter": "https://pbs.twimg.com/profile_images/984800628554772480/s3UfUUfO_bigger.jpg"
     },
     "match": [
+      "amenity/post_box|Packstation",
       "amenity/vending_machine|Packstation"
     ],
     "tags": {
       "amenity": "vending_machine",
-      "brand": "DHL",
-      "brand:wikidata": "Q489815",
-      "brand:wikipedia": "en:DHL Express",
+      "brand": "Packstation",
+      "brand:wikidata": "Q1766703",
+      "brand:wikipedia": "en:Packstation",
       "name": "DHL Packstation",
       "operator": "DHL",
+      "operator:wikidata": "Q489815",
+      "operator:wikipedia": "en:DHL Express",
       "vending": "parcel_pickup;parcel_mail_in"
     }
   },
@@ -48,7 +51,8 @@
     "tags": {
       "amenity": "vending_machine",
       "brand": "Dog-Station",
-      "name": "Dog-Station"
+      "name": "Dog-Station",
+      "vending": "excrement_bags"
     }
   },
   "amenity/vending_machine|KKM": {
@@ -79,10 +83,17 @@
   },
   "amenity/vending_machine|Paketbox": {
     "count": 52,
+    "countryCodes": ["de"],
     "tags": {
       "amenity": "vending_machine",
       "brand": "Paketbox",
-      "name": "Paketbox"
+      "brand:wikidata": "Q2046604",
+      "brand:wikipedia": "de:Paketbox",
+      "name": "Paketbox",
+      "operator": "DHL",
+      "operator:wikidata": "Q489815",
+      "operator:wikipedia": "de:DHL",
+      "vending": "parcel_mail_in"
     }
   },
   "amenity/vending_machine|ParkPlus": {
@@ -115,7 +126,8 @@
       "brand": "Robidog",
       "brand:wikidata": "Q2159689",
       "brand:wikipedia": "de:Robidog",
-      "name": "Robidog"
+      "name": "Robidog",
+      "vending": "excrement_bags"
     }
   },
   "amenity/vending_machine|Tobaccoland": {
@@ -126,18 +138,21 @@
       "brand": "Tobaccoland",
       "brand:wikidata": "Q1439872",
       "brand:wikipedia": "de:Tobaccoland Automatengesellschaft",
-      "name": "Tobaccoland"
+      "name": "Tobaccoland",
+      "vending": "cigarettes"
     }
   },
   "amenity/vending_machine|VVO Fahrausweise": {
     "count": 128,
+    "countryCodes": ["de"],
     "tags": {
       "amenity": "vending_machine",
       "brand": "VVO Fahrausweise",
       "name": "VVO Fahrausweise",
       "operator": "Verkehrsverbund Oberelbe",
       "operator:wikidata": "Q1426445",
-      "operator:wikipedia": "en:Verkehrsverbund Oberelbe"
+      "operator:wikipedia": "en:Verkehrsverbund Oberelbe",
+      "vending": "public_transport_tickets"
     }
   },
   "amenity/vending_machine|Ключ здоровья": {


### PR DESCRIPTION
Packstation (self-service collection and dispatch of parcels): "Packstation" is the brand name of this kind of machine, while "DHL" is the brand of the operator.

"Paketbox" is a similar machine by the same operator under a different brand where you can only send parcels.

Add vending tags to some more entries.

Fixes #959