### PR TITLE
Adding wikidata information for America's Best Value Inn

### DIFF
--- a/brands/tourism/motel.json
+++ b/brands/tourism/motel.json
@@ -2,6 +2,8 @@
   "tourism/motel|Americas Best Value Inn": {
     "tags": {
       "brand": "Americas Best Value Inn",
+      "brand:wikidata": "Q7915203",
+      "brand:wikipedia": "America's Best Value Inn",
       "name": "Americas Best Value Inn",
       "tourism": "motel"
     }


### PR DESCRIPTION
Added the Wikidata/Wikipedia entry for America's Best Value Inn. The Wikipedia page redirects to its parent company, which is the target of the wikidata entry.