### PR TITLE
Add info for shoe chain

### DIFF
--- a/brands/shop/shoes.json
+++ b/brands/shop/shoes.json
@@ -249,8 +249,11 @@
   },
   "shop/shoes|Görtz": {
     "count": 51,
+    "countryCodes": ["de"],
     "tags": {
       "brand": "Görtz",
+      "brand:wikidata": "Q1559593",
+      "brand:wikipedia": "de:Ludwig Görtz",
       "name": "Görtz",
       "shop": "shoes"
     }


### PR DESCRIPTION
"Görtz" is a chain of shoe shops in Germany