### PR TITLE
Aladdin Bail Bonds

### DIFF
--- a/brands/office/bail_bond_agent.json
+++ b/brands/office/bail_bond_agent.json
@@ -1,0 +1,26 @@
+{
+  "office/bail_bond_agent|Aladdin Bail Bonds": {
+    "countryCodes": ["us"],
+    "matchNames": [
+      "aladdin",
+      "aladin bail bonds",
+      "alladin bail bonds"
+    ],
+    "matchTags": [
+      "amenity/bail_bond",
+      "amenity/bail_bonds",
+      "office/bail_bond",
+      "office/bail_bonds",
+      "shop/bail_bond",
+      "shop/bail_bonds",
+      "shop/money_lender"
+    ],
+    "tags": {
+      "brand": "Aladdin Bail Bonds",
+      "brand:wikidata": "Q64166257",
+      "name": "Aladdin Bail Bonds",
+      "office": "bail_bond_agent",
+      "opening_hours": "24/7"
+    }
+  }
+}


### PR DESCRIPTION
Added Aladdin Bail Bonds. Several tags are currently being used for bail bond agents; I went with `office=bail_bond_agent`, the second most popular tag behind `amenity=bail_bonds` and ahead of `shop=bail_bonds`. I’ve never been inside one, but I think they feel more like insurance offices (`office=insurance`) than payday loan shops (`shop=money_lender`) and bank branches (`amenity=bank`) where you can quickly complete some transactions without sitting down. But `office=bail_bonds` seems reasonable too.

[![aladdin](https://user-images.githubusercontent.com/1231218/58644388-fb667c80-82b5-11e9-8eaf-f78dbe74fcc0.png)](https://www.mapillary.com/map/im/Vlp_1SwJR2K80imWlq9w6g)