### PR TITLE
Papyrus & American Greetings

### DIFF
--- a/brands/shop/gift.json
+++ b/brands/shop/gift.json
@@ -1,4 +1,15 @@
 {
+  "shop/gift|American Greetings": {
+    "countryCodes": ["us"],
+    "matchTags": ["shop/stationery"],
+    "tags": {
+      "brand": "American Greetings",
+      "brand:wikidata": "Q464767",
+      "brand:wikipedia": "en:American Greetings",
+      "name": "American Greetings",
+      "shop": "gift"
+    }
+  },
   "shop/gift|Card Factory": {
     "countryCodes": ["gb", "im"],
     "matchTags": ["shop/stationery"],

--- a/brands/shop/gift.json
+++ b/brands/shop/gift.json
@@ -87,6 +87,17 @@
       "shop": "gift"
     }
   },
+  "shop/gift|Papyrus": {
+    "countryCodes": ["us"],
+    "matchTags": ["shop/stationery"],
+    "tags": {
+      "brand": "Papyrus",
+      "brand:wikidata": "Q28222692",
+      "brand:wikipedia": "en:Papyrus (company)",
+      "name": "Papyrus",
+      "shop": "gift"
+    }
+  },
   "shop/gift|Spencer's": {
     "countryCodes": ["ca", "us"],
     "tags": {

--- a/brands/shop/stationery.json
+++ b/brands/shop/stationery.json
@@ -86,16 +86,6 @@
       "shop": "stationery"
     }
   },
-  "shop/stationery|Papyrus": {
-    "countryCodes": ["us"],
-    "tags": {
-      "brand": "Papyrus",
-      "brand:wikidata": "Q28222692",
-      "brand:wikipedia": "en:Papyrus (company)",
-      "name": "Papyrus",
-      "shop": "stationery"
-    }
-  },
   "shop/stationery|Ryman": {
     "countryCodes": ["gb"],
     "tags": {


### PR DESCRIPTION
Worth pointing out that Papyrus has 17 of `shop=stationery` and 7 of `shop=gift`, but it seems clear to me both from the OSM wiki and the remainder of this brands index that this is incorrect.