### PR TITLE
Update Dressbarn

### DIFF
--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -869,12 +869,12 @@
       "shop": "clothes"
     }
   },
-  "shop/clothes|Dressbarn": {
+  "shop/clothes|Dress Barn": {
     "tags": {
-      "brand": "Dressbarn",
+      "brand": "Dress Barn",
       "brand:wikidata": "Q65090033",
       "brand:wikipedia": "en:DressBarn",
-      "name": "Dressbarn",
+      "name": "Dress Barn",
       "shop": "clothes"
     }
   },

--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -869,12 +869,12 @@
       "shop": "clothes"
     }
   },
-  "shop/clothes|Dress Barn": {
+  "shop/clothes|Dressbarn": {
     "tags": {
-      "brand": "Dress Barn",
-      "brand:wikidata": "Q5307031",
-      "brand:wikipedia": "en:Ascena Retail Group",
-      "name": "Dress Barn",
+      "brand": "Dressbarn",
+      "brand:wikidata": "Q65090033",
+      "brand:wikipedia": "en:DressBarn",
+      "name": "Dressbarn",
       "shop": "clothes"
     }
   },


### PR DESCRIPTION
Switches to specific brand wiki pages.

Looking for feedback on name as newer stores and website seem to use both 'dressbarn' and 'Dressbarn', while older stores seem to use 'Dress Barn' on signage.