### PR TITLE
Fixed Tesco duplicate and added wikidata

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -1308,7 +1308,7 @@
   },
   "shop/convenience|Tesco Express": {
     "count": 728,
-    "nomatch": ["shop/convenience|Tesco Express"],
+    "nomatch": ["amenity/fuel|Tesco"],
     "tags": {
       "brand": "Tesco Express",
       "brand:wikidata": "Q487494",

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -1296,24 +1296,23 @@
     "count": 53,
     "nomatch": [
       "amenity/fuel|Tesco",
-      "shop/convenience|Tesco Express",
-      "shop/supermarket|Tesco"
+      "shop/convenience|Tesco Express"
     ],
     "tags": {
       "brand": "Tesco",
+      "brand:wikidata": "Q487494",
+      "brand:wikipedia": "en:Tesco",
       "name": "Tesco",
       "shop": "convenience"
     }
   },
   "shop/convenience|Tesco Express": {
     "count": 728,
-    "nomatch": [
-      "amenity/fuel|Tesco",
-      "shop/convenience|Tesco",
-      "shop/supermarket|Tesco"
-    ],
+    "nomatch": ["shop/convenience|Tesco Express"],
     "tags": {
       "brand": "Tesco Express",
+      "brand:wikidata": "Q487494",
+      "brand:wikipedia": "en:Tesco",
       "name": "Tesco Express",
       "shop": "convenience"
     }

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -1294,7 +1294,11 @@
   },
   "shop/convenience|Tesco": {
     "count": 53,
-    "nomatch": ["amenity/fuel|Tesco"],
+    "nomatch": [
+      "amenity/fuel|Tesco",
+      "shop/convenience|Tesco Express",
+      "shop/supermarket|Tesco"
+    ],
     "tags": {
       "brand": "Tesco",
       "name": "Tesco",
@@ -1303,6 +1307,11 @@
   },
   "shop/convenience|Tesco Express": {
     "count": 728,
+    "nomatch": [
+      "amenity/fuel|Tesco",
+      "shop/convenience|Tesco",
+      "shop/supermarket|Tesco"
+    ],
     "tags": {
       "brand": "Tesco Express",
       "name": "Tesco Express",


### PR DESCRIPTION
I was expecting to remove `shop/convenience|Tesco` and `shop/supermarket|Tesco Express` as Tesco Express is the convenience store brand of Tesco. Unfortunately the Tesco Expresses mapped as supermarkets are big enough to be supermarkets, with racks of trolleys outside, and the Tescos mapped as convenience stores are the ones that are attached to the petrol stations of larger stores, meaning that these are mapped correctly as well.