### PR TITLE
Add info for La vie claire

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -2005,8 +2005,9 @@
     "tags": {
       "brand": "La Vie Claire",
       "brand:wikidata": "Q3213589",
-      "brand:wikipedia": "en:La Vie Claire (company)",
+      "brand:wikipedia": "fr:La Vie Claire",
       "name": "La Vie Claire",
+      "organic": "only",
       "shop": "supermarket"
     }
   },


### PR DESCRIPTION
This is a organic only shop and use French Wikipedia as the article is more complete and La Vie Claire is french based afaik