### PR TITLE
add 3 German brands

### DIFF
--- a/brands/office/insurance.json
+++ b/brands/office/insurance.json
@@ -122,6 +122,17 @@
       "office": "insurance"
     }
   },
+  "office/insurance|BGV": {
+    "countryCodes": ["de"],
+    "tags": {
+      "brand": "BGV",
+      "brand:wikidata": "Q795911",
+      "brand:wikipedia": "de:BGV / Badische Versicherungen",
+      "name": "BGV",
+      "alt_name": "Badische Versicherungen",
+      "office": "insurance"
+    }
+  },
   "office/insurance|CUK Ubezpieczenia": {
     "countryCodes": ["pl"],
     "tags": {
@@ -489,6 +500,16 @@
       "brand:wikidata": "Q7833457",
       "brand:wikipedia": "en:Tranquilidade",
       "name": "Tranquilidade",
+      "office": "insurance"
+    }
+  },
+  "office/insurance|Württembergische": {
+    "countryCodes": ["de"],
+    "tags": {
+      "brand": "Württembergische",
+      "brand:wikidata": "Q1412465",
+      "brand:wikipedia": "de:Württembergische Versicherung",
+      "name": "Württembergische",
       "office": "insurance"
     }
   },

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -506,6 +506,17 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|CAP-Markt": {
+    "countryCodes": ["de"],
+    "matchNames": ["CAP"],
+    "tags": {
+      "brand": "CAP",
+      "brand:wikidata": "Q1022827",
+      "brand:wikipedia": "de:CAP (Markt)",
+      "name": "CAP-Markt",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|Caprabo": {
     "countryCodes": ["ad", "es"],
     "tags": {
@@ -1095,7 +1106,7 @@
     "tags": {
       "brand": "E-Center",
       "brand:wikidata": "Q701755",
-      "brand:wikipedia": "en:Edeka",
+      "brand:wikipedia": "de:Edeka",
       "name": "E-Center",
       "shop": "supermarket"
     }
@@ -1136,7 +1147,7 @@
     "tags": {
       "brand": "Edeka",
       "brand:wikidata": "Q701755",
-      "brand:wikipedia": "en:Edeka",
+      "brand:wikipedia": "de:Edeka",
       "name": "Edeka",
       "shop": "supermarket"
     }
@@ -1146,7 +1157,7 @@
     "tags": {
       "brand": "Edeka",
       "brand:wikidata": "Q701755",
-      "brand:wikipedia": "en:Edeka",
+      "brand:wikipedia": "de:Edeka",
       "name": "Edeka xpress",
       "shop": "supermarket"
     }
@@ -4266,7 +4277,7 @@
     "tags": {
       "brand": "nah und gut",
       "brand:wikidata": "Q701755",
-      "brand:wikipedia": "en:Edeka",
+      "brand:wikipedia": "de:Edeka",
       "name": "nah und gut",
       "shop": "supermarket"
     }


### PR DESCRIPTION
New brands:
* BGV
* CAP-Markt
* Württembergische

I also corrected the Edeka Wikipedia link to de: because it only operates in Germany