### PR TITLE
Correct Block Advisors country codes, Wikidata item

### DIFF
--- a/brands/office/tax_advisor.json
+++ b/brands/office/tax_advisor.json
@@ -3,9 +3,8 @@
     "countryCodes": ["us"],
     "matchTags": ["office/accountant"],
     "tags": {
-      "brand": "H&R Block",
-      "brand:wikidata": "Q5627799",
-      "brand:wikipedia": "en:H&R Block",
+      "brand": "Block Advisors",
+      "brand:wikidata": "Q64166231",
       "name": "Block Advisors",
       "office": "tax_advisor"
     }

--- a/brands/office/tax_advisor.json
+++ b/brands/office/tax_advisor.json
@@ -1,6 +1,6 @@
 {
   "office/tax_advisor|Block Advisors": {
-    "countryCodes": ["ca", "us"],
+    "countryCodes": ["us"],
     "matchTags": ["office/accountant"],
     "tags": {
       "brand": "H&R Block",
@@ -11,7 +11,7 @@
     }
   },
   "office/tax_advisor|H&R Block": {
-    "countryCodes": ["pr", "us"],
+    "countryCodes": ["ca", "pr", "us"],
     "matchTags": ["office/accountant"],
     "tags": {
       "brand": "H&R Block",


### PR DESCRIPTION
H&R Block is in Canada, but Block Advisors doesn’t seem to be. Also separated the Block Advisors Wikidata item from the H&R Block item, since they’re separate brands with separate names and logos.

/ref #2711