### PR TITLE
Add Tostao' cafe brand

### DIFF
--- a/brands/amenity/cafe.json
+++ b/brands/amenity/cafe.json
@@ -802,6 +802,19 @@
       "takeaway": "yes"
     }
   },
+  "amenity/cafe|Tostao’": {
+    "countryCodes": ["co"],
+    "tags": {
+      "amenity": "cafe",
+      "brand": "Tostao’",
+      "brand:wikidata": "Q60632476",
+      "cuisine": "coffee_shop",
+      "name": "Tostao’",
+      "name:es": "Tostao’",
+      "official_name": "TOSTAO’ Café & Pan",
+      "takeaway": "yes"
+    }
+  },
   "amenity/cafe|Traveler's Coffee": {
     "countryCodes": ["ru"],
     "tags": {

--- a/brands/amenity/cafe.json
+++ b/brands/amenity/cafe.json
@@ -804,6 +804,7 @@
   },
   "amenity/cafe|Tostao’": {
     "countryCodes": ["co"],
+    "matchNames": ["tostao", "tostao'"],
     "tags": {
       "amenity": "cafe",
       "brand": "Tostao’",


### PR DESCRIPTION
https://www.wikidata.org/wiki/Q60632476
http://tostaocafeypan.com/

The name stylization  is a bit funky. The name on the website is `TOSTAO’ Café & Pan`, so I used that for `official_name`. I'm not sure what the index standards are for all-caps and apostrophes (`'` vs. `’`), but `Tostao’` seemed more reasonable for the `brand` and `name`.