### PR TITLE
Hampton Inn has been renamed Hampton

### DIFF
--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -188,13 +188,15 @@
       "tourism": "hotel"
     }
   },
-  "tourism/hotel|Hampton Inn": {
-    "count": 495,
+  "tourism/hotel|Hampton": {
     "match": [
+      "tourism/hotel|Hampton Inn",
       "tourism/hotel|Hampton Inn & Suites"
     ],
+    "nocount": true,
     "tags": {
-      "brand": "Hampton Inn",
+      "alt_name": "Hampton Inn",
+      "brand": "Hampton",
       "brand:wikidata": "Q5646230",
       "brand:wikipedia": "en:Hampton by Hilton",
       "name": "Hampton Inn",

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -199,7 +199,7 @@
       "brand": "Hampton",
       "brand:wikidata": "Q5646230",
       "brand:wikipedia": "en:Hampton by Hilton",
-      "name": "Hampton Inn",
+      "name": "Hampton",
       "tourism": "hotel"
     }
   },


### PR DESCRIPTION
From the wikipedia page "Hampton by Hilton, formerly known as Hampton
Inn"

Signed-off-by: Tim Smith <tsmith@chef.io>