### PR TITLE
Velcom rebranding

### DIFF
--- a/brands/office/telecommunication.json
+++ b/brands/office/telecommunication.json
@@ -10,11 +10,13 @@
   },
   "office/telecommunication|Velcom": {
     "countryCodes": ["by"],
+    "matchNames": ["А1", "Велком", "velcom | A1", "velcom"],
     "tags": {
-      "brand": "velcom | A1",
+      "brand": "A1",
       "brand:wikidata": "Q1888809",
-      "brand:wikipedia": "en:Velcom",
-      "name": "velcom | A1",
+      "brand:wikipedia": "en:A1_Belarus",
+      "name": "A1",
+      "name:en": "A1 Belarus",
       "office": "telecommunication"
     }
   },

--- a/brands/shop/mobile_phone.json
+++ b/brands/shop/mobile_phone.json
@@ -478,11 +478,13 @@
   },
   "shop/mobile_phone|Velcom": {
     "countryCodes": ["by"],
+    "matchNames": ["А1", "Велком", "velcom | A1", "velcom"],
     "tags": {
-      "brand": "velcom | A1",
+      "brand": "A1",
       "brand:wikidata": "Q1888809",
-      "brand:wikipedia": "en:Velcom",
-      "name": "velcom | A1",
+      "brand:wikipedia": "en:A1_Belarus",
+      "name": "A1",
+      "name:en": "A1 Belarus",
       "shop": "mobile_phone"
     }
   },


### PR DESCRIPTION
Now A1 nationwide, signage being replaced. 
Added name:en to differentiate from other A1 in the EU