### PR TITLE
Add Wikidata tag for Altar'd State brand

### DIFF
--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -101,6 +101,7 @@
     "countryCodes": ["us"],
     "tags": {
       "brand": "Altar'd State",
+      "brand:wikidata": "Q71022008",
       "name": "Altar'd State",
       "shop": "clothes"
     }


### PR DESCRIPTION
I created a Wikidata Item for the Altar'd State brand and added the newly created Wikidata tag to this index.

Addresses the other part of #3054.