### PR TITLE
Chicken Express (Q5096235) dont operate in UK

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -441,7 +441,7 @@
     }
   },
   "amenity/fast_food|Chicken Express": {
-    "countryCodes": ["gb", "us"],
+    "countryCodes": ["us"],
     "tags": {
       "amenity": "fast_food",
       "brand": "Chicken Express",


### PR DESCRIPTION
The entry for Chicken Express is allowing iD users to make incorrect edits attaching brand tags for a regional US entity "Chicken Express" to small independent operated UK fast food outlets with a similar name. Available information suggests that the wikidata entity only operates in the US. Further evidence needs to be provided for any UK based existence. Specific example: [https://www.openstreetmap.org/user_blocks/3277](https://www.openstreetmap.org/user_blocks/3277). 