### PR TITLE
Distinguish Ulta cosmetics store from beauty studios

### DIFF
--- a/brands/shop/beauty.json
+++ b/brands/shop/beauty.json
@@ -49,8 +49,9 @@
   "shop/beauty|Ulta Beauty": {
     "countryCodes": ["us"],
     "matchNames": ["ulta"],
+    "nomatch": ["shop/cosmetics|Ulta Beauty"],
     "tags": {
-      "beauty": "cosmetics;eyebrow;eyelash;hair;skin_care;supplies;waxing",
+      "beauty": "eyebrow;eyelash;hair;skin_care;waxing",
       "brand": "Ulta Beauty",
       "brand:wikidata": "Q7880076",
       "brand:wikipedia": "en:Ulta Beauty",

--- a/brands/shop/cosmetics.json
+++ b/brands/shop/cosmetics.json
@@ -132,6 +132,18 @@
       "shop": "cosmetics"
     }
   },
+  "shop/cosmetics|Ulta Beauty": {
+    "countryCodes": ["us"],
+    "matchNames": ["ulta"],
+    "nomatch": ["shop/beauty|Ulta Beauty"],
+    "tags": {
+      "brand": "Ulta Beauty",
+      "brand:wikidata": "Q7880076",
+      "brand:wikipedia": "en:Ulta Beauty",
+      "name": "Ulta Beauty",
+      "shop": "cosmetics"
+    }
+  },
   "shop/cosmetics|Vente de Cosmétique": {
     "countryCodes": ["ci"],
     "tags": {


### PR DESCRIPTION
Copied the Ulta Beauty entry as a `shop=cosmetics` entry. An Ultra Beauty store is primarily a cosmetics store, but there are salon studios inside it. This index considers a drugstore to be separate from the pharmacy counter within it, so by analogy the cosmetic store should be separate from the salon studios within it.