### PR TITLE
Update Bath & Body Works to be a cosmetics store

### DIFF
--- a/brands/shop/beauty.json
+++ b/brands/shop/beauty.json
@@ -1,13 +1,4 @@
 {
-  "shop/beauty|Bath & Body Works": {
-    "tags": {
-      "brand": "Bath & Body Works",
-      "brand:wikidata": "Q810773",
-      "brand:wikipedia": "en:Bath & Body Works",
-      "name": "Bath & Body Works",
-      "shop": "beauty"
-    }
-  },
   "shop/beauty|Coiffure Dame": {
     "tags": {
       "brand": "Coiffure Dame",

--- a/brands/shop/cosmetics.json
+++ b/brands/shop/cosmetics.json
@@ -1,4 +1,13 @@
 {
+  "shop/cosmetics|Bath & Body Works": {
+    "tags": {
+      "brand": "Bath & Body Works",
+      "brand:wikidata": "Q810773",
+      "brand:wikipedia": "en:Bath & Body Works",
+      "name": "Bath & Body Works",
+      "shop": "cosmetics"
+    }
+  },
   "shop/cosmetics|Eva": {
     "countryCodes": ["ru", "ua"],
     "tags": {
@@ -114,7 +123,7 @@
     }
   },
   "shop/cosmetics|The Body Shop": {
-    "matchTags": ["shop/beauty", "shop/chemist"],
+    "matchTags": ["shop/chemist"],
     "tags": {
       "brand": "The Body Shop",
       "brand:wikidata": "Q837851",

--- a/config/match_groups.json
+++ b/config/match_groups.json
@@ -19,6 +19,9 @@
         "shop/convenience",
         "shop/cosmetics"
     ],
+    "cosmetics": [
+      "shop/beauty"
+    ],
     "electronics": [
         "shop/computer",
         "shop/electronics",


### PR DESCRIPTION
They sell perfume, soap, and lotions. They don't provide services. Similar stores like Lush and The Body Shop are already considered to be cosmetics stores.

I also added a tag match for all cosmetics shops to beauty shop tags.

Fixes #2729 

Signed-off-by: Tim Smith <tsmith@chef.io>