### PR TITLE
Correct information for Matsuya Foods in amenity/fast_food|松屋

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -2787,7 +2787,7 @@
     }
   },
   "amenity/fast_food|松屋": {
-    "count": 630,
+    "count": 1080,
     "countryCodes": [
       "cn",
       "hk",

--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -2787,7 +2787,7 @@
     }
   },
   "amenity/fast_food|松屋": {
-    "count": 1080,
+    "count": 630,
     "countryCodes": [
       "cn",
       "hk",

--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -2791,6 +2791,7 @@
     "countryCodes": [
       "cn",
       "hk",
+      "jp",
       "mo",
       "sg",
       "tw"
@@ -2800,7 +2801,7 @@
       "brand": "松屋",
       "brand:en": "Matsuya Foods",
       "brand:wikidata": "Q848773",
-      "brand:wikipedia": "zh:松屋食品",
+      "brand:wikipedia": "ja:松屋フーズ",
       "cuisine": "japanese",
       "name": "松屋",
       "name:en": "Matsuya Foods",


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/Matsuya_Foods the number of stores is 1080 not 630 (as of 2018), so I have updated the count.

The company is Japanese, so I made the brand:wikipedia point to the Japanese wikipedia page rather than the Chinese page.

Also I have added the country code for Japan.