### PR TITLE
Added cuisine for several restaurants in Japan

### DIFF
--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -1687,7 +1687,7 @@
       "brand:ja": "はなまるうどん",
       "brand:wikidata": "Q11275674",
       "brand:wikipedia": "ja:はなまるうどん",
-      "cuisine":"japanese;udon",
+      "cuisine": "japanese;udon",
       "name": "はなまるうどん",
       "name:en": "Hanamarūdon",
       "name:ja": "はなまるうどん"
@@ -1703,6 +1703,7 @@
       "brand:ja": "びっくりドンキー",
       "brand:wikidata": "Q11276815",
       "brand:wikipedia": "ja:びっくりドンキー",
+      "cuisine":"burger",
       "name": "びっくりドンキー",
       "name:en": "Bikkuri Donkey",
       "name:ja": "びっくりドンキー"
@@ -1718,6 +1719,7 @@
       "brand:ja": "やよい軒",
       "brand:wikidata": "Q11280577",
       "brand:wikipedia": "ja:やよい軒",
+      "cuisine":"japanese",
       "name": "やよい軒",
       "name:en": "Yayoiken",
       "name:ja": "やよい軒"
@@ -1745,8 +1747,9 @@
     "tags": {
       "amenity": "restaurant",
       "brand": "ガスト",
-      "brand:en": "Gusto",
+      "brand:en": "びっくりドンキー",
       "brand:ja": "ガスト",
+      "cuisine":"western;japanese",
       "name": "ガスト",
       "name:en": "Gusto",
       "name:ja": "ガスト"
@@ -1762,6 +1765,7 @@
       "brand:ja": "ココス",
       "brand:wikidata": "Q11301951",
       "brand:wikipedia": "ja:ココスジャパン",
+      "cuisine":"western;japanese",
       "name": "ココス",
       "name:en": "Coco's",
       "name:ja": "ココス"
@@ -1777,7 +1781,7 @@
       "brand:ja": "サイゼリヤ",
       "brand:wikidata": "Q886564",
       "brand:wikipedia": "en:Saizeriya",
-      "cuisine":"italian",
+      "cuisine": "italian",
       "name": "サイゼリヤ",
       "name:en": "Saizeriya",
       "name:ja": "サイゼリヤ"
@@ -1793,6 +1797,7 @@
       "brand:ja": "ジョイフル",
       "brand:wikidata": "Q11310517",
       "brand:wikipedia": "ja:ジョイフル",
+      "cuisine":"western",
       "name": "ジョイフル",
       "name:en": "Joyfull",
       "name:ja": "ジョイフル"
@@ -1808,6 +1813,7 @@
       "brand:ja": "ジョナサン",
       "brand:wikidata": "Q11310628",
       "brand:wikipedia": "ja:ジョナサン (ファミリーレストラン)",
+      "cuisine":"italian;japanese",
       "name": "ジョナサン",
       "name:en": "Jonathan's",
       "name:ja": "ジョナサン"
@@ -1836,7 +1842,7 @@
       "amenity": "restaurant",
       "brand": "ステーキガスト",
       "brand:ja": "ステーキガスト",
-      "cuisine":"japanese;western",
+      "cuisine": "japanese;western",
       "name": "ステーキガスト",
       "name:ja": "ステーキガスト"
     }
@@ -1881,8 +1887,8 @@
       "brand:ja": "ビッグボーイ",
       "brand:wikidata": "Q4386779",
       "brand:wikipedia": "en:Big Boy Restaurants",
+      "cuisine": "burger",
       "name": "ビッグボーイ",
-      "cuisine":"burger",
       "name:en": "Big Boy Restaurants",
       "name:ja": "ビッグボーイ"
     }
@@ -1897,7 +1903,7 @@
       "brand:ja": "リンガーハット",
       "brand:wikidata": "Q7334856",
       "brand:wikipedia": "en:Ringer Hut",
-      "cuisine":"japanese",
+      "cuisine": "japanese",
       "name": "リンガーハット",
       "name:en": "Ringer Hut",
       "name:ja": "リンガーハット"
@@ -1913,7 +1919,7 @@
       "brand:ja": "ロイヤルホスト",
       "brand:wikidata": "Q11120884",
       "brand:wikipedia": "ja:ロイヤルホスト",
-      "cuisine":"japanese;italian;french",
+      "cuisine": "japanese;italian;french",
       "name": "ロイヤルホスト",
       "name:en": "Royal Host",
       "name:ja": "ロイヤルホスト"
@@ -1959,7 +1965,7 @@
       "brand": "和食さと",
       "brand:en": "Washoku Sato",
       "brand:ja": "和食さと",
-      "cuisine":"japanese",
+      "cuisine": "japanese",
       "name": "和食さと",
       "name:en": "Washoku Sato",
       "name:ja": "和食さと"
@@ -1973,7 +1979,7 @@
       "brand": "夢庵",
       "brand:en": "Yumean",
       "brand:ja": "夢庵",
-      "cuisine":"japanese",
+      "cuisine": "japanese",
       "name": "夢庵",
       "name:en": "Yumean",
       "name:ja": "夢庵"
@@ -2005,7 +2011,7 @@
       "brand:ja": "大阪王将",
       "brand:wikidata": "Q48743717",
       "brand:wikipedia": "ja:大阪王将",
-      "cuisine":"japanese;chinese",
+      "cuisine": "japanese;chinese",
       "name": "大阪王将",
       "name:en": "Osaka Ohsho",
       "name:ja": "大阪王将"
@@ -2020,6 +2026,7 @@
       "brand:en": "Tenkaippin",
       "brand:wikidata": "Q11442172",
       "brand:wikipedia": "en:Tenkaippin",
+      "cuisine":"ramen",
       "name": "天下一品",
       "name:en": "Tenkaippin"
     }
@@ -2117,7 +2124,7 @@
       "brand:ja": "餃子の王将",
       "brand:wikidata": "Q11666805",
       "brand:wikipedia": "en:Gyoza no Ohsho",
-      "cuisine":"chinese;gyoza",
+      "cuisine": "chinese;gyoza",
       "name": "餃子の王将",
       "name:en": "Gyoza no Ohsho",
       "name:ja": "餃子の王将"

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -1747,7 +1747,7 @@
     "tags": {
       "amenity": "restaurant",
       "brand": "ガスト",
-      "brand:en": "びっくりドンキー",
+      "brand:en": "Gusto",
       "brand:ja": "ガスト",
       "cuisine":"western;japanese",
       "name": "ガスト",

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -1687,6 +1687,7 @@
       "brand:ja": "はなまるうどん",
       "brand:wikidata": "Q11275674",
       "brand:wikipedia": "ja:はなまるうどん",
+      "cuisine":"japanese;udon",
       "name": "はなまるうどん",
       "name:en": "Hanamarūdon",
       "name:ja": "はなまるうどん"
@@ -1776,6 +1777,7 @@
       "brand:ja": "サイゼリヤ",
       "brand:wikidata": "Q886564",
       "brand:wikipedia": "en:Saizeriya",
+      "cuisine":"italian",
       "name": "サイゼリヤ",
       "name:en": "Saizeriya",
       "name:ja": "サイゼリヤ"
@@ -1834,6 +1836,7 @@
       "amenity": "restaurant",
       "brand": "ステーキガスト",
       "brand:ja": "ステーキガスト",
+      "cuisine":"japanese;western",
       "name": "ステーキガスト",
       "name:ja": "ステーキガスト"
     }
@@ -1879,6 +1882,7 @@
       "brand:wikidata": "Q4386779",
       "brand:wikipedia": "en:Big Boy Restaurants",
       "name": "ビッグボーイ",
+      "cuisine":"burger",
       "name:en": "Big Boy Restaurants",
       "name:ja": "ビッグボーイ"
     }
@@ -1893,6 +1897,7 @@
       "brand:ja": "リンガーハット",
       "brand:wikidata": "Q7334856",
       "brand:wikipedia": "en:Ringer Hut",
+      "cuisine":"japanese",
       "name": "リンガーハット",
       "name:en": "Ringer Hut",
       "name:ja": "リンガーハット"
@@ -1908,6 +1913,7 @@
       "brand:ja": "ロイヤルホスト",
       "brand:wikidata": "Q11120884",
       "brand:wikipedia": "ja:ロイヤルホスト",
+      "cuisine":"japanese;italian;french",
       "name": "ロイヤルホスト",
       "name:en": "Royal Host",
       "name:ja": "ロイヤルホスト"
@@ -1953,6 +1959,7 @@
       "brand": "和食さと",
       "brand:en": "Washoku Sato",
       "brand:ja": "和食さと",
+      "cuisine":"japanese",
       "name": "和食さと",
       "name:en": "Washoku Sato",
       "name:ja": "和食さと"
@@ -1966,6 +1973,7 @@
       "brand": "夢庵",
       "brand:en": "Yumean",
       "brand:ja": "夢庵",
+      "cuisine":"japanese",
       "name": "夢庵",
       "name:en": "Yumean",
       "name:ja": "夢庵"
@@ -1997,6 +2005,7 @@
       "brand:ja": "大阪王将",
       "brand:wikidata": "Q48743717",
       "brand:wikipedia": "ja:大阪王将",
+      "cuisine":"japanese;chinese",
       "name": "大阪王将",
       "name:en": "Osaka Ohsho",
       "name:ja": "大阪王将"
@@ -2108,6 +2117,7 @@
       "brand:ja": "餃子の王将",
       "brand:wikidata": "Q11666805",
       "brand:wikipedia": "en:Gyoza no Ohsho",
+      "cuisine":"chinese;gyoza",
       "name": "餃子の王将",
       "name:en": "Gyoza no Ohsho",
       "name:ja": "餃子の王将"


### PR DESCRIPTION
Unsure how to handle the case when a restaurant have two profiles. I separated them with `;`, like ` "cuisine":"western;japanese"`. Please confirm if this is correct or not.

This kind of things are very common for "Family Restaurants" in Japan. It is basically restaurants catering to families serving both Western and Japanese food.