### PR TITLE
fixed norauto dupe error

### DIFF
--- a/brands/shop/car_repair.json
+++ b/brands/shop/car_repair.json
@@ -288,6 +288,7 @@
       "pt",
       "ro"
     ],
+    "nomatch": ["shop/car_parts|Norauto"],
     "tags": {
       "brand": "Norauto",
       "brand:wikidata": "Q3317698",


### PR DESCRIPTION
I added the nomatch tag
`shop/car_parts|Norauto`
to brands>shop>car_repair|Norauto
this fixed the dupe error when running `npm run build`.
edit: it's actually a warning, not an error.