### PR TITLE
Add CZ countyCode for Czech branch

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -4502,7 +4502,8 @@
       "brand:wikidata": "Q24282825",
       "brand:wikipedia": "cs:Raiffeisenbank",
       "name": "Raiffeisenbank"
-    }
+    },
+    "countryCodes": ["cz"]
   },
   "amenity/bank|Regions Bank": {
     "countryCodes": ["us"],


### PR DESCRIPTION
Q24282825 is only for the bank's Czech branch. I was prompted to upgrade the tags in iD for a German bank and initially accepted: it doesn't show the tags it wants to add beforehand, so I didn't see that the tags were wrong. Then I edited its other tags and noticed it now referred to a Wikipedia article about the Czech branch, only available in Czech. I'm not sure how this error could slip in and if maybe Wikidata is wrong, but this solution was suggested to me in the OpenStreetMap Telegram chat, and sounds like it would at least be a workaround.