### PR TITLE
Paris Baguette

### DIFF
--- a/brands/shop/bakery.json
+++ b/brands/shop/bakery.json
@@ -409,42 +409,13 @@
       "shop": "bakery"
     }
   },
-  "shop/bakery|Paris Baguette~(China)": {
-    "countryCodes": ["cn"],
-    "matchNames": ["paris baguette cafe", "巴黎贝甜"],
-    "tags": {
-      "brand": "Paris Baguette",
-      "brand:en": "Paris Baguette",
-      "brand:wikidata": "Q62605260",
-      "brand:zh": "巴黎贝甜",
-      "name": "Paris Baguette",
-      "name:en": "Paris Baguette",
-      "name:zh": "巴黎贝甜",
-      "shop": "bakery"
-    }
-  },
-  "shop/bakery|Paris Baguette~(South Korea)": {
-    "countryCodes": ["kr"],
-    "matchNames": [
-      "paris baguette cafe",
-      "파리바게뜨",
-      "파리바게트"
-    ],
-    "tags": {
-      "alt_name:ko": "파리바게트",
-      "brand": "Paris Baguette",
-      "brand:en": "Paris Baguette",
-      "brand:ko": "파리바게뜨",
-      "brand:wikidata": "Q62605260",
-      "name": "Paris Baguette",
-      "name:en": "Paris Baguette",
-      "name:ko": "파리바게뜨",
-      "shop": "bakery"
-    }
-  },
   "shop/bakery|Paris Baguette~(worldwide)": {
     "countryCodes": ["sg", "us", "vn"],
     "matchNames": ["paris baguette cafe"],
+    "nomatch": [
+      "shop/bakery|巴黎贝甜",
+      "shop/bakery|파리바게뜨"
+    ],
     "tags": {
       "brand": "Paris Baguette",
       "brand:wikidata": "Q62605260",
@@ -582,6 +553,28 @@
       "shop": "bakery"
     }
   },
+  "shop/bakery|巴黎贝甜~(China)": {
+    "countryCodes": ["cn"],
+    "matchNames": [
+      "paris baguette",
+      "paris baguette cafe",
+      "巴黎貝甜"
+    ],
+    "nomatch": [
+      "shop/bakery|Paris Baguette",
+      "shop/bakery|파리바게뜨"
+    ],
+    "tags": {
+      "brand": "巴黎贝甜",
+      "brand:en": "Paris Baguette",
+      "brand:wikidata": "Q62605260",
+      "brand:zh": "巴黎贝甜",
+      "name": "巴黎贝甜",
+      "name:en": "Paris Baguette",
+      "name:zh": "巴黎贝甜",
+      "shop": "bakery"
+    }
+  },
   "shop/bakery|뚜레쥬르": {
     "countryCodes": ["kr"],
     "matchNames": ["뚜레주르"],
@@ -594,6 +587,29 @@
       "name": "뚜레쥬르",
       "name:en": "Tous Les Jours",
       "name:ko": "뚜레쥬르",
+      "shop": "bakery"
+    }
+  },
+  "shop/bakery|파리바게뜨~(South Korea)": {
+    "countryCodes": ["kr"],
+    "matchNames": [
+      "paris baguette",
+      "paris baguette cafe",
+      "파리바게트"
+    ],
+    "nomatch": [
+      "shop/bakery|Paris Baguette",
+      "shop/bakery|巴黎贝甜"
+    ],
+    "tags": {
+      "alt_name:ko": "파리바게트",
+      "brand": "파리바게뜨",
+      "brand:en": "Paris Baguette",
+      "brand:ko": "파리바게뜨",
+      "brand:wikidata": "Q62605260",
+      "name": "파리바게뜨",
+      "name:en": "Paris Baguette",
+      "name:ko": "파리바게뜨",
       "shop": "bakery"
     }
   }

--- a/brands/shop/bakery.json
+++ b/brands/shop/bakery.json
@@ -409,6 +409,49 @@
       "shop": "bakery"
     }
   },
+  "shop/bakery|Paris Baguette~(China)": {
+    "countryCodes": ["cn"],
+    "matchNames": ["paris baguette cafe", "巴黎贝甜"],
+    "tags": {
+      "brand": "Paris Baguette",
+      "brand:en": "Paris Baguette",
+      "brand:wikidata": "Q62605260",
+      "brand:zh": "巴黎贝甜",
+      "name": "Paris Baguette",
+      "name:en": "Paris Baguette",
+      "name:zh": "巴黎贝甜",
+      "shop": "bakery"
+    }
+  },
+  "shop/bakery|Paris Baguette~(South Korea)": {
+    "countryCodes": ["kr"],
+    "matchNames": [
+      "paris baguette cafe",
+      "파리바게뜨",
+      "파리바게트"
+    ],
+    "tags": {
+      "alt_name:ko": "파리바게트",
+      "brand": "Paris Baguette",
+      "brand:en": "Paris Baguette",
+      "brand:ko": "파리바게뜨",
+      "brand:wikidata": "Q62605260",
+      "name": "Paris Baguette",
+      "name:en": "Paris Baguette",
+      "name:ko": "파리바게뜨",
+      "shop": "bakery"
+    }
+  },
+  "shop/bakery|Paris Baguette~(worldwide)": {
+    "countryCodes": ["sg", "us", "vn"],
+    "matchNames": ["paris baguette cafe"],
+    "tags": {
+      "brand": "Paris Baguette",
+      "brand:wikidata": "Q62605260",
+      "name": "Paris Baguette",
+      "shop": "bakery"
+    }
+  },
   "shop/bakery|Paul": {
     "tags": {
       "brand": "Paul",
@@ -551,26 +594,6 @@
       "name": "뚜레쥬르",
       "name:en": "Tous Les Jours",
       "name:ko": "뚜레쥬르",
-      "shop": "bakery"
-    }
-  },
-  "shop/bakery|파리바게뜨": {
-    "countryCodes": ["kr"],
-    "tags": {
-      "brand": "파리바게뜨",
-      "brand:ko": "파리바게뜨",
-      "name": "파리바게뜨",
-      "name:ko": "파리바게뜨",
-      "shop": "bakery"
-    }
-  },
-  "shop/bakery|파리바게트": {
-    "countryCodes": ["kr"],
-    "tags": {
-      "brand": "파리바게트",
-      "brand:ko": "파리바게트",
-      "name": "파리바게트",
-      "name:ko": "파리바게트",
       "shop": "bakery"
     }
   }


### PR DESCRIPTION
Added Paris Baguette as `shop=bakery`. Some locations are [more like bakery-cafés](https://commons.wikimedia.org/wiki/File:Paris_Baguette_Café_in_2015_02.jpg), while others are [more like traditional patisseries](http://www.nvp.co.kr/news/articleView.html?idxno=121141), with cases where you shop for premade pastries yourself. Maybe there need to be separate entries for Paris Baguette (`shop=bakery` or `shop=pastry`) versus Paris Baguette Café (`amenity=fast_food`)?

I set `name` to `Paris Baguette`, in English, even for the entries that are limited to South Korea and China. Storefront signage in South Korea and [China](http://www.tzcy37.com/zixun/39289.html) is primarily in English, and the Korean name is [relegated to a tiny font](https://commons.wikimedia.org/wiki/File:20150209-20150214최광모C46.JPG) off to the side. [In OSM](http://overpass-turbo.eu/s/JBg), 99 features are currently tagged `파리바게트` (using a more common word for “baguette”), 73 are tagged `파리바게뜨` (the chain’s official Korean name), and 45 are tagged `Paris Baguette`. To me, the on-the-ground rule favors “Paris Baguette”, and the most common name seems to be the result of people translating the English name to Korean word for word. But if the local community’s preference is for POIs to be in Hangul, then we can change `name` to `파리바게뜨`.