### PR TITLE
Added Innogy/RWE Charging stations

### DIFF
--- a/brands/amenity/charging_station.json
+++ b/brands/amenity/charging_station.json
@@ -90,7 +90,17 @@
       "name": "FLO"
     }
   },
-  "amenity/charging_station|Source London": {
+  "amenity/charging_station|Innogy": {
+    "matchNames": ["RWE"],
+    "tags": {
+      "amenity": "charging_station",
+      "brand": "Innogy",
+      "brand:wikidata": "Q2124721",
+      "brand:wikipedia": "de:Innogy",
+      "name": "Innogy"
+    }
+  },
+  "amenity/charging_station|Source-London": {
     "countryCodes": ["gb"],
     "tags": {
       "amenity": "charging_station",


### PR DESCRIPTION
Hi,

This PR adds the charging stations of Innogy/RWE, as per the [OSM Wiki](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dcharging_station#Examples).