### PR TITLE
Add Jerome’s Furniture

### DIFF
--- a/brands/shop/furniture.json
+++ b/brands/shop/furniture.json
@@ -257,6 +257,17 @@
       "shop": "furniture"
     }
   },
+  "shop/furniture|Jerome’s Furniture": {
+    "countryCodes": ["us"],
+    "tags": {
+      "brand": "Jerome’s Furniture",
+      "brand:wikidata": "Q16997693",
+      "brand:wikipedia": "en:Jerome's",
+      "name": "Jerome’s Furniture",
+      "short_name": "Jerome’s",
+      "shop": "furniture"
+    }
+  },
   "shop/furniture|JYSK": {
     "tags": {
       "brand": "JYSK",


### PR DESCRIPTION
Adds Jerome's Furniture store located in San Diego, California (US).

Wikipedia: https://en.wikipedia.org/wiki/Jerome%27s