### PR TITLE
Add NASA Federal Credit Union

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -4250,6 +4250,15 @@
       "name": "NAB"
     }
   },
+  "amenity/bank|NASA Federal Credit Union": {
+    "tags": {
+      "amenity": "bank",
+      "brand": "NASA Federal Credit Union",
+      "brand:wikidata": "Q6952409",
+      "brand:wikipedia": "en:NASA Federal Credit Union",
+      "name": "NASA Federal Credit Union"
+    }
+  },
   "amenity/bank|NLB": {
     "countryCodes": ["si"],
     "tags": {


### PR DESCRIPTION
Added NASA Federal Credit Union to brand/bank.json. Along with wikidata that is associated. 

This is my first contribution to an open-source project, so if there is anything that needs to be changed or if you have any feedback let me know!