### PR TITLE
Add the two Bealls department stores in the US

### DIFF
--- a/brands/shop/department_store.json
+++ b/brands/shop/department_store.json
@@ -10,6 +10,26 @@
       "shop": "department_store"
     }
   },
+  "shop/department_store|Bealls (Florida)": {
+    "countryCodes": ["us"],
+    "tags": {
+      "brand": "Bealls",
+      "brand:wikidata": "Q4876153",
+      "brand:wikipedia": "en:Bealls (Florida)",
+      "name": "Bealls",
+      "shop": "department_store"
+    }
+  },
+  "shop/department_store|Bealls (Texas)": {
+    "countryCodes": ["us"],
+    "tags": {
+      "brand": "Bealls",
+      "brand:wikidata": "Q4876156",
+      "brand:wikipedia": "en:Bealls (Texas)",
+      "name": "Bealls",
+      "shop": "department_store"
+    }
+  },
   "shop/department_store|Belk": {
     "countryCodes": ["us"],
     "tags": {

--- a/brands/shop/department_store.json
+++ b/brands/shop/department_store.json
@@ -10,7 +10,7 @@
       "shop": "department_store"
     }
   },
-  "shop/department_store|Bealls (Florida)": {
+  "shop/department_store|Bealls (Florida-based)": {
     "countryCodes": ["us"],
     "tags": {
       "brand": "Bealls",
@@ -20,7 +20,7 @@
       "shop": "department_store"
     }
   },
-  "shop/department_store|Bealls (Texas)": {
+  "shop/department_store|Bealls (Texas-based )": {
     "countryCodes": ["us"],
     "tags": {
       "brand": "Bealls",


### PR DESCRIPTION
So from what I can tell there's Bealls in just Florida and then Bealls
based out of Texas, but with stores throughout the US (except Florida).
I'm opening this as a PR to discuss how to name the geographic
restriction. (Texas) doesn't seem right since there's stores in Oregon
too. Would (non-Florida) be appropriate.

Signed-off-by: Tim Smith <tsmith@chef.io>