### PR TITLE
Add Unleased by Petco

### DIFF
--- a/brands/shop/pet.json
+++ b/brands/shop/pet.json
@@ -149,6 +149,20 @@
       "shop": "pet"
     }
   },
+  "shop/pet|Unleashed": {
+    "countryCodes": ["us"],
+    "nocount": true,
+    "tags": {
+      "alt_name": "Unleashed by Petco",
+      "brand": "Unleashed",
+      "brand:wikidata": "Q62122874",
+      "name": "Unleashed",
+      "operator": "Petco",
+      "operator:wikidata": "Q7171798",
+      "operator:wikipedia": "en:Petco",
+      "shop": "pet"
+    }
+  },
   "shop/pet|Бетховен": {
     "count": 65,
     "tags": {


### PR DESCRIPTION
These are popping up all over the place in the US and they're tagged super inconsistently. I gave it an alt_name for search since the signs use the "by Petco" bit and they have it in a lot of their branding, but not the point where I'd say it's an official_name.

Signed-off-by: Tim Smith <tsmith@chef.io>