### PR TITLE
Added Kastner & Öhler

### DIFF
--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -1559,6 +1559,17 @@
       "shop": "clothes"
     }
   },
+  "shop/clothes|K&Ö": {
+    "countryCodes": ["at"],
+    "tags": {
+      "alt_name": "Kastner & Öhler",
+      "brand": "K&Ö",
+      "brand:wikidata": "Q1735474",
+      "brand:wikipedia": "de:Kastner & Öhler",
+      "name": "K&Ö",
+      "shop": "clothes"
+    }
+  },
   "shop/clothes|KappAhl": {
     "countryCodes": ["fi", "no", "pl", "se"],
     "tags": {


### PR DESCRIPTION
This PR adds the clothes store chain Kastner & Öhler ([Q1735474](https://www.wikidata.org/wiki/Q1735474)) to NSI.

Happy Halloween 👻🎃🎉, don't get spooked and keep up the great work!