### PR TITLE
YMCA is a sports center

### DIFF
--- a/brands/leisure/fitness_centre.json
+++ b/brands/leisure/fitness_centre.json
@@ -161,15 +161,6 @@
       "name": "Snap Fitness"
     }
   },
-  "leisure/fitness_centre|YMCA": {
-    "tags": {
-      "brand": "YMCA",
-      "brand:wikidata": "Q157169",
-      "brand:wikipedia": "en:YMCA",
-      "leisure": "fitness_centre",
-      "name": "YMCA"
-    }
-  },
   "leisure/fitness_centre|clever fit": {
     "countryCodes": ["at", "ch", "de"],
     "tags": {

--- a/brands/leisure/sports_centre.json
+++ b/brands/leisure/sports_centre.json
@@ -1,0 +1,13 @@
+{
+  "leisure/sports_centre|YMCA": {
+    "matchTags": ["leisure/fitness_centre"],
+    "tags": {
+      "brand": "YMCA",
+      "brand:wikidata": "Q157169",
+      "brand:wikipedia": "en:YMCA",
+      "leisure": "sports_centre",
+      "name": "YMCA",
+      "religion": "christian"
+    }
+  }
+}


### PR DESCRIPTION
The YMCA’s programs are centered around sports but are broader than a typical commercial fitness center. This PR moves the Y from `leisure=fitness_centre` to `leisure=sports_centre`. Depending on the region, `amenity=community_centre`, `amenity=childcare`, `tourism=hostel`, or `tourism=camp_site` may also be appropriate, but I think this is more or less the lowest common denominator.