### PR TITLE
Add San Diego County Credit Union

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -4550,6 +4550,17 @@
       "name": "Sampath Bank"
     }
   },
+  "amenity/bank|San Diego County Credit Union": {
+    "countryCodes": ["us"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "San Diego County Credit Union",
+      "brand:wikidata": "Q7413628",
+      "brand:wikipedia": "en:San Diego County Credit Union",
+      "name": "San Diego County Credit Union",
+      "alt_name": "SDCCU"
+    }
+  },
   "amenity/bank|Santander": {
     "matchNames": ["santander consumer bank"],
     "nomatch": ["amenity/bank|Banco Santander"],


### PR DESCRIPTION
Adds San Diego County Credit Union which has 43 locations in Southern California (US).