### PR TITLE
add cash withdrawal tags to Rewe supermarket

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -3167,7 +3167,11 @@
       "brand:wikidata": "Q16968817",
       "brand:wikipedia": "en:REWE",
       "name": "Rewe",
-      "shop": "supermarket"
+      "shop": "supermarket",
+      "cash_withdrawal": "girocard",
+      "cash_withdrawal:limit": "200",
+      "cash_withdrawal:purchase_required": "yes",
+      "cash_withdrawal:purchase_minimum": "10"
     }
   },
   "shop/supermarket|Rewe City": {


### PR DESCRIPTION
* [The new cash_withdrawal tag has been approved](https://wiki.openstreetmap.org/wiki/Proposed_features/Cash_withdrawal)
* [Every Rewe supermarket has cash withdrawal under the same conditions](https://www.rewe.de/service/bargeld-abheben/)