### PR TITLE
Added Biscuitville as mentioned in issue #3368

### DIFF
--- a/brands/amenity/fast_fhttps:/github.com/osmlab/name-suggestion-index/tree/master/brandsood.json
+++ b/brands/amenity/fast_fhttps:/github.com/osmlab/name-suggestion-index/tree/master/brandsood.json
@@ -164,6 +164,18 @@
       "takeaway": "yes"
     }
   },
+    "amenity/fast_food|A&W~(USA)": {
+    "countryCodes": ["us"],
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "Biscuitville",
+      "brand:wikidata": "Q4917274",
+      "brand:wikipedia": "en:Biscuitville",
+      "cuisine": "biscuit",
+      "name": "Biscuitville",
+      "takeaway": "yes"
+    }
+  },
   "amenity/fast_food|Blimpie": {
     "countryCodes": ["us"],
     "tags": {


### PR DESCRIPTION
I have added the Biscucitville brand to brands/amenity/fast_food.json. As per the information available on the and from Biscuitville's offical website, the company is primarily involved in selling biscuits made from their own recipe. It was involved in the pizza and bread business but biscuits is what they are known for. So, "cuisine" is given the value of "biscuit". Other better options can be "cuisine" : "snacks".