### PR TITLE
wikidata and wikipedia for DB Reisezentrum

### DIFF
--- a/brands/shop/ticket.json
+++ b/brands/shop/ticket.json
@@ -12,6 +12,8 @@
   },
   "shop/ticket|DB Reisezentrum": {
     "count": 52,
+    "countryCodes": ["de"],
+    "match": ["shop/ticket|Reisezentrum"],
     "tags": {
       "brand": "DB Reisezentrum",
       "brand:wikidata": "Q15842100",

--- a/brands/shop/ticket.json
+++ b/brands/shop/ticket.json
@@ -14,6 +14,8 @@
     "count": 52,
     "tags": {
       "brand": "DB Reisezentrum",
+      "brand:wikidata": "Q15842100",
+      "brand:wikipedia": "de:Reisezentrum",
       "name": "DB Reisezentrum",
       "shop": "ticket"
     }


### PR DESCRIPTION
Brand of railway ticket shops of the German national railway operator Deutsche Bahn found mostly in train stations.