### PR TITLE
Avalon

### DIFF
--- a/brands/landuse/residential.json
+++ b/brands/landuse/residential.json
@@ -1,0 +1,15 @@
+{
+  "landuse/residential|Avalon": {
+    "countryCodes": ["us"],
+    "tags": {
+      "brand": "Avalon",
+      "brand:wikidata": "Q64665938",
+      "landuse": "residential",
+      "name": "Avalon",
+      "operator": "AvalonBay Communities",
+      "operator:wikidata": "Q4827537",
+      "operator:wikipedia": "en:AvalonBay Communities",
+      "residential": "apartments"
+    }
+  }
+}


### PR DESCRIPTION
Added Avalon, a large American chain of apartment complexes. Each complex carries the same Avalon logo (distinct from the AvalonBay corporate logo) and a name that begins with “Avalon”. AvalonBay also owns a few other apartment chains, but those chains are too small for the index.