### PR TITLE
Sherwin-Williams is hyphenated

### DIFF
--- a/brands/shop/paint.json
+++ b/brands/shop/paint.json
@@ -34,13 +34,13 @@
       "shop": "paint"
     }
   },
-  "shop/paint|Sherwin Williams": {
-    "matchNames": ["sherwin williams paints"],
+  "shop/paint|Sherwin-Williams": {
+    "matchNames": ["sherwin-williams paints"],
     "tags": {
-      "brand": "Sherwin Williams",
+      "brand": "Sherwin-Williams",
       "brand:wikidata": "Q48881",
       "brand:wikipedia": "en:Sherwin-Williams",
-      "name": "Sherwin Williams",
+      "name": "Sherwin-Williams",
       "shop": "paint"
     }
   }


### PR DESCRIPTION
Sherwin-Williams is always written hyphenated in plain text. Although the chain’s main logo has “Sherwin” and “Williams” on two separate lines with no hyphen, the horizontal wordmark does have a hyphen.

[![horizontal](https://user-images.githubusercontent.com/1231218/58443944-4613a900-80aa-11e9-8a3a-47ea40485202.png)](https://commons.wikimedia.org/wiki/File:Sherwin-Williams_Paints_in_Gillette,_Wyoming.jpg)