### PR TITLE
Also catch Iceland as convenience or frozen_food

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -1728,6 +1728,7 @@
     }
   },
   "shop/supermarket|Iceland": {
+    "matchTags": ["shop/convenience", "shop/frozen_food"],
     "tags": {
       "brand": "Iceland",
       "brand:wikidata": "Q721810",


### PR DESCRIPTION
Personally I think it should be frozen_food as per:
https://wiki.openstreetmap.org/wiki/Tag:shop%3Dfrozen_food

But Overpass Turbo suggests supermarket is far more popular.

CC @maxerickson @bhousel 