### PR TITLE
Major U.S. cinema chains

### DIFF
--- a/brands/amenity/cinema.json
+++ b/brands/amenity/cinema.json
@@ -26,6 +26,32 @@
       "name": "AMC"
     }
   },
+  "amenity/cinema|B&B Theatres": {
+    "countryCodes": ["us"],
+    "matchNames": [
+      "b and b theatres",
+      "b&b",
+      "b&b theaters"
+    ],
+    "tags": {
+      "amenity": "cinema",
+      "brand": "B&B Theatres",
+      "brand:wikidata": "Q835638",
+      "brand:wikipedia": "en:B&B Theatres",
+      "name": "B&B Theatres"
+    }
+  },
+  "amenity/cinema|Century Theatres": {
+    "countryCodes": ["us"],
+    "matchNames": ["century"],
+    "tags": {
+      "amenity": "cinema",
+      "brand": "Century Theatres",
+      "brand:wikidata": "Q2946307",
+      "brand:wikipedia": "en:Century Theatres",
+      "name": "Century Theatres"
+    }
+  },
   "amenity/cinema|CineStar": {
     "countryCodes": ["de"],
     "tags": {
@@ -129,6 +155,17 @@
       "name": "Cineworld"
     }
   },
+  "amenity/cinema|Landmark Theatres": {
+    "countryCodes": ["us"],
+    "matchNames": ["landmark"],
+    "tags": {
+      "amenity": "cinema",
+      "brand": "Landmark Theatres",
+      "brand:wikidata": "Q6484805",
+      "brand:wikipedia": "en:Landmark Theatres",
+      "name": "Landmark Theatres"
+    }
+  },
   "amenity/cinema|MOVIX": {
     "countryCodes": ["jp"],
     "tags": {
@@ -141,6 +178,29 @@
       "official_name:en": "Shochiku Multiplex Theatres",
       "operator": "株式会社松竹マルチプレックスシアターズ",
       "operator:en": "Shochiku Multiplex Theatres, Ltd."
+    }
+  },
+  "amenity/cinema|Marcus Cinema": {
+    "countryCodes": ["us"],
+    "matchNames": [
+      "marcus",
+      "marcus cinemas",
+      "marcus theatres"
+    ],
+    "tags": {
+      "amenity": "cinema",
+      "brand": "Marcus Cinema",
+      "brand:wikidata": "Q64083352",
+      "name": "Marcus Cinema"
+    }
+  },
+  "amenity/cinema|Movie Tavern": {
+    "countryCodes": ["us"],
+    "tags": {
+      "amenity": "cinema",
+      "brand": "Movie Tavern",
+      "brand:wikidata": "Q64083534",
+      "name": "Movie Tavern"
     }
   },
   "amenity/cinema|Multikino": {
@@ -160,6 +220,28 @@
       "brand:wikidata": "Q6127470",
       "brand:wikipedia": "en:Odeon Cinemas",
       "name": "Odeon"
+    }
+  },
+  "amenity/cinema|Regal Cinemas": {
+    "countryCodes": ["us"],
+    "matchNames": ["regal", "regal cinema"],
+    "tags": {
+      "amenity": "cinema",
+      "brand": "Regal Cinemas",
+      "brand:wikidata": "Q835638",
+      "brand:wikipedia": "en:Regal Cinemas",
+      "name": "Regal Cinemas"
+    }
+  },
+  "amenity/cinema|Showcase Cinemas": {
+    "countryCodes": ["ar", "gb", "us"],
+    "matchNames": ["showcase"],
+    "tags": {
+      "amenity": "cinema",
+      "brand": "Showcase Cinemas",
+      "brand:wikidata": "Q7503170",
+      "brand:wikipedia": "en:Showcase Cinemas",
+      "name": "Showcase Cinemas"
     }
   },
   "amenity/cinema|TOHOシネマズ": {


### PR DESCRIPTION
Added several U.S. cinema chains with 50 locations or more. (There are a number of other regional chains that are notable enough for their own Wikipedia articles but with far fewer than 50 locations each.) As with hotels, many cinemas are individually named. Many cinemas are named according to the number of screens, for example “Century 16” or “Showcase Cinemas 16”.