### PR TITLE
Correct uSmile convenience stores in PetroChina fuel stations

### DIFF
--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -2983,7 +2983,7 @@
       "name": "din-X"
     }
   },
-  "amenity/fuel|uSmile 昆仑好客: {
+  "amenity/fuel|uSmile 昆仑好客": {
     "countryCodes": ["cn"],
     "matchNames": ["usmile", "usmile 便利店", "昆仑好","昆仑好客"],
     "nomatch": ["shop/convenience|uSmile 昆仑好客"],

--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -2983,19 +2983,19 @@
       "name": "din-X"
     }
   },
-  "amenity/fuel|uSmile 昆仑好": {
+  "amenity/fuel|uSmile 昆仑好客: {
     "countryCodes": ["cn"],
-    "matchNames": ["usmile", "usmile 便利店", "昆仑好"],
-    "nomatch": ["shop/convenience|uSmile 昆仑好"],
+    "matchNames": ["usmile", "usmile 便利店", "昆仑好","昆仑好客"],
+    "nomatch": ["shop/convenience|uSmile 昆仑好客"],
     "tags": {
       "amenity": "fuel",
-      "brand": "uSmile 昆仑好",
+      "brand": "uSmile 昆仑好客",
       "brand:en": "uSmile",
       "brand:wikidata": "Q66480830",
-      "brand:zh": "uSmile 便利店",
+      "brand:zh": "昆仑好客",
       "name": "uSmile 昆仑好",
       "name:en": "uSmile",
-      "name:zh": "uSmile 便利店"
+      "name:zh": "昆仑好客"
     }
   },
   "amenity/fuel|Авіас": {

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -1961,19 +1961,19 @@
       "shop": "convenience"
     }
   },
-  "shop/convenience|uSmile 昆仑好": {
+  "shop/convenience|uSmile 昆仑好客": {
     "countryCodes": ["cn"],
-    "matchNames": ["usmile", "usmile 便利店", "昆仑好"],
+    "matchNames": ["usmile", "usmile 便利店", "昆仑好","昆仑好客"],
     "matchTags": ["shop/supermarket"],
     "nomatch": ["amenity/fuel|uSmile 昆仑好"],
     "tags": {
-      "brand": "uSmile 昆仑好",
+      "brand": "uSmile 昆仑好客",
       "brand:en": "uSmile",
       "brand:wikidata": "Q66480830",
-      "brand:zh": "uSmile 便利店",
-      "name": "uSmile 昆仑好",
+      "brand:zh": "昆仑好客",
+      "name": "uSmile 昆仑好客",
       "name:en": "uSmile",
-      "name:zh": "uSmile 便利店",
+      "name:zh": "昆仑好客",
       "shop": "convenience"
     }
   },


### PR DESCRIPTION
I noticed there are styling issues from #2977 not fixed before merging. The name should be "昆仑好客", and "便利店" (convenience store) is a generic suffix 