### PR TITLE
Start adding urgent care clinics in the US

### DIFF
--- a/brands/healthcare/clinic.json
+++ b/brands/healthcare/clinic.json
@@ -2,6 +2,7 @@
   "healthcare/clinic|ZoomCare": {
     "countryCodes": ["us"],
     "tags": {
+      "amenity": "clinic",
       "brand": "ZoomCare",
       "brand:wikidata": "Q64120374",
       "brand:wikipedia": "en:ZoomCare",

--- a/brands/healthcare/clinic.json
+++ b/brands/healthcare/clinic.json
@@ -1,0 +1,12 @@
+{
+  "healthcare/clinic|ZoomCare": {
+    "countryCodes": ["us"],
+    "tags": {
+      "brand": "ZoomCare",
+      "brand:wikidata": "Q64120374",
+      "brand:wikipedia": "en:ZoomCare",
+      "healthcare": "clinic",
+      "name": "ZoomCare"
+    }
+  }
+}

--- a/brands/healthcare/clinic.json
+++ b/brands/healthcare/clinic.json
@@ -7,7 +7,8 @@
       "brand:wikidata": "Q64120374",
       "brand:wikipedia": "en:ZoomCare",
       "healthcare": "clinic",
-      "name": "ZoomCare"
+      "name": "ZoomCare",
+      "urgent_care": "yes"
     }
   }
 }


### PR DESCRIPTION
Due to our wonderfully backwards health care system there's a big
business for private care urgent care clinics. I added ZoomCare which is
a big one in Portland & Seattle. This could probably be expanded to
include some of the clinics here: https://www.healthdatamanagement.com/list/30-largest-urgent-care-center-chains-in-healthcare

Signed-off-by: Tim Smith <tsmith@chef.io>