### PR TITLE
Correct ExtraMile wiki tags

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -426,10 +426,8 @@
     "countryCodes": ["us"],
     "tags": {
       "brand": "ExtraMile",
+      "brand:wikidata": "Q64224605",
       "name": "ExtraMile",
-      "operator": "Chevron",
-      "operator:wikidata": "Q319642",
-      "operator:wikipedia": "en:Chevron Corporation",
       "shop": "convenience"
     }
   },


### PR DESCRIPTION
`operator` should be reserved for the franchisee of a gas station or convenience store, not the franchise’s corporate parent. Wikidata is better suited for detailing corporate structures. I created [a new Wikidata item](https://www.wikidata.org/wiki/Q64224605) to represent the ExtraMile brand, which makes it possible for the index to feature the store’s own logo instead of the Chevron logo. If a data consumer does need to determine the brand’s corporate parent, it can refer to the [parent organization](https://www.wikidata.org/wiki/Property:P749) claim in the Wikidata item.