### PR TITLE
Literary → Traditional Chinese

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -3240,13 +3240,15 @@
       "amenity": "fast_food",
       "brand": "麥當勞",
       "brand:en": "McDonald's",
-      "brand:lzh": "麥當勞",
       "brand:wikidata": "Q38076",
-      "brand:wikipedia": "zh_classical:麥當勞",
+      "brand:wikipedia": "zh:麥當勞",
+      "brand:zh": "麥當勞",
+      "brand:zh-Hant": "麥當勞",
       "cuisine": "burger",
       "name": "麥當勞",
       "name:en": "McDonald's",
-      "name:lzh": "麥當勞",
+      "name:zh": "麥當勞",
+      "name:zh-Hant": "麥當勞",
       "takeaway": "yes"
     }
   },
@@ -3259,10 +3261,12 @@
       "brand:wikidata": "Q38076",
       "brand:wikipedia": "zh:麦当劳",
       "brand:zh": "麦当劳",
+      "brand:zh-Hans": "麦当劳",
       "cuisine": "burger",
       "name": "麦当劳",
       "name:en": "McDonald's",
       "name:zh": "麦当劳",
+      "name:zh-Hans": "麦当劳",
       "takeaway": "yes"
     }
   },


### PR DESCRIPTION
Hong Kong and Taiwan write in Traditional Chinese; literary or classical Chinese fell out of use a century ago and is only studied in the context of classical literature.

/ref 9fe1f3935d4cd1e1b298faf9d573c732d24cc81d