### PR TITLE
Added missing Wiki tags for Decò

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -907,6 +907,8 @@
     "countryCodes": ["it"],
     "tags": {
       "brand": "Decò",
+      "brand:wikidata": "Q65127915",
+      "brand:wikipedia": "it:Decò",
       "name": "Decò",
       "shop": "supermarket"
     }


### PR DESCRIPTION
A few months ago, a new Wikipedia article and Wikidata object has been created for the Italian supermarket chain Decò and it was not linked yet in the NSI.