### PR TITLE
Break Microtel up into 2 brands

### DIFF
--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -489,23 +489,33 @@
   },
   "tourism/hotel|Microtel": {
     "countryCodes": [
-      "ar",
       "ca",
+      "cn",
       "mx",
       "ph",
       "us"
     ],
-    "matchNames": [
-      "microtel by wyndham",
-      "microtel inn",
-      "microtel inn & suites",
-      "microtel inn and suites"
+    "matchNames": ["microtel inn"],
+    "nomatch": [
+      "tourism/hotel|Microtel Inn & Suites"
     ],
     "tags": {
       "brand": "Microtel",
       "brand:wikidata": "Q6840402",
       "brand:wikipedia": "en:Microtel Inn and Suites",
       "name": "Microtel",
+      "official_name": "Microtel by Wyndham",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|Microtel Inn & Suites": {
+    "countryCodes": ["ca", "mx", "us"],
+    "nomatch": ["tourism/hotel|Microtel"],
+    "tags": {
+      "brand": "Microtel Inn & Suites",
+      "brand:wikidata": "Q6840402",
+      "brand:wikipedia": "en:Microtel Inn and Suites",
+      "name": "Microtel Inn & Suites",
       "official_name": "Microtel Inn & Suites by Wyndham",
       "tourism": "hotel"
     }


### PR DESCRIPTION
This is another case of different brands under the same sub brand. Hotels are crazy complex brand wise, but removing the "suites" bit from a name in North America is wrong they do the real rebrand. For now there's only 3 Microtels in the US and Canada.

Signed-off-by: Tim Smith <tsmith@chef.io>