### PR TITLE
Add Wiki tag for Red Lion Hotels to brands/tourism/hotels, issue #3367

### DIFF
--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -792,6 +792,16 @@
       "tourism": "hotel"
     }
   },
+  "tourism/hotel|Red Lion Hotels": {
+    "countryCodes": ["us"],
+    "tags": {
+      "brand": "Red Lion Hotels",
+      "brand:wikidata": "Q25047720",
+      "brand:wikipedia": "en:Red Lion Hotels",
+      "name": "Red Lion Hotels",
+      "tourism": "hotel"
+    }
+  },
   "tourism/hotel|Red Roof Inn": {
     "countryCodes": ["us"],
     "tags": {


### PR DESCRIPTION
Added Wiki tags for Red Lion Hotels - issue #3367 to brands/tourism/hotels.json file. Hope everything is okay. Thanks!!

https://en.wikipedia.org/wiki/Red_Lion_Hotels

