### PR TITLE
Add Ralph's Italian Ices

### DIFF
--- a/brands/amenity/ice_cream.json
+++ b/brands/amenity/ice_cream.json
@@ -91,6 +91,24 @@
       "name": "La Michoacana"
     }
   },
+  "amenity/ice_cream|Ralph's Italian Ices": {
+    "countryCodes": ["us"],
+    "match": [
+      "amenity/ice_cream|Ralph's Famous Italian Ices",
+      "amenity/ice_cream|Ralph's Famous Italian Ices & Ice Cream",
+      "amenity/ice_cream|Ralph's Italian Ice",
+      "amenity/ice_cream|Ralph's Italian Ices & Ice Cream"
+    ],
+    "nocount": true,
+    "tags": {
+      "amenity": "ice_cream",
+      "brand": "Ralph's Italian Ices",
+      "brand:wikidata": "Q62576909",
+      "cuisine": "ice_cream",
+      "name": "Ralph's Italian Ices",
+      "official_name": "Ralph's Famous Italian Ices"
+    }
+  },
   "amenity/ice_cream|Rita's Italian Ice": {
     "countryCodes": ["us"],
     "match": [


### PR DESCRIPTION
Not totally sure about naming here. Open to changes.
- **The common name is "Ralph's Italian Ices".** If asked for something more than "Ralph's", I think this is the name most people would give.
- **The official name is "Ralph's Famous Italian Ices".** (On paper, ["Ralph's Famous Italian Ices Franchise Corp."](https://opencorporates.com/companies/us_ny/2567819)) This is the name on smaller logos.
- **On larger logos, they write "Ralph's Famous Italian Ices & Ice Cream".** Again, this doesn't seem to be their legal name, but it is a [registered trademark](https://tsdr.uspto.gov/#caseNumber=77726943&caseSearchType=US_APPLICATION&caseType=DEFAULT&searchType=statusSearch).
- I also found "Ralph's Italian Ices & Ice Cream" and "Ralph's Italian Ice" (without the 's' at the end) in use on <del>JOSM</del> <ins>Overpass Turbo</ins>.

My best interpretation: I used "Ralph's Italian Ices" for `"brand"` and `"name"`, "Ralph's Famous Italian Ices" for `"official_name"`, and only added "Ralph's Famous Italian Ices & Ice Cream" under `"match"`.