### PR TITLE
Add wikidata + wikipedia info for convenience Proxi

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -1040,8 +1040,11 @@
   },
   "shop/convenience|Proxi": {
     "count": 301,
+    "match": ["shop/supermarket|Proxi"],
     "tags": {
       "brand": "Proxi",
+      "brand:wikidata": "Q3408522",
+      "brand:wikipedia": "fr:Proxi",
       "name": "Proxi",
       "shop": "convenience"
     }

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -2925,16 +2925,6 @@
       "shop": "supermarket"
     }
   },
-  "shop/supermarket|Proxi": {
-    "count": 105,
-    "tags": {
-      "brand": "Proxi",
-      "brand:wikidata": "Q3408522",
-      "brand:wikipedia": "fr:Proxi",
-      "name": "Proxi",
-      "shop": "supermarket"
-    }
-  },
   "shop/supermarket|Proxy Delhaize": {
     "count": 81,
     "tags": {


### PR DESCRIPTION
Proxi is more a convenience shop rather than a supermarket so delete duplicate shop/supermarket entry.