### PR TITLE
Frankie & Bennie's cuisine change

### DIFF
--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -822,7 +822,7 @@
       "brand": "Frankie & Benny's",
       "brand:wikidata": "Q5490892",
       "brand:wikipedia": "en:Frankie & Benny's",
-      "cuisine": "italian",
+      "cuisine": "american",
       "name": "Frankie & Benny's"
     }
   },


### PR DESCRIPTION
Frankie & Bennie's offering is distinctly American in style, and definitely not the same as other restaurants with cuisine=Italian. As Italian-American is not represented on taginfo, I've changed this from 'italian' to 'american'. Current tag values are deceptive as they represent a single individual updating multiple restaurants and not a consensus of UK mappers (see values at start of year: https://overpass-turbo.eu/s/OFK)