### PR TITLE
Major U.S. retail health clinics

### DIFF
--- a/brands/amenity/doctors.json
+++ b/brands/amenity/doctors.json
@@ -1,0 +1,58 @@
+{
+  "amenity/doctors|MinuteClinic": {
+    "countryCodes": ["us"],
+    "matchTags": ["amenity/clinic"],
+    "tags": {
+      "amenity": "doctors",
+      "brand": "MinuteClinic",
+      "brand:wikidata": "Q6871141",
+      "brand:wikipedia": "en:MinuteClinic",
+      "healthcare": "doctor",
+      "healthcare:speciality": "community",
+      "name": "MinuteClinic"
+    }
+  },
+  "amenity/doctors|RediClinic": {
+    "countryCodes": ["us"],
+    "matchTags": ["amenity/clinic"],
+    "tags": {
+      "amenity": "doctors",
+      "brand": "RediClinic",
+      "brand:wikidata": "Q64138408",
+      "healthcare": "doctor",
+      "healthcare:speciality": "community",
+      "name": "RediClinic"
+    }
+  },
+  "amenity/doctors|The Little Clinic": {
+    "countryCodes": ["us"],
+    "matchNames": ["little clinic"],
+    "matchTags": ["amenity/clinic"],
+    "tags": {
+      "amenity": "doctors",
+      "brand": "The Little Clinic",
+      "brand:wikidata": "Q64138262",
+      "healthcare": "doctor",
+      "healthcare:speciality": "community",
+      "name": "The Little Clinic"
+    }
+  },
+  "amenity/doctors|Walgreens Healthcare Clinic": {
+    "countryCodes": ["us"],
+    "matchNames": [
+      "healthcare clinic",
+      "takecare",
+      "takecare clinic",
+      "walgreens"
+    ],
+    "matchTags": ["amenity/clinic"],
+    "tags": {
+      "amenity": "doctors",
+      "brand": "Walgreens",
+      "brand:wikidata": "Q1591889",
+      "healthcare": "doctor",
+      "healthcare:speciality": "community",
+      "name": "Walgreens Healthcare Clinic"
+    }
+  }
+}


### PR DESCRIPTION
Similar to #2692, here are the largest retail health clinic chains in the U.S. These clinics are located inside pharmacies or supermarkets and are too small to justify `amenity=clinic`, which is supposed to be larger than `amenity=doctors`. On the other hand, `amenity=doctors` is suboptimal, because these clinics are usually headed by (or staffed solely by) a nurse practitioner rather than a doctor.