### PR TITLE
Migrate "office/telecommunication" -> "shop/telecommunication"

### DIFF
--- a/brands/shop/telecommunication.json
+++ b/brands/shop/telecommunication.json
@@ -1,5 +1,5 @@
 {
-  "office/telecommunication|A1": {
+  "shop/telecommunication|A1": {
     "countryCodes": [
       "at",
       "bg",
@@ -18,33 +18,33 @@
       "brand:wikidata": "Q688755",
       "brand:wikipedia": "en:A1 Telekom Austria Group",
       "name": "A1",
-      "office": "telecommunication"
+      "shop": "telecommunication"
     }
   },
-  "office/telecommunication|Agencia ICE": {
+  "shop/telecommunication|Agencia ICE": {
     "tags": {
       "brand": "Agencia ICE",
       "name": "Agencia ICE",
-      "office": "telecommunication"
+      "shop": "telecommunication"
     }
   },
-  "office/telecommunication|Ooredoo": {
+  "shop/telecommunication|Ooredoo": {
     "tags": {
       "brand": "Ooredoo",
       "brand:wikidata": "Q919935",
       "brand:wikipedia": "en:Ooredoo",
       "name": "Ooredoo",
-      "office": "telecommunication"
+      "shop": "telecommunication"
     }
   },
-  "office/telecommunication|Дом.ru": {
+  "shop/telecommunication|Дом.ru": {
     "tags": {
       "brand": "Дом.ru",
       "name": "Дом.ru",
-      "office": "telecommunication"
+      "shop": "telecommunication"
     }
   },
-  "office/telecommunication|МТС": {
+  "shop/telecommunication|МТС": {
     "countryCodes": ["by", "ru", "ua"],
     "nomatch": ["shop/mobile_phone|МТС"],
     "tags": {
@@ -54,37 +54,37 @@
       "brand:wikipedia": "en:MTS (network provider)",
       "name": "МТС",
       "name:en": "MTS",
-      "office": "telecommunication"
+      "shop": "telecommunication"
     }
   },
-  "office/telecommunication|Магазин lifecell": {
+  "shop/telecommunication|Магазин lifecell": {
     "tags": {
       "brand": "Магазин lifecell",
       "name": "Магазин lifecell",
-      "office": "telecommunication"
+      "shop": "telecommunication"
     }
   },
-  "office/telecommunication|Ростелеком": {
+  "shop/telecommunication|Ростелеком": {
     "countryCodes": ["ru"],
     "tags": {
       "brand": "Ростелеком",
       "brand:wikidata": "Q1477012",
       "brand:wikipedia": "en:Rostelecom",
       "name": "Ростелеком",
-      "office": "telecommunication"
+      "shop": "telecommunication"
     }
   },
-  "office/telecommunication|Укртелеком": {
+  "shop/telecommunication|Укртелеком": {
     "countryCodes": ["ua"],
     "tags": {
       "brand": "Укртелеком",
       "brand:wikidata": "Q1505321",
       "brand:wikipedia": "en:Ukrtelecom",
       "name": "Укртелеком",
-      "office": "telecommunication"
+      "shop": "telecommunication"
     }
   },
-  "office/telecommunication|中華電信": {
+  "shop/telecommunication|中華電信": {
     "countryCodes": ["tw"],
     "tags": {
       "brand": "中華電信",
@@ -95,10 +95,10 @@
       "name": "中華電信",
       "name:en": "Chunghwa Telecom",
       "name:zh": "中華電信",
-      "office": "telecommunication"
+      "shop": "telecommunication"
     }
   },
-  "office/telecommunication|遠傳電信": {
+  "shop/telecommunication|遠傳電信": {
     "countryCodes": ["tw"],
     "tags": {
       "brand": "遠傳電信",
@@ -109,7 +109,7 @@
       "name": "遠傳電信",
       "name:en": "FarEasTone",
       "name:zh": "遠傳電信",
-      "office": "telecommunication"
+      "shop": "telecommunication"
     }
   }
 }

--- a/config/match_groups.json
+++ b/config/match_groups.json
@@ -39,7 +39,8 @@
         "shop/electronics",
         "shop/hifi",
         "shop/mobile",
-        "shop/mobile_phone"
+        "shop/mobile_phone",
+        "shop/telecommunication"
     ],
     "fashion": [
         "shop/accessories",


### PR DESCRIPTION
The "office=telecommunication" tag has been causing confusion.
PRing this one for visibility.  I think switching to a "shop" tag is the right thing to do.

These are telecom companies that do more than just sell mobile phones, but they operate storefronts where people can go in and shop, so they are really a better fit for "shop" than "office".

re: #3113 #2900 and probably others.
