### PR TITLE
Corrected name of The Home Depot

### DIFF
--- a/brands/shop/doityourself.json
+++ b/brands/shop/doityourself.json
@@ -204,17 +204,6 @@
       "shop": "doityourself"
     }
   },
-  "shop/doityourself|Home Depot": {
-    "countryCodes": ["ca", "mx", "pr", "us"],
-    "matchNames": ["the home depot"],
-    "tags": {
-      "brand": "Home Depot",
-      "brand:wikidata": "Q864407",
-      "brand:wikipedia": "en:The Home Depot",
-      "name": "Home Depot",
-      "shop": "doityourself"
-    }
-  },
   "shop/doityourself|Home Hardware Building Centre": {
     "countryCodes": ["ca"],
     "matchNames": ["home hardware"],
@@ -399,6 +388,17 @@
       "brand:wikidata": "Q25475379",
       "brand:wikipedia": "tr:Tekzen",
       "name": "Tekzen",
+      "shop": "doityourself"
+    }
+  },
+  "shop/doityourself|The Home Depot": {
+    "countryCodes": ["ca", "mx", "pr", "us"],
+    "matchNames": ["home depot"],
+    "tags": {
+      "brand": "The Home Depot",
+      "brand:wikidata": "Q864407",
+      "brand:wikipedia": "en:The Home Depot",
+      "name": "The Home Depot",
       "shop": "doityourself"
     }
   },

--- a/brands/shop/doityourself.json
+++ b/brands/shop/doityourself.json
@@ -395,6 +395,7 @@
     "countryCodes": ["ca", "mx", "pr", "us"],
     "matchNames": ["home depot"],
     "tags": {
+      "alt_name": "Home Depot",
       "brand": "The Home Depot",
       "brand:wikidata": "Q864407",
       "brand:wikipedia": "en:The Home Depot",


### PR DESCRIPTION
The Home Depot is very consistent in calling itself “The Home Depot” rather than just “Home Depot”. The “The” is prominent in the chain’s logo.