### PR TITLE
HSBC UK

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -3353,6 +3353,16 @@
       "name": "HSBC"
     }
   },
+  "amenity/bank|HSBC UK": {
+    "countryCodes": ["gb"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "HSBC",
+      "brand:wikidata": "Q190464",
+      "brand:wikipedia": "en:HSBC",
+      "name": "HSBC UK"
+    }
+  },
   "amenity/bank|Halifax": {
     "countryCodes": ["gb"],
     "tags": {

--- a/docs/brands/amenity/bank.html
+++ b/docs/brands/amenity/bank.html
@@ -7378,6 +7378,30 @@ This page is generated from a <a target="_blank" href="https://github.com/osmlab
 <td class="logo"><img class="logo" src="https://pbs.twimg.com/profile_images/1029690966758895616/3T9gt_mL_bigger.jpg"/></td>
 </tr>
 <tr>
+<td class="namesuggest"><h3 class="slug" id="amenitybankhsbc-uk"><a href="#amenitybankhsbc-uk"/>#</a><span class="anchor">HSBC UK</span></h3>
+  <div class="nsikey"><pre>'amenity/bank|HSBC UK'</pre></div>
+  <div class="countries">🌐 <code>gb</code></div>
+  <div class="viewlink"><a target="_blank" href="https://overpass-turbo.eu/?Q=%5Bout%3Ajson%5D%5Btimeout%3A60%5D%3B%0A(nwr%5B%22amenity%22%3D%22bank%22%5D%5B%22name%22~%22%5C%5CbHSBC%20UK%5C%5Cb%22%2Ci%5D%3B)%3B%0Aout%20body%3B%0A%3E%3B%0Aout%20skel%20qt%3B&R"/>View on Overpass Turbo</a></div>
+</td>
+<td class="count">< 50</td>
+<td class="tags"><pre class="tags">
+"amenity": "bank"
+"brand": "HSBC"
+"brand:wikidata": "Q190464"
+"brand:wikipedia": "en:HSBC"
+"name": "HSBC UK"</pre></td>
+<td class="wikidata">
+  <h3>HSBC Holdings</h3>
+  <span>"British multinational banking and financial services"</span><br/>
+<div class="viewlink"><a target="_blank" href="https://www.wikidata.org/wiki/Q190464">Q190464</a></div>
+<div class="viewlink"><a target="_blank" href="http://www.hsbc.com/">http://www.hsbc.com/</a></div>
+<div class="sociallinks"><a target="_blank" href="https://twitter.com/HSBC"><i class="fab fa-lg fa-twitter-square"></i></a><a target="_blank" href="https://www.youtube.com/channel/UCTbuSzdKMgyVRjlr1EWE-gg"><i class="fab fa-lg fa-youtube-square"></i></a></div>
+</td>
+<td class="logo"><img class="logo" src="https://commons.wikimedia.org/w/index.php?title=Special%3ARedirect%2Ffile%2FHSBC%20logo%20(2018).svg&width=100"/></td>
+<td class="logo"></td>
+<td class="logo"><img class="logo" src="https://pbs.twimg.com/profile_images/1029690966758895616/3T9gt_mL_bigger.jpg"/></td>
+</tr>
+<tr>
 <td class="namesuggest"><h3 class="slug" id="amenitybankhalifax"><a href="#amenitybankhalifax"/>#</a><span class="anchor">Halifax</span></h3>
   <div class="nsikey"><pre>'amenity/bank|Halifax'</pre></div>
   <div class="countries">🌐 <code>gb</code></div>

--- a/docs/brands/index.html
+++ b/docs/brands/index.html
@@ -25,7 +25,7 @@ See <a target="_blank" href="https://github.com/osmlab/name-suggestion-index/blo
 </div>
 
 <div class="container">
-<div class="child"><a href="amenity/bank.html">amenity/bank (478/623)</a></div>
+<div class="child"><a href="amenity/bank.html">amenity/bank (479/624)</a></div>
 <div class="child"><a href="amenity/bar.html">amenity/bar (3/3)</a></div>
 <div class="child"><a href="amenity/bicycle_rental.html">amenity/bicycle_rental (6/6)</a></div>
 <div class="child"><a href="amenity/bureau_de_change.html">amenity/bureau_de_change (2/2)</a></div>


### PR DESCRIPTION
This is deliberately a tiny change just to get things started. OSMUK would like to send through more details of presets for the UK after this one.

In the UK, HSBC banks are now branded "HSBC UK" and have that wording on their external signage. They would still have the main HSBC Brand and Wikidata:id applied. Please tell me if my config change is wrong or misguided.