### PR TITLE
Add the remaining common Marriott brands

### DIFF
--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -221,7 +221,7 @@
     }
   },
   "tourism/hotel|Fairfield Inn & Suites": {
-    "countryCodes": ["ca", "us"],
+    "countryCodes": ["ca", "mx", "us"],
     "nomatch": ["tourism/hotel|Fairfield Inn"],
     "tags": {
       "brand": "Fairfield Inn & Suites",

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -2,7 +2,7 @@
   "tourism/hotel|AC Hotel": {
     "tags": {
       "brand": "AC Hotel",
-      "brand:wikidata": "Q1141173",
+      "brand:wikidata": "Q5653536",
       "brand:wikipedia": "en:Marriott International",
       "name": "AC Hotel",
       "tourism": "hotel"

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -268,7 +268,7 @@
   "tourism/hotel|Four Points": {
     "tags": {
       "brand": "Four Points",
-      "brand:wikidata": "Q634831",
+      "brand:wikidata": "Q1439966",
       "brand:wikipedia": "en:Sheraton Hotels and Resorts",
       "name": "Four Points",
       "official_name": "Four Points by Sheraton",

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -147,7 +147,21 @@
     }
   },
   "tourism/hotel|Days Inn": {
-    "countryCodes": ["ca", "gb", "us"],
+    "countryCodes": [
+      "ca",
+      "ch",
+      "gb",
+      "id",
+      "in",
+      "kr",
+      "mx",
+      "my",
+      "ph",
+      "sg",
+      "sn",
+      "th",
+      "us"
+    ],
     "tags": {
       "brand": "Days Inn",
       "brand:wikidata": "Q1047239",

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -269,7 +269,7 @@
     "tags": {
       "brand": "Four Points",
       "brand:wikidata": "Q1439966",
-      "brand:wikipedia": "en:Sheraton Hotels and Resorts",
+      "brand:wikipedia": "en:Four Points by Sheraton",
       "name": "Four Points",
       "official_name": "Four Points by Sheraton",
       "tourism": "hotel"

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -208,7 +208,17 @@
     }
   },
   "tourism/hotel|Fairfield Inn": {
-    "countryCodes": ["ca", "us"],
+    "countryCodes": [
+      "ca",
+      "cn",
+      "id",
+      "in",
+      "kr",
+      "mx",
+      "my",
+      "sv",
+      "us"
+    ],
     "nomatch": [
       "tourism/hotel|Fairfield Inn & Suites"
     ],

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -270,7 +270,7 @@
       "brand": "Four Points",
       "brand:wikidata": "Q1439966",
       "brand:wikipedia": "en:Four Points by Sheraton",
-      "name": "Four Points",
+      "name": "Four Points by Sheraton",
       "official_name": "Four Points by Sheraton",
       "tourism": "hotel"
     }

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -127,7 +127,6 @@
     }
   },
   "tourism/hotel|Courtyard": {
-    "countryCodes": ["ca", "us"],
     "matchNames": ["courtyard marriott"],
     "tags": {
       "brand": "Courtyard",

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -372,7 +372,6 @@
     }
   },
   "tourism/hotel|Holiday Inn Express & Suites": {
-    "countryCodes": ["ca", "us"],
     "tags": {
       "brand": "Holiday Inn Express & Suites",
       "brand:wikidata": "Q5880423",

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -265,7 +265,7 @@
       "tourism": "hotel"
     }
   },
-  "tourism/hotel|Four Points": {
+  "tourism/hotel|Four Points by Sheraton": {
     "tags": {
       "brand": "Four Points",
       "brand:wikidata": "Q1439966",

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -209,6 +209,9 @@
   },
   "tourism/hotel|Fairfield Inn": {
     "countryCodes": ["ca", "us"],
+    "nomatch": [
+      "tourism/hotel|Fairfield Inn & Suites"
+    ],
     "tags": {
       "brand": "Fairfield Inn",
       "brand:wikidata": "Q5430314",
@@ -219,6 +222,7 @@
   },
   "tourism/hotel|Fairfield Inn & Suites": {
     "countryCodes": ["ca", "us"],
+    "nomatch": ["tourism/hotel|Fairfield Inn"],
     "tags": {
       "brand": "Fairfield Inn & Suites",
       "brand:wikidata": "Q5430314",

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -267,7 +267,7 @@
   },
   "tourism/hotel|Four Points by Sheraton": {
     "tags": {
-      "brand": "Four Points",
+      "brand": "Four Points by Sheraton",
       "brand:wikidata": "Q1439966",
       "brand:wikipedia": "en:Four Points by Sheraton",
       "name": "Four Points by Sheraton",

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -271,7 +271,7 @@
       "brand:wikidata": "Q1439966",
       "brand:wikipedia": "en:Four Points by Sheraton",
       "name": "Four Points by Sheraton",
-      "official_name": "Four Points by Sheraton",
+      "short_name": "Four Points",
       "tourism": "hotel"
     }
   },

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -236,6 +236,7 @@
       "tourism/hotel|Fairfield Inn & Suites"
     ],
     "tags": {
+      "alt_name": "Fairfield by Marriott",
       "brand": "Fairfield Inn",
       "brand:wikidata": "Q5430314",
       "brand:wikipedia": "en:Fairfield Inn by Marriott",

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -877,8 +877,8 @@
   "tourism/hotel|Westin": {
     "tags": {
       "brand": "Westin",
-      "brand:wikidata": "Q261077",
-      "brand:wikipedia": "en:Le Méridien",
+      "brand:wikidata": "Q1969162",
+      "brand:wikipedia": "en:Westin Hotels & Resorts",
       "name": "Westin",
       "tourism": "hotel"
     }

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -495,6 +495,7 @@
     }
   },
   "tourism/hotel|JW Marriott": {
+    "matchNames": ["jw marriott hotels"],
     "tags": {
       "brand": "JW Marriott",
       "brand:wikidata": "Q1067636",
@@ -631,7 +632,7 @@
   "tourism/hotel|Moxy": {
     "tags": {
       "brand": "Moxy",
-      "brand:wikidata": "Q1053170",
+      "brand:wikidata": "Q70287020",
       "brand:wikipedia": "en:Marriott International",
       "name": "Moxy",
       "tourism": "hotel"
@@ -784,6 +785,7 @@
   },
   "tourism/hotel|St. Regis": {
     "tags": {
+      "alt_name": "Saint Regis",
       "brand": "St. Regis",
       "brand:wikidata": "Q30715430",
       "brand:wikipedia": "en:St. Regis Hotels & Resorts",
@@ -802,11 +804,25 @@
     }
   },
   "tourism/hotel|The Ritz-Carlton": {
+    "matchNames": [
+      "ritz",
+      "ritz carlton",
+      "the ritz"
+    ],
     "tags": {
       "brand": "The Ritz-Carlton",
       "brand:wikidata": "Q782200",
       "brand:wikipedia": "en:The Ritz-Carlton Hotel Company",
       "name": "The Ritz-Carlton",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|The Westin": {
+    "tags": {
+      "brand": "Westin",
+      "brand:wikidata": "Q1969162",
+      "brand:wikipedia": "en:Westin Hotels & Resorts",
+      "name": "The Westin",
       "tourism": "hotel"
     }
   },
@@ -871,15 +887,6 @@
       "brand:wikipedia": "en:W Hotels",
       "name": "W Hotels",
       "short_name": "W",
-      "tourism": "hotel"
-    }
-  },
-  "tourism/hotel|Westin": {
-    "tags": {
-      "brand": "Westin",
-      "brand:wikidata": "Q1969162",
-      "brand:wikipedia": "en:Westin Hotels & Resorts",
-      "name": "Westin",
       "tourism": "hotel"
     }
   },

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -3,7 +3,7 @@
     "tags": {
       "brand": "AC Hotel",
       "brand:wikidata": "Q5653536",
-      "brand:wikipedia": "en:Marriott International",
+      "brand:wikipedia": "en:AC Hotels",
       "name": "AC Hotel",
       "tourism": "hotel"
     }

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -775,8 +775,8 @@
   "tourism/hotel|SpringHill Suites": {
     "tags": {
       "brand": "SpringHill Suites",
-      "brand:wikidata": "Q1141173",
-      "brand:wikipedia": "en:Marriott International",
+      "brand:wikidata": "Q7580351",
+      "brand:wikipedia": "en:SpringHill Suites",
       "name": "SpringHill Suites",
       "tourism": "hotel"
     }

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -1,4 +1,13 @@
 {
+  "tourism/hotel|AC Hotel": {
+    "tags": {
+      "brand": "AC Hotel",
+      "brand:wikidata": "Q1141173",
+      "brand:wikipedia": "en:Marriott International",
+      "name": "AC Hotel",
+      "tourism": "hotel"
+    }
+  },
   "tourism/hotel|Aloft": {
     "tags": {
       "brand": "Aloft",
@@ -148,13 +157,13 @@
       "tourism": "hotel"
     }
   },
-  "tourism/hotel|Delta": {
+  "tourism/hotel|Delta Hotels": {
+    "matchNames": ["delta"],
     "tags": {
-      "brand": "Delta",
+      "brand": "Delta Hotels",
       "brand:wikidata": "Q5254663",
       "brand:wikipedia": "en:Delta Hotels",
-      "name": "Delta",
-      "official_name": "Delta Hotels",
+      "name": "Delta Hotels",
       "tourism": "hotel"
     }
   },
@@ -200,12 +209,21 @@
   },
   "tourism/hotel|Fairfield Inn": {
     "countryCodes": ["ca", "us"],
-    "matchNames": ["fairfield inn and suites"],
     "tags": {
       "brand": "Fairfield Inn",
       "brand:wikidata": "Q5430314",
       "brand:wikipedia": "en:Fairfield Inn by Marriott",
       "name": "Fairfield Inn",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|Fairfield Inn & Suites": {
+    "countryCodes": ["ca", "us"],
+    "tags": {
+      "brand": "Fairfield Inn & Suites",
+      "brand:wikidata": "Q5430314",
+      "brand:wikipedia": "en:Fairfield Inn by Marriott",
+      "name": "Fairfield Inn & Suites",
       "tourism": "hotel"
     }
   },
@@ -216,6 +234,25 @@
       "brand:wikidata": "Q1630895",
       "brand:wikipedia": "en:Hotel Formule 1",
       "name": "Formule 1",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|Four Points": {
+    "tags": {
+      "brand": "Four Points",
+      "brand:wikidata": "Q634831",
+      "brand:wikipedia": "en:Sheraton Hotels and Resorts",
+      "name": "Four Points",
+      "official_name": "Four Points by Sheraton",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|Gaylord": {
+    "tags": {
+      "brand": "Gaylord",
+      "brand:wikidata": "Q1141173",
+      "brand:wikipedia": "en:Marriott International",
+      "name": "Gaylord",
       "tourism": "hotel"
     }
   },
@@ -430,6 +467,15 @@
       "tourism": "hotel"
     }
   },
+  "tourism/hotel|JW Marriott": {
+    "tags": {
+      "brand": "JW Marriott",
+      "brand:wikidata": "Q1141173",
+      "brand:wikipedia": "en:Marriott International",
+      "name": "JW Marriott",
+      "tourism": "hotel"
+    }
+  },
   "tourism/hotel|Kyriad": {
     "countryCodes": ["fr"],
     "tags": {
@@ -493,6 +539,15 @@
       "tourism": "hotel"
     }
   },
+  "tourism/hotel|Marriott Executive Apartments": {
+    "tags": {
+      "brand": "Marriott Executive Apartments",
+      "brand:wikidata": "Q1053170",
+      "brand:wikipedia": "en:Marriott International",
+      "name": "Marriott Executive Apartments",
+      "tourism": "hotel"
+    }
+  },
   "tourism/hotel|Meininger": {
     "matchNames": ["hoteles meininger"],
     "tags": {
@@ -546,6 +601,15 @@
       "tourism": "hotel"
     }
   },
+  "tourism/hotel|Moxy": {
+    "tags": {
+      "brand": "Moxy",
+      "brand:wikidata": "Q1053170",
+      "brand:wikipedia": "en:Marriott International",
+      "name": "Moxy",
+      "tourism": "hotel"
+    }
+  },
   "tourism/hotel|Novotel": {
     "tags": {
       "brand": "Novotel",
@@ -581,6 +645,15 @@
       "brand:wikidata": "Q5964551",
       "brand:wikipedia": "en:Hôtel Première Classe",
       "name": "Première Classe",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|Protea Hotel": {
+    "tags": {
+      "brand": "Protea Hotel",
+      "brand:wikidata": "Q1141173",
+      "brand:wikipedia": "en:Marriott International",
+      "name": "Protea Hotel",
       "tourism": "hotel"
     }
   },
@@ -672,6 +745,24 @@
       "tourism": "hotel"
     }
   },
+  "tourism/hotel|SpringHill Suites": {
+    "tags": {
+      "brand": "SpringHill Suites",
+      "brand:wikidata": "Q1141173",
+      "brand:wikipedia": "en:Marriott International",
+      "name": "SpringHill Suites",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|St. Regis": {
+    "tags": {
+      "brand": "St. Regis",
+      "brand:wikidata": "Q1141173",
+      "brand:wikipedia": "en:Marriott International",
+      "name": "St. Regis",
+      "tourism": "hotel"
+    }
+  },
   "tourism/hotel|Staybridge Suites": {
     "countryCodes": ["ca", "gb", "us"],
     "tags": {
@@ -679,6 +770,15 @@
       "brand:wikidata": "Q7605116",
       "brand:wikipedia": "en:Staybridge Suites",
       "name": "Staybridge Suites",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|The Ritz-Carlton": {
+    "tags": {
+      "brand": "The Ritz-Carlton",
+      "brand:wikidata": "Q1141173",
+      "brand:wikipedia": "en:Marriott International",
+      "name": "The Ritz-Carlton",
       "tourism": "hotel"
     }
   },
@@ -743,6 +843,15 @@
       "brand:wikipedia": "en:W Hotels",
       "name": "W Hotels",
       "short_name": "W",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|Westin": {
+    "tags": {
+      "brand": "Westin",
+      "brand:wikidata": "Q261077",
+      "brand:wikipedia": "en:Le Méridien",
+      "name": "Westin",
       "tourism": "hotel"
     }
   },

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -570,8 +570,7 @@
   "tourism/hotel|Marriott Executive Apartments": {
     "tags": {
       "brand": "Marriott Executive Apartments",
-      "brand:wikidata": "Q1053170",
-      "brand:wikipedia": "en:Marriott International",
+      "brand:wikidata": "Q72636824",
       "name": "Marriott Executive Apartments",
       "tourism": "hotel"
     }

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -680,7 +680,7 @@
     "tags": {
       "brand": "Protea Hotel",
       "brand:wikidata": "Q17092570",
-      "brand:wikipedia": "en:Marriott International",
+      "brand:wikipedia": "en:Protea Hotels by Marriott",
       "name": "Protea Hotel",
       "tourism": "hotel"
     }

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -773,6 +773,7 @@
     }
   },
   "tourism/hotel|SpringHill Suites": {
+    "countryCodes": ["ca", "mx", "us"],
     "tags": {
       "brand": "SpringHill Suites",
       "brand:wikidata": "Q7580351",

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -277,8 +277,8 @@
   "tourism/hotel|Gaylord": {
     "tags": {
       "brand": "Gaylord",
-      "brand:wikidata": "Q1141173",
-      "brand:wikipedia": "en:Marriott International",
+      "brand:wikidata": "Q3099664",
+      "brand:wikipedia": "en:Gaylord Hotels",
       "name": "Gaylord",
       "tourism": "hotel"
     }
@@ -497,8 +497,8 @@
   "tourism/hotel|JW Marriott": {
     "tags": {
       "brand": "JW Marriott",
-      "brand:wikidata": "Q1141173",
-      "brand:wikipedia": "en:Marriott International",
+      "brand:wikidata": "Q1067636",
+      "brand:wikipedia": "en:JW Marriott Hotels",
       "name": "JW Marriott",
       "tourism": "hotel"
     }
@@ -784,8 +784,8 @@
   "tourism/hotel|St. Regis": {
     "tags": {
       "brand": "St. Regis",
-      "brand:wikidata": "Q1141173",
-      "brand:wikipedia": "en:Marriott International",
+      "brand:wikidata": "Q30715430",
+      "brand:wikipedia": "en:St. Regis Hotels & Resorts",
       "name": "St. Regis",
       "tourism": "hotel"
     }
@@ -803,8 +803,8 @@
   "tourism/hotel|The Ritz-Carlton": {
     "tags": {
       "brand": "The Ritz-Carlton",
-      "brand:wikidata": "Q1141173",
-      "brand:wikipedia": "en:Marriott International",
+      "brand:wikidata": "Q782200",
+      "brand:wikipedia": "en:The Ritz-Carlton Hotel Company",
       "name": "The Ritz-Carlton",
       "tourism": "hotel"
     }

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -734,13 +734,14 @@
       "tourism": "hotel"
     }
   },
-  "tourism/hotel|Renaissance Hotel": {
+  "tourism/hotel|Renaissance": {
     "countryCodes": ["us"],
+    "matchNames": ["Renaissance Hotel"],
     "tags": {
-      "brand": "Renaissance Hotels",
+      "brand": "Renaissance",
       "brand:wikidata": "Q2143252",
       "brand:wikipedia": "en:Renaissance Hotels",
-      "name": "Renaissance Hotel",
+      "name": "Renaissance",
       "tourism": "hotel"
     }
   },

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -679,7 +679,7 @@
   "tourism/hotel|Protea Hotel": {
     "tags": {
       "brand": "Protea Hotel",
-      "brand:wikidata": "Q1141173",
+      "brand:wikidata": "Q17092570",
       "brand:wikipedia": "en:Marriott International",
       "name": "Protea Hotel",
       "tourism": "hotel"

--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -735,7 +735,6 @@
     }
   },
   "tourism/hotel|Renaissance": {
-    "countryCodes": ["us"],
     "matchNames": ["Renaissance Hotel"],
     "tags": {
       "brand": "Renaissance",


### PR DESCRIPTION
Wow they have a lot of brands. I think this adds all the major ones and cleans up some bad brand vs company issues + restrictive country codes.

I also split out Fairfield Inn and Fairfield Inn & Suites. This one is total mess. They appear to be rebranding the whole lineup, but depending on what type of location and where you are it's either Fairfield by Marriott, Fairfield Inn, or Fairfield Inn & Suites. Hopefully they rebrand them all in the next few years and we can fix it, but this is close enough for now and allows folks to continue to distinguish the suite variant.

Signed-off-by: Tim Smith <tsmith@chef.io>