### PR TITLE
Remove "by Marriott" from Courtyard hotel chain

### DIFF
--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -125,10 +125,11 @@
       "courtyard marriott"
     ],
     "tags": {
-      "brand": "Courtyard by Marriott",
+      "brand": "Courtyard",
       "brand:wikidata": "Q1053170",
       "brand:wikipedia": "en:Courtyard by Marriott",
-      "name": "Courtyard by Marriott",
+      "name": "Courtyard",
+      "official_name": "Courtyard by Marriott",
       "tourism": "hotel"
     }
   },


### PR DESCRIPTION
Changes the `name` and `brand` of "Courtyard by Marriott" to "Courtyard" to be consistent with other Marriott brands in the NSI (e.g. Fairfield Inn, Residence Inn, TownePlace Suites).