### PR TITLE
Add Holland Blumen Mark (dissolved)

### DIFF
--- a/brands/shop/florist.json
+++ b/brands/shop/florist.json
@@ -21,6 +21,7 @@
   },
   "shop/florist|Holland Blumen Mark": {
     "countryCodes": ["at"],
+    "matchNames": ["holland blumen"],
     "tags": {
       "brand": "Holland Blumen Mark",
       "brand:wikidata": "Q1624739",

--- a/brands/shop/florist.json
+++ b/brands/shop/florist.json
@@ -19,6 +19,16 @@
       "shop": "florist"
     }
   },
+  "shop/florist|Holland Blumen Mark": {
+    "countryCodes": ["at"],
+    "tags": {
+      "brand": "Holland Blumen Mark",
+      "brand:wikidata": "Q1624739",
+      "brand:wikipedia": "de:Holland Blumen Mark",
+      "name": "Holland Blumen Mark",
+      "shop": "florist"
+    }
+  },
   "shop/florist|Interflora": {
     "countryCodes": ["fr", "gb", "no", "se"],
     "tags": {


### PR DESCRIPTION
This PR adds the dissolved florist store chain "Holland Blumen Mark" to the index. There are still quite a few mapped although most of them have been closed or taken over by a different company. Wikidata already contains the dissolved information and running `npm run wikidata` should therefore also add it to dissolved.json.