### PR TITLE
Dream Dinners

### DIFF
--- a/brands/shop/frozen_food.json
+++ b/brands/shop/frozen_food.json
@@ -8,14 +8,12 @@
       "shop/grocery"
     ],
     "tags": {
-      "amenity": "kitchen",
       "brand": "Dream Dinners",
       "brand:wikidata": "Q5306355",
       "brand:wikipedia": "en:Dream Dinners",
-      "fee": "yes",
       "name": "Dream Dinners",
-      "shop": "frozen_food",
-      "supervised": "yes"
+      "opening_hours": "\"by appointment\"",
+      "shop": "frozen_food"
     }
   },
   "shop/frozen_food|Picard": {

--- a/brands/shop/frozen_food.json
+++ b/brands/shop/frozen_food.json
@@ -1,4 +1,23 @@
 {
+  "shop/frozen_food|Dream Dinners": {
+    "countryCodes": ["us"],
+    "matchTags": [
+      "amenity/fast_food",
+      "amenity/restaurant",
+      "shop/food",
+      "shop/grocery"
+    ],
+    "tags": {
+      "amenity": "kitchen",
+      "brand": "Dream Dinners",
+      "brand:wikidata": "Q5306355",
+      "brand:wikipedia": "en:Dream Dinners",
+      "fee": "yes",
+      "name": "Dream Dinners",
+      "shop": "frozen_food",
+      "supervised": "yes"
+    }
+  },
   "shop/frozen_food|Picard": {
     "countryCodes": ["fr"],
     "tags": {


### PR DESCRIPTION
[Dream Dinners](https://en.wikipedia.org/wiki/Dream_Dinners) is an unusual chain: [this video](https://dreamdinners.com/main.php?static=how_it_works) shows how it works, but basically you make an appointment to visit the store, assemble already washed and cut ingredients into individual uncooked meals in reserved kitchen space, then bring them home to freeze and cook later.

Existing features in OSM are all over the map in terms of tagging. Yelp categorizes it as “do-it-yourself food”, which is fine but doesn’t suggest a suitable OSM tagging scheme. Google Maps classifies it as a “takeout restaurant”, which is incorrect, implying more convenience than a restaurant.

In the end, I went with `amenity=kitchen` and `shop=frozen_food`. `amenity=kitchen` is [documented](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dkitchen) as if it’s mainly for public kitchens at campsites, but the documentation also leaves the door open to requiring fees and offering supervision, which basically sums up how these things work. `shop=frozen_food` is appropriate because customers go home with food they’re supposed to stick in the freezer. The Dream Dinners business model is sometimes described as “make-and-take-and-bake”, and similarly I think we could retag [Papa Murphy’s](https://en.wikipedia.org/wiki/Papa_Murphy's) (“take-and-bake pizza”) as `shop=frozen_food` too.