### PR TITLE
Split up Travelodge

### DIFF
--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -693,7 +693,28 @@
       "tourism": "hotel"
     }
   },
-  "tourism/hotel|Travelodge": {
+  "tourism/hotel|Travelodge~(Asia/Oceania)": {
+    "countryCodes": ["au", "hk", "id", "kr", "my", "nz", "sg", "th"],
+    "tags": {
+      "brand": "Travelodge",
+      "brand:wikidata": "Q24997583",
+      "brand:wikipedia": "en:Travelodge Australia",
+      "name": "Travelodge",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|Travelodge~(Europe)": {
+    "countryCodes": ["es", "gb", "ie"],
+    "tags": {
+      "brand": "Travelodge",
+      "brand:wikidata": "Q9361374",
+      "brand:wikipedia": "en:Travelodge UK",
+      "name": "Travelodge",
+      "tourism": "hotel"
+    }
+  },
+  "tourism/hotel|Travelodge~(North America)": {
+    "countryCodes": ["ca", "us"],
     "tags": {
       "brand": "Travelodge",
       "brand:wikidata": "Q7836087",


### PR DESCRIPTION
Change current brand to seperate brands for regions which are owned and operated seperately.