### PR TITLE
Add Leslie's Pool Supplies

### DIFF
--- a/brands/shop/swimming_pool.json
+++ b/brands/shop/swimming_pool.json
@@ -1,11 +1,15 @@
 {
   "shop/swimming_pool|Leslie's Pool Supplies": {
     "countryCodes": ["us"],
+    "matchNames": [
+      "leslie's swimming pool supplies"
+    ],
     "tags": {
       "brand": "Leslie's Pool Supplies",
       "brand:wikidata": "Q6530568",
       "brand:wikipedia": "en:Leslie's Poolmart",
       "name": "Leslie's Pool Supplies",
+      "official_name": "Leslie's Pool Supplies Service & Repair",
       "shop": "swimming_pool"
     }
   }

--- a/brands/shop/swimming_pool.json
+++ b/brands/shop/swimming_pool.json
@@ -1,0 +1,12 @@
+{
+  "shop/swimming_pool|Leslie's Pool Supplies": {
+    "countryCodes": ["us"],
+    "tags": {
+      "brand": "Leslie's Pool Supplies",
+      "brand:wikidata": "Q6530568",
+      "brand:wikipedia": "en:Leslie's Poolmart",
+      "name": "Leslie's Pool Supplies",
+      "shop": "swimming_pool"
+    }
+  }
+}


### PR DESCRIPTION
Add new category of shop/swimming_pool which is listed as a defacto
standard tag. There's about 900 of these stores total and most are just
tagged as stores from my experience. Getting it in the index would
really help us cleanup bad data.

Signed-off-by: Tim Smith <tsmith@chef.io>