### PR TITLE
Added Northern Store, additional information on Mercator

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -2398,10 +2398,13 @@
     }
   },
   "shop/supermarket|Mercator": {
+    "countryCodes": ["hz", "ba", "si", "rs", "me"],
     "tags": {
       "brand": "Mercator",
       "name": "Mercator",
       "shop": "supermarket"
+      "brand:wikidata": "Q738412"
+      "brand:wikipedia": "en:Mercator (retail)"
     }
   },
   "shop/supermarket|Merkur": {
@@ -2610,6 +2613,16 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Northern Store": {
+    "countryCodes": ["ca"]
+    "tags": {
+      "brand": "Northern Store"
+      "brand:wikidata": "Q7754361"
+      "brand:wikipedia": "en:The North West Company"
+      "name": "Northern Store"
+      "shop": "supermarket"
+    }
+},
   "shop/supermarket|Okay": {
     "countryCodes": ["be"],
     "tags": {

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -2402,8 +2402,8 @@
     "tags": {
       "brand": "Mercator",
       "name": "Mercator",
-      "shop": "supermarket"
-      "brand:wikidata": "Q738412"
+      "shop": "supermarket",
+      "brand:wikidata": "Q738412",
       "brand:wikipedia": "en:Mercator (retail)"
     }
   },
@@ -2616,10 +2616,10 @@
   "shop/supermarket|Northern Store": {
     "countryCodes": ["ca"]
     "tags": {
-      "brand": "Northern Store"
-      "brand:wikidata": "Q7754361"
-      "brand:wikipedia": "en:The North West Company"
-      "name": "Northern Store"
+      "brand": "Northern Store",
+      "brand:wikidata": "Q7754361",
+      "brand:wikipedia": "en:The North West Company",
+      "name": "Northern Store",
       "shop": "supermarket"
     }
 },


### PR DESCRIPTION
Added the Northern Store, the supermarket chain of the North West Company that operates in remote parts of Northern Canada. Additionally, added Wikidata information about Mercator, a Slovenian chain.