### PR TITLE
Remove disambiguator from Phở Hòa

### DIFF
--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -1488,8 +1488,16 @@
       "name:vi": "Phở 24"
     }
   },
-  "amenity/restaurant|Phở Hòa~(Branded)": {
-    "countryCodes": ["us"],
+  "amenity/restaurant|Phở Hòa": {
+    "countryCodes": [
+      "ca",
+      "id",
+      "kr",
+      "ms",
+      "ph",
+      "tw",
+      "us"
+    ],
     "tags": {
       "alt_name": "Phở Hoà",
       "alt_name:en": "Pho Hoa",


### PR DESCRIPTION
This PR removes the disambiguating suffix from the Phở Hòa entry. It was added in 7ff45e5375f591ddc53bdc52fae17e15b887409c after I pointed out that, while this is one of the largest phở chains, it’s also a common name for phở restaurants. I’ve gone through and added `not:brand:wikidata` tags on every unaffiliated Phở Hòa I could find in OpenStreetMap, including the original restaurant in Vietnam that the chain was named in honor of. (There were a few in Vietnam and the Philippines for which no website was given and no street-level imagery was available.) openstreetmap/iD#6577 tracks respecting the `not:brand:wikidata` tag.

This PR also adds country codes for the countries where Phở Hòa operates.

The build script complains that `alt_name=Phở Hoà` is redundant to `name=Phở Hòa` after case-folding:

```
  "amenity/restaurant|Phở Hòa" -> matches? -> "amenity/restaurant|Phở Hòa ("phohoa")"
```

However, this is intentional tagging. In Vietnamese, “Hòa” is equivalent to “Hoà” but not equivalent to “Hoa”, “Hóa”, “Hoả”, etc. The build script performs aggressive case-folding that treats any diacritic as superfluous and interchangeable, which can be useful for spotting typos, but geocoders should penalize such matches heavily compared to actual equivalences like Hòa/Hoà. Thanks to the widespread use of `alt_name` for these equivalences, geocoders don’t have to build language detection and language-specific special cases just to be usable in Vietnam; instead, they can boost `alt_name`s over anything matched via case-folding.