### PR TITLE
Added Cactus supermarket in Luxembourg / Wikidata for Big-A in Japan

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -503,6 +503,16 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Cactus": {
+    "countryCodes": ["lu"],
+    "tags": {
+      "brand": "Cactus",
+      "brand:wikidata": "Q466918",
+      "brand:wikipedia": "lb:Cactus",
+      "name": "Cactus",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|CAP-Markt": {
     "countryCodes": ["de"],
     "matchNames": ["cap"],

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -332,9 +332,16 @@
     }
   },
   "shop/supermarket|Big-A": {
+    "countryCodes": ["jp"],
     "tags": {
       "brand": "Big-A",
+      "brand:en": "Big-A",
+      "brand:jp": "ビッグ・エー",
       "name": "Big-A",
+      "name:en": "Big-A",
+      "name:ja": "ビッグ・エー",
+      "brand:wikidata": "Q11330804",
+      "brand:wikipedia": "jp:ビッグ・エー",
       "shop": "supermarket"
     }
   },


### PR DESCRIPTION
(for info see https://en.wikipedia.org/wiki/Cactus_(supermarket) and https://www.cactus.lu/fr/magasins-horaires#&supermarche+marche+hobbi+shoppi&), for Big-A https://ja.wikipedia.org/wiki/%E3%83%93%E3%83%83%E3%82%B0%E3%83%BB%E3%82%A8%E3%83%BC