### PR TITLE
Add F1 Autocentre

### DIFF
--- a/brands/shop/car_repair.json
+++ b/brands/shop/car_repair.json
@@ -142,7 +142,7 @@
   "shop/car_repair|F1 Autocentre": {
     "countryCodes": ["gb"],
     "tags": {
-      "brand": "F1 Auocentre",
+      "brand": "F1 Autocentre",
       "brand:wikidata": "Q79239635",
       "name": "F1 Autocentre",
       "shop": "car_repair"

--- a/brands/shop/car_repair.json
+++ b/brands/shop/car_repair.json
@@ -139,6 +139,15 @@
       "shop": "car_repair"
     }
   },
+  "shop/car_repair|F1 Autocentre": {
+    "countryCodes": ["gb"],
+    "tags": {
+      "brand": "F1 Auocentre",
+      "brand:wikidata": "Q79239635",
+      "name": "F1 Autocentre",
+      "shop": "car_repair"
+    }
+  },
   "shop/car_repair|Feu Vert": {
     "countryCodes": ["fr"],
     "tags": {


### PR DESCRIPTION
A UK based car repair chain specialising in Tyres, Batteries, Exhausts and Servicing