### PR TITLE
Add Malitel and Orange Mali

### DIFF
--- a/brands/shop/telecommunication.json
+++ b/brands/shop/telecommunication.json
@@ -40,6 +40,16 @@
       "shop": "telecommunication"
     }
   },
+  "shop/telecommunication|Malitel": {
+    "countryCodes": ["ml"],
+    "tags": {
+      "brand": "Malitel",
+      "brand:wikidata": "Q6743829",
+      "brand:wikipedia": "en:Malitel",
+      "name": "Malitel",
+      "shop": "telecommunication"
+    }
+  },
   "shop/telecommunication|Ooredoo": {
     "tags": {
       "brand": "Ooredoo",

--- a/brands/shop/telecommunication.json
+++ b/brands/shop/telecommunication.json
@@ -49,6 +49,16 @@
       "shop": "telecommunication"
     }
   },
+  "shop/telecommunication|Orange Mali": {
+    "countryCodes": ["ml"],
+    "tags": {
+      "brand": "Orange Mali",
+      "brand:wikidata": "Q3355061",
+      "brand:wikipedia": "fr:Orange Mali",
+      "name": "Orange Mali",
+      "shop": "telecommunication"
+    }
+  },
   "shop/telecommunication|Spectrum": {
     "countryCodes": ["us"],
     "tags": {


### PR DESCRIPTION
Adds two `shop=telecommunication` brands in Mali (West Africa).  Orange Mali is a subsidiary of the French Orange.  Both brands operate stores which sell telecommunication devices beyond just mobile phones, such as modems, wireless routers, USB receivers, etc.