### PR TITLE
Add California Coast Credit Union

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -2246,6 +2246,16 @@
       "brand:wikipedia": "es:Cajamar",
       "name": "Cajamar"
     }
+ },
+  "amenity/bank|California Coast Credit Union": {
+    "countryCodes": ["us"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "California Coast Credit Union",
+      "brand:wikidata": "Q25025281",
+      "brand:wikipedia": "en:California Coast Credit Union",
+      "name": "California Coast Credit Union"
+    }
   },
   "amenity/bank|Canara Bank": {
     "countryCodes": ["in"],


### PR DESCRIPTION
Adds California Coast Credit Union which has 25 branches in Southern California.