### PR TITLE
Rename amenity/bank/OTP to OTP Bank

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -4348,7 +4348,7 @@
       "brand": "OTP",
       "brand:wikidata": "Q912778",
       "brand:wikipedia": "en:OTP Bank",
-      "name": "OTP"
+      "name": "OTP Bank"
     }
   },
   "amenity/bank|Oberbank": {


### PR DESCRIPTION
Hi!

Based on Hungarian OSM Group discussion
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/openstreetmap-hungary/Op0Cju-f0mM/2hsN7ldNCQAJ
, real name of the bank and Wikidata: We would like to change OTP to OTP Bank in the name tag.