### PR TITLE
Add Ubaldi Electronic shop.

### DIFF
--- a/brands/shop/electronics.json
+++ b/brands/shop/electronics.json
@@ -395,6 +395,14 @@
       "shop": "electronics"
     }
   },
+  "shop/electronics|Ubaldi": {
+    "countryCodes": ["fr"],
+    "tags": {
+      "brand": "Ubaldi",
+      "name": "Ubaldi",
+      "shop": "electronics"
+    }
+  },
   "shop/electronics|Unieuro": {
     "countryCodes": ["it"],
     "tags": {


### PR DESCRIPTION
Ubaldi is a electronic (mainly) shops chain which has few shops in south of France.
Not a lot are currently reported in OSM though.

https://overpass-turbo.eu/s/MYx