### PR TITLE
Wikidata and Wikipedia tags for some supermarkets/convenience stores

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -177,6 +177,8 @@
     "count": 303,
     "tags": {
       "brand": "CBA",
+      "brand:wikidata": "Q779845",
+      "brand:wikipedia": "en:CBA (food retail)",
       "name": "CBA",
       "shop": "convenience"
     }

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -495,6 +495,8 @@
     "count": 113,
     "tags": {
       "brand": "Franprix",
+      "brand:wikidata": "Q2420096",
+      "brand:wikipedia": "fr:Franprix",
       "name": "Franprix",
       "shop": "convenience"
     }

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -338,8 +338,11 @@
   },
   "shop/supermarket|Bodega Aurrera": {
     "count": 364,
+    "match": ["shop/supermarket|Bodega Aurrerá"],
     "tags": {
       "brand": "Bodega Aurrera",
+      "brand:wikidata": "Q3365858",
+      "brand:wikipedia": "en:Bodega Aurrerá",
       "name": "Bodega Aurrera",
       "shop": "supermarket"
     }
@@ -1391,6 +1394,8 @@
     "count": 452,
     "tags": {
       "brand": "Franprix",
+      "brand:wikidata": "Q2420096",
+      "brand:wikipedia": "fr:Franprix",
       "name": "Franprix",
       "shop": "supermarket"
     }

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -156,6 +156,8 @@
     "count": 177,
     "tags": {
       "brand": "Alfamart",
+      "brand:wikidata": "Q23745600",
+      "brand:wikipedia": "en:Alfamart",
       "name": "Alfamart",
       "shop": "supermarket"
     }
@@ -298,6 +300,8 @@
     "match": ["shop/supermarket|BIM"],
     "tags": {
       "brand": "Bim",
+      "brand:wikidata": "Q1022075",
+      "brand:wikipedia": "en:Bim (company)",
       "name": "Bim",
       "shop": "supermarket"
     }
@@ -425,6 +429,8 @@
     "count": 235,
     "tags": {
       "brand": "CBA",
+      "brand:wikidata": "Q779845",
+      "brand:wikipedia": "en:CBA (food retail)",
       "name": "CBA",
       "shop": "supermarket"
     }
@@ -3882,6 +3888,18 @@
       "brand:wikidata": "Q8058833",
       "brand:wikipedia": "en:Your Independent Grocer",
       "name": "Your Independent Grocer",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|abc~(Poland)": {
+    "countryCodes": ["pl"],
+    "match": ["shop/supermarket|Abc"],
+    "nocount": true,
+    "tags": {
+      "brand": "abc",
+      "brand:wikidata": "Q11683985",
+      "brand:wikipedia": "pl:abc (sieć handlowa)",
+      "name": "abc",
       "shop": "supermarket"
     }
   },


### PR DESCRIPTION
Add "shop/supermarket|abc~(Poland)" as own chain for Poland. Most are tagged as shop=convenience, but some as shop=supermarket as well. As "ABC" seems to appear for supermarkets elsewhere in the world, leave that entry as it is.