### PR TITLE
Split out Bonobo and Bonobos

### DIFF
--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -187,7 +187,7 @@
     "tags": {
       "brand": "Bonobo",
       "brand:wikidata": "Q63682093",
-      "clothes": "women",
+      "clothes": "men;women",
       "name": "Bonobo",
       "shop": "clothes"
     }

--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -182,11 +182,25 @@
     }
   },
   "shop/clothes|Bonobo": {
+    "countryCodes": ["fr"],
+    "nomatch": ["shop/clothes|Bonobos"],
     "tags": {
       "brand": "Bonobo",
+      "brand:wikidata": "Q63682093",
+      "clothes": "women",
+      "name": "Bonobo",
+      "shop": "clothes"
+    }
+  },
+  "shop/clothes|Bonobos": {
+    "countryCodes": ["us"],
+    "nomatch": ["shop/clothes|Bonobo"],
+    "tags": {
+      "brand": "Bonobos",
       "brand:wikidata": "Q4942546",
       "brand:wikipedia": "en:Bonobos (apparel)",
-      "name": "Bonobo",
+      "clothes": "men",
+      "name": "Bonobos",
       "shop": "clothes"
     }
   },


### PR DESCRIPTION
Bonobo is a retailer in France, but we gave it wikidata for Bonobos which is a retailer in the US. Split out these two entries and give them country codes. I created a wikidata page for Bonobo, but I'm not having luck finding the necessary information to fill it in. I'd appreciate help from someone in France who might have better luck searching for their Twitter / Facebook account / anything.

Signed-off-by: Tim Smith <tsmith@chef.io>