### PR TITLE
Remove 'Horodateur' brand (is not a brand name)

### DIFF
--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -134,13 +134,6 @@
       "vending": "ice_cubes"
     }
   },
-  "amenity/vending_machine|Horodateur": {
-    "tags": {
-      "amenity": "vending_machine",
-      "brand": "Horodateur",
-      "name": "Horodateur"
-    }
-  },
   "amenity/vending_machine|KKM": {
     "countryCodes": ["pl"],
     "tags": {


### PR DESCRIPTION
'Horodateur' is not a brand. It's a commonly french name to define 'parking meter'