### PR TITLE
Update redbox to vend video_games and movies

### DIFF
--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -125,7 +125,7 @@
       "brand:wikidata": "Q7305489",
       "brand:wikipedia": "en:Redbox",
       "name": "Redbox",
-      "vending": "dvd"
+      "vending": "movies"
     }
   },
   "amenity/vending_machine|Reddy Ice": {


### PR DESCRIPTION
They stopped selling just DVDs a long time ago.

Signed-off-by: Tim Smith <tsmith@chef.io>