### PR TITLE
Match Volg convenience with Volg supermarket

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -1672,13 +1672,6 @@
       "shop": "convenience"
     }
   },
-  "shop/convenience|Volg": {
-    "tags": {
-      "brand": "Volg",
-      "name": "Volg",
-      "shop": "convenience"
-    }
-  },
   "shop/convenience|Wawa": {
     "nomatch": ["amenity/fuel|Wawa"],
     "tags": {

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -3888,6 +3888,7 @@
   },
   "shop/supermarket|Volg": {
     "countryCodes": ["ch", "li"],
+    "matchTags": ["shop/convenience"]
     "tags": {
       "brand": "Volg",
       "brand:wikidata": "Q2530746",

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -3888,7 +3888,7 @@
   },
   "shop/supermarket|Volg": {
     "countryCodes": ["ch", "li"],
-    "matchTags": ["shop/convenience"]
+    "matchTags": ["shop/convenience"],
     "tags": {
       "brand": "Volg",
       "brand:wikidata": "Q2530746",


### PR DESCRIPTION
Volg is mistakenly mapped as `shop=convenience` but should be `shop=supermarket`.  This adds a matchTag to the Volg supermarket entry.

Resolves #3046 