### PR TITLE
Add supermarket and bank brands (part 2)

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -7609,6 +7609,20 @@
       "name:en": "China Merchants Bank"
     }
   },
+  "amenity/bank|新生銀行": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "新生銀行",
+      "brand:en": "Shinsei Bank",
+      "brand:ja": "新生銀行",
+      "brand:wikidata": "Q571997",
+      "brand:wikipedia": "ja:新生銀行",
+      "name": "新生銀行",
+      "name:en": "Shinsei Bank",
+      "name:ja": "新生銀行"
+    }
+  },
   "amenity/bank|日本銀行": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -7105,6 +7105,20 @@
       "name:ja": "りそな銀行"
     }
   },
+  "amenity/bank|スルガ銀行": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "スルガ銀行",
+      "brand:en": "Suruga Bank",
+      "brand:ja": "スルガ銀行",
+      "brand:wikidata": "Q11313470",
+      "brand:wikipedia": "ja:スルガ銀行",
+      "name": "スルガ銀行",
+      "name:en": "Suruga Bank",
+      "name:ja": "スルガ銀行"
+    }
+  },
   "amenity/bank|三井住友信託銀行": {
     "countryCodes": ["jp"],
     "tags": {
@@ -7411,10 +7425,17 @@
     }
   },
   "amenity/bank|千葉銀行": {
+    "countryCodes": ["jp"],
     "tags": {
       "amenity": "bank",
       "brand": "千葉銀行",
-      "name": "千葉銀行"
+      "brand:en": "The Chiba Bank",
+      "brand:ja": "千葉銀行",
+      "brand:wikidata": "Q1071712",
+      "brand:wikipedia": "en:Chiba Bank",
+      "name": "千葉銀行",
+      "name:en": "Chiba Bank",
+      "name:ja": "千葉銀行"
     }
   },
   "amenity/bank|台中商業銀行": {

--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -7105,6 +7105,20 @@
       "name:ja": "りそな銀行"
     }
   },
+  "amenity/bank|イオン銀行": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "イオン銀行",
+      "brand:en": "Aeon Bank",
+      "brand:ja": "イオン銀行",
+      "brand:wikidata": "Q11286327",
+      "brand:wikipedia": "ja:イオン銀行",
+      "name": "イオン銀行",
+      "name:en": "Aeon Bank",
+      "name:ja": "イオン銀行"
+    }
+  },
   "amenity/bank|スルガ銀行": {
     "countryCodes": ["jp"],
     "tags": {
@@ -7762,6 +7776,20 @@
       "brand:wikipedia": "zh:華南銀行",
       "name": "華南商業銀行",
       "name:en": "Hua Nan Commercial Bank"
+    }
+  },
+  "amenity/bank|近畿大阪銀行": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "近畿大阪銀行",
+      "brand:en": "The Kinki Osaka Bank",
+      "brand:ja": "近畿大阪銀行",
+      "brand:wikidata": "Q11638628",
+      "brand:wikipedia": "ja:近畿大阪銀行",
+      "name": "近畿大阪銀行",
+      "name:en": "Kinki Osaka Bank",
+      "name:ja": "近畿大阪銀行"
     }
   },
   "amenity/bank|遠東國際商業銀行": {

--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -7123,10 +7123,26 @@
       "amenity": "bank",
       "brand": "三井住友銀行",
       "brand:en": "Sumitomo Mitsui Banking Corporation",
+      "brand:ja": "三井住友銀行",
       "brand:wikidata": "Q2660418",
       "brand:wikipedia": "en:Sumitomo Mitsui Banking Corporation",
       "name": "三井住友銀行",
-      "name:en": "Sumitomo Mitsui Banking Corporation"
+      "name:en": "Sumitomo Mitsui Banking Corporation",
+      "name:ja": "三井住友銀行"
+    }
+  },
+  "amenity/bank|三菱UFJ信託銀行": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "三菱UFJ信託銀行",
+      "brand:en": "Mitsubishi UFJ Trust and Banking Corporation",
+      "brand:ja": "三菱UFJ信託銀行",
+      "brand:wikidata": "Q6883178",
+      "brand:wikipedia": "en:Mitsubishi UFJ Trust and Banking Corporation",
+      "name": "三菱UFJ信託銀行",
+      "name:en": "Sumitomo Mitsui Banking Corporation",
+      "name:ja": "三菱UFJ信託銀行"
     }
   },
   "amenity/bank|三菱UFJ銀行": {

--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -7477,6 +7477,20 @@
       "name:en": "Cathay United Bank"
     }
   },
+  "amenity/bank|埼玉りそな銀行": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "埼玉りそな銀行",
+      "brand:en": "Saitama Resona Bank",
+      "brand:ja": "埼玉りそな銀行",
+      "brand:wikidata": "Q4671591",
+      "brand:wikipedia": "ja:埼玉りそな銀行",
+      "name": "埼玉りそな銀行",
+      "name:en": "Saitama Resona Bank",
+      "name:ja": "埼玉りそな銀行"
+    }
+  },
   "amenity/bank|大眾商業銀行": {
     "countryCodes": ["tw"],
     "tags": {
@@ -7702,6 +7716,19 @@
       "brand:wikipedia": "en:Bank of Taiwan",
       "name": "臺灣銀行",
       "name:en": "Bank of Taiwan"
+    }
+  },
+  "amenity/bank|芝信用金庫": {
+    "tags": {
+      "amenity": "bank",
+      "brand": "芝信用金庫",
+      "brand:en": "Shiba Shinkin Bank",
+      "brand:ja": "芝信用金庫",
+      "brand:wikidata": "Q11614605",
+      "brand:wikipedia": "ja:芝信用金庫",
+      "name": "芝信用金庫",
+      "name:en": "Shiba Shinkin Bank",
+      "name:ja": "芝信用金庫"
     }
   },
   "amenity/bank|華南商業銀行": {

--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -4896,6 +4896,18 @@
       "name": "SEB"
     }
   },
+  "amenity/bank|SMBC信託銀行": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "SMBC信託銀行",
+      "brand:en": "SMBC Trust Bank",
+      "brand:wikidata": "Q17218805",
+      "brand:wikipedia": "jp:SMBC信託銀行",
+      "name": "SMBC信託銀行",
+      "name:en": " SMBC Trust Bank "
+    }
+  },
   "amenity/bank|SNS Bank": {
     "countryCodes": ["nl"],
     "tags": {
@@ -7156,7 +7168,8 @@
       "brand:wikipedia": "en:Sumitomo Mitsui Banking Corporation",
       "name": "三井住友銀行",
       "name:en": "Sumitomo Mitsui Banking Corporation",
-      "name:ja": "三井住友銀行"
+      "name:ja": "三井住友銀行",
+      "short_name:en": "SMBC"
     }
   },
   "amenity/bank|三菱UFJ信託銀行": {

--- a/brands/amenity/cafe.json
+++ b/brands/amenity/cafe.json
@@ -1310,6 +1310,7 @@
   },
   "amenity/cafe|スターバックス": {
     "countryCodes": ["jp"],
+    "matchNames": ["スターバックスコーヒー"],
     "tags": {
       "amenity": "cafe",
       "brand": "スターバックス",

--- a/brands/amenity/pharmacy.json
+++ b/brands/amenity/pharmacy.json
@@ -1816,6 +1816,24 @@
       "name:ja": "クリエイトSD"
     }
   },
+  "amenity/pharmacy|コクミン": {
+    "countryCodes": ["jp"],
+    "matchNames": ["コクミンドラッグ"],
+    "tags": {
+      "amenity": "pharmacy",
+      "brand": "コクミン",
+      "brand:en": "Kokumin",
+      "brand:ja": "コクミン",
+      "brand:wikidata": "Q11301923",
+      "brand:wikipedia": "ja:コクミン",
+      "healthcare": "pharmacy",
+      "name": "コクミン",
+      "name:en": "Kokumin",
+      "name:ja": "コクミン",
+      "official_name": "コクミンドラッグ",
+      "official_name:en": "Kokumin Drug"
+    }
+  },
   "amenity/pharmacy|ココカラファイン": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -2245,6 +2245,21 @@
       "name:he": "בורגר סאלון"
     }
   },
+  "amenity/restaurant|あさくま": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "restaurant",
+      "brand": "あさくま",
+      "brand:en": "Asakuma",
+      "brand:ja": "あさくま",
+      "brand:wikidata": "Q11257174",
+      "brand:wikipedia": "ja:あさくま",
+      "cuisine": "steak_house",
+      "name": "あさくま",
+      "name:en": "Asakuma",
+      "name:ja": "あさくま"
+    }
+  },
   "amenity/restaurant|いきなり！ステーキ": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/shop/books.json
+++ b/brands/shop/books.json
@@ -444,6 +444,20 @@
       "shop": "books"
     }
   },
+  "shop/books|有隣堂": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "有隣堂",
+      "brand:en": "Yurindo",
+      "brand:ja": "有隣堂",
+      "brand:wikidata": "Q8061680",
+      "brand:wikipedia": "ja:有隣堂",
+      "name": "有隣堂",
+      "name:en": "Yurindo",
+      "name:ja": "有隣堂",
+      "shop": "books"
+    }
+  },
   "shop/books|未来屋書店": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/shop/books.json
+++ b/brands/shop/books.json
@@ -345,6 +345,20 @@
       "shop": "books"
     }
   },
+  "shop/books|オリオン書房": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "オリオン書房",
+      "brand:en": "Books Onion",
+      "brand:ja": "オリオン書房",
+      "brand:wikidata": "Q11292597",
+      "brand:wikipedia": "ja:オリオン書房",
+      "name": "オリオン書房",
+      "name:en": "Books Onion",
+      "name:ja": "オリオン書房",
+      "shop": "books"
+    }
+  },
   "shop/books|ブックオフ": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/shop/music.json
+++ b/brands/shop/music.json
@@ -41,5 +41,21 @@
       "name": "TSUTAYA",
       "shop": "music"
     }
+  },
+  "shop/music|タワーレコード": {
+    "countryCodes": ["jp"],
+    "matchNames": ["タワレコ"],
+    "tags": {
+      "alt_name": "タワレコ",
+      "brand": "タワーレコード",
+      "brand:en": "Tower Records",
+      "brand:ja": "タワーレコード",
+      "brand:wikidata": "Q3265728",
+      "brand:wikipedia": "ja:タワーレコード",
+      "name": "タワーレコード",
+      "name:en": "Tower Records",
+      "name:ja": "タワーレコード",
+      "shop": "music"
+    }
   }
 }

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -244,16 +244,6 @@
       "shop": "supermarket"
     }
   },
-  "shop/supermarket|Bashas'": {
-    "countryCodes": ["us"],
-    "tags": {
-      "brand": "Bashas'",
-      "brand:wikidata": "Q4866786",
-      "brand:wikipedia": "en:Bashas'",
-      "name": "Bashas'",
-      "shop": "supermarket"
-    }
-  },
   "shop/supermarket|BI-LO": {
     "countryCodes": ["us"],
     "tags": {
@@ -270,6 +260,16 @@
       "brand": "BM",
       "brand:wikidata": "Q62073462",
       "name": "BM",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|Bashas'": {
+    "countryCodes": ["us"],
+    "tags": {
+      "brand": "Bashas'",
+      "brand:wikidata": "Q4866786",
+      "brand:wikipedia": "en:Bashas'",
+      "name": "Bashas'",
       "shop": "supermarket"
     }
   },
@@ -4851,6 +4851,20 @@
       "name": "サミット",
       "name:en": "Summit",
       "name:ja": "サミット",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|ダイエー": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "ダイエー",
+      "brand:en": "daiei",
+      "brand:ja": "ダイエー",
+      "brand:wikidata": "Q11316644",
+      "brand:wikipedia": "ja:ダイエー (店舗ブランド)",
+      "name": "ダイエー",
+      "name:en": "Daiei",
+      "name:ja": "ダイエー",
       "shop": "supermarket"
     }
   },

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -4896,6 +4896,20 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|ベイシア": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "ベイシア",
+      "brand:en": "Beisia",
+      "brand:ja": "ベイシア",
+      "brand:wikidata": "Q11336776",
+      "brand:wikipedia": "ja:ベイシア",
+      "name": "ベイシア",
+      "name:en": "Beisia",
+      "name:ja": "ベイシア",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|マックスバリュ": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -4793,6 +4793,20 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|オリンピック": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "オリンピック",
+      "brand:en": "Olympic",
+      "brand:ja": "オリンピック",
+      "brand:wikidata": "Q11292764",
+      "brand:wikipedia": "ja:Olympicグループ",
+      "name": "オリンピック",
+      "name:en": "Olympic",
+      "name:ja": "オリンピック",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|カスミ": {
     "countryCodes": ["jp"],
     "tags": {
@@ -4963,6 +4977,21 @@
       "name": "ライフ",
       "name:en": "Life",
       "name:ja": "ライフ",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|ワイズマート": {
+    "countryCodes": ["jp"],
+    "matchNames": ["よしのぶっさん"],
+    "tags": {
+      "brand": "ワイズマート",
+      "brand:en": "Y'smart",
+      "brand:ja": "ワイズマート",
+      "brand:wikidata": "Q11351175",
+      "brand:wikipedia": "ja:ワイズマート",
+      "name": "ワイズマート",
+      "name:en": "Y'smart",
+      "name:ja": "ワイズマート",
       "shop": "supermarket"
     }
   },


### PR DESCRIPTION
This updates complements the addition of brands in Japan. It seems that these are the most relevant brands in the country, specifically Tokyo. I added other brands like book stores and restaurants.