### PR TITLE
update 屈臣氏 brand:wikidata

### DIFF
--- a/brands/shop/chemist.json
+++ b/brands/shop/chemist.json
@@ -284,9 +284,12 @@
     }
   },
   "shop/chemist|屈臣氏": {
+    "countryCodes": ["cn","hk","tw"],
     "nomatch": ["amenity/pharmacy|屈臣氏"],
     "tags": {
       "brand": "屈臣氏",
+      "brand:wikidata": "Q7974785",
+      "brand:wikipedia": "zh:屈臣氏",
       "name": "屈臣氏",
       "shop": "chemist"
     }


### PR DESCRIPTION
The Chinese name of Watsons is 屈臣氏