### PR TITLE
Add nomatch tags to get rid of the warnings for Fresh and Casino

### DIFF
--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -417,6 +417,7 @@
     }
   },
   "amenity/fuel|Casino": {
+    "nomatch": ["shop/convenience|Casino"],
     "tags": {
       "amenity": "fuel",
       "brand": "Casino",

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -278,6 +278,7 @@
     }
   },
   "shop/convenience|Casino": {
+    "nomatch": ["amenity/fuel|Casino"],
     "tags": {
       "brand": "Casino",
       "name": "Casino",
@@ -553,6 +554,7 @@
     }
   },
   "shop/convenience|Fresh": {
+    "nomatch": ["shop/supermarket|Fresh"],
     "tags": {
       "brand": "Fresh",
       "name": "Fresh",

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -1430,6 +1430,7 @@
     }
   },
   "shop/supermarket|Fresh": {
+    "nomatch": ["shop/convenience|Fresh"],
     "tags": {
       "brand": "Fresh",
       "brand:wikidata": "Q50737403",


### PR DESCRIPTION
Got rid of two duplicates warning for Fresh and Casino. This is my first commit. If it goes well, I'm going to resolve more. This change set takes care of two out of 26. 24 more warnings to go! 