### PR TITLE
Add Oak Furnitureland

### DIFF
--- a/brands/shop/furniture.json
+++ b/brands/shop/furniture.json
@@ -394,6 +394,16 @@
       "shop": "furniture"
     }
   },
+  "shop/furniture|Oak Furnitureland": {
+    "countryCodes": ["gb"],
+    "tags": {
+      "brand": "Oak Furnitureland",
+      "brand:wikidata": "Q16959724",
+      "brand:wikipedia": "en:Oak Furniture Land",
+      "name": "Oak Furnitureland",
+      "shop": "furniture"
+    }
+  },
   "shop/furniture|Pottery Barn": {
     "countryCodes": [
       "au",


### PR DESCRIPTION
Add Oak Furnitureland Furniture retailer.

https://en.wikipedia.org/wiki/Oak_Furniture_Land