### PR TITLE
add support for marking entries as gone

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -541,3 +541,65 @@ can show you where the Wikidata information is missing or incomplete.
 
 <img width="800px" alt="Adding information on Wikidata" src="https://raw.githubusercontent.com/osmlab/name-suggestion-index/master/docs/img/wikidata.gif"/>
 
+### Mark brands as no longer existing
+
+Brands may disappear over time. To aboid cluttering suggestion lists with defunct brands and to allow flagging likely outdated entries it is possible to mark brands as no longer existing. For example following entry has `"notExisting": true` and `notExistingDescription` fields.
+
+```js
+  "shop/toys|Toys R Us~(partial closure)": {
+    "countryCodes": ["au", "us"],
+    "match": ["shop/toys|Toys \"R\" Us"],
+    "nocount": true,
+    "notExisting": true,
+    "notExistingDescription": "There are no Toys R Us branded toy shops in USA and Australia - see https://www.cnn.com/2019/02/11/business/toys-r-us-return/index.html",
+    "tags": {
+      "brand": "Toys R Us",
+      "brand:wikidata": "Q696334",
+      "brand:wikipedia": "en:Toys \"R\" Us",
+      "name": "Toys R Us",
+      "shop": "toys"
+    }
+  },
+```
+
+Note that thanks to `countryCodes` it is possible to have also entry describing that `Toys R Us` continues to function in other countries:
+
+```js
+  "shop/toys|Toys R Us": {
+    "count": 240,
+    "countryCodes": [
+      "ae",
+      "at",
+      "bh",
+      "ca",
+      "ch",
+      "cn",
+      "de",
+      "es",
+      "fr",
+      "il",
+      "jp",
+      "kw",
+      "my",
+      "nl",
+      "no",
+      "ph",
+      "pl",
+      "pt",
+      "qa",
+      "sa",
+      "se",
+      "sg",
+      "th",
+      "za"
+    ],
+    "match": ["shop/toys|Toys \"R\" Us"],
+    "tags": {
+      "brand": "Toys R Us",
+      "brand:wikidata": "Q696334",
+      "brand:wikipedia": "en:Toys \"R\" Us",
+      "name": "Toys R Us",
+      "shop": "toys"
+    }
+  },
+```

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -704,6 +704,7 @@
   },
   "shop/supermarket|Comercial Mexicana": {
     "nocount": true,
+    "notExisting": true,
     "tags": {
       "brand": "Comercial Mexicana",
       "brand:wikidata": "Q2985173",

--- a/brands/shop/toys.json
+++ b/brands/shop/toys.json
@@ -130,7 +130,47 @@
   },
   "shop/toys|Toys R Us": {
     "count": 240,
+    "countryCodes": [
+      "ae",
+      "at",
+      "bh",
+      "ca",
+      "ch",
+      "cn",
+      "de",
+      "es",
+      "fr",
+      "il",
+      "jp",
+      "kw",
+      "my",
+      "nl",
+      "no",
+      "ph",
+      "pl",
+      "pt",
+      "qa",
+      "sa",
+      "se",
+      "sg",
+      "th",
+      "za"
+    ],
     "match": ["shop/toys|Toys \"R\" Us"],
+    "tags": {
+      "brand": "Toys R Us",
+      "brand:wikidata": "Q696334",
+      "brand:wikipedia": "en:Toys \"R\" Us",
+      "name": "Toys R Us",
+      "shop": "toys"
+    }
+  },
+  "shop/toys|Toys R Us~(partial closure)": {
+    "countryCodes": ["au", "us"],
+    "match": ["shop/toys|Toys \"R\" Us"],
+    "nocount": true,
+    "notExisting": true,
+    "notExistingDescription": "There are no Toys R Us branded toy shops in USA and Australia - see https://www.cnn.com/2019/02/11/business/toys-r-us-return/index.html",
     "tags": {
       "brand": "Toys R Us",
       "brand:wikidata": "Q696334",

--- a/build_dist.js
+++ b/build_dist.js
@@ -45,6 +45,11 @@ function buildJSON() {
         const value = tag[1];
         const name = parts[1].replace('~', ' ');
         const countryCodes = obj.countryCodes;
+        const notExisting = obj.notExisting;
+
+        if (notExisting === true) {
+            return;
+        }
 
         if (!out[key]) {
             out[key] = {};

--- a/schema/entries.json
+++ b/schema/entries.json
@@ -51,6 +51,15 @@
                     "description": "(optional) If true, suppress warning about uncommon name",
                     "enum": [ true ]
                 },
+                "notExisting": {
+                    "type": "boolean",
+                    "description": "(optional) If true, it means that entry represents no longer existing entity",
+                    "enum": [ true ]
+                },
+                "notExistingDescription": {
+                    "type": "string",
+                    "description": "(optional) Description why entry represents no longer existing entity"
+                },
                 "tags": {
                     "description": "(required) OpenStreetMap tags to associate with this entry (parent properties not allowed here)",
                     "type": "object",


### PR DESCRIPTION
Opened as a PR as it extends data structure and makes collecting no longer existing brands (that are still mapped in OSM) as an explicit goal.

This PR add support for marking brand as gone, including cases where brand is gone only in some countries. Such entries are dropped from `/dist/` files.

In future it may be possible to start distributing also list of ghost brands, still present in OSM but it is nod done for now.

fixes #2415 though some new issues needs to be created for likely no more existing brands mentioned there

------

@rjw62 I am pinging you as you maintain [entries and pretty graph](https://osm.mathmos.net/ghosts/) for UK about defunct brands. This PR add supports for marking brands as gone in this global index. Given that you have bigger experience with such data gathering I would welcome your feedback!

Thanks to looking at how your idex is generated I already added comment field alowing to add explanation what happened with a brand.

BTW, would it be OK to use your brand list and descriptions in this index? It would require releasing them under BSD 3-Clause license (see https://github.com/osmlab/name-suggestion-index/blob/master/LICENSE.md for details).

In addition to intention mentioned above this data could be used to make site similar to https://osm.mathmos.net/ghosts/ but with a global coverage.