### PR TITLE
Add Cinemas UGC

### DIFF
--- a/brands/amenity/cinema.json
+++ b/brands/amenity/cinema.json
@@ -347,6 +347,16 @@
       "name": "The Space Cinema"
     }
   },
+  "amenity/cinema|UGC": {
+    "countryCodes": ["fr"],
+    "tags": {
+      "amenity": "cinema",
+      "brand": "UGC",
+      "brand:wikidata": "Q1643241",
+      "brand:wikipedia": "fr:Union générale cinématographique",
+      "name": "UGC"
+    }
+  },
   "amenity/cinema|Vue~(IrelandAndUK)": {
     "countryCodes": ["gb", "ie"],
     "matchNames": ["vue cinema", "vue cinemas"],


### PR DESCRIPTION
ssia

initially I did not want to set the tag "name" because each cinema has its own name - usually "UGC $something", but this tag is mandatory.

https://overpass-turbo.eu/s/MRM