### PR TITLE
Boston Market is a chicken restaurant

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -213,7 +213,7 @@
       "brand": "Boston Market",
       "brand:wikidata": "Q603617",
       "brand:wikipedia": "en:Boston Market",
-      "cuisine": "american",
+      "cuisine": "american;chicken",
       "name": "Boston Market",
       "takeaway": "yes"
     }


### PR DESCRIPTION
Added `cuisine=chicken` to Boston Market. After all, the chain was previously called Boston _Chicken_. I realize the other entries tagged `cuisine=chicken` are all fried chicken or fried chicken sandwich joints, but that shouldn’t stop us from using the tag for rotisserie chicken too. If more specificity is needed, that’s what the [`cuisine=fried_chicken`](https://taginfo.openstreetmap.org/tags/cuisine=fried_chicken) tag is for.