### PR TITLE
Kampgrounds of America

### DIFF
--- a/brands/leisure/dog_park.json
+++ b/brands/leisure/dog_park.json
@@ -1,0 +1,13 @@
+{
+  "leisure/dog_park|Kamp K9": {
+    "countryCodes": ["ca", "us"],
+    "matchTags": ["leisure/park"],
+    "tags": {
+      "brand": "KOA",
+      "brand:wikidata": "Q16988635",
+      "brand:wikipedia": "en:Kampgrounds of America",
+      "leisure": "dog_park",
+      "name": "Kamp K9"
+    }
+  }
+}

--- a/brands/tourism/caravan_site.json
+++ b/brands/tourism/caravan_site.json
@@ -1,0 +1,64 @@
+{
+  "tourism/caravan_site|KOA Holiday": {
+    "countryCodes": ["ca", "us"],
+    "matchTags": [
+      "leisure/park",
+      "tourism/camp_site"
+    ],
+    "tags": {
+      "brand": "KOA",
+      "brand:wikidata": "Q16988635",
+      "brand:wikipedia": "en:Kampgrounds of America",
+      "name": "KOA Holiday",
+      "short_name": "KOA",
+      "tourism": "caravan_site"
+    }
+  },
+  "tourism/caravan_site|KOA Journey": {
+    "countryCodes": ["ca", "us"],
+    "matchTags": [
+      "leisure/park",
+      "tourism/camp_site"
+    ],
+    "tags": {
+      "brand": "KOA",
+      "brand:wikidata": "Q16988635",
+      "brand:wikipedia": "en:Kampgrounds of America",
+      "name": "KOA Journey",
+      "short_name": "KOA",
+      "tourism": "caravan_site"
+    }
+  },
+  "tourism/caravan_site|KOA Kampground": {
+    "countryCodes": ["ca", "us"],
+    "matchNames": ["kampgrounds of america"],
+    "matchTags": [
+      "leisure/park",
+      "tourism/camp_site"
+    ],
+    "tags": {
+      "alt_name": "KOA Campground",
+      "brand": "KOA",
+      "brand:wikidata": "Q16988635",
+      "brand:wikipedia": "en:Kampgrounds of America",
+      "name": "KOA Kampground",
+      "short_name": "KOA",
+      "tourism": "caravan_site"
+    }
+  },
+  "tourism/caravan_site|KOA Resort": {
+    "countryCodes": ["ca", "us"],
+    "matchTags": [
+      "leisure/park",
+      "tourism/camp_site"
+    ],
+    "tags": {
+      "brand": "KOA",
+      "brand:wikidata": "Q16988635",
+      "brand:wikipedia": "en:Kampgrounds of America",
+      "name": "KOA Resort",
+      "short_name": "KOA",
+      "tourism": "caravan_site"
+    }
+  }
+}


### PR DESCRIPTION
Added the KOA Kampground, KOA Journey, KOA Holiday, and KOA Resort campground chains, plus the Kamp K9 dog park found at each campsite.

This PR introduces the following warnings because each of the four campground formats has a `short_name` of `KOA`, which I think is appropriate in each case. I couldn’t suppress these warnings using `nomatch`, but maybe that’s a bug.

```
  "tourism/caravan_site|KOA Holiday" -> matches? -> "tourism/caravan_site|KOA Journey ("koa")"
  "tourism/caravan_site|KOA Holiday" -> matches? -> "tourism/caravan_site|KOA Journey ("koa")"
  "tourism/caravan_site|KOA Holiday" -> matches? -> "tourism/caravan_site|KOA Journey ("koa")"
  "tourism/caravan_site|KOA Holiday" -> matches? -> "tourism/caravan_site|KOA Kampground ("koa")"
  "tourism/caravan_site|KOA Holiday" -> matches? -> "tourism/caravan_site|KOA Kampground ("koa")"
  "tourism/caravan_site|KOA Holiday" -> matches? -> "tourism/caravan_site|KOA Kampground ("koa")"
  "tourism/caravan_site|KOA Holiday" -> matches? -> "tourism/caravan_site|KOA Resort ("koa")"
  "tourism/caravan_site|KOA Holiday" -> matches? -> "tourism/caravan_site|KOA Resort ("koa")"
  "tourism/caravan_site|KOA Holiday" -> matches? -> "tourism/caravan_site|KOA Resort ("koa")"
```