### PR TITLE
Major language school chains

### DIFF
--- a/brands/amenity/language_school.json
+++ b/brands/amenity/language_school.json
@@ -135,5 +135,21 @@
       "name:ja": "シェーン英会話",
       "name:ja-Latn": "Shēn Eikaiwa"
     }
+  },
+  "amenity/language_school|ベルリッツ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "language_school",
+      "brand": "ベルリッツ",
+      "brand:en": "Berlitz",
+      "brand:ja": "ベルリッツ",
+      "brand:ja-Hira": "ベルリッツ",
+      "brand:wikidata": "Q4892545",
+      "brand:wikipedia": "ja:ベルリッツ・ジャパン",
+      "name": "ベルリッツ",
+      "name:en": "Berlitz",
+      "name:ja": "ベルリッツ",
+      "name:ja-Hira": "ベルリッツ"
+    }
   }
 }

--- a/brands/amenity/language_school.json
+++ b/brands/amenity/language_school.json
@@ -22,11 +22,59 @@
     "tags": {
       "amenity": "language_school",
       "brand": "ELS",
+      "brand:en": "ELS",
       "brand:wikidata": "Q5323325",
       "brand:wikipedia": "en:ELS Language Centers",
       "language:en": "main",
       "name": "ELS",
-      "official_name": "ELS Language Centers"
+      "name:en": "ELS",
+      "official_name": "ELS Language Centers",
+      "official_name:en": "ELS Language Centers"
+    }
+  },
+  "amenity/language_school|Shane English School": {
+    "countryCodes": [
+      "cn",
+      "dz",
+      "gb",
+      "hk",
+      "id",
+      "kr",
+      "pl",
+      "th",
+      "tw",
+      "vn"
+    ],
+    "tags": {
+      "amenity": "language_school",
+      "brand": "Shane English School",
+      "brand:en": "Shane English School",
+      "brand:ja": "シェーン英会話",
+      "brand:ja-Latn": "Shēn Eikaiwa",
+      "brand:wikidata": "Q17054332",
+      "brand:wikipedia": "en:Shane English School",
+      "language:en": "main",
+      "name": "Shane English School",
+      "name:en": "Shane English School",
+      "name:ja": "シェーン英会話",
+      "name:ja-Latn": "Shēn Eikaiwa"
+    }
+  },
+  "amenity/language_school|シェーン英会話": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "language_school",
+      "brand": "シェーン英会話",
+      "brand:en": "Shane English School",
+      "brand:ja": "シェーン英会話",
+      "brand:ja-Latn": "Shēn Eikaiwa",
+      "brand:wikidata": "Q17054332",
+      "brand:wikipedia": "ja:シェーン英会話スクール",
+      "language:en": "main",
+      "name": "シェーン英会話",
+      "name:en": "Shane English School",
+      "name:ja": "シェーン英会話",
+      "name:ja-Latn": "Shēn Eikaiwa"
     }
   }
 }

--- a/brands/amenity/language_school.json
+++ b/brands/amenity/language_school.json
@@ -7,5 +7,26 @@
       "brand:wikipedia": "en:Berlitz Corporation",
       "name": "Berlitz"
     }
+  },
+  "amenity/language_school|ELS": {
+    "countryCodes": [
+      "ca",
+      "in",
+      "my",
+      "pa",
+      "sa",
+      "tr",
+      "us",
+      "vn"
+    ],
+    "tags": {
+      "amenity": "language_school",
+      "brand": "ELS",
+      "brand:wikidata": "Q5323325",
+      "brand:wikipedia": "en:ELS Language Centers",
+      "language:en": "main",
+      "name": "ELS",
+      "official_name": "ELS Language Centers"
+    }
   }
 }

--- a/brands/amenity/language_school.json
+++ b/brands/amenity/language_school.json
@@ -1,0 +1,11 @@
+{
+  "amenity/language_school|Berlitz": {
+    "tags": {
+      "amenity": "language_school",
+      "brand": "Berlitz",
+      "brand:wikidata": "Q821960",
+      "brand:wikipedia": "en:Berlitz Corporation",
+      "name": "Berlitz"
+    }
+  }
+}

--- a/brands/amenity/language_school.json
+++ b/brands/amenity/language_school.json
@@ -4,6 +4,7 @@
     "tags": {
       "amenity": "language_school",
       "brand": "AEON",
+      "brand:en": "Aeon",
       "brand:ja": "AEON",
       "brand:ja-Hira": "イーオン",
       "brand:ja-Latn": "AEON",
@@ -11,6 +12,7 @@
       "brand:wikipedia": "ja:イーオン",
       "language:en": "main",
       "name": "AEON",
+      "name:en": "Aeon",
       "name:ja": "AEON",
       "name:ja-Hira": "イーオン",
       "name:ja-Latn": "AEON"
@@ -30,6 +32,7 @@
     "tags": {
       "amenity": "language_school",
       "brand": "ECC外語学院",
+      "brand:en": "ECC Foreign Language Institute",
       "brand:ja": "ECC外語学院",
       "brand:ja-Hira": "イーシーシーがいごがくいん",
       "brand:ja-Latn": "ECC Gaigo Gakuin",
@@ -37,10 +40,12 @@
       "brand:wikipedia": "ja:ECC総合教育機関",
       "language:en": "main",
       "name": "ECC外語学院",
+      "name:en": "ECC Foreign Language Institute",
       "name:ja": "ECC外語学院",
       "name:ja-Hira": "イーシーシーがいごがくいん",
       "name:ja-Latn": "ECC Gaigo Gakuin",
       "short_name": "ECC",
+      "short_name:en": "ECC",
       "short_name:ja": "ECC",
       "short_name:ja-Hira": "イーシーシー",
       "short_name:ja-Latn": "ECC"
@@ -75,6 +80,7 @@
     "tags": {
       "amenity": "language_school",
       "brand": "GABA",
+      "brand:en": "Gaba",
       "brand:ja": "GABA",
       "brand:ja-Kana": "ガバ",
       "brand:ja-Latn": "GABA",
@@ -82,6 +88,7 @@
       "brand:wikipedia": "ja:GABA (企業)",
       "language:en": "main",
       "name": "GABA",
+      "name:en": "Gaba",
       "name:ja": "GABA",
       "name:ja-Kana": "ガバ",
       "name:ja-Latn": "GABA"
@@ -96,6 +103,7 @@
     "tags": {
       "amenity": "language_school",
       "brand": "NOVA",
+      "brand:en": "Nova",
       "brand:ja": "NOVA",
       "brand:ja-Hira": "ノヴァ",
       "brand:ja-Latn": "NOVA",
@@ -103,6 +111,7 @@
       "brand:wikipedia": "ja:NOVA",
       "language:en": "main",
       "name": "NOVA",
+      "name:en": "Nova",
       "name:ja": "NOVA",
       "name:ja-Hira": "ノヴァ",
       "name:ja-Latn": "NOVA"

--- a/brands/amenity/language_school.json
+++ b/brands/amenity/language_school.json
@@ -1,4 +1,21 @@
 {
+  "amenity/language_school|AEON": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "language_school",
+      "brand": "AEON",
+      "brand:ja": "AEON",
+      "brand:ja-Hira": "イーオン",
+      "brand:ja-Latn": "AEON",
+      "brand:wikidata": "Q5322655",
+      "brand:wikipedia": "ja:イーオン",
+      "language:en": "main",
+      "name": "AEON",
+      "name:ja": "AEON",
+      "name:ja-Hira": "イーオン",
+      "name:ja-Latn": "AEON"
+    }
+  },
   "amenity/language_school|Berlitz": {
     "tags": {
       "amenity": "language_school",

--- a/brands/amenity/language_school.json
+++ b/brands/amenity/language_school.json
@@ -32,6 +32,27 @@
       "official_name:en": "ELS Language Centers"
     }
   },
+  "amenity/language_school|NOVA": {
+    "countryCodes": ["jp"],
+    "matchTags": [
+      "amenity/college",
+      "amenity/school"
+    ],
+    "tags": {
+      "amenity": "language_school",
+      "brand": "NOVA",
+      "brand:ja": "NOVA",
+      "brand:ja-Hira": "ノヴァ",
+      "brand:ja-Latn": "NOVA",
+      "brand:wikidata": "Q7064000",
+      "brand:wikipedia": "ja:NOVA",
+      "language:en": "main",
+      "name": "NOVA",
+      "name:ja": "NOVA",
+      "name:ja-Hira": "ノヴァ",
+      "name:ja-Latn": "NOVA"
+    }
+  },
   "amenity/language_school|Shane English School": {
     "countryCodes": [
       "cn",

--- a/brands/amenity/language_school.json
+++ b/brands/amenity/language_school.json
@@ -80,6 +80,7 @@
       "brand:ja-Latn": "GABA",
       "brand:wikidata": "Q5515241",
       "brand:wikipedia": "ja:GABA (企業)",
+      "language:en": "main",
       "name": "GABA",
       "name:ja": "GABA",
       "name:ja-Kana": "ガバ",
@@ -152,6 +153,24 @@
       "name:ja-Latn": "Shēn Eikaiwa"
     }
   },
+  "amenity/language_school|セイハ英語学院": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "language_school",
+      "brand": "セイハ英語学院",
+      "brand:en": "Seiha English Academy",
+      "brand:ja": "セイハ英語学院",
+      "brand:ja-Hani": "セイハえいごがくいん",
+      "brand:ja-Latn": "Seiha Eigo Gakuin",
+      "brand:wikidata": "Q7446694",
+      "language:en": "main",
+      "name": "セイハ英語学院",
+      "name:en": "Seiha English Academy",
+      "name:ja": "セイハ英語学院",
+      "name:ja-Hani": "セイハえいごがくいん",
+      "name:ja-Latn": "Seiha Eigo Gakuin"
+    }
+  },
   "amenity/language_school|ベルリッツ": {
     "countryCodes": ["jp"],
     "tags": {
@@ -166,6 +185,23 @@
       "name:en": "Berlitz",
       "name:ja": "ベルリッツ",
       "name:ja-Hira": "ベルリッツ"
+    }
+  },
+  "amenity/language_school|ペッピーキッズクラブ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "language_school",
+      "brand": "ペッピーキッズクラブ",
+      "brand:en": "Peppy Kids Club",
+      "brand:ja": "ペッピーキッズクラブ",
+      "brand:ja-Latn": "Peppi Kizzu Kurabu",
+      "brand:wikidata": "Q7166471",
+      "brand:wikipedia": "ja:ペッピーキッズクラブ",
+      "language:en": "main",
+      "name": "ペッピーキッズクラブ",
+      "name:en": "Peppy Kids Club",
+      "name:ja": "ペッピーキッズクラブ",
+      "name:ja-Latn": "Peppi Kizzu Kurabu"
     }
   }
 }

--- a/brands/amenity/language_school.json
+++ b/brands/amenity/language_school.json
@@ -70,6 +70,22 @@
       "official_name:en": "ELS Language Centers"
     }
   },
+  "amenity/language_school|GABA": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "language_school",
+      "brand": "GABA",
+      "brand:ja": "GABA",
+      "brand:ja-Kana": "ガバ",
+      "brand:ja-Latn": "GABA",
+      "brand:wikidata": "Q5515241",
+      "brand:wikipedia": "ja:GABA (企業)",
+      "name": "GABA",
+      "name:ja": "GABA",
+      "name:ja-Kana": "ガバ",
+      "name:ja-Latn": "GABA"
+    }
+  },
   "amenity/language_school|NOVA": {
     "countryCodes": ["jp"],
     "matchTags": [

--- a/brands/amenity/language_school.json
+++ b/brands/amenity/language_school.json
@@ -8,6 +8,27 @@
       "name": "Berlitz"
     }
   },
+  "amenity/language_school|ECC外語学院": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "language_school",
+      "brand": "ECC外語学院",
+      "brand:ja": "ECC外語学院",
+      "brand:ja-Hira": "イーシーシーがいごがくいん",
+      "brand:ja-Latn": "ECC Gaigo Gakuin",
+      "brand:wikidata": "Q5322655",
+      "brand:wikipedia": "ja:ECC総合教育機関",
+      "language:en": "main",
+      "name": "ECC外語学院",
+      "name:ja": "ECC外語学院",
+      "name:ja-Hira": "イーシーシーがいごがくいん",
+      "name:ja-Latn": "ECC Gaigo Gakuin",
+      "short_name": "ECC",
+      "short_name:ja": "ECC",
+      "short_name:ja-Hira": "イーシーシー",
+      "short_name:ja-Latn": "ECC"
+    }
+  },
   "amenity/language_school|ELS": {
     "countryCodes": [
       "ca",

--- a/brands/amenity/prep_school.json
+++ b/brands/amenity/prep_school.json
@@ -70,5 +70,23 @@
       "brand:wikipedia": "en:Sylvan Learning",
       "name": "Sylvan"
     }
+  },
+  "amenity/prep_school|栄光ゼミナール": {
+    "countryCodes": ["jp"],
+    "matchNames": ["eikoh"],
+    "tags": {
+      "amenity": "prep_school",
+      "brand": "栄光ゼミナール",
+      "brand:ja": "栄光ゼミナール",
+      "brand:ja-Hira": "えいこうゼミナール",
+      "brand:ja-Latn": "Eikō Zemināru",
+      "brand:wikidata": "Q11535632",
+      "brand:wikipedia": "ja:栄光ゼミナール",
+      "name": "栄光ゼミナール",
+      "name:en": "Eikoh Seminar",
+      "name:ja": "栄光ゼミナール",
+      "name:ja-Hira": "えいこうゼミナール",
+      "name:ja-Latn": "Eikō Zemināru"
+    }
   }
 }


### PR DESCRIPTION
Added several major language school chains, mostly [English language school chains in Japan](https://en.wikipedia.org/wiki/Eikaiwa_school).

Also added Eikoh, a cram school chain in Japan that owns a language school chain. (@jeisenbe‎ has [started a discussion](https://wiki.openstreetmap.org/wiki/Talk:Tag:amenity%3Dprep_school) about replacing `amenity=prep_school` with a less confusingly named tag, but _tons_ of Eikoh locations were already mapped using this tag, so adding an entry here makes it easier to switch over to a new tag should that become necessary.)