### PR TITLE
Common U.S. fraternal orders

### DIFF
--- a/brands/amenity/social_centre.json
+++ b/brands/amenity/social_centre.json
@@ -1,20 +1,77 @@
 {
-  "amenity/social_centre|American Legion": {
+  "amenity/social_centre|American Legion Hall": {
     "countryCodes": ["us"],
+    "matchNames": ["american legion"],
     "tags": {
+      "alt_name": "American Legion Hall",
       "amenity": "social_centre",
       "brand": "American Legion",
       "brand:wikidata": "Q468865",
       "brand:wikipedia": "en:American Legion",
-      "name": "American Legion",
+      "name": "American Legion Hall",
       "social_centre:for": "veterans"
     }
   },
-  "amenity/social_centre|Odd Fellow": {
+  "amenity/social_centre|Eagles Lodge": {
+    "countryCodes": ["us"],
+    "matchNames": [
+      "aeries lodge",
+      "foe",
+      "fraternal order of eagles"
+    ],
+    "tags": {
+      "alt_name": "Aeries Lodge",
+      "amenity": "social_centre",
+      "brand": "Fraternal Order of Eagles",
+      "brand:wikidata": "Q5493810",
+      "brand:wikipedia": "en:Fraternal Order of Eagles",
+      "name": "Eagles Lodge",
+      "official_name": "Fraternal Order of Eagles"
+    }
+  },
+  "amenity/social_centre|Elks Lodge": {
+    "countryCodes": ["us"],
+    "matchNames": [
+      "benevolent and protective order of elks",
+      "bpoe",
+      "elks"
+    ],
     "tags": {
       "amenity": "social_centre",
-      "brand": "Odd Fellow",
-      "name": "Odd Fellow"
+      "brand": "Benevolent and Protective Order of Elks",
+      "brand:wikidata": "Q2895789",
+      "brand:wikipedia": "en:Benevolent and Protective Order of Elks",
+      "name": "Elks Lodge",
+      "official_name": "Benevolent and Protective Order of Elks"
+    }
+  },
+  "amenity/social_centre|Moose Lodge": {
+    "countryCodes": ["bm", "ca", "us"],
+    "matchNames": ["loyal order of moose"],
+    "tags": {
+      "alt_name": "Moose Lodge",
+      "amenity": "social_centre",
+      "brand": "Loyal Order of Moose",
+      "brand:wikidata": "Q6908585",
+      "brand:wikipedia": "en:Loyal Order of Moose",
+      "name": "Moose Lodge",
+      "official_name": "Loyal Order of Moose"
+    }
+  },
+  "amenity/social_centre|Odd Fellows Hall": {
+    "matchNames": [
+      "independent order of odd fellows",
+      "ioof",
+      "odd fellow",
+      "odd fellows"
+    ],
+    "tags": {
+      "amenity": "social_centre",
+      "brand": "Independent Order of Odd Fellows",
+      "brand:wikidata": "Q1425508",
+      "brand:wikipedia": "en:Independent Order of Odd Fellows",
+      "name": "Odd Fellows Hall",
+      "official_name": "Independent Order of Odd Fellows"
     }
   }
 }


### PR DESCRIPTION
Added a few common U.S. fraternal orders, since a couple were already there. Existing tagging is pretty inconsistent: some bear the full organization’s name, others the nickname, still others the individual lodge name and number. It may be due to inconsistencies in signage from lodge to lodge. (We could probably expect the same situation with labor union halls.) I’m open to paring back or abandoning this PR if others share my uncertainty about how to tag the names.