### PR TITLE
Add support for dissolved brands

### DIFF
--- a/build_dist.js
+++ b/build_dist.js
@@ -1,5 +1,6 @@
 const colors = require('colors/safe');
 const fs = require('fs');
+const dissolved = require('./dist/dissolved.json');
 const namesKeep = require('./dist/names_keep.json');
 const packageJSON = require('./package.json');
 const shell = require('shelljs');
@@ -43,6 +44,10 @@ function buildJSON() {
 
         const wd = obj.tags['brand:wikidata'];
         if (!wd || !/^Q\d+$/.test(wd)) return;   // wikidata tag missing or looks wrong..
+
+        if (dissolved[kvnd]) {
+            return; // brand does not exist anymore, so it should not be in the index
+        }
 
         const parts = toParts(kvnd);
         const k = parts.k;

--- a/dist/dissolved.json
+++ b/dist/dissolved.json
@@ -1,0 +1,62 @@
+{
+  "amenity/bank|Allied Bank~(defunct bank in Philipiness)": [
+    {"date": "2013-01-01T00:00:00.000Z"}
+  ],
+  "amenity/bank|Antonveneta": [{"date": "2013-01-01T00:00:00.000Z"}],
+  "amenity/bank|BMN": [{"date": "2018-01-01T00:00:00.000Z"}],
+  "amenity/bank|Banca Intesa": [{"date": "2007-01-01T00:00:00.000Z"}],
+  "amenity/bank|Banca Popolare di Milano": [
+    {"date": "2018-11-26T00:00:00.000Z"}
+  ],
+  "amenity/bank|Banca Popolare di Novara": [
+    {"date": "2011-12-27T00:00:00.000Z"}
+  ],
+  "amenity/bank|Banca Popolare di Verona": [
+    {"date": "2002-06-01T00:00:00.000Z"}
+  ],
+  "amenity/bank|Banco Pastor": [{"date": "2018-01-01T00:00:00.000Z"}],
+  "amenity/bank|Banco di Napoli": [{"date": "2018-11-25T00:00:00.000Z"}],
+  "amenity/bank|Bancpost": [
+    {
+      "date": "2019-01-03T00:00:00.000Z",
+      "upgrade": ["amenity/bank|Banca Transilvania"]
+    }
+  ],
+  "amenity/bank|Caja Duero": [{"date": "2010-01-01T00:00:00.000Z"}],
+  "amenity/bank|Caja España": [{"date": "2010-01-01T00:00:00.000Z"}],
+  "amenity/bank|CajaSur": [{"date": "2011-01-01T00:00:00.000Z"}],
+  "amenity/bank|CatalunyaCaixa": [{"date": "2016-01-01T00:00:00.000Z"}],
+  "amenity/bank|Chase": [{"date": "2000-01-01T00:00:00.000Z"}],
+  "amenity/bank|하나은행": [{"date": "2015-01-01T00:00:00.000Z"}],
+  "amenity/fuel|Agip": [{"date": "2008-01-01T00:00:00.000Z"}],
+  "amenity/fuel|CAMPSA": [{"date": "1992-01-01T00:00:00.000Z"}],
+  "amenity/fuel|Conoco": [{"date": "2002-01-01T00:00:00.000Z"}],
+  "amenity/fuel|Gulf": [{"date": "1984-01-01T00:00:00.000Z"}],
+  "amenity/fuel|TotalErg": [{"date": "2018-01-10T00:00:00.000Z"}],
+  "amenity/fuel|ТНК": [{"date": "2013-01-01T00:00:00.000Z"}],
+  "shop/clothes|Wilsons Leather": [{"date": "2008-01-01T00:00:00.000Z"}],
+  "shop/doityourself|Praktiker": [{"date": "2014-01-01T00:00:00.000Z"}],
+  "shop/interior_decoration|Fired Earth": [
+    {"date": "1998-01-01T00:00:00.000Z"}
+  ],
+  "shop/mobile_phone|Wind": [{"date": "2016-12-30T00:00:00.000Z"}],
+  "shop/mobile_phone|ソフトバンク": [{"date": "2015-04-01T00:00:00.000Z"}],
+  "shop/newsagent|Белсоюзпечать": [{"date": "1994-01-01T00:00:00.000Z"}],
+  "shop/newsagent|Витебскоблсоюзпечать": [{"date": "1994-01-01T00:00:00.000Z"}],
+  "shop/newsagent|Союзпечать": [{"date": "1994-01-01T00:00:00.000Z"}],
+  "shop/shoes|ЦентрОбувь": [{"date": "2018-01-01T00:00:00.000Z"}],
+  "shop/supermarket|Comercial Mexicana": [{"date": "2015-01-28T00:00:00.000Z"}],
+  "shop/supermarket|Rimi": [{"date": "2015-01-01T00:00:00.000Z"}],
+  "shop/toys|Toys R Us": [
+    {"date": "2018-06-29T00:00:00.000Z", "countries": ["us"]},
+    {"date": "2018-04-24T00:00:00.000Z", "countries": ["gb"]},
+    {"date": "2018-08-05T00:00:00.000Z", "countries": ["au"]},
+    {"date": "2019-06-19T00:00:00.000Z", "countries": ["fr"]},
+    {
+      "date": "2018-04-21T00:00:00.000Z",
+      "countries": ["de", "at", "ch"],
+      "upgrade": ["shop/toys|Smyths"]
+    }
+  ],
+  "shop/video|Blockbuster": [{"date": "2013-01-01T00:00:00.000Z"}]
+}


### PR DESCRIPTION
This is an addition to the `build_wikidata.js` script which checks whether a linked wikidata entity is actually a dissolved brand.
All entities which have a [P576 (date of dissolution)](https://www.wikidata.org/wiki/Property:P576) claim are currently treated as a dissolved brand. If there is either a [P156 (followed by)](https://www.wikidata.org/wiki/Property:P156) or a [P1366 (replaced by)](https://www.wikidata.org/wiki/Property:P1366) claim, these values are used to add a possible `upgrade` value. (if this gets implemented in iD, then users would not only see a warning, but there would be also a solution on how to fix this warning)

All dissolved brands are stored in an additional file (`dist/dissolved.json`) which can be used for further processing of possible data consumers like iD. All entries of this file are not included in the main name-suggestion-index file.

Also rather complex situations like the situation of "[Toys R Us](https://www.wikidata.org/wiki/Q696334)" are processed in a way that it is even possible to show individual warnings per country:
```json
"shop/toys|Toys R Us": [
  {"date": "2018-06-29T00:00:00.000Z", "countries": ["us"]},
  {"date": "2018-04-24T00:00:00.000Z", "countries": ["gb"]},
  {"date": "2018-08-05T00:00:00.000Z", "countries": ["au"]},
  {"date": "2019-06-19T00:00:00.000Z", "countries": ["fr"]},
  {
    "date": "2018-04-21T00:00:00.000Z",
    "countries": ["de", "at", "ch"],
    "upgrade": ["shop/toys|Smyths"]
  }
]
```
I'm not sure whether this is the wanted data format, but I think it might be a good base to start 😄
This pull request fixes #2415