### PR TITLE
AAA

### DIFF
--- a/brands/office/insurance.json
+++ b/brands/office/insurance.json
@@ -1,4 +1,21 @@
 {
+  "office/insurance|AAA Insurance": {
+    "countryCodes": ["us"],
+    "matchNames": [
+      "american automobile association"
+    ],
+    "nomatch": [
+      "office/travel_agency|American Automobile Association"
+    ],
+    "tags": {
+      "brand": "American Automobile Association",
+      "brand:wikidata": "Q463436",
+      "brand:wikipedia": "en:American Automobile Association",
+      "name": "AAA Insurance",
+      "office": "insurance",
+      "short_name": "AAA"
+    }
+  },
   "office/insurance|Allstate": {
     "countryCodes": ["us"],
     "matchNames": ["allstate insurance"],

--- a/brands/shop/travel_agency.json
+++ b/brands/shop/travel_agency.json
@@ -1,4 +1,20 @@
 {
+  "shop/travel_agency|American Automobile Association": {
+    "countryCodes": ["us"],
+    "matchTags": [
+      "office/travel_agent",
+      "shop/car"
+    ],
+    "nomatch": ["office/insurance|AAA Insurance"],
+    "tags": {
+      "brand": "American Automobile Association",
+      "brand:wikidata": "Q463436",
+      "brand:wikipedia": "en:American Automobile Association",
+      "name": "American Automobile Association",
+      "shop": "travel_agency",
+      "short_name": "AAA"
+    }
+  },
   "shop/travel_agency|Coral Travel": {
     "countryCodes": ["pl", "ru", "ua"],
     "tags": {


### PR DESCRIPTION
Added American Automobile Association travel agencies and insurance agencies. I didn’t add the AAA car care centers, because each AAA affiliate runs its own small chain of owned-and-operated centers (not to be confused with AAA-approved mechanics), each with a similar name but a distinct `operator:wikidata`. Until we start filtering brands by state, the risk of a mapper getting confused and choosing the wrong chain is too high.