### PR TITLE
remove Giant Eagle fuel; it's a duplicate of GetGo

### DIFF
--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -1016,6 +1016,7 @@
   },
   "amenity/fuel|GetGo": {
     "countryCodes": ["us"],
+    "matchNames": ["giant eagle fuel"],
     "tags": {
       "amenity": "fuel",
       "brand": "GetGo",
@@ -1030,18 +1031,6 @@
       "amenity": "fuel",
       "brand": "Giant",
       "name": "Giant"
-    }
-  },
-  "amenity/fuel|Giant Eagle": {
-    "countryCodes": ["us"],
-    "matchNames": ["giant eagle fuel"],
-    "nomatch": ["shop/supermarket|Giant Eagle"],
-    "tags": {
-      "amenity": "fuel",
-      "brand": "Giant Eagle",
-      "brand:wikidata": "Q1522721",
-      "brand:wikipedia": "en:Giant Eagle",
-      "name": "Giant Eagle"
     }
   },
   "amenity/fuel|Global": {


### PR DESCRIPTION
Preserve the matchNames.