### PR TITLE
DRY up the list with additional match_groups

### DIFF
--- a/brands/shop/variety_store.json
+++ b/brands/shop/variety_store.json
@@ -5,11 +5,6 @@
       "99 cent only stores",
       "99 cents only"
     ],
-    "matchTags": [
-      "shop/convenience",
-      "shop/department_store",
-      "shop/supermarket"
-    ],
     "tags": {
       "brand": "99 Cents Only Stores",
       "brand:wikidata": "Q4646294",
@@ -28,7 +23,6 @@
       "nl",
       "pl"
     ],
-    "matchTags": ["shop/supermarket"],
     "tags": {
       "brand": "Action",
       "brand:wikidata": "Q2634111",
@@ -91,11 +85,6 @@
   },
   "shop/variety_store|Dollar General": {
     "countryCodes": ["us"],
-    "matchTags": [
-      "shop/convenience",
-      "shop/department_store",
-      "shop/supermarket"
-    ],
     "nomatch": [
       "amenity/bank|Dollar Bank",
       "amenity/car_rental|Dollar",
@@ -114,11 +103,6 @@
   },
   "shop/variety_store|Dollar Tree": {
     "countryCodes": ["ca", "us"],
-    "matchTags": [
-      "shop/convenience",
-      "shop/department_store",
-      "shop/supermarket"
-    ],
     "nomatch": [
       "amenity/bank|Dollar Bank",
       "amenity/car_rental|Dollar",
@@ -136,11 +120,6 @@
   },
   "shop/variety_store|Dollarama": {
     "countryCodes": ["ca"],
-    "matchTags": [
-      "shop/convenience",
-      "shop/department_store",
-      "shop/supermarket"
-    ],
     "nomatch": [
       "amenity/bank|Dollar Bank",
       "amenity/car_rental|Dollar",
@@ -168,11 +147,6 @@
   },
   "shop/variety_store|Family Dollar": {
     "countryCodes": ["us"],
-    "matchTags": [
-      "shop/convenience",
-      "shop/department_store",
-      "shop/supermarket"
-    ],
     "nomatch": [
       "amenity/bank|Dollar Bank",
       "amenity/car_rental|Dollar",
@@ -231,7 +205,6 @@
   },
   "shop/variety_store|Home Bargains": {
     "countryCodes": ["gb"],
-    "matchTags": ["shop/supermarket"],
     "tags": {
       "brand": "Home Bargains",
       "brand:wikidata": "Q5888229",
@@ -431,7 +404,6 @@
   },
   "shop/variety_store|ダイレックス": {
     "countryCodes": ["jp"],
-    "matchTags": ["shop/supermarket"],
     "tags": {
       "brand": "ダイレックス",
       "brand:en": "Direx",
@@ -446,7 +418,6 @@
   },
   "shop/variety_store|トライアル": {
     "countryCodes": ["jp"],
-    "matchTags": ["shop/supermarket"],
     "tags": {
       "brand": "トライアル",
       "brand:en": "Trial",
@@ -461,7 +432,6 @@
   },
   "shop/variety_store|ドン・キホーテ": {
     "countryCodes": ["jp"],
-    "matchTags": ["shop/supermarket"],
     "tags": {
       "brand": "ドン・キホーテ",
       "brand:en": "Don Quijote",

--- a/brands/shop/wholesale.json
+++ b/brands/shop/wholesale.json
@@ -2,7 +2,6 @@
   "shop/wholesale|BJ's Wholesale Club": {
     "countryCodes": ["us"],
     "matchNames": ["bjs", "bjs wholesale"],
-    "matchTags": ["shop/department_store"],
     "tags": {
       "brand": "BJ's Wholesale Club",
       "brand:wikidata": "Q4835754",
@@ -13,7 +12,6 @@
   },
   "shop/wholesale|Costco": {
     "matchNames": ["costco wholesale"],
-    "matchTags": ["shop/department_store"],
     "nomatch": [
       "amenity/fuel|Costco Gasoline",
       "amenity/pharmacy|Costco Pharmacy"
@@ -27,7 +25,6 @@
     }
   },
   "shop/wholesale|Makro": {
-    "matchTags": ["shop/department_store"],
     "tags": {
       "brand": "Makro",
       "brand:wikidata": "Q704606",
@@ -37,7 +34,6 @@
     }
   },
   "shop/wholesale|Metro": {
-    "matchTags": ["shop/department_store"],
     "nomatch": [
       "amenity/bank|Metrobank",
       "shop/supermarket|Metro~(Canada)"
@@ -51,7 +47,6 @@
     }
   },
   "shop/wholesale|Sam's Club": {
-    "matchTags": ["shop/department_store"],
     "nomatch": ["amenity/fuel|Sam's Club"],
     "tags": {
       "brand": "Sam's Club",
@@ -62,7 +57,6 @@
     }
   },
   "shop/wholesale|Sligro": {
-    "matchTags": ["shop/department_store"],
     "tags": {
       "brand": "Sligro",
       "brand:wikidata": "Q3170052",
@@ -74,7 +68,6 @@
   },
   "shop/wholesale|コストコ": {
     "countryCodes": ["jp"],
-    "matchTags": ["shop/department_store"],
     "tags": {
       "brand": "コストコ",
       "brand:en": "Costco",

--- a/config/match_groups.json
+++ b/config/match_groups.json
@@ -149,6 +149,16 @@
     "vending": [
         "amenity/vending_machine",
         "shop/vending_machine"
+    ],
+    "wholesale": [
+        "shop/wholesale",
+        "shop/supermarket",
+        "shop/department_store"
+    ],
+    "variety_store": [
+        "shop/variety_store",
+        "shop/supermarket",
+        "shop/convenience"
     ]
   }
 }


### PR DESCRIPTION
Avoid repetition in the match tags by using the match groups.

Signed-off-by: Tim Smith <tsmith@chef.io>