### PR TITLE
Add Greyhound bus lines (US)

### DIFF
--- a/brands/public_transport/station.json
+++ b/brands/public_transport/station.json
@@ -1,0 +1,16 @@
+{
+  "public_transport/station|Greyhound Station": {
+    "countryCodes": ["us"],
+    "matchNames": ["greyhound terminal"],
+    "tags": {
+      "amenity": "bus_station",
+      "brand": "Greyhound Lines",
+      "brand:wikidata": "Q755309",
+      "brand:wikipedia": "en:Greyhound Lines",
+      "bus": "yes",
+      "name": "Greyhound Station",
+      "name:en": "Greyhound Station",
+      "public_transport": "station"
+    }
+  }
+}


### PR DESCRIPTION
Inspired by discussion in #2846, I'd like to see what people think about adding branded transit stops/stations. I think it'd be useful, especially for data consumers focused on public transport routing.

The main obstacle I see is that a single transit station can sometimes be used by multiple carriers. Another obstacle is that this index can only filter geographically on a country-wide basis, while most transit brands are just city-wide.

I'm starting with Greyhound since they're national and tend to run their own stations.