### PR TITLE
KinderCare

### DIFF
--- a/brands/amenity/kindergarten.json
+++ b/brands/amenity/kindergarten.json
@@ -1,0 +1,21 @@
+{
+  "amenity/kindergarten|KinderCare": {
+    "countryCodes": ["us"],
+    "matchNames": ["kindercare learning center"],
+    "tags": {
+      "after_school": "yes",
+      "alt_name": "KinderCare Learning Center",
+      "amenity": "kindergarten",
+      "brand": "KinderCare",
+      "brand:wikidata": "Q6410551",
+      "brand:wikipedia": "en:KinderCare Learning Centers",
+      "fee": "yes",
+      "isced:level": "0",
+      "max_age": "12",
+      "min_age": "6 weeks",
+      "name": "KinderCare",
+      "nursery": "yes",
+      "preschool": "yes"
+    }
+  }
+}


### PR DESCRIPTION
Added KinderCare, a U.S. childcare center chain, with a bevy of tags that I’m pretty sure are uniform across all locations. There are similar chains in other countries, but I’m not sure whether `amenity=kindergarten` or `amenity=childcare` would be better for those chains.