### PR TITLE
Fold the defunct Sleepy's into Mattress Firm

### DIFF
--- a/brands/shop/bed.json
+++ b/brands/shop/bed.json
@@ -21,6 +21,7 @@
   },
   "shop/bed|Mattress Firm": {
     "countryCodes": ["us"],
+    "matchNames": ["sleepys"],
     "tags": {
       "brand": "Mattress Firm",
       "brand:wikidata": "Q6791878",
@@ -55,16 +56,6 @@
       "brand:wikidata": "Q7447640",
       "brand:wikipedia": "en:Sleep Number",
       "name": "Sleep Number",
-      "shop": "bed"
-    }
-  },
-  "shop/bed|Sleepy's": {
-    "countryCodes": ["us"],
-    "tags": {
-      "brand": "Sleepy's",
-      "brand:wikidata": "Q17088336",
-      "brand:wikipedia": "en:Sleepy's",
-      "name": "Sleepy's",
       "shop": "bed"
     }
   }


### PR DESCRIPTION
Mattress Firm bought and rebranded all the Sleepy's locations. It's in the wiki we're tagging locations with. I created a challenge to fix all of these and we should see it drop out of the all names file next week since there are only 57 locations right now.

https://maproulette.org/admin/project/430/challenge/8003

Signed-off-by: Tim Smith <tsmith@chef.io>