### PR TITLE
Charging Stations in Luxembourg

### DIFF
--- a/brands/amenity/charging_station.json
+++ b/brands/amenity/charging_station.json
@@ -17,6 +17,16 @@
       "name": "ChargePoint"
     }
   },
+  "amenity/charging_station|Chargy": {
+    "countryCodes": ["lu"],
+    "tags": {
+      "amenity": "charging_station",
+      "brand": "Chargy",
+      "brand:wikidata": "Q62702950",
+      "brand:wikipedia": "lb:Chargy",
+      "name": "Chargy"
+    }
+  },
   "amenity/charging_station|Circuit électrique": {
     "countryCodes": ["ca"],
     "tags": {
@@ -89,12 +99,14 @@
       "ch",
       "de",
       "fr",
-      "it"
+      "it",
+      "lu"
     ],
     "tags": {
       "amenity": "charging_station",
-      "brand": "bike-energy Ladestation",
-      "name": "bike-energy Ladestation"
+      "brand": "bike-energy",
+      "brand:wikidata": "Q67770877",
+      "name": "bike-energy"
     }
   },
   "amenity/charging_station|eVgo": {


### PR DESCRIPTION
Hello,

I've added "Chargy" Charging Stations in Luxembourg, added the availability of Bike-Energy in Luxembourg and improved the generic name of the Bike-Energy brand.

Regards
David