### PR TITLE
Add missing brand tags.

### DIFF
--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -512,6 +512,7 @@
     "countryCodes": ["us"],
     "tags": {
       "amenity": "restaurant",
+      "brand": "Eat'n Park",
       "brand:wikidata": "Q5331211",
       "brand:wikipedia": "en:Eat'n Park",
       "cuisine": "american",

--- a/brands/office/insurance.json
+++ b/brands/office/insurance.json
@@ -114,6 +114,7 @@
   "office/insurance|MAAF": {
     "countryCodes": ["fr"],
     "tags": {
+      "brand": "MAAF",
       "brand:wikidata": "Q3331028",
       "brand:wikipedia": "fr:Mutuelle d'assurance des artisans de France",
       "name": "MAAF",

--- a/brands/shop/confectionery.json
+++ b/brands/shop/confectionery.json
@@ -13,6 +13,7 @@
   "shop/confectionery|Hemmakvall": {
     "countryCodes": ["se"],
     "tags": {
+      "brand": "Hemmakväll",
       "brand:wikidata": "Q10521791",
       "brand:wikipedia": "sv:Hemmakväll",
       "name": "Hemmakväll",


### PR DESCRIPTION
    ¶ cat $(git ls-files brands/) | jq -c '.[].tags|select(has("name")|not)'
    ¶ cat $(git ls-files brands/) | jq -c '.[].tags|select(has("brand")|not)'
    {"amenity":"restaurant","brand:wikidata":"Q5331211","brand:wikipedia":"en:Eat'n Park","cuisine":"american","name":"Eat'n Park"}
    {"brand:wikidata":"Q3331028","brand:wikipedia":"fr:Mutuelle d'assurance des artisans de France","name":"MAAF","office":"insurance"}
    {"brand:wikidata":"Q10521791","brand:wikipedia":"sv:Hemmakväll","name":"Hemmakväll","shop":"confectionery"}