### PR TITLE
Add Hog's Australia's Steakhouse

### DIFF
--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -959,6 +959,16 @@
       "name": "Hippopotamus"
     }
   },
+  "amenity/restaurant|Hog's Australia's Steakhouse": {
+    "tags": {
+      "amenity": "restaurant",
+      "brand": "Hog's Australia's Steakhouse",
+      "brand:wikidata": "Q5876920",
+      "brand:wikipedia": "en:Hog's Australia's Steakhouse",
+      "cuisine": "steak_house",
+      "name": "Hog's Australia's Steakhouse"
+    }
+  },
   "amenity/restaurant|Hooters": {
     "tags": {
       "amenity": "restaurant",


### PR DESCRIPTION
Solves #3294 

I wasn't able to find clear and current info about countries. It looks like they're present in multiple countries. Should I add `"countryCodes": ["au"]`?

Also, it looks like the name changed from Hog's Breath Cafe to Hog's Australia's Steakhouse. https://www.wikidata.org/wiki/Q5876920 still shows Hog's Breath Cafe. Not sure if that's a problem.