### PR TITLE
Add big fernand

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -164,6 +164,18 @@
       "takeaway": "yes"
     }
   },
+    "amenity/fast_food|Big Fernand": {
+    "countryCodes": ["fr"],
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "Big Fernand",
+      "brand:wikidata": "Q19521346",
+      "brand:wikipedia": "fr:Big Fernand",
+      "cuisine": "burger",
+      "name": "Big Fernand",
+      "takeaway": "yes"
+    }
+  },
   "amenity/fast_food|Biscuitville": {
     "countryCodes": ["us"],
     "tags": {

--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -165,7 +165,7 @@
     }
   },
     "amenity/fast_food|Big Fernand": {
-    "countryCodes": ["fr"],
+    "countryCodes": ["fr", "lu", "ae"],
     "tags": {
       "amenity": "fast_food",
       "brand": "Big Fernand",


### PR DESCRIPTION
Add Big Fernand fast foods brand. It is located in : 
- France : 49 restaurants (included Martinique and Guadeloupe)
- Luxembourg : 1 restaurant
- United Arab Emirates : 3 restaurants