### PR TITLE
Resolve duplicate brand for CBA

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -223,6 +223,7 @@
     }
   },
   "shop/convenience|CBA": {
+    "nomatch": ["shop/supermarket|CBA"],
     "tags": {
       "brand": "CBA",
       "brand:wikidata": "Q779845",

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -469,6 +469,7 @@
     }
   },
   "shop/supermarket|CBA": {
+    "nomatch": ["shop/convenience|CBA"],
     "tags": {
       "brand": "CBA",
       "brand:wikidata": "Q779845",


### PR DESCRIPTION
Resolve duplicate of Hungarian food retail store CBA, classifying it as a supermarket.