### PR TITLE
Add Kroger Marketplace

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -1940,6 +1940,16 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Kroger Marketplace": {
+    "nomatch": ["amenity/fuel|Kroger"],
+    "tags": {
+      "brand": "Kroger Marketplace",
+      "brand:wikidata": "Q153417",
+      "brand:wikipedia": "en:Kroger",
+      "name": "Kroger Marketplace",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|Kvickly": {
     "countryCodes": ["dk"],
     "tags": {


### PR DESCRIPTION
This is Krogers new Fred Meyer like supercenter store. They have over
100 over them in the US and it looks like they're converting other
brands to this new format. I'm sure in a few years they'll finally kill
of Fred Meyer and replace it with this :(

This uses the same wiki IDs like how we did it with Walmart. I did make the brand Kroger Marketplace since that seems like the correct thing, but let me know if that should be something different.

Signed-off-by: Tim Smith <tsmith@chef.io>