### PR TITLE
Rename Pearle to Pearle Vision

### DIFF
--- a/brands/shop/optician.json
+++ b/brands/shop/optician.json
@@ -237,13 +237,13 @@
       "shop": "optician"
     }
   },
-  "shop/optician|Pearle": {
-    "matchNames": ["pearle vision"],
+  "shop/optician|Pearle Vision": {
+    "matchNames": ["pearle"],
     "tags": {
-      "brand": "Pearle",
+      "brand": "Pearle Vision",
       "brand:wikidata": "Q2231148",
       "brand:wikipedia": "en:Pearle Vision",
-      "name": "Pearle",
+      "name": "Pearle Vision",
       "shop": "optician"
     }
   },


### PR DESCRIPTION
It's on the wikipedia page, their website, and their past and present
logos.

Signed-off-by: Tim Smith <tsmith@chef.io>