### PR TITLE
Major boba tea chains

### DIFF
--- a/brands/amenity/cafe.json
+++ b/brands/amenity/cafe.json
@@ -537,6 +537,21 @@
       "takeaway": "yes"
     }
   },
+  "amenity/cafe|Quickly": {
+    "tags": {
+      "amenity": "cafe",
+      "brand": "Quickly",
+      "brand:en": "Quickly",
+      "brand:wikidata": "Q3771463",
+      "brand:wikipedia": "en:Quickly",
+      "brand:zh": "快可立",
+      "cuisine": "bubble_tea",
+      "name": "Quickly",
+      "name:en": "Quickly",
+      "name:zh": "快可立",
+      "takeaway": "yes"
+    }
+  },
   "amenity/cafe|Second Cup": {
     "tags": {
       "amenity": "cafe",
@@ -1013,6 +1028,22 @@
       "name": "ドトールコーヒーショップ",
       "name:en": "Doutor Coffee Shop",
       "name:ja": "ドトールコーヒーショップ",
+      "takeaway": "yes"
+    }
+  },
+  "amenity/cafe|快可立": {
+    "countryCodes": ["tw"],
+    "tags": {
+      "amenity": "cafe",
+      "brand": "快可立",
+      "brand:en": "Quickly",
+      "brand:wikidata": "Q3771463",
+      "brand:wikipedia": "zh:快可立",
+      "brand:zh": "快可立",
+      "cuisine": "bubble_tea",
+      "name": "快可立",
+      "name:en": "Quickly",
+      "name:zh": "快可立",
       "takeaway": "yes"
     }
   },

--- a/brands/amenity/cafe.json
+++ b/brands/amenity/cafe.json
@@ -156,10 +156,14 @@
     "tags": {
       "amenity": "cafe",
       "brand": "Chatime",
+      "brand:en": "Chatime",
       "brand:wikidata": "Q16829306",
       "brand:wikipedia": "en:Chatime",
-      "cuisine": "coffee_shop",
+      "brand:zh": "日出茶太",
+      "cuisine": "bubble_tea",
       "name": "Chatime",
+      "name:en": "Chatime",
+      "name:zh": "日出茶太",
       "takeaway": "yes"
     }
   },
@@ -1044,6 +1048,22 @@
       "name": "快可立",
       "name:en": "Quickly",
       "name:zh": "快可立",
+      "takeaway": "yes"
+    }
+  },
+  "amenity/cafe|日出茶太": {
+    "countryCodes": ["tw"],
+    "tags": {
+      "amenity": "cafe",
+      "brand": "日出茶太",
+      "brand:en": "Chatime",
+      "brand:wikidata": "Q16829306",
+      "brand:wikipedia": "zh:日出茶太",
+      "brand:zh": "日出茶太",
+      "cuisine": "bubble_tea",
+      "name": "日出茶太",
+      "name:en": "Chatime",
+      "name:zh": "日出茶太",
       "takeaway": "yes"
     }
   },

--- a/brands/amenity/cafe.json
+++ b/brands/amenity/cafe.json
@@ -328,6 +328,49 @@
       "takeaway": "yes"
     }
   },
+  "amenity/cafe|Gong Cha~(Vietnam)": {
+    "countryCodes": ["vn"],
+    "tags": {
+      "alt_name:vi": "Cống Trà",
+      "amenity": "cafe",
+      "brand": "Gong Cha",
+      "brand:vi": "Gong Cha",
+      "brand:wikidata": "Q5581670",
+      "brand:wikipedia": "vi:Gong Cha",
+      "brand:zh": "貢茶",
+      "cuisine": "bubble_tea",
+      "name": "Gong Cha",
+      "name:vi": "Gong Cha",
+      "name:zh": "貢茶",
+      "takeaway": "yes"
+    }
+  },
+  "amenity/cafe|Gong Cha~(worldwide)": {
+    "countryCodes": [
+      "au",
+      "bn",
+      "ca",
+      "mm",
+      "mo",
+      "my",
+      "nz",
+      "ph",
+      "sg",
+      "us"
+    ],
+    "tags": {
+      "amenity": "cafe",
+      "brand": "Gong Cha",
+      "brand:wikidata": "Q5581670",
+      "brand:wikipedia": "en:Gong Cha",
+      "brand:zh": "貢茶",
+      "cuisine": "bubble_tea",
+      "int_name": "Gong Cha",
+      "name": "Gong Cha",
+      "name:zh": "貢茶",
+      "takeaway": "yes"
+    }
+  },
   "amenity/cafe|Havanna": {
     "countryCodes": ["ar", "pe"],
     "tags": {
@@ -1002,6 +1045,87 @@
       "name": "珈琲館",
       "name:en": "Kohikan",
       "name:ja": "珈琲館",
+      "takeaway": "yes"
+    }
+  },
+  "amenity/cafe|貢茶 Gong Cha": {
+    "countryCodes": ["hk"],
+    "tags": {
+      "amenity": "cafe",
+      "brand": "貢茶 Gong Cha",
+      "brand:en": "Gong Cha",
+      "brand:wikidata": "Q5581670",
+      "brand:wikipedia": "zh:貢茶 (連鎖店)",
+      "brand:zh": "貢茶",
+      "cuisine": "bubble_tea",
+      "name": "貢茶 Gong Cha",
+      "name:en": "Gong Cha",
+      "name:zh": "貢茶",
+      "takeaway": "yes"
+    }
+  },
+  "amenity/cafe|貢茶~(Japan)": {
+    "countryCodes": ["ja"],
+    "tags": {
+      "amenity": "cafe",
+      "brand": "貢茶",
+      "brand:ja": "貢茶",
+      "brand:wikidata": "Q5581670",
+      "brand:wikipedia": "ja:貢茶",
+      "brand:zh": "貢茶",
+      "cuisine": "bubble_tea",
+      "int_name": "Gong Cha",
+      "name": "貢茶",
+      "name:ja": "貢茶",
+      "name:zh": "貢茶",
+      "takeaway": "yes"
+    }
+  },
+  "amenity/cafe|貢茶~(Taiwan)": {
+    "countryCodes": ["tw"],
+    "tags": {
+      "amenity": "cafe",
+      "brand": "貢茶",
+      "brand:wikidata": "Q5581670",
+      "brand:wikipedia": "zh:貢茶 (連鎖店)",
+      "cuisine": "bubble_tea",
+      "int_name": "Gong Cha",
+      "name": "貢茶",
+      "name:zh": "貢茶",
+      "takeaway": "yes"
+    }
+  },
+  "amenity/cafe|贡茶~(China)": {
+    "countryCodes": ["cn"],
+    "tags": {
+      "amenity": "cafe",
+      "brand": "贡茶",
+      "brand:wikidata": "Q5581670",
+      "brand:wikipedia": "zh:贡茶 (连锁店)",
+      "brand:zh-Hans": "贡茶",
+      "brand:zh-Hant": "貢茶",
+      "cuisine": "bubble_tea",
+      "int_name": "Gong Cha",
+      "name": "贡茶",
+      "name:zh-Hans": "贡茶",
+      "name:zh-Hant": "貢茶",
+      "takeaway": "yes"
+    }
+  },
+  "amenity/cafe|공차": {
+    "countryCodes": ["kr"],
+    "tags": {
+      "amenity": "cafe",
+      "brand": "공차",
+      "brand:ko": "공차",
+      "brand:wikidata": "Q5581670",
+      "brand:wikipedia": "ko:공차",
+      "brand:zh": "貢茶",
+      "cuisine": "bubble_tea",
+      "int_name": "Gong Cha",
+      "name": "공차",
+      "name:ko": "공차",
+      "name:zh": "貢茶",
       "takeaway": "yes"
     }
   },


### PR DESCRIPTION
Added major international boba tea chains. Each chain originated in Taiwan with a Chinese name, so there are different ways to tag a given chain in each country that uses a CJKV language, in addition to the international tag set. I used `name:en` instead of `int_name` for Chatime and Quickly because those names seemed to be English-inspired names rather than ordinary transliterations.