### PR TITLE
Add Austrian furniture stores

### DIFF
--- a/brands/shop/furniture.json
+++ b/brands/shop/furniture.json
@@ -285,6 +285,16 @@
       "short_name": "Jerome's"
     }
   },
+  "shop/furniture|Kika": {
+    "countryCodes": ["at"],
+    "tags": {
+      "brand": "Kika",
+      "brand:wikidata": "Q256456",
+      "brand:wikipedia": "de:Kika (Möbelhaus)",
+      "name": "Kika",
+      "shop": "furniture"
+    }
+  },
   "shop/furniture|Kwantum": {
     "countryCodes": ["nl"],
     "tags": {
@@ -312,6 +322,16 @@
       "brand:wikidata": "Q3333662",
       "brand:wikipedia": "nl:Leen Bakker",
       "name": "Leen Bakker",
+      "shop": "furniture"
+    }
+  },
+  "shop/furniture|Leiner": {
+    "countryCodes": ["at"],
+    "tags": {
+      "brand": "Leiner",
+      "brand:wikidata": "Q1661472",
+      "brand:wikipedia": "de:Rudolf Leiner (Unternehmen)",
+      "name": "Leiner",
       "shop": "furniture"
     }
   },
@@ -351,6 +371,14 @@
       "brand:wikidata": "Q877547",
       "brand:wikipedia": "hu:Möbelix",
       "name": "Möbelix",
+      "shop": "furniture"
+    }
+  },
+  "shop/furniture|Mömax": {
+    "countryCodes": ["at", "de", "hu", "si"],
+    "tags": {
+      "brand": "Mömax",
+      "name": "Mömax",
       "shop": "furniture"
     }
   },
@@ -427,6 +455,16 @@
       "shop": "furniture"
     }
   },
+  "shop/furniture|Rutar": {
+    "countryCodes": ["at"],
+    "tags": {
+      "brand": "Rutar",
+      "brand:wikidata": "Q22910157",
+      "brand:wikipedia": "de:RUTAR Group",
+      "name": "Rutar",
+      "shop": "furniture"
+    }
+  },
   "shop/furniture|ScS": {
     "countryCodes": ["gb"],
     "tags": {
@@ -466,6 +504,7 @@
     }
   },
   "shop/furniture|XXXLutz": {
+    "countryCodes": ["at", "de"],
     "tags": {
       "brand": "XXXLutz",
       "name": "XXXLutz",

--- a/brands/shop/furniture.json
+++ b/brands/shop/furniture.json
@@ -378,6 +378,8 @@
     "countryCodes": ["at", "de", "hu", "si"],
     "tags": {
       "brand": "Mömax",
+      "brand:wikidata": "Q56388481",
+      "brand:wikipedia": "hu:Mömax",
       "name": "Mömax",
       "shop": "furniture"
     }
@@ -507,6 +509,8 @@
     "countryCodes": ["at", "de"],
     "tags": {
       "brand": "XXXLutz",
+      "brand:wikidata": "Q70339467",
+      "brand:wikipedia": "de:XXXLutz",
       "name": "XXXLutz",
       "shop": "furniture"
     }


### PR DESCRIPTION
This PR adds the following Austrian furniture stores:

- Kika ([Q256456](https://www.wikidata.org/wiki/Q256456))
- Leiner ([Q1661472](https://www.wikidata.org/wiki/Q1661472))
- Mömax (a subsidiary of _Möbelix_)
- Rutar ([Q22910157](https://www.wikidata.org/wiki/Q22910157))