### PR TITLE
malangligis kelkajn "brand:wikipedia"

### DIFF
--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -166,7 +166,7 @@
     "tags": {
       "brand": "Bershka",
       "brand:wikidata": "Q827258",
-      "brand:wikipedia": "en:Bershka",
+      "brand:wikipedia": "pl:Bershka",
       "name": "Bershka",
       "shop": "clothes"
     }
@@ -341,7 +341,7 @@
     "tags": {
       "brand": "Calzedonia",
       "brand:wikidata": "Q1027874",
-      "brand:wikipedia": "en:Calzedonia",
+      "brand:wikipedia": "pl:Calzedonia",
       "name": "Calzedonia",
       "shop": "clothes"
     }
@@ -880,7 +880,7 @@
     "tags": {
       "brand": "H&M",
       "brand:wikidata": "Q188326",
-      "brand:wikipedia": "en:H&M",
+      "brand:wikipedia": "eo:Hennes & Mauritz",
       "name": "H&M",
       "shop": "clothes"
     }
@@ -945,7 +945,7 @@
     "tags": {
       "brand": "Hugo Boss",
       "brand:wikidata": "Q491627",
-      "brand:wikipedia": "en:Hugo Boss",
+      "brand:wikipedia": "pl:Hugo Boss AG",
       "name": "Hugo Boss",
       "shop": "clothes"
     }
@@ -1182,7 +1182,7 @@
     "tags": {
       "brand": "Lacoste",
       "brand:wikidata": "Q309031",
-      "brand:wikipedia": "en:Lacoste",
+      "brand:wikipedia": "eo:Lacoste",
       "name": "Lacoste",
       "shop": "clothes"
     }
@@ -1913,7 +1913,7 @@
     "tags": {
       "brand": "Reserved",
       "brand:wikidata": "Q21809354",
-      "brand:wikipedia": "en:Reserved",
+      "brand:wikipedia": "pl:Reserved",
       "name": "Reserved",
       "shop": "clothes"
     }


### PR DESCRIPTION
Mi ŝanĝis kelkajn etikedojn "brand:wikipedia" por ligi al artikoloj en Pola aŭ en Esperanto. Anglalingvanoj ne havas rajton altrudi sian lingvaĉon al la resto de mondo.

Zmieniłem kilka etykiet "brand:wikipedia", aby łączyły się z artykułami w języku polskim lub Esperanto. Anglicy nie mają prawa narzucać swojego języka reszcie świata.