### PR TITLE
Update "Co-op" brand in UK

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -313,7 +313,7 @@
       "shop": "convenience"
     }
   },
-  "shop/convenience|Co-op": {
+  "shop/convenience|Co-op Food": {
     "count": 275,
     "match": [
       "shop/convenience|COOP",
@@ -325,9 +325,9 @@
       "shop/supermarket|Co-op"
     ],
     "tags": {
-      "brand": "Federated Co-operatives",
-      "brand:wikidata": "Q5440676",
-      "brand:wikipedia": "en:Federated Co-operatives",
+      "brand": "Co-op Food",
+      "brand:wikidata": "Q3277439",
+      "brand:wikipedia": "en:Co-op Food",
       "name": "Co-op",
       "shop": "convenience"
     }

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -648,7 +648,7 @@
       "shop": "supermarket"
     }
   },
-  "shop/supermarket|Co-op": {
+  "shop/supermarket|Co-op Food": {
     "count": 492,
     "match": [
       "shop/supermarket|COOP",
@@ -661,9 +661,9 @@
       "shop/convenience|Co-op"
     ],
     "tags": {
-      "brand": "Federated Co-operatives",
-      "brand:wikidata": "Q5440676",
-      "brand:wikipedia": "en:Federated Co-operatives",
+      "brand": "Co-op Food",
+      "brand:wikidata": "Q3277439",
+      "brand:wikipedia": "en:Co-op Food",
       "name": "Co-op",
       "shop": "supermarket"
     }


### PR DESCRIPTION
Hi, I changed the tags data (brand, brand:wikidata and brand:wikipedia) of Co-op in 2 files supermarket.json and convenience.json. Also, I changed the name from Co-op to Co-op Food because the latter seems more better and "UK belongs to" than the previous one.