### PR TITLE
Add TownePlace Suites (Marriott Brand)

### DIFF
--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -520,6 +520,18 @@
       "tourism": "hotel"
     }
   },
+  "tourism/hotel|TownePlace Suites": {
+    "countryCodes": ["ca", "us"],
+    "matchNames": [
+      "TownePlace Suites by Marriott"],
+    "tags": {
+      "brand": "Courtyard by Marriott",
+      "brand:wikidata": "",
+      "brand:wikipedia": "en:TownePlace Suites",
+      "name": "Courtyard by Marriott",
+      "tourism": "hotel"
+    }
+  },
   "tourism/hotel|Travelodge": {
     "tags": {
       "brand": "Travelodge",

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -520,15 +520,18 @@
       "tourism": "hotel"
     }
   },
-  "tourism/hotel|TownePlace Suites by Marriott": {
+  "tourism/hotel|TownePlace Suites": {
     "countryCodes": ["ca", "us"],
     "matchNames": [
-      "TownePlace Suites"],
+      "TownePlace Suites Marriott"
+      "TownePlace Marriott"
+    ],
     "tags": {
       "brand": "TownePlace Suites",
       "brand:wikidata": "Q7830092",
       "brand:wikipedia": "en:TownePlace Suites",
-      "name": "TownePlace Suites by Marriott",
+      "name": "TownePlace Suites",
+      "official_name": "TownePlace Suites by Marriott",
       "tourism": "hotel"
     }
   },

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -520,15 +520,15 @@
       "tourism": "hotel"
     }
   },
-  "tourism/hotel|TownePlace Suites": {
+  "tourism/hotel|TownePlace Suites by Marriott": {
     "countryCodes": ["ca", "us"],
     "matchNames": [
-      "TownePlace Suites by Marriott"],
+      "TownePlace Suites"],
     "tags": {
-      "brand": "Courtyard by Marriott",
-      "brand:wikidata": "",
+      "brand": "TownePlace Suites",
+      "brand:wikidata": "Q7830092",
       "brand:wikipedia": "en:TownePlace Suites",
-      "name": "Courtyard by Marriott",
+      "name": "TownePlace Suites",
       "tourism": "hotel"
     }
   },

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -523,7 +523,7 @@
   "tourism/hotel|TownePlace Suites": {
     "countryCodes": ["ca", "us"],
     "matchNames": [
-      "TownePlace Suites Marriott"
+      "TownePlace Suites Marriott",
       "TownePlace Marriott"
     ],
     "tags": {

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -528,7 +528,7 @@
       "brand": "TownePlace Suites",
       "brand:wikidata": "Q7830092",
       "brand:wikipedia": "en:TownePlace Suites",
-      "name": "TownePlace Suites",
+      "name": "TownePlace Suites by Marriott",
       "tourism": "hotel"
     }
   },


### PR DESCRIPTION
TownePlace Suites is a brand of specialized hotel in owned by Marriott.  I am a bit unsure if the name and brand should be “TownePlace Suites” or “TownePlace Suites by Marriott” but the logo states the latter.

According to the website there are “over 400 locations across the US and Canada”
