### PR TITLE
Added Altar'd State brand to shop json file.

### DIFF
--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -97,6 +97,14 @@
       "shop": "clothes"
     }
   },
+  "shop/clothes|Altar'd State": {
+    "countryCodes": ["us"],
+    "tags": {
+      "brand": "Altar'd State",
+      "name": "Altar'd State",
+      "shop": "clothes"
+    }
+  },
   "shop/clothes|American Eagle Outfitters": {
     "countryCodes": ["ca", "us"],
     "tags": {


### PR DESCRIPTION
As noted, added Altar'd State brand information.  Was not able to locate a wikipedia page for this smaller brand.  This in reference to Issue #3054 