### PR TITLE
Remove duplicate bank (EastWest Bank)

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -2772,15 +2772,6 @@
       "name": "Dubai Islamic Bank"
     }
   },
-  "amenity/bank|EastWest Bank": {
-    "tags": {
-      "amenity": "bank",
-      "brand": "EastWest Bank",
-      "brand:wikidata": "Q5327595",
-      "brand:wikipedia": "en:EastWest Bank",
-      "name": "EastWest Bank"
-    }
-  },
   "amenity/bank|EastWest Unibank": {
     "countryCodes": ["ph"],
     "tags": {


### PR DESCRIPTION
Note: Name of bank as seen in their signages is "EastWest Unibank" although the Wikipedia article is under "EastWest Bank".