### PR TITLE
Update M&S

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -881,11 +881,14 @@
     }
   },
   "shop/convenience|M&S Simply Food": {
+    "matchNames": ["marks & spencer simply food", "m & s simply food", "marks and spencer simply food"],
     "nomatch": [
       "shop/supermarket|M&S Simply Food"
     ],
     "tags": {
       "brand": "M&S Simply Food",
+      "brand:wikidata": "Q714491",
+      "brand:wikipedia": "en:Marks & Spencer",
       "name": "M&S Simply Food",
       "shop": "convenience"
     }

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -881,7 +881,7 @@
     }
   },
   "shop/convenience|M&S Simply Food": {
-    "matchNames": ["marks & spencer simply food", "m & s simply food", "marks and spencer simply food"],
+    "matchNames": ["marks & spencer simply food"],
     "nomatch": [
       "shop/supermarket|M&S Simply Food"
     ],

--- a/brands/shop/department_store.json
+++ b/brands/shop/department_store.json
@@ -377,6 +377,17 @@
       "shop": "department_store"
     }
   },
+  "shop/department_store|M&S Outlet": {
+    "matchNames": ["marks & spencer outlet"],
+    "matchTags": ["shop/supermarket"],
+    "tags": {
+      "brand": "M&S Outlet",
+      "brand:wikidata": "Q714491",
+      "brand:wikipedia": "en:Marks & Spencer",
+      "name": "M&S Outlet",
+      "shop": "department_store"
+    }
+  },
   "shop/department_store|Macy's": {
     "countryCodes": ["us"],
     "tags": {
@@ -394,17 +405,6 @@
       "brand:wikidata": "Q382686",
       "brand:wikipedia": "en:Manor (department store)",
       "name": "Manor",
-      "shop": "department_store"
-    }
-  },
-  "shop/department_store|M&S Outlet": {
-    "matchNames": ["marks & spencer outlet", "m & s outlet", "marks and spencer outlet"],
-    "matchTags": ["shop/supermarket"],
-    "tags": {
-      "brand": "M&S Outlet",
-      "brand:wikidata": "Q714491",
-      "brand:wikipedia": "en:Marks & Spencer",
-      "name": "M&S Outlet",
       "shop": "department_store"
     }
   },

--- a/brands/shop/department_store.json
+++ b/brands/shop/department_store.json
@@ -397,9 +397,21 @@
       "shop": "department_store"
     }
   },
+  "shop/department_store|M&S Outlet": {
+    "matchNames": ["marks & spencer outlet", "m & s outlet", "marks and spencer outlet"],
+    "matchTags": ["shop/supermarket"],
+    "tags": {
+      "brand": "M&S Outlet",
+      "brand:wikidata": "Q714491",
+      "brand:wikipedia": "en:Marks & Spencer",
+      "name": "M&S Outlet",
+      "shop": "department_store"
+    }
+  },
   "shop/department_store|Marks & Spencer": {
     "countryCodes": ["gb", "gr", "ie"],
     "matchNames": ["m and s"],
+    "matchTags": ["shop/supermarket"],
     "tags": {
       "brand": "Marks & Spencer",
       "brand:wikidata": "Q714491",

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -2316,6 +2316,16 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|M&S Foodhall": {
+    "matchNames": ["marks & spencer foodhall", "m & s foodhall", "marks and spencer foodhall"],
+    "tags": {
+      "brand": "M&S Foodhall",
+      "brand:wikidata": "Q714491",
+      "brand:wikipedia": "en:Marks & Spencer",
+      "name": "M&S Foodhall",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|M&S Simply Food": {
     "matchNames": ["marks & spencer simply food", "m & s simply food", "marks and spencer simply food"],
     "nomatch": [

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -2317,7 +2317,7 @@
     }
   },
   "shop/supermarket|M&S Foodhall": {
-    "matchNames": ["marks & spencer foodhall", "m & s foodhall", "marks and spencer foodhall"],
+    "matchNames": ["marks & spencer foodhall"],
     "tags": {
       "brand": "M&S Foodhall",
       "brand:wikidata": "Q714491",
@@ -2327,7 +2327,7 @@
     }
   },
   "shop/supermarket|M&S Simply Food": {
-    "matchNames": ["marks & spencer simply food", "m & s simply food", "marks and spencer simply food"],
+    "matchNames": ["marks & spencer simply food"],
     "nomatch": [
       "shop/convenience|M&S Simply Food"
     ],

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -2317,11 +2317,14 @@
     }
   },
   "shop/supermarket|M&S Simply Food": {
+    "matchNames": ["marks & spencer simply food", "m & s simply food", "marks and spencer simply food"],
     "nomatch": [
       "shop/convenience|M&S Simply Food"
     ],
     "tags": {
       "brand": "M&S Simply Food",
+      "brand:wikidata": "Q714491",
+      "brand:wikipedia": "en:Marks & Spencer",
       "name": "M&S Simply Food",
       "shop": "supermarket"
     }


### PR DESCRIPTION
Adding the different types of M&S stores, wiki tags and matchNames, still more to add.

Also, looking at https://en.wikipedia.org/wiki/Marks_%26_Spencer#Store_formats and https://www.marksandspencer.com/s/store-listing there's 'Home' stores (see https://www.marksandspencer.com/MSResStoreFinderGlobalBaseCmd?storeId=10151&langId=-24&SAPStoreId=4077) and 'Outlet' stores (see https://www.marksandspencer.com/MSResStoreFinderGlobalBaseCmd?storeId=10151&langId=-24&SAPStoreId=7511).