### PR TITLE
Correct Union Bank details

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -4585,6 +4585,25 @@
       "name": "Union Bank of India"
     }
   },
+  "amenity/bank|Union Bank~(USA)": {
+    "countryCodes": ["us"],
+    "matchNames": [
+      "mufg union bank",
+      "union bank of california"
+    ],
+    "nomatch": [
+      "amenity/bank|Banco Unión",
+      "amenity/money_transfer|Express Union"
+    ],
+    "tags": {
+      "alt_name": "UnionBank",
+      "amenity": "bank",
+      "brand": "Union Bank",
+      "brand:wikidata": "Q1442804",
+      "brand:wikipedia": "en:MUFG Union Bank",
+      "name": "Union Bank"
+    }
+  },
   "amenity/bank|UnionBank~(Philippines)": {
     "countryCodes": ["ph"],
     "matchNames": [
@@ -4599,20 +4618,6 @@
       "brand": "UnionBank",
       "brand:wikidata": "Q7885403",
       "brand:wikipedia": "en:Union Bank of the Philippines",
-      "name": "UnionBank"
-    }
-  },
-  "amenity/bank|UnionBank~(USA)": {
-    "countryCodes": ["us"],
-    "nomatch": [
-      "amenity/bank|Banco Unión",
-      "amenity/money_transfer|Express Union"
-    ],
-    "tags": {
-      "amenity": "bank",
-      "brand": "UnionBank",
-      "brand:wikidata": "Q1442804",
-      "brand:wikipedia": "en:MUFG Union Bank",
       "name": "UnionBank"
     }
   },


### PR DESCRIPTION
MUFG Union Bank’s name is always written Union Bank in plain text, even though the logo has very tight kerning. Also added “Union Bank of California” as another name to match against, because the name change was fairly recent.