### PR TITLE
Add Arabic name and brand to Herfy (fast food)

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -876,6 +876,27 @@
       "takeaway": "yes"
     }
   },
+    "amenity/fast_food|هرفي": {
+    "countryCodes": [
+      "ae",
+      "bh",
+      "kw",
+      "sa"
+    ],
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "هرفي",
+      "brand:en": "Herfy",
+      "brand:ar": "هرفي",
+      "brand:wikidata": "Q5738371",
+      "brand:wikipedia": "ar:هرفي",
+      "cuisine": "burger",
+      "name": "هرفي",
+      "name:en": "Herfy",
+      "name:ar": "هرفي",
+      "takeaway": "yes"
+    }
+  },
   "amenity/fast_food|Hesburger": {
     "tags": {
       "amenity": "fast_food",

--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -865,10 +865,14 @@
     "tags": {
       "amenity": "fast_food",
       "brand": "Herfy",
+      "brand:en": "Herfy",
+      "brand:ar": "هرفي",
       "brand:wikidata": "Q5738371",
       "brand:wikipedia": "en:Herfy",
       "cuisine": "burger",
       "name": "Herfy",
+      "name:en": "Herfy",
+      "name:ar": "هرفي",
       "takeaway": "yes"
     }
   },


### PR DESCRIPTION
Herfy is a Saudi Arabia based fast food chain with both English and Arabic signs and logos.  The English branding is already in the NSI and this PR adds `brand:ar` and `name:ar`.