### PR TITLE
require clothes tag for shop=clothes

### DIFF
--- a/build_brands.js
+++ b/build_brands.js
@@ -273,6 +273,9 @@ function checkBrands() {
             case 'shop/beauty':
                 if (!obj.tags.beauty) { warnMissingTag.push([kvnd, 'beauty']); }
                 break;
+            case 'shop/clothes':
+                if (!obj.tags.clothes) { warnMissingTag.push([kvnd, 'clothes']); }
+                break;
         }
     });
 


### PR DESCRIPTION
I think that it would be desirable to expect `clothes` tag for every `shop=clothes`.

Making PR as it would add many new warnings - see https://gist.github.com/matkoniecz/79cdaa913b71a49fe564890db3bd43be
