### PR TITLE
Add Walmart gas stations

### DIFF
--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -2665,6 +2665,21 @@
       "name": "WOG"
     }
   },
+  "amenity/fuel|Walmart": {
+    "nocount": true,
+    "nomatch": [
+      "shop/department_store|Walmart",
+      "shop/supermarket|Walmart Neighborhood Market",
+      "shop/supermarket|Walmart Supercenter"
+    ],
+    "tags": {
+      "amenity": "fuel",
+      "brand": "Walmart",
+      "brand:wikidata": "Q62606411",
+      "brand:wikipedia": "en:Walmart",
+      "name": "Walmart"
+    }
+  },
   "amenity/fuel|Wawa": {
     "count": 261,
     "nomatch": ["shop/convenience|Wawa"],


### PR DESCRIPTION
In 2016 Walmart took over the operation of their gas stations from Murphy so they're getting rebranded to Walmart now. There's a bunch of them starting to pop up in OSM.

Signed-off-by: Tim Smith <tsmith@chef.io>