### PR TITLE
Saint Algue: Add wikidata reference

### DIFF
--- a/brands/shop/hairdresser.json
+++ b/brands/shop/hairdresser.json
@@ -156,6 +156,7 @@
   "shop/hairdresser|Saint Algue": {
     "tags": {
       "brand": "Saint Algue",
+      "brand:wikidata": "Q62973210",
       "name": "Saint Algue",
       "shop": "hairdresser"
     }


### PR DESCRIPTION
Saint Algue does not have a dedicated wikipedia page, this is a
subsidiary of Provaliance, a group specialized in hair-dessers salons

fix #2689