### PR TITLE
Add Hudson Convenience Stores

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -570,6 +570,16 @@
       "shop": "convenience"
     }
   },
+  "shop/convenience|Hudson": {
+    "nomatch": ["shop/newsagent|Hudson News"],
+    "tags": {
+      "brand": "Hudson",
+      "brand:wikidata": "Q5928787",
+      "brand:wikipedia": "en:Hudson Group",
+      "name": "Hudson",
+      "shop": "convenience"
+    }
+  },
   "shop/convenience|Husky": {
     "countryCodes": ["ca"],
     "nomatch": [


### PR DESCRIPTION
So read this one all the way before thinking it's wrong. Hudson News is the traditional newsagent we're used to at every airport. According to Wikipedia in 2013 they added the Hudson brand, which is what this tag is for. Since 2013 they're been slowly (not so slowly) converting their stores over to the new Hudson brand. I've noticed that everywhere I fly for work lately only has the new Hudson format, which does not sell newspapers. It's just a convenience store, with a much smaller magazine and book section than the previous stores had.

Signed-off-by: Tim Smith <tsmith@chef.io>