### PR TITLE
added CVS vending machine

### DIFF
--- a/brands/amenity/pharmacy.json
+++ b/brands/amenity/pharmacy.json
@@ -140,7 +140,10 @@
   },
   "amenity/pharmacy|CVS": {
     "matchNames": ["cvs pharmacy"],
-    "nomatch": ["shop/chemist|CVS"],
+    "nomatch": [
+      "amenity/vending_machine|CVS",
+      "shop/chemist|CVS"
+    ],
     "tags": {
       "amenity": "pharmacy",
       "brand": "CVS",

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -43,6 +43,20 @@
       "vending": "public_transport_tickets"
     }
   },
+  "amenity/vending_machine|CVS": {
+    "countryCodes": ["us"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "CVS",
+      "brand:wikidata": "Q2078880",
+      "brand:wikipedia": "en:CVS Pharmacy",
+      "payment": "yes",
+      "weelchair": "yes",
+      "covered": "yes",
+      "name": "CVS Pharmacy",
+      "vending": "chemist"
+    }
+  },  
   "amenity/vending_machine|DHL Packstation": {
     "countryCodes": ["de"],
     "matchTags": ["amenity/post_box"],

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -45,18 +45,19 @@
   },
   "amenity/vending_machine|CVS": {
     "countryCodes": ["us"],
+    "nomatch": ["shop/chemist|CVS"],
     "tags": {
       "amenity": "vending_machine",
       "brand": "CVS",
       "brand:wikidata": "Q2078880",
       "brand:wikipedia": "en:CVS Pharmacy",
-      "payment": "yes",
-      "weelchair": "yes",
       "covered": "yes",
       "name": "CVS Pharmacy",
-      "vending": "chemist"
+      "payment": "yes",
+      "vending": "chemist",
+      "weelchair": "yes"
     }
-  },  
+  },
   "amenity/vending_machine|DHL Packstation": {
     "countryCodes": ["de"],
     "matchTags": ["amenity/post_box"],


### PR DESCRIPTION
I've added the CVS vending machine using the recommend code form bhousel  in #2894 as well as these tags

`payment: yes`
`weelchair: yes`
`covered: yes`

taken from [this press release](https://cvshealth.com/newsroom/press-releases/cvs-pharmacy-thinks-outside-box-introduction-health-and-wellness-vending) from CVS Health about the machines.
