### PR TITLE
Add Puerto Rico to many entries

### DIFF
--- a/brands/amenity/pharmacy.json
+++ b/brands/amenity/pharmacy.json
@@ -1065,7 +1065,7 @@
     }
   },
   "amenity/pharmacy|Walgreens": {
-    "countryCodes": ["us"],
+    "countryCodes": ["pr", "us"],
     "matchNames": ["walgreens pharmacy"],
     "nomatch": ["shop/chemist|Walgreens"],
     "tags": {

--- a/brands/amenity/post_box.json
+++ b/brands/amenity/post_box.json
@@ -14,7 +14,7 @@
     }
   },
   "amenity/post_box|USPS": {
-    "countryCodes": ["us"],
+    "countryCodes": ["pr", "us"],
     "nomatch": ["amenity/post_office|USPS"],
     "tags": {
       "amenity": "post_box",

--- a/brands/amenity/post_office.json
+++ b/brands/amenity/post_office.json
@@ -270,7 +270,7 @@
     }
   },
   "amenity/post_office|United States Post Office": {
-    "countryCodes": ["us"],
+    "countryCodes": ["pr", "us"],
     "matchNames": [
       "united states postal service",
       "us post office",

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -344,7 +344,7 @@
     }
   },
   "amenity/restaurant|Chuck E. Cheese's": {
-    "countryCodes": ["ca", "us"],
+    "countryCodes": ["ca", "pr", "us"],
     "tags": {
       "amenity": "restaurant",
       "brand": "Chuck E. Cheese's",

--- a/brands/leisure/fitness_centre.json
+++ b/brands/leisure/fitness_centre.json
@@ -135,7 +135,7 @@
     }
   },
   "leisure/fitness_centre|Planet Fitness": {
-    "countryCodes": ["ca", "us"],
+    "countryCodes": ["ca", "pr", "us"],
     "tags": {
       "brand": "Planet Fitness",
       "brand:wikidata": "Q7201095",

--- a/brands/office/tax_advisor.json
+++ b/brands/office/tax_advisor.json
@@ -11,7 +11,7 @@
     }
   },
   "office/tax_advisor|H&R Block": {
-    "countryCodes": ["us"],
+    "countryCodes": ["pr", "us"],
     "matchTags": ["office/accountant"],
     "tags": {
       "brand": "H&R Block",

--- a/brands/shop/car_parts.json
+++ b/brands/shop/car_parts.json
@@ -10,7 +10,7 @@
     }
   },
   "shop/car_parts|AutoZone": {
-    "countryCodes": ["br", "mx", "us"],
+    "countryCodes": ["br", "mx", "pr", "us"],
     "tags": {
       "brand": "AutoZone",
       "brand:wikidata": "Q4826087",

--- a/brands/shop/charity.json
+++ b/brands/shop/charity.json
@@ -134,7 +134,13 @@
     }
   },
   "shop/charity|The Salvation Army": {
-    "countryCodes": ["au", "ca", "gb", "us"],
+    "countryCodes": [
+      "au",
+      "ca",
+      "gb",
+      "pr",
+      "us"
+    ],
     "matchNames": ["salvation army"],
     "tags": {
       "brand": "The Salvation Army",

--- a/brands/shop/chemist.json
+++ b/brands/shop/chemist.json
@@ -171,7 +171,7 @@
     }
   },
   "shop/chemist|Walgreens": {
-    "countryCodes": ["us"],
+    "countryCodes": ["pr", "us"],
     "matchNames": ["walgreens pharmacy"],
     "tags": {
       "brand": "Walgreens",

--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -282,7 +282,7 @@
     }
   },
   "shop/clothes|Burlington Coat Factory": {
-    "countryCodes": ["us"],
+    "countryCodes": ["pr", "us"],
     "tags": {
       "brand": "Burlington Coat Factory",
       "brand:wikidata": "Q4999220",
@@ -591,7 +591,7 @@
     }
   },
   "shop/clothes|David's Bridal": {
-    "countryCodes": ["ca", "us"],
+    "countryCodes": ["ca", "pr", "us"],
     "tags": {
       "brand": "David's Bridal",
       "brand:wikidata": "Q5230388",
@@ -2126,7 +2126,7 @@
     }
   },
   "shop/clothes|TJ Maxx": {
-    "countryCodes": ["us"],
+    "countryCodes": ["pr", "us"],
     "tags": {
       "brand": "TJ Maxx",
       "brand:wikidata": "Q10860683",

--- a/brands/shop/cosmetics.json
+++ b/brands/shop/cosmetics.json
@@ -19,7 +19,7 @@
     }
   },
   "shop/cosmetics|Kiehl's": {
-    "countryCodes": ["ca", "us"],
+    "countryCodes": ["ca", "pr", "us"],
     "matchNames": ["kiehl's since 1851"],
     "tags": {
       "brand": "Kiehl's",

--- a/brands/shop/department_store.json
+++ b/brands/shop/department_store.json
@@ -192,7 +192,7 @@
     }
   },
   "shop/department_store|JCPenney": {
-    "countryCodes": ["us"],
+    "countryCodes": ["pr", "us"],
     "tags": {
       "brand": "JCPenney",
       "brand:wikidata": "Q920037",
@@ -236,7 +236,7 @@
     }
   },
   "shop/department_store|Kmart~(USA)": {
-    "countryCodes": ["us"],
+    "countryCodes": ["pr", "us"],
     "matchTags": ["shop/supermarket"],
     "nomatch": [
       "shop/department_store|Kmart~(Australia)"
@@ -340,7 +340,7 @@
     }
   },
   "shop/department_store|Nordstrom": {
-    "countryCodes": ["ca", "us"],
+    "countryCodes": ["ca", "pr", "us"],
     "tags": {
       "brand": "Nordstrom",
       "brand:wikidata": "Q174310",

--- a/brands/shop/doityourself.json
+++ b/brands/shop/doityourself.json
@@ -205,7 +205,7 @@
     }
   },
   "shop/doityourself|Home Depot": {
-    "countryCodes": ["ca", "mx", "us"],
+    "countryCodes": ["ca", "mx", "pr", "us"],
     "matchNames": ["the home depot"],
     "tags": {
       "brand": "Home Depot",

--- a/brands/shop/mobile_phone.json
+++ b/brands/shop/mobile_phone.json
@@ -11,7 +11,7 @@
     }
   },
   "shop/mobile_phone|AT&T": {
-    "countryCodes": ["mx", "us"],
+    "countryCodes": ["mx", "pr", "us"],
     "tags": {
       "brand": "AT&T",
       "brand:wikidata": "Q298594",
@@ -41,7 +41,7 @@
     }
   },
   "shop/mobile_phone|Boost Mobile": {
-    "countryCodes": ["us"],
+    "countryCodes": ["pr", "us"],
     "tags": {
       "brand": "Boost Mobile",
       "brand:wikidata": "Q4943790",
@@ -435,7 +435,7 @@
     }
   },
   "shop/mobile_phone|Verizon Wireless": {
-    "countryCodes": ["us"],
+    "countryCodes": ["pr", "us"],
     "matchNames": ["verizon"],
     "tags": {
       "brand": "Verizon Wireless",

--- a/brands/shop/nutrition_supplements.json
+++ b/brands/shop/nutrition_supplements.json
@@ -10,7 +10,7 @@
     }
   },
   "shop/nutrition_supplements|The Vitamin Shoppe": {
-    "countryCodes": ["us"],
+    "countryCodes": ["pr", "us"],
     "tags": {
       "brand": "The Vitamin Shoppe",
       "brand:wikidata": "Q7772938",

--- a/brands/shop/pet.json
+++ b/brands/shop/pet.json
@@ -85,7 +85,7 @@
     }
   },
   "shop/pet|PetSmart": {
-    "countryCodes": ["ca", "us"],
+    "countryCodes": ["ca", "pr", "us"],
     "tags": {
       "brand": "PetSmart",
       "brand:wikidata": "Q3307147",
@@ -95,7 +95,7 @@
     }
   },
   "shop/pet|Petco": {
-    "countryCodes": ["us"],
+    "countryCodes": ["pr", "us"],
     "tags": {
       "brand": "Petco",
       "brand:wikidata": "Q7171798",

--- a/brands/shop/shoes.json
+++ b/brands/shop/shoes.json
@@ -496,7 +496,7 @@
     }
   },
   "shop/shoes|Shoe Carnival": {
-    "countryCodes": ["us"],
+    "countryCodes": ["pr", "us"],
     "tags": {
       "brand": "Shoe Carnival",
       "brand:wikidata": "Q7500007",

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -50,7 +50,7 @@
     }
   },
   "tourism/hotel|Comfort Inn": {
-    "countryCodes": ["ca", "gb", "us"],
+    "countryCodes": ["ca", "gb", "pr", "us"],
     "nomatch": ["tourism/hotel|Comfort Suites"],
     "tags": {
       "brand": "Comfort Inn",


### PR DESCRIPTION
Puerto Rico has a different ISO 3166 country code than the United States. Added `pr` to the country codes of a number of entries where OSM has Puerto Rico locations mapped.