### PR TITLE
Move Upper Crust (UK) from bakery to fast food

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -2904,6 +2904,21 @@
       "takeaway": "yes"
     }
   },
+    "amenity/fast_food|Upper Crust": {
+     "countryCodes": ["de","dk","eg","es","fi","ie","gb","no","se"],
+      "matchTags": [ 
+      "shop/bakery"
+    ],
+    "tags": {
+      "brand": "Upper Crust",
+      "brand:wikidata": "Q7898585",
+      "brand:wikipedia": "en:Upper Crust (restaurant chain)",
+      "name": "Upper Crust",
+      "amenity": "fast_food",
+      "cuisine": "sandwich",
+      "takeaway": "yes"
+    }
+  },
   "amenity/fast_food|Valentine": {
     "countryCodes": ["ca"],
     "tags": {

--- a/brands/shop/bakery.json
+++ b/brands/shop/bakery.json
@@ -687,15 +687,7 @@
       "shop": "bakery"
     }
   },
-  "shop/bakery|Upper Crust": {
-    "tags": {
-      "brand": "Upper Crust",
-      "brand:wikidata": "Q7898585",
-      "brand:wikipedia": "en:Upper Crust (restaurant chain)",
-      "name": "Upper Crust",
-      "shop": "bakery"
-    }
-  },
+
   "shop/bakery|Wiener Feinbäcker": {
     "countryCodes": ["de"],
     "tags": {


### PR DESCRIPTION
Upper Crust is a chain of sandwich bars largely located in transport hubs (railway stations and airports). They sell crusty baquette style sandwiches, coffee and pastries, but are distinctly not a bakery. Mainly UK based they have outlets in Fennoscandinavia and airport outlets elsewhere (including, according to Wikipedia, one in the US). Many currently mapped outlets in Norway & Sweden are mapped as cafes and as I am not familiar with them I have not added this as a matching value. In addition the Upper Crust Pizza chain has a number of already mapped outlets in the US, so for now, because I suspect it might cause more erroneous tagging than it may avoided, I've not added US as a country code.

Although tag usage is split pretty evenly three ways: café, fast_food or bakery. Bakery is clearly inappropriate: they remain open very late, bakeries are not typically located on stations (at least in UK), they don't sell full range of bakery products and not described as such on Wikipedia. Many have seating, but most are just an enclosure on the station concourse, but café may be appropriate in other cases. Fast food will not be wrong in all cases.

Proximate cause for this PR is a inexperienced editor [changing](https://www.openstreetmap.org/changeset/77841609) an element with the fast food tags.