### PR TITLE
Add Maximarkt

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -2501,7 +2501,6 @@
   },
   "shop/supermarket|Maximarkt": {
     "countryCodes": ["at"],
-    "nomatch": ["shop/supermarket|Maximarkt"],
     "tags": {
       "brand": "Maximarkt",
       "brand:wikidata": "Q55524814",

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -2499,6 +2499,17 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Maximarkt": {
+    "countryCodes": ["at"],
+    "nomatch": ["shop/supermarket|Maximarkt"],
+    "tags": {
+      "brand": "Maximarkt",
+      "brand:wikidata": "Q55524814",
+      "brand:wikipedia": "de:Maximarkt",
+      "name": "Maximarkt",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|Maxi~(Canada)": {
     "countryCodes": ["ca"],
     "nomatch": ["shop/supermarket|Maxi~(Serbia)"],


### PR DESCRIPTION
This PR adds the Austrian supermarket chain _Maximarkt_ ([Q55524814](https://www.wikidata.org/wiki/Q55524814)).