### PR TITLE
Distinguish between Checkers and Rally’s

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -243,8 +243,7 @@
     "tags": {
       "amenity": "fast_food",
       "brand": "Checkers",
-      "brand:wikidata": "Q3419341",
-      "brand:wikipedia": "en:Checkers and Rally's",
+      "brand:wikidata": "Q63919315",
       "cuisine": "burger",
       "name": "Checkers",
       "takeaway": "yes"
@@ -1404,8 +1403,7 @@
     "tags": {
       "amenity": "fast_food",
       "brand": "Rally's",
-      "brand:wikidata": "Q3419341",
-      "brand:wikipedia": "en:Checkers and Rally's",
+      "brand:wikidata": "Q63919323",
       "cuisine": "burger",
       "name": "Rally's",
       "takeaway": "yes"


### PR DESCRIPTION
I split apart [Wikidata’s item for Checkers](https://www.wikidata.org/wiki/Q3419341) into separate [Checkers](https://www.wikidata.org/wiki/Q63919315) and [Rally’s](https://www.wikidata.org/wiki/Q63919323) items, leaving the original to cover the umbrella company as opposed to the specific brands. This PR updates the `brand:wikidata` tags for these brands but also removes the `brand:wikidata` tag, since the Wikipedia article is for the pair of brands and no longer corresponds to the tagged Wikidata items. Now the index can associate each brand with its own logo.