### PR TITLE
Overpass link fix

### DIFF
--- a/build_docs.js
+++ b/build_docs.js
@@ -184,7 +184,7 @@ function overpassLink(k, v, name) {
 out body;
 >;
 out skel qt;`);
-    let href = `https://overpass-turbo.eu/?Q=${q}&R`;
+    let href = `https://overpass-turbo.eu/?Q=${q.replace(`&`, `%26`)}&R`;
     return `<a target="_blank" href="${href}"/>View on Overpass Turbo</a>`;
 }
 

--- a/build_docs.js
+++ b/build_docs.js
@@ -179,12 +179,12 @@ You can add the brand's Facebook, Instagram, or Twitter usernames, and this proj
 
 
 function overpassLink(k, v, name) {
-    let q = encodeURI(`[out:json][timeout:25];
+    let q = encodeURIComponent(`[out:json][timeout:25];
 (nwr["${k}"="${v}"]["name"="${name}"];);
 out body;
 >;
 out skel qt;`);
-    let href = `https://overpass-turbo.eu/?Q=${q.replace(`&`, `%26`)}&R`;
+    let href = `https://overpass-turbo.eu/?Q=${q}&R`;
     return `<a target="_blank" href="${href}"/>View on Overpass Turbo</a>`;
 }
 


### PR DESCRIPTION
This should fix issue #2503, there were 59 links with the problem as far as I could tell.
This will change all of the overpass links to a form with more of the characters escaped, I've tested several links and they all seem to work now.

Since this is the first time I've created and solved an issue on GitHub please let me know if I've done anything wrong.