### PR TITLE
Winn✓Dixie has a hyphen

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -3632,13 +3632,13 @@
       "shop": "supermarket"
     }
   },
-  "shop/supermarket|Winn Dixie": {
+  "shop/supermarket|Winn-Dixie": {
     "countryCodes": ["us"],
     "tags": {
-      "brand": "Winn Dixie",
+      "brand": "Winn-Dixie",
       "brand:wikidata": "Q1264366",
       "brand:wikipedia": "en:Winn-Dixie",
-      "name": "Winn Dixie",
+      "name": "Winn-Dixie",
       "shop": "supermarket"
     }
   },


### PR DESCRIPTION
Winn-Dixie is written with a hyphen in plain text. The usual wordmark is stylized with a checkmark instead of a hyphen, but the hyphen can be seen inside the store and in front of some older locations.

[![hyphen](https://user-images.githubusercontent.com/1231218/58444035-f386bc80-80aa-11e9-8fa3-9ed16ab4e768.png)](https://commons.wikimedia.org/wiki/File:Winn_Dixie_Millidgeville,_GA_%287967695282%29.jpg)