### PR TITLE
Fix issue where countryCodes property could be called on an undefined match

### DIFF
--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -124,7 +124,7 @@ module.exports = function() {
           match = _matchIndex[otherkv] && _matchIndex[otherkv][parts.nsimple];
         }
 
-        if (!matchesCountryCode(match)) {
+        if (match && !matchesCountryCode(match)) {
           match = null;
         }
 


### PR DESCRIPTION
Ran into this while working on https://github.com/openstreetmap/iD/issues/6479. This fix will need to be released before I can address the other issue.