### PR TITLE
Creating police section for major Canadian police forces

### DIFF
--- a/brands/amenity/police
+++ b/brands/amenity/police
@@ -1,0 +1,33 @@
+{
+  "amenity/police|RCMP": {
+    "countryCodes": ["ca"],
+    "tags": {
+      "amenity": "police",
+      "brand": "Royal Canadian Mounted Police",
+      "brand:wikidata": "Q335175",
+      "brand:wikipedia": "en:Royal Canadian Mounted Police",
+      "official_name": "Royal Canadian Mounted Police",
+      "official_name:fr": "Gendarmerie royale du Canada,
+    }
+  }
+  "amenity/police|OPP": { 
+    "countryCodes": ["ca"],
+    "tags": {
+      "amenity": "police",
+      "brand": "Ontario Provincial Police",
+      "brand:wikidata": "Q1046157",
+      "brand:wikipedia": "Ontario Provincial Police",
+      "official_name": "Ontario Provincial Police",
+     }
+   } 
+   "amenity/police|SQ": {
+    "countryCodes": ["ca"],
+    "tags": {
+      "amenity": "police",
+      "brand": "Sûreté du Québec",
+      "brand:wikidata": "Q2915034",
+      "brand:wikipedia": "Sûreté du Québec",
+      "name": "Sûreté du Québec",
+      }
+    }
+}


### PR DESCRIPTION
The RCMP (Royal Canadian Mounted Police) is the police force in most of Canada, except for Ontario and Quebec, which both have their own provincial police forces. Edits were made in the online client, so apologies in advance for possible syntax errors. Getting back on this project after a while away.