### PR TITLE
Add Australian pharmacy/chemist retail chains

### DIFF
--- a/brands/amenity/pharmacy.json
+++ b/brands/amenity/pharmacy.json
@@ -24,6 +24,22 @@
       "name": "Amavita"
     }
   },
+  "amenity/pharmacy|Amcal": {
+    "countryCodes": ["au"],
+    "match": [
+      "amenity/pharmacy|Amcal Pharmacy",
+      "shop/chemist|Amcal",
+      "shop/chemist|Amcal Pharmacy"
+    ],
+    "nocount": true,
+    "tags": {
+      "amenity": "pharmacy",
+      "brand": "Amcal",
+      "brand:wikidata": "Q63367373",
+      "healthcare": "pharmacy",
+      "name": "Amcal"
+    }
+  },
   "amenity/pharmacy|Apollo Pharmacy": {
     "count": 128,
     "countryCodes": ["in"],
@@ -91,6 +107,19 @@
       "brand:wikidata": "Q62562792",
       "healthcare": "pharmacy",
       "name": "Benu"
+    }
+  },
+  "amenity/pharmacy|Blooms The Chemist": {
+    "countryCodes": ["au"],
+    "match": ["shop/chemist|Blooms The Chemist"],
+    "nocount": true,
+    "tags": {
+      "amenity": "pharmacy",
+      "brand": "Blooms The Chemist",
+      "brand:wikidata": "Q63367543",
+      "healthcare": "pharmacy",
+      "name": "Blooms The Chemist",
+      "shop": "chemist"
     }
   },
   "amenity/pharmacy|Boots": {
@@ -181,8 +210,34 @@
       "name": "Catena"
     }
   },
+  "amenity/pharmacy|Chemist King Discount Pharmacy": {
+    "countryCodes": ["au"],
+    "match": [
+      "amenity/pharmacy|Chemist King",
+      "amenity/pharmacy|Chemist King Discount Pharmacies",
+      "amenity/pharmacy|ChemistKing",
+      "amenity/pharmacy|ChemistKing Discount Pharmacies",
+      "amenity/pharmacy|ChemistKing Discount Pharmacy",
+      "shop/chemist|Chemist King",
+      "shop/chemist|Chemist King Discount Pharmacies",
+      "shop/chemist|Chemist King Discount Pharmacy",
+      "shop/chemist|ChemistKing",
+      "shop/chemist|ChemistKing Discount Pharmacies",
+      "shop/chemist|ChemistKing Discount Pharmacy"
+    ],
+    "nocount": true,
+    "tags": {
+      "amenity": "pharmacy",
+      "brand": "Chemist King Discount Pharmacy",
+      "brand:wikidata": "Q63367667",
+      "healthcare": "pharmacy",
+      "name": "Chemist King Discount Pharmacy"
+    }
+  },
   "amenity/pharmacy|Chemist Warehouse": {
     "count": 128,
+    "countryCodes": ["au", "nz"],
+    "match": ["shop/chemist|Chemist Warehouse"],
     "tags": {
       "amenity": "pharmacy",
       "brand": "Chemist Warehouse",
@@ -597,12 +652,36 @@
     }
   },
   "amenity/pharmacy|Guardian": {
-    "count": 105,
+    "countryCodes": [
+      "bn",
+      "id",
+      "kh",
+      "my",
+      "ph",
+      "sg",
+      "vn"
+    ],
     "tags": {
       "amenity": "pharmacy",
       "brand": "Guardian",
-      "brand:wikidata": "Q13646560",
-      "brand:wikipedia": "en:Mannings",
+      "brand:wikidata": "Q63371124",
+      "healthcare": "pharmacy",
+      "name": "Guardian"
+    }
+  },
+  "amenity/pharmacy|Guardian Pharmacy": {
+    "countryCodes": ["au"],
+    "match": [
+      "amenity/pharmacy|Guardian",
+      "amenity/pharmacy|Guardian Pharmacies",
+      "shop/chemist|Guardian",
+      "shop/chemist|Guardian Pharmacies",
+      "shop/chemist|Guardian Pharmacy"
+    ],
+    "nocount": true,
+    "tags": {
+      "brand": "Guardian",
+      "brand:wikidata": "Q63367814",
       "healthcare": "pharmacy",
       "name": "Guardian"
     }
@@ -718,6 +797,18 @@
       "name": "London Drugs"
     }
   },
+  "amenity/pharmacy|Mannings": {
+    "countryCodes": ["cn", "hk", "mo"],
+    "nocount": true,
+    "tags": {
+      "amenity": "pharmacy",
+      "brand": "Mannings",
+      "brand:wikidata": "Q13646560",
+      "brand:wikipedia": "en:Mannings",
+      "healthcare": "pharmacy",
+      "name": "Mannings"
+    }
+  },
   "amenity/pharmacy|Mercury Drug": {
     "count": 683,
     "countryCodes": ["ph"],
@@ -790,6 +881,22 @@
       "name": "Panvel"
     }
   },
+  "amenity/pharmacy|PharmaSave": {
+    "countryCodes": ["au"],
+    "match": [
+      "amenity/pharmacy|Pharmasave",
+      "shop/chemist|PharmaSave",
+      "shop/chemist|Pharmasave"
+    ],
+    "nocount": true,
+    "tags": {
+      "amenity": "pharmacy",
+      "brand": "PharmaSave",
+      "brand:wikidata": "Q63367906",
+      "healthcare": "pharmacy",
+      "name": "PharmaSave"
+    }
+  },
   "amenity/pharmacy|Pharmacie Principale": {
     "count": 86,
     "tags": {
@@ -799,6 +906,21 @@
       "brand:wikipedia": "fr:Groupe PP Holding",
       "healthcare": "pharmacy",
       "name": "Pharmacie Principale"
+    }
+  },
+  "amenity/pharmacy|Pharmacy 4 Less": {
+    "countryCodes": ["au"],
+    "match": [
+      "shop/chemist|Pharmacy 4 Less",
+      "shop/chemist|Pharmacy4Less"
+    ],
+    "nocount": true,
+    "tags": {
+      "amenity": "pharmacy",
+      "brand": "Pharmacy 4 Less",
+      "brand:wikidata": "Q63367608",
+      "healthcare": "pharmacy",
+      "name": "Pharmacy 4 Less"
     }
   },
   "amenity/pharmacy|Pharmaprix": {
@@ -814,6 +936,7 @@
   },
   "amenity/pharmacy|Pharmasave": {
     "count": 195,
+    "countryCodes": ["ca"],
     "tags": {
       "amenity": "pharmacy",
       "brand": "Pharmasave",
@@ -821,6 +944,23 @@
       "brand:wikipedia": "en:Pharmasave",
       "healthcare": "pharmacy",
       "name": "Pharmasave"
+    }
+  },
+  "amenity/pharmacy|Priceline Pharmacy": {
+    "countryCodes": ["au"],
+    "match": [
+      "amenity/pharmacy|Priceline",
+      "shop/chemist|Priceline",
+      "shop/chemist|Priceline Pharmacy"
+    ],
+    "nocount": true,
+    "tags": {
+      "amenity": "pharmacy",
+      "brand": "Priceline Pharmacy",
+      "brand:wikidata": "Q7242652",
+      "brand:wikipedia": "en:Priceline (Australia)",
+      "healthcare": "pharmacy",
+      "name": "Priceline Pharmacy"
     }
   },
   "amenity/pharmacy|Punto Farma~(Colombia)": {
@@ -1005,6 +1145,51 @@
       "healthcare": "pharmacy",
       "name": "TGP",
       "official_name": "The Generics Pharmacy"
+    }
+  },
+  "amenity/pharmacy|TerryWhite Chemmart": {
+    "countryCodes": ["au"],
+    "match": [
+      "amenity/pharmacy|Terry White",
+      "amenity/pharmacy|Terry White Chemist",
+      "amenity/pharmacy|Terry White Chemists",
+      "amenity/pharmacy|Terry White Chemmart",
+      "amenity/pharmacy|TerryWhite",
+      "amenity/pharmacy|TerryWhite Chemist",
+      "amenity/pharmacy|TerryWhite Chemists",
+      "shop/chemist|Terry White",
+      "shop/chemist|Terry White Chemist",
+      "shop/chemist|Terry White Chemists",
+      "shop/chemist|Terry White Chemmart",
+      "shop/chemist|TerryWhite",
+      "shop/chemist|TerryWhite Chemist",
+      "shop/chemist|TerryWhite Chemists",
+      "shop/chemist|TerryWhite Chemmart"
+    ],
+    "nocount": true,
+    "tags": {
+      "amenity": "pharmacy",
+      "brand": "TerryWhite Chemmart",
+      "brand:wikidata": "Q24089773",
+      "brand:wikipedia": "en:Terry White Chemmart",
+      "healthcare": "pharmacy",
+      "name": "TerryWhite Chemmart"
+    }
+  },
+  "amenity/pharmacy|UFS": {
+    "countryCodes": ["au"],
+    "match": [
+      "amenity/pharmacy|UFS Dispensaries",
+      "shop/chemist|UFS",
+      "shop/chemist|UFS Dispensaries"
+    ],
+    "nocount": true,
+    "tags": {
+      "amenity": "pharmacy",
+      "brand": "UFS",
+      "brand:wikidata": "Q63367573",
+      "healthcare": "pharmacy",
+      "name": "UFS"
     }
   },
   "amenity/pharmacy|Unichem Pharmacy": {


### PR DESCRIPTION
Note that some Australian pharmacy/chemist retail names have identical names to different chains located in other countries. Some "npm run build" warnings about possible duplicates are therefore seen.