### PR TITLE
Fix Souyuzpechat wikidata refs

### DIFF
--- a/brands/shop/newsagent.json
+++ b/brands/shop/newsagent.json
@@ -111,8 +111,7 @@
     ],
     "tags": {
       "brand": "Белсоюзпечать",
-      "brand:wikidata": "Q4430611",
-      "brand:wikipedia": "ru:Союзпечать",
+      "brand:wikidata": "Q67723214",
       "name": "Белсоюзпечать",
       "shop": "newsagent"
     }
@@ -126,8 +125,7 @@
     ],
     "tags": {
       "brand": "Витебскоблсоюзпечать",
-      "brand:wikidata": "Q4430611",
-      "brand:wikipedia": "ru:Союзпечать",
+      "brand:wikidata": "Q67723214",
       "name": "Витебскоблсоюзпечать",
       "shop": "newsagent"
     }
@@ -149,7 +147,7 @@
     }
   },
   "shop/newsagent|Союзпечать": {
-    "countryCodes": ["by", "kz", "ru", "ua"],
+    "countryCodes": ["ru", "ua"],
     "matchTags": ["shop/kiosk"],
     "nomatch": [
       "shop/newsagent|Белсоюзпечать",


### PR DESCRIPTION
No relation between the Soviet brand and modern entities in BY to keep the old wikidata page