### PR TITLE
Icelandic supermarket chains

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -1,4 +1,14 @@
 {
+  "shop/convenience|10-11": {
+    "countryCodes": ["is"],
+    "tags": {
+      "brand": "10-11",
+      "brand:wikidata": "Q65336720",
+      "brand:wikipedia": "is:10-11",
+      "name": "10-11",
+      "shop": "convenience"
+    }
+  },
   "shop/convenience|1st Stop": {
     "countryCodes": ["us"],
     "matchNames": ["first stop"],

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -2607,22 +2607,42 @@
       "shop": "supermarket"
     }
   },
-  "shop/supermarket|Netto": {
-    "tags": {
-      "brand": "Netto",
-      "brand:wikidata": "Q552652",
-      "brand:wikipedia": "en:Netto (store)",
-      "name": "Netto",
-      "shop": "supermarket"
-    }
-  },
   "shop/supermarket|Netto Marken-Discount": {
     "countryCodes": ["de"],
     "tags": {
       "brand": "Netto Marken-Discount",
       "brand:wikidata": "Q879858",
-      "brand:wikipedia": "en:Netto Marken-Discount",
+      "brand:wikipedia": "de:Netto Marken-Discount",
       "name": "Netto Marken-Discount",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|Netto~(Les Mousquetaires)": {
+    "countryCodes": ["fr", "pt"],
+    "tags": {
+      "brand": "Netto",
+      "brand:wikidata": "Q2720988",
+      "brand:wikipedia": "fr:Netto",
+      "name": "Netto",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|Netto~(Salling)": {
+    "countryCodes": ["da", "de", "pl", "se"],
+    "tags": {
+      "brand": "Netto",
+      "brand:wikidata": "Q552652",
+      "brand:wikipedia": "da:Netto (supermarkedskæde)",
+      "name": "Netto",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|Nettó": {
+    "countryCodes": ["is"],
+    "tags": {
+      "brand": "Nettó",
+      "brand:wikidata": "Q67205962",
+      "name": "Nettó",
       "shop": "supermarket"
     }
   },

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -436,6 +436,16 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Bónus": {
+    "countryCodes": ["fo", "is"],
+    "tags": {
+      "brand": "Bónus",
+      "brand:wikidata": "Q3480158",
+      "brand:wikipedia": "en:Bónus",
+      "name": "Bónus",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|C-Town Supermarkets": {
     "countryCodes": ["us"],
     "tags": {

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -1979,6 +1979,16 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Krónan": {
+    "countryCodes": ["is"],
+    "tags": {
+      "brand": "Krónan",
+      "brand:wikidata": "Q16419327",
+      "brand:wikipedia": "is:Krónan (verslun)",
+      "name": "Krónan",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|Kvickly": {
     "countryCodes": ["dk"],
     "tags": {


### PR DESCRIPTION
Added a few Icelandic supermarket chains based on [this list](https://en.wikipedia.org/wiki/List_of_supermarket_chains_in_Iceland). Differentiated between the three Netto (Nettó) chains.

/ref #3000