### PR TITLE
Add secondary cuisines to some fast food locations

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -386,7 +386,7 @@
       "brand": "DQ Grill & Chill",
       "brand:wikidata": "Q1141226",
       "brand:wikipedia": "en:Dairy Queen",
-      "cuisine": "burger",
+      "cuisine": "burger;ice_cream",
       "name": "DQ Grill & Chill",
       "takeaway": "yes"
     }
@@ -401,7 +401,7 @@
       "brand": "Dairy Queen",
       "brand:wikidata": "Q1141226",
       "brand:wikipedia": "en:Dairy Queen",
-      "cuisine": "ice_cream",
+      "cuisine": "burger;ice_cream",
       "name": "Dairy Queen",
       "takeaway": "yes"
     }
@@ -461,7 +461,7 @@
       "brand": "Dunkin' Donuts",
       "brand:wikidata": "Q847743",
       "brand:wikipedia": "en:Dunkin' Donuts",
-      "cuisine": "donut",
+      "cuisine": "donut;coffee",
       "name": "Dunkin' Donuts",
       "takeaway": "yes"
     }
@@ -560,7 +560,7 @@
       "brand": "Freddy's",
       "brand:wikidata": "Q5496837",
       "brand:wikipedia": "en:Freddy's Frozen Custard & Steakburgers",
-      "cuisine": "burger",
+      "cuisine": "burger;ice_cream",
       "name": "Freddy's",
       "takeaway": "yes"
     }


### PR DESCRIPTION
I added secondary cuisines for brands where they are distinctly known for two things and people would go there for either or both of these things. Dairy Queen for instance is a classic american burger joint, but also an ice cream place. It's a flip of the coin if a person in line is going to get a full meal or just some ice cream.

Signed-off-by: Tim Smith <tsmith@chef.io>