### PR TITLE
Major U.S. insurance companies with independent agents

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -3682,6 +3682,7 @@
     }
   },
   "amenity/bank|Nationwide": {
+    "nomatch": ["office/insurance|Nationwide"],
     "tags": {
       "amenity": "bank",
       "brand": "Nationwide",

--- a/brands/office/insurance.json
+++ b/brands/office/insurance.json
@@ -14,7 +14,7 @@
     "countryCodes": ["us"],
     "matchNames": ["american family", "amfam"],
     "tags": {
-      "brand": "Allstate",
+      "brand": "American Family Insurance",
       "brand:wikidata": "Q4743730",
       "brand:wikipedia": "en:American Family Insurance",
       "name": "American Family Insurance",

--- a/brands/office/insurance.json
+++ b/brands/office/insurance.json
@@ -1,0 +1,90 @@
+{
+  "office/insurance|Allstate": {
+    "countryCodes": ["us"],
+    "matchNames": ["allstate insurance"],
+    "tags": {
+      "brand": "Allstate",
+      "brand:wikidata": "Q2645636",
+      "brand:wikipedia": "en:Allstate",
+      "name": "Allstate",
+      "office": "insurance"
+    }
+  },
+  "office/insurance|American Family Insurance": {
+    "countryCodes": ["us"],
+    "matchNames": ["american family", "amfam"],
+    "tags": {
+      "brand": "Allstate",
+      "brand:wikidata": "Q4743730",
+      "brand:wikipedia": "en:American Family Insurance",
+      "name": "American Family Insurance",
+      "office": "insurance"
+    }
+  },
+  "office/insurance|Erie Insurance": {
+    "countryCodes": ["us"],
+    "matchNames": ["erie"],
+    "tags": {
+      "brand": "Erie Insurance",
+      "brand:wikidata": "Q5388314",
+      "brand:wikipedia": "en:Erie Insurance Group",
+      "name": "Erie Insurance",
+      "office": "insurance"
+    }
+  },
+  "office/insurance|Farmers Insurance": {
+    "countryCodes": ["us"],
+    "matchNames": ["farmers"],
+    "tags": {
+      "brand": "Farmers Insurance",
+      "brand:wikidata": "Q1396863",
+      "brand:wikipedia": "en:Farmers Insurance Group",
+      "name": "Farmers Insurance",
+      "office": "insurance"
+    }
+  },
+  "office/insurance|GEICO": {
+    "countryCodes": ["us"],
+    "tags": {
+      "brand": "GEICO",
+      "brand:wikidata": "Q1498689",
+      "brand:wikipedia": "en:GEICO",
+      "name": "GEICO",
+      "office": "insurance"
+    }
+  },
+  "office/insurance|Nationwide": {
+    "countryCodes": ["us"],
+    "matchNames": ["nationwide insurance"],
+    "nomatch": ["amenity/bank|Nationwide"],
+    "tags": {
+      "brand": "Nationwide",
+      "brand:wikidata": "Q6979886",
+      "brand:wikipedia": "en:Nationwide Mutual Insurance Company",
+      "name": "Nationwide",
+      "office": "insurance"
+    }
+  },
+  "office/insurance|Progressive": {
+    "countryCodes": ["us"],
+    "matchNames": ["progressive insurance"],
+    "tags": {
+      "brand": "Progressive",
+      "brand:wikidata": "Q7248721",
+      "brand:wikipedia": "en:Progressive Corporation",
+      "name": "Progressive",
+      "office": "insurance"
+    }
+  },
+  "office/insurance|State Farm": {
+    "countryCodes": ["us"],
+    "matchNames": ["state farm insurance"],
+    "tags": {
+      "brand": "State Farm",
+      "brand:wikidata": "Q2007336",
+      "brand:wikipedia": "en:State Farm",
+      "name": "State Farm",
+      "office": "insurance"
+    }
+  }
+}


### PR DESCRIPTION
Added a new `office/insurance` file containing major U.S. insurance companies that have independent agents in their own offices (typically auto and home insurance companies).

I included `name` in these entries, but the `name` should really be the agent’s name or d/b/a, which we can’t predetermine. Typically, the corporate branding is prominent but secondary to the agent’s name, and a single agent may be affiliated with two or more insurance companies.