### PR TITLE
fix wikipedia reference for Swiss "Landi" shops

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -2015,7 +2015,7 @@
     "tags": {
       "brand": "Landi",
       "brand:wikidata": "Q1803010",
-      "brand:wikipedia": "en:Landi (Unternehmen)",
+      "brand:wikipedia": "de:Landi (Unternehmen)",
       "name": "Landi",
       "shop": "supermarket"
     }


### PR DESCRIPTION
Link to https://de.wikipedia.org/wiki/Landi_(Unternehmen) instead of the non-existing https://en.wikipedia.org/wiki/Landi_(Unternehmen)

(As of now, there seems to be no English Wikipedia article about the company.)