### PR TITLE
Planned Parenthood

### DIFF
--- a/brands/amenity/clinic.json
+++ b/brands/amenity/clinic.json
@@ -52,6 +52,21 @@
       "name": "Fresenius Medical Care"
     }
   },
+  "amenity/clinic|Planned Parenthood": {
+    "countryCodes": ["us"],
+    "matchTags": [
+      "amenity/doctors",
+      "amenity/social_facility"
+    ],
+    "tags": {
+      "amenity": "clinic",
+      "brand": "Planned Parenthood",
+      "brand:wikidata": "Q2553262",
+      "healthcare": "counselling",
+      "healthcare:counselling": "antenatal;sexual",
+      "name": "Planned Parenthood"
+    }
+  },
   "amenity/clinic|Satellite Healthcare": {
     "countryCodes": ["us"],
     "matchNames": [


### PR DESCRIPTION
Added an entry for Planned Parenthood, since they have a number of locations across the U.S. and existing features in OSM have a wide variety of tags. Not sure if there are any other [healthcare tags](https://wiki.openstreetmap.org/wiki/Key:healthcare) that I should add besides the counseling ones. Note that I didn’t include `healthcare:speciality=abortion`, because not all locations offer that service.