### PR TITLE
More Japanese Brands (part 4)

### DIFF
--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -168,5 +168,47 @@
       "name": "Ключ здоровья",
       "vending": "water"
     }
+  },
+  "amenity/vending_machine|コカ・コーラ": {
+    "countryCodes": ["jp"],
+    "match": ["shop/vending_machine|コカコーラ"],
+    "nocount": true,
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "コカ・コーラ",
+      "brand:en": "Coca-Cola",
+      "brand:ja": "コカ・コーラ",
+      "drink": "cola",
+      "name": "コカ・コーラ",
+      "name:en": "Coca-Cola",
+      "name:ja": "コカ・コーラ",
+      "operator": "Nippon Coca Cola Co., Ltd.",
+      "operator:wikidata": "Q11506438",
+      "operator:wikipedia": "ja:日本コカ・コーラ",
+      "vending": "drinks",
+      "wikidata": "Q2813",
+      "wikipedia": "ja:コカ・コーラ"
+    }
+  },
+  "amenity/vending_machine|ポッカサッポロ": {
+    "countryCodes": ["jp"],
+    "match": [
+      "shop/vending_machine|POKKA SAPPORO"
+    ],
+    "nocount": true,
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "ポッカサッポロ",
+      "brand:en": "Pokka Sapporo",
+      "brand:ja": "ポッカサッポロ",
+      "name": "ポッカサッポロ",
+      "name:en": "Pokka Sapporo",
+      "name:ja": "ポッカサッポロ",
+      "operator": "ポッカサッポロフード&ビバレッジ",
+      "operator:en": "Pokka Sapporo Food & Beverage",
+      "vending": "water;food",
+      "wikidata": "Q7208665",
+      "wikipedia": "ja:Q7208665"
+    }
   }
 }

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -178,6 +178,8 @@
       "brand": "コカ・コーラ",
       "brand:en": "Coca-Cola",
       "brand:ja": "コカ・コーラ",
+      "brand:wikidata": "Q2813",
+      "brand:wikipedia": "ja:コカ・コーラ",
       "drink": "cola",
       "name": "コカ・コーラ",
       "name:en": "Coca-Cola",
@@ -185,9 +187,7 @@
       "operator": "Nippon Coca Cola Co., Ltd.",
       "operator:wikidata": "Q11506438",
       "operator:wikipedia": "ja:日本コカ・コーラ",
-      "vending": "drinks",
-      "wikidata": "Q2813",
-      "wikipedia": "ja:コカ・コーラ"
+      "vending": "drinks"
     }
   },
   "amenity/vending_machine|ポッカサッポロ": {

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -206,8 +206,6 @@
       "name": "ポッカサッポロ",
       "name:en": "Pokka Sapporo",
       "name:ja": "ポッカサッポロ",
-      "operator": "ポッカサッポロフード&ビバレッジ",
-      "operator:en": "Pokka Sapporo Food & Beverage",
       "vending": "water;food"
     }
   }

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -201,14 +201,14 @@
       "brand": "ポッカサッポロ",
       "brand:en": "Pokka Sapporo",
       "brand:ja": "ポッカサッポロ",
+      "brand:wikidata": "Q7208665",
+      "brand:wikipedia": "ja:Q7208665",
       "name": "ポッカサッポロ",
       "name:en": "Pokka Sapporo",
       "name:ja": "ポッカサッポロ",
       "operator": "ポッカサッポロフード&ビバレッジ",
       "operator:en": "Pokka Sapporo Food & Beverage",
-      "vending": "water;food",
-      "wikidata": "Q7208665",
-      "wikipedia": "ja:Q7208665"
+      "vending": "water;food"
     }
   }
 }

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -184,7 +184,7 @@
       "name": "コカ・コーラ",
       "name:en": "Coca-Cola",
       "name:ja": "コカ・コーラ",
-      "operator": "Nippon Coca Cola Co., Ltd.",
+      "operator": "Coca Cola Japan Co., Ltd.",
       "operator:wikidata": "Q11506438",
       "operator:wikipedia": "ja:日本コカ・コーラ",
       "vending": "drinks"

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -916,6 +916,19 @@
       "shop": "convenience"
     }
   },
+  "shop/convenience|NewDays": {
+    "countryCodes": ["jp"],
+    "match": ["shop/convenience|NewDays ミニ"],
+    "nocount": true,
+    "tags": {
+      "alt_name": "ニューデイズ",
+      "brand": "NewDays",
+      "brand:wikidata": "Q11234763",
+      "brand:wikipedia": "ja:NewDays",
+      "name": "NewDays",
+      "shop": "convenience"
+    }
+  },
   "shop/convenience|Nisa": {
     "count": 87,
     "countryCodes": ["gb"],

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -918,7 +918,10 @@
   },
   "shop/convenience|NewDays": {
     "countryCodes": ["jp"],
-    "match": ["shop/convenience|NewDays ミニ"],
+    "match": [
+      "shop/convenience|NewDays ミニ",
+      "shop/convenience|ニューデイズ"
+    ],
     "nocount": true,
     "tags": {
       "alt_name": "ニューデイズ",

--- a/brands/shop/dry_cleaning.json
+++ b/brands/shop/dry_cleaning.json
@@ -8,6 +8,22 @@
       "shop": "dry_cleaning"
     }
   },
+  "shop/dry_cleaning|タカケンサンシャイン": {
+    "countryCodes": ["jp"],
+    "match": ["shop/dry_cleaning|タカケンクリーング"],
+    "nocount": true,
+    "tags": {
+      "brand": "タカケンサンシャイン",
+      "brand:en": "Takaken Sunshine",
+      "brand:ja": "タカケンサンシャイン",
+      "brand:wikidata": "Q11315914",
+      "brand:wikipedia": "ja:タカケンサンシャイン",
+      "name": "タカケンサンシャイン",
+      "name:en": "Takaken Sunshine",
+      "name:ja": "タカケンサンシャイン",
+      "shop": "dry_cleaning"
+    }
+  },
   "shop/dry_cleaning|ホワイト急便": {
     "count": 273,
     "countryCodes": ["jp"],

--- a/brands/shop/variety_store.json
+++ b/brands/shop/variety_store.json
@@ -300,6 +300,38 @@
       "shop": "variety_store"
     }
   },
+  "shop/variety_store|ダイレックス": {
+    "countryCodes": ["jp"],
+    "match": ["shop/supermarket|ダイレックス"],
+    "nocount": true,
+    "tags": {
+      "brand": "ダイレックス",
+      "brand:en": "Direx",
+      "brand:ja": "ダイレックス",
+      "brand:wikidata": "Q11317051",
+      "brand:wikipedia": "ja:ダイレックス (ディスカウントストア)",
+      "name": "ダイレックス",
+      "name:en": "Direx",
+      "name:ja": "ダイレックス",
+      "shop": "variety_store"
+    }
+  },
+  "shop/variety_store|トライアル": {
+    "countryCodes": ["jp"],
+    "match": ["shop/supermarket|トライアル"],
+    "nocount": true,
+    "tags": {
+      "brand": "トライアル",
+      "brand:en": "Trial",
+      "brand:ja": "トライアル",
+      "brand:wikidata": "Q11321723",
+      "brand:wikipedia": "ja:トライアルカンパニー",
+      "name": "トライアル",
+      "name:en": "Trial",
+      "name:ja": "トライアル",
+      "shop": "variety_store"
+    }
+  },
   "shop/variety_store|ドン・キホーテ": {
     "countryCodes": ["jp"],
     "match": [


### PR DESCRIPTION
This pull request adds six new brands in Japan (to reduce the workload in this request, I will add others in the future). With Wikipedia, Wikidata info and english name. In the articles that I found in this encyclopedia they say that the companies have several headquarters of which they are mapped in Openstreetmap.