### PR TITLE
Add Brazilian branch of Itaú bank.

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -3304,11 +3304,33 @@
       "name": "Intesa Sanpaolo"
     }
   },
-  "amenity/bank|Itaú": {
-    "matchNames": ["banco itaú"],
+  "amenity/bank|Itaú~(Brazil)": {
+    "countryCodes": ["br"],
+    "matchNames": [
+      "banco itau",
+      "banco itaú",
+      "itau"
+    ],
+    "nomatch": ["amenity/bank|Itaú~(Brazil)"],
     "tags": {
       "amenity": "bank",
-      "brand": "Itaú",
+      "brand": "Itaú Unibanco",
+      "brand:wikidata": "Q1424293",
+      "brand:wikipedia": "pt:Itaú Unibanco",
+      "name": "Itaú"
+    }
+  },
+  "amenity/bank|Itaú~(Chile)": {
+    "countryCodes": ["cl"],
+    "matchNames": [
+      "banco itau",
+      "banco itaú",
+      "itau"
+    ],
+    "nomatch": ["amenity/bank|Itaú~(Chile)"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Itaú Corpbanca",
       "brand:wikidata": "Q2423252",
       "brand:wikipedia": "en:Itaú Corpbanca",
       "name": "Itaú"


### PR DESCRIPTION
Itaú has branches in many countries, this change separates the Brazilian and Chilean. Also improves name matching, as it might be spelled without the accent.