### PR TITLE
malangligis kelkajn "brand:wikipedia" (2)

### DIFF
--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -166,7 +166,7 @@
     "tags": {
       "brand": "Bershka",
       "brand:wikidata": "Q827258",
-      "brand:wikipedia": "pl:Bershka",
+      "brand:wikipedia": "es:Bershka",
       "name": "Bershka",
       "shop": "clothes"
     }
@@ -341,7 +341,7 @@
     "tags": {
       "brand": "Calzedonia",
       "brand:wikidata": "Q1027874",
-      "brand:wikipedia": "pl:Calzedonia",
+      "brand:wikipedia": "it:Gruppo Calzedonia",
       "name": "Calzedonia",
       "shop": "clothes"
     }
@@ -880,7 +880,7 @@
     "tags": {
       "brand": "H&M",
       "brand:wikidata": "Q188326",
-      "brand:wikipedia": "eo:Hennes & Mauritz",
+      "brand:wikipedia": "sv:Hennes & Mauritz",
       "name": "H&M",
       "shop": "clothes"
     }
@@ -945,7 +945,7 @@
     "tags": {
       "brand": "Hugo Boss",
       "brand:wikidata": "Q491627",
-      "brand:wikipedia": "pl:Hugo Boss AG",
+      "brand:wikipedia": "de:Hugo Boss",
       "name": "Hugo Boss",
       "shop": "clothes"
     }
@@ -1182,7 +1182,7 @@
     "tags": {
       "brand": "Lacoste",
       "brand:wikidata": "Q309031",
-      "brand:wikipedia": "eo:Lacoste",
+      "brand:wikipedia": "fr:Lacoste (entreprise)",
       "name": "Lacoste",
       "shop": "clothes"
     }

--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -166,7 +166,7 @@
     "tags": {
       "brand": "Bershka",
       "brand:wikidata": "Q827258",
-      "brand:wikipedia": "en:Bershka",
+      "brand:wikipedia": "pl:Bershka",
       "name": "Bershka",
       "shop": "clothes"
     }
@@ -341,7 +341,7 @@
     "tags": {
       "brand": "Calzedonia",
       "brand:wikidata": "Q1027874",
-      "brand:wikipedia": "en:Calzedonia",
+      "brand:wikipedia": "pl:Calzedonia",
       "name": "Calzedonia",
       "shop": "clothes"
     }
@@ -880,7 +880,7 @@
     "tags": {
       "brand": "H&M",
       "brand:wikidata": "Q188326",
-      "brand:wikipedia": "en:H&M",
+      "brand:wikipedia": "eo:Hennes & Mauritz",
       "name": "H&M",
       "shop": "clothes"
     }
@@ -945,7 +945,7 @@
     "tags": {
       "brand": "Hugo Boss",
       "brand:wikidata": "Q491627",
-      "brand:wikipedia": "en:Hugo Boss",
+      "brand:wikipedia": "pl:Hugo Boss AG",
       "name": "Hugo Boss",
       "shop": "clothes"
     }
@@ -1182,7 +1182,7 @@
     "tags": {
       "brand": "Lacoste",
       "brand:wikidata": "Q309031",
-      "brand:wikipedia": "en:Lacoste",
+      "brand:wikipedia": "eo:Lacoste",
       "name": "Lacoste",
       "shop": "clothes"
     }
@@ -1913,7 +1913,7 @@
     "tags": {
       "brand": "Reserved",
       "brand:wikidata": "Q21809354",
-      "brand:wikipedia": "en:Reserved",
+      "brand:wikipedia": "pl:Reserved",
       "name": "Reserved",
       "shop": "clothes"
     }


### PR DESCRIPTION
Pluigo de https://github.com/osmlab/name-suggestion-index/pull/2712
@Adamant36 > English isn't "imposing" their language on the rest of the world. These aren't mainly Polish brands and English is spoken in a lot more places where they are located than Polish is. If they were confined to Polish countries I'd zero problem with them being linked to Polish Wikipedia articles.
Bone, Bershka estas Hispana marko, do mi ŝanĝis ligilon al Hispana Vikipedio, kaj simile.

@matkoniecz > Using local wikipedia versions for given area is preferable during editing and it may be a good idea to somehow provide info that would make it easier.
La problemo estas, ke la redaktilo iD montras averton, "etikedoj estas kadukaj" kaj proponas "ĝisdatigi ilin".

**Do por eviti tiajn problemojn, mi proponas forigi la etikedojn "brand:wikipedia" el name-suggestion-index kaj restigi nur "brand:wikidata".**