### PR TITLE
Split Danske Bank into Danske Bank and Danske Bank (Northern Ireland)

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -2918,6 +2918,18 @@
       "name": "Danske Bank"
     }
   },
+  "amenity/bank|Danske Bank (Northern Ireland)": {
+    "countryCodes": [
+      "ie"
+    ],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Danske Bank (Northern Ireland)",
+      "brand:wikidata": "Q2378066",
+      "brand:wikipedia": "en:Danske Bank (Northern Ireland)",
+      "name": "Danske Bank (Northern Ireland)"
+    }
+  },
   "amenity/bank|Davivienda": {
     "tags": {
       "amenity": "bank",


### PR DESCRIPTION
Fixed issue [https://github.com/osmlab/name-suggestion-index/issues/2679](https://github.com/osmlab/name-suggestion-index/issues/2679) by adding missing amenity.