### PR TITLE
Reambiguate Noah’s Bagels

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -1224,7 +1224,7 @@
       "takeaway": "yes"
     }
   },
-  "amenity/fast_food|Noah's Bagels~(California)": {
+  "amenity/fast_food|Noah's Bagels": {
     "countryCodes": ["us"],
     "matchNames": [
       "noahs new york bagels",

--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -1226,16 +1226,14 @@
   },
   "amenity/fast_food|Noah's Bagels": {
     "countryCodes": ["us"],
-    "matchNames": [
-      "noahs new york bagels",
-      "noahs ny bagels"
-    ],
+    "matchNames": ["noahs ny bagels"],
     "tags": {
       "amenity": "fast_food",
       "brand": "Noah's Bagels",
       "brand:wikidata": "Q64517373",
       "cuisine": "bagel",
       "name": "Noah's Bagels",
+      "official_name": "Noah's New York Bagels",
       "takeaway": "yes"
     }
   },


### PR DESCRIPTION
I [confirmed in Slack](https://osmus.slack.com/archives/CDJ4LKA2Y/p1560269924093500) that the handful of “Noah’s Bagels” stores on the East Coast aren’t going to be included in the index. It’s either a bunch of independent stores or a very small chain. So this PR reverts the disambiguating suffix added in 2fc39b458d5ec02f6f91443f892ee2909feee402.

Naming conflicts do happen between chains in a given country, but I’m thinking we should reserve disambiguating suffixes for actual conflicts between entries in the index, or cases like Phở Hòa where independent restaurants are very common in the same countries as the main chain. Otherwise, we’d have to disambiguate [Wendy’s](https://en.wikipedia.org/wiki/Wendy's_Supa_Sundaes), [Burger King](https://en.wikipedia.org/wiki/Burger_King_%28Mattoon,_Illinois%29), and possibly other brands in some countries, preventing iD from upgrading many stores for the sake of a few obscure stores. (There were also smaller Waffle House and Burger King chains until fairly recently.) The handful of Noah’s Bagels stores on the East Coast will get a warning in iD, but there’s an option to ignore the warning.

An official name has also been added, because the chain’s logo says “Noah’s New York Bagels”, even though no one seems to call it that. (New York bagels are a special thing, I hear.)