### PR TITLE
estate_agent.json - adding missing brand:wikidata

### DIFF
--- a/brands/office/estate_agent.json
+++ b/brands/office/estate_agent.json
@@ -109,6 +109,7 @@
     "tags": {
       "brand": "Harcourts",
       "brand:wikidata": "Q5655056",
+      "brand:wikipedia": "en:Harcourts International",
       "name": "Harcourts",
       "office": "estate_agent"
     }

--- a/brands/office/estate_agent.json
+++ b/brands/office/estate_agent.json
@@ -3,6 +3,7 @@
     "countryCodes": ["gb"],
     "tags": {
       "brand": "Bairstow Eves",
+      "brand:wikidata": "Q81074787",
       "name": "Bairstow Eves",
       "office": "estate_agent"
     }
@@ -107,6 +108,7 @@
   "office/estate_agent|Harcourts": {
     "tags": {
       "brand": "Harcourts",
+      "brand:wikidata": "Q5655056",
       "name": "Harcourts",
       "office": "estate_agent"
     }
@@ -163,6 +165,7 @@
     "countryCodes": ["au", "nz"],
     "tags": {
       "brand": "Ray White",
+      "brand:wikidata": "Q81077729",
       "name": "Ray White",
       "office": "estate_agent"
     }
@@ -201,6 +204,7 @@
     "countryCodes": ["gb"],
     "tags": {
       "brand": "Your Move",
+      "brand:wikidata": "Q81078416",
       "name": "Your Move",
       "office": "estate_agent"
     }


### PR DESCRIPTION
Trying out my first fork / pull request - added **brand:wikidata** to _/brand/office/estate_agent.json_ for:

- Bairstow Eves
- Harcourts
- Ray White
- Your Move