### PR TITLE
Add Aloha Petroleum

### DIFF
--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -58,7 +58,7 @@
       "brand": "Aloha Petroleum",
       "brand:wikidata": "Q4734197",
       "brand:wikipedia": "en:Aloha Petroleum",
-      "name": "Aloha Petroleum"
+      "name": "Aloha Petroleum",
       "official_name": "Aloha Petroleum Ltd"
     }
   },

--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -51,6 +51,17 @@
       "name": "ADNOC"
     }
   },
+  "amenity/fuel|Aloha Petroleum": {
+    "countryCodes": ["us"],
+    "tags": {
+      "amenity": "fuel",
+      "brand": "Aloha Petroleum",
+      "brand:wikidata": "Q4734197",
+      "brand:wikipedia": "en:Aloha Petroleum",
+      "name": "Aloha Petroleum"
+      "official_name": "Aloha Petroleum Ltd"
+    }
+  },
   "amenity/fuel|ANP": {
     "countryCodes": ["ru", "ua"],
     "tags": {


### PR DESCRIPTION
Aloha Petroleum is a subsidiary of Sunoco LP which operates gas stations under both their own brand and Shell stations in Hawaii.

