### PR TITLE
Add nomacth tags to supress warnings for gortz bakery and gortz shoes

### DIFF
--- a/brands/shop/bakery.json
+++ b/brands/shop/bakery.json
@@ -352,6 +352,7 @@
     }
   },
   "shop/bakery|Görtz": {
+    "nomatch": ["shop/shoes|Görtz"],
     "tags": {
       "brand": "Görtz",
       "name": "Görtz",

--- a/brands/shop/shoes.json
+++ b/brands/shop/shoes.json
@@ -360,6 +360,7 @@
   },
   "shop/shoes|Görtz": {
     "countryCodes": ["de"],
+    "nomatch": ["shop/bakery|Görtz"],
     "tags": {
       "brand": "Görtz",
       "brand:wikidata": "Q1559593",


### PR DESCRIPTION
Add nomatch tags to supress duplicate warnings, since there are two places with the same name on different categories. This is my first pull request, hope it goes well!