### PR TITLE
Retag Honey Baked Ham

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -1001,6 +1001,22 @@
       "takeaway": "yes"
     }
   },
+  "amenity/fast_food|Honey Baked Ham": {
+    "countryCodes": ["us"],
+    "matchNames": ["honey baked ham company"],
+    "matchTags": ["shop/butcher", "shop/deli"],
+    "tags": {
+      "alt_name": "HoneyBaked Ham",
+      "amenity": "fast_food",
+      "brand": "Honey Baked Ham",
+      "brand:wikidata": "Q5893363",
+      "brand:wikipedia": "en:The Honey Baked Ham Company",
+      "cuisine": "american",
+      "name": "Honey Baked Ham",
+      "official_name": "The Honey Baked Ham Company",
+      "takeaway": "yes"
+    }
+  },
   "amenity/fast_food|Hot Dog on a Stick": {
     "countryCodes": ["us"],
     "tags": {

--- a/brands/shop/butcher.json
+++ b/brands/shop/butcher.json
@@ -35,16 +35,6 @@
       "shop": "butcher"
     }
   },
-  "shop/butcher|HoneyBaked Ham": {
-    "countryCodes": ["us"],
-    "tags": {
-      "brand": "HoneyBaked Ham",
-      "brand:wikidata": "Q5893363",
-      "brand:wikipedia": "en:The Honey Baked Ham Company",
-      "name": "HoneyBaked Ham",
-      "shop": "butcher"
-    }
-  },
   "shop/butcher|M&M Food Market": {
     "countryCodes": ["ca"],
     "tags": {


### PR DESCRIPTION
Like Boston Market, Honey Baked Ham is a fast food restaurant chain that also sells larger portions of meat to go. Like Arby’s, Honey Baked Ham is not a butcher shop, though it shares a lot in common with butcher shops.

Previously the stores were branded HoneyBaked Ham (or, more fully, The HoneyBaked Ham Company). Recently they adopted a new logo and tweaked the name to The Honey Baked Ham Company, but HoneyBaked still appears in some of their marketing materials, perhaps only as the name of the prepared ham product.