### PR TITLE
Wahoo’s Fish Taco

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -1754,6 +1754,19 @@
       "takeaway": "yes"
     }
   },
+  "amenity/fast_food|Wahoo's Fish Taco": {
+    "countryCodes": ["us"],
+    "matchNames": ["wahoo's"],
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "Wahoo's Fish Taco",
+      "brand:wikidata": "Q7959827",
+      "brand:wikipedia": "en:Wahoo's Fish Taco",
+      "cuisine": "seafood",
+      "name": "Wahoo's Fish Taco",
+      "takeaway": "yes"
+    }
+  },
   "amenity/fast_food|Wendy's": {
     "tags": {
       "amenity": "fast_food",

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -1448,18 +1448,6 @@
       "name": "Wagamama"
     }
   },
-  "amenity/restaurant|Wahoo's Fish Taco": {
-    "countryCodes": ["us"],
-    "matchNames": ["wahoo's"],
-    "tags": {
-      "amenity": "restaurant",
-      "brand": "Wahoo's Fish Taco",
-      "brand:wikidata": "Q7959827",
-      "brand:wikipedia": "en:Wahoo's Fish Taco",
-      "cuisine": "seafood",
-      "name": "Wahoo's Fish Taco"
-    }
-  },
   "amenity/restaurant|Wasabi": {
     "tags": {
       "amenity": "restaurant",

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -1448,6 +1448,18 @@
       "name": "Wagamama"
     }
   },
+  "amenity/restaurant|Wahoo's Fish Taco": {
+    "countryCodes": ["us"],
+    "matchNames": ["wahoo's"],
+    "tags": {
+      "amenity": "restaurant",
+      "brand": "Wahoo's Fish Taco",
+      "brand:wikidata": "Q7959827",
+      "brand:wikipedia": "en:Wahoo's Fish Taco",
+      "cuisine": "seafood",
+      "name": "Wahoo's Fish Taco"
+    }
+  },
   "amenity/restaurant|Wasabi": {
     "tags": {
       "amenity": "restaurant",


### PR DESCRIPTION
This one is somewhat difficult to place. Wahoo’s is a fast-casual restaurant where you order at the front but have to wait a while; there’s no waitstaff, but the food comes on ceramic dishes. Existing nodes in OSM are split about half-and-half between `amenity=restaurant` and `amenity=fast_food`, but I went with `amenity=restaurant` figuring that it’s a broader classification.

As for the cuisine, `seafood` is the only one that’s for sure. It’s a fusion between `mexican`, `brazilian`, `hawaiian`, and more. Existing nodes in OSM are all over the place, but I don’t know if people would really expect to find Wahoo’s by searching for Mexican, Hawaiian, or Brazilian food per se.