### PR TITLE
Add Londis (Ireland)

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -828,6 +828,8 @@
     "countryCodes": ["gb"],
     "tags": {
       "brand": "Londis",
+      "brand:wikidata": "Q21008564",
+      "brand:wikipedia": "en:Londis (United Kingdom)",
       "name": "Londis",
       "shop": "convenience"
     }

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -824,7 +824,17 @@
       "shop": "convenience"
     }
   },
-  "shop/convenience|Londis": {
+  "shop/convenience|Londis~Ireland": {
+    "countryCodes": ["ie"],
+    "tags": {
+      "brand": "Londis",
+      "brand:wikidata": "Q21015800",
+      "brand:wikipedia": "en:Londis (Ireland) ",
+      "name": "Londis",
+      "shop": "convenience"
+    }
+  },
+  "shop/convenience|Londis~UK": {
     "countryCodes": ["gb"],
     "tags": {
       "brand": "Londis",


### PR DESCRIPTION
Adds Londis (Ireland) and adds Wikidata and Wikipedia tags to the existing Londis (UK) entry.  Per: #2966 