### PR TITLE
Replace Thomson with TUI UK

### DIFF
--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -2379,16 +2379,6 @@
       "shop": "clothes"
     }
   },
-  "shop/clothes|Slaters": {
-    "countryCodes": ["gb"],
-    "tags": {
-      "brand": "Slaters",
-      "brand:wikidata": "Q7538912",
-      "clothes": "suits",
-      "name": "Slaters",
-      "shop": "clothes"
-    }
-  },
   "shop/clothes|Spanx": {
     "countryCodes": ["us"],
     "tags": {

--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -2379,6 +2379,16 @@
       "shop": "clothes"
     }
   },
+  "shop/clothes|Slaters": {
+    "countryCodes": ["gb"],
+    "tags": {
+      "brand": "Slaters",
+      "brand:wikidata": "Q7538912",
+      "clothes": "suits",
+      "name": "Slaters",
+      "shop": "clothes"
+    }
+  },
   "shop/clothes|Spanx": {
     "countryCodes": ["us"],
     "tags": {

--- a/brands/shop/travel_agency.json
+++ b/brands/shop/travel_agency.json
@@ -111,12 +111,23 @@
       "shop": "travel_agency"
     }
   },
-  "shop/travel_agency|TUI": {
+  "shop/travel_agency|TUI~(Group)": {
     "matchNames": ["tui reisecenter"],
     "tags": {
       "brand": "TUI",
       "brand:wikidata": "Q573103",
       "brand:wikipedia": "en:TUI Group",
+      "name": "TUI",
+      "shop": "travel_agency"
+    }
+  },
+  "shop/travel_agency|TUI~(UK)": {
+    "countryCodes": ["gb"],
+    "matchNames": ["thomson"],
+    "tags": {
+      "brand": "TUI",
+      "brand:wikidata": "Q7795876",
+      "brand:wikipedia": "en:TUI UK",
       "name": "TUI",
       "shop": "travel_agency"
     }
@@ -137,16 +148,6 @@
       "brand:wikidata": "Q2141800",
       "brand:wikipedia": "en:Thomas Cook Group",
       "name": "Thomas Cook",
-      "shop": "travel_agency"
-    }
-  },
-  "shop/travel_agency|Thomson": {
-    "countryCodes": ["gb"],
-    "tags": {
-      "brand": "Thomson",
-      "brand:wikidata": "Q7795876",
-      "brand:wikipedia": "en:TUI UK",
-      "name": "Thomson",
       "shop": "travel_agency"
     }
   },


### PR DESCRIPTION
Thomson became TUI UK in 2017, the wiki tagging already reflected this and this just updates the name and brand to match. Unsure if any signage in the UK would still have Thomson on it so opening as a PR for discussion purposes.

For reference:
https://en.wikipedia.org/wiki/TUI_UK