### PR TITLE
muji 無印良品 in jp, tw

### DIFF
--- a/brands/shop/department_store.json
+++ b/brands/shop/department_store.json
@@ -334,10 +334,27 @@
   "shop/department_store|Muji": {
     "tags": {
       "brand": "Muji",
+      "brand:en": "Muji",
+      "brand:jp": "無印良品",
       "brand:wikidata": "Q708789",
       "brand:wikipedia": "en:Muji",
       "name": "Muji",
-      "name:zh": "無印良品",
+      "name:en": "Muji",
+      "name:jp": "無印良品",
+      "shop": "department_store"
+    }
+  },
+  "shop/department_store|無印良品": {
+    "countryCodes": ["jp", "tw"],
+    "tags": {
+      "brand": "無印良品",
+      "brand:jp": "無印良品",
+      "brand:en": "Muji",
+      "brand:wikidata": "Q708789",
+      "brand:wikipedia": "jp:Muji",
+      "name": "無印良品",
+      "name:jp": "無印良品",
+      "name:en": "Muji",
       "shop": "department_store"
     }
   },

--- a/brands/shop/department_store.json
+++ b/brands/shop/department_store.json
@@ -351,7 +351,7 @@
       "brand:jp": "無印良品",
       "brand:en": "Muji",
       "brand:wikidata": "Q708789",
-      "brand:wikipedia": "jp:Muji",
+      "brand:wikipedia": "jp:無印良品",
       "name": "無印良品",
       "name:jp": "無印良品",
       "name:en": "Muji",


### PR DESCRIPTION
follow up to #2757 @bhousel @Adamant36 

sorry I was in the middle of updating my PR when it was merged.

I've tried to follow the international example used at https://github.com/osmlab/name-suggestion-index/blob/b877596e309f95b35dcf1027dbac4defc75ebe73/CONTRIBUTING.md#card_file_box--about-the-brand-files

In Japan and Taiwan, possibly Singapore and other asian countries, the main name is known in the native language not English. This PR tried to address that to these stores in JP and TW are hopefully given better tags.