### PR TITLE
Added to estate_agent.json

### DIFF
--- a/brands/office/estate_agent.json
+++ b/brands/office/estate_agent.json
@@ -294,7 +294,7 @@
       "name": "Sequence",
       "office": "estate_agent"
     }
-  }
+  },
   "office/estate_agent|Shipways": {
     "countryCodes": ["gb"],
     "tags": {

--- a/brands/office/estate_agent.json
+++ b/brands/office/estate_agent.json
@@ -1,10 +1,48 @@
 {
+  "office/estate_agent|Allen & Harris": {
+    "countryCodes": ["gb"],
+    "matchNames": ["Allen and Harris"],
+    "tags": {
+      "brand": "Allen & Harris",
+      "brand:wikidata": "Q81856601",
+      "name": "Allen & Harris",
+      "office": "estate_agent"
+    }
+  },
+  "office/estate_agent|Bagshaws Residential": {
+    "countryCodes": ["gb"],
+    "tags": {
+      "brand": "Bagshaws Residential",
+      "brand:wikidata": "Q81859084",
+      "name": "Bagshaws Residential",
+      "office": "estate_agent"
+    }
+  },
   "office/estate_agent|Bairstow Eves": {
     "countryCodes": ["gb"],
     "tags": {
       "brand": "Bairstow Eves",
       "brand:wikidata": "Q81074787",
       "name": "Bairstow Eves",
+      "office": "estate_agent"
+    }
+  },
+  "office/estate_agent|Barnard Marcus": {
+    "countryCodes": ["gb"],
+    "tags": {
+      "brand": "Barnard Marcus",
+      "brand:wikidata": "Q81860444",
+      "name": "Barnard Marcus",
+      "office": "estate_agent"
+    }
+  },
+  "office/estate_agent|Brown & Merry": {
+    "countryCodes": ["gb"],
+    "matchNames": ["Brown and Merry"],
+    "tags": {
+      "brand": "Brown & Merry",
+      "brand:wikidata": "Q81859714",
+      "name": "Brown & Merry",
       "office": "estate_agent"
     }
   },
@@ -57,6 +95,16 @@
       "brand:wikidata": "Q1435638",
       "brand:wikipedia": "fr:Foncia",
       "name": "Foncia",
+      "office": "estate_agent"
+    }
+  },
+  "office/estate_agent|Fox & Sons": {
+    "countryCodes": ["gb"],
+    "matchNames": ["Fox and Sons"],
+    "tags": {
+      "brand": "Fox & Sons",
+      "brand:wikidata": "Q81855298",
+      "name": "Fox & Sons",
       "office": "estate_agent"
     }
   },
@@ -134,6 +182,16 @@
       "office": "estate_agent"
     }
   },
+  "office/estate_agent|Jones & Chapman": {
+    "countryCodes": ["gb"],
+    "matchNames": ["Jones and Chapman"],
+    "tags": {
+      "brand": "Jones & Chapman",
+      "brand:wikidata": "Q81858007",
+      "name": "Jones & Chapman",
+      "office": "estate_agent"
+    }
+  },
   "office/estate_agent|Knight Frank": {
     "tags": {
       "brand": "Knight Frank",
@@ -150,6 +208,16 @@
       "brand:wikidata": "Q56310946",
       "brand:wikipedia": "fr:Laforêt (immobilier)",
       "name": "Laforêt",
+      "office": "estate_agent"
+    }
+  },
+  "office/estate_agent|Manners & Harrison": {
+    "countryCodes": ["gb"],
+    "matchNames": ["Manners and Harrison"],
+    "tags": {
+      "brand": "Manners & Harrison",
+      "brand:wikidata": "Q81857241",
+      "name": "Manners & Harrison",
       "office": "estate_agent"
     }
   },
@@ -199,6 +267,15 @@
       "office": "estate_agent"
     }
   },
+  "office/estate_agent|Roger Platt": {
+    "countryCodes": ["gb"],
+    "tags": {
+      "brand": "Roger Platt",
+      "brand:wikidata": "Q81859999",
+      "name": "Roger Platt",
+      "office": "estate_agent"
+    }
+  },
   "office/estate_agent|Royal LePage": {
     "countryCodes": ["ca"],
     "tags": {
@@ -206,6 +283,24 @@
       "brand:wikidata": "Q7374385",
       "brand:wikipedia": "en:Royal LePage",
       "name": "Royal LePage",
+      "office": "estate_agent"
+    }
+  },
+  "office/estate_agent|Sequence": {
+    "countryCodes": ["gb"],
+    "tags": {
+      "brand": "Sequence",
+      "brand:wikidata": "Q81853603",
+      "name": "Sequence",
+      "office": "estate_agent"
+    }
+  }
+  "office/estate_agent|Shipways": {
+    "countryCodes": ["gb"],
+    "tags": {
+      "brand": "Shipways",
+      "brand:wikidata": "Q81859397",
+      "name": "Shipways",
       "office": "estate_agent"
     }
   },
@@ -225,6 +320,15 @@
       "brand": "Stirling Ackroyd",
       "brand:wikidata": "Q81062228",
       "name": "Stirling Ackroyd",
+      "office": "estate_agent"
+    }
+  },
+  "office/estate_agent|Swetenhams": {
+    "countryCodes": ["gb"],
+    "tags": {
+      "brand": "Swetenhams",
+      "brand:wikidata": "Q81858340",
+      "name": "Swetenhams",
       "office": "estate_agent"
     }
   },

--- a/brands/office/estate_agent.json
+++ b/brands/office/estate_agent.json
@@ -1,7 +1,6 @@
 {
   "office/estate_agent|Allen & Harris": {
     "countryCodes": ["gb"],
-    "matchNames": ["Allen and Harris"],
     "tags": {
       "brand": "Allen & Harris",
       "brand:wikidata": "Q81856601",
@@ -38,7 +37,6 @@
   },
   "office/estate_agent|Brown & Merry": {
     "countryCodes": ["gb"],
-    "matchNames": ["Brown and Merry"],
     "tags": {
       "brand": "Brown & Merry",
       "brand:wikidata": "Q81859714",
@@ -100,7 +98,6 @@
   },
   "office/estate_agent|Fox & Sons": {
     "countryCodes": ["gb"],
-    "matchNames": ["Fox and Sons"],
     "tags": {
       "brand": "Fox & Sons",
       "brand:wikidata": "Q81855298",
@@ -184,7 +181,6 @@
   },
   "office/estate_agent|Jones & Chapman": {
     "countryCodes": ["gb"],
-    "matchNames": ["Jones and Chapman"],
     "tags": {
       "brand": "Jones & Chapman",
       "brand:wikidata": "Q81858007",
@@ -213,7 +209,6 @@
   },
   "office/estate_agent|Manners & Harrison": {
     "countryCodes": ["gb"],
-    "matchNames": ["Manners and Harrison"],
     "tags": {
       "brand": "Manners & Harrison",
       "brand:wikidata": "Q81857241",
@@ -283,15 +278,6 @@
       "brand:wikidata": "Q7374385",
       "brand:wikipedia": "en:Royal LePage",
       "name": "Royal LePage",
-      "office": "estate_agent"
-    }
-  },
-  "office/estate_agent|Sequence": {
-    "countryCodes": ["gb"],
-    "tags": {
-      "brand": "Sequence",
-      "brand:wikidata": "Q81853603",
-      "name": "Sequence",
       "office": "estate_agent"
     }
   },


### PR DESCRIPTION
I was initially going to add _William H. Brown_ after seeing #3441, but see @bhousel beat me to it :)

But, after seeing _William H. Brown_ was a part of _Sequence (UK) Ltd_, I've added _Sequence (UK) Ltd_ brands of Estate Agents to the estate_agent.json file.

I've also included _Sequence (UK) Ltd_ as an estate agent in itself, not because they have branded shops now, but because of the possibility of a blanket re-branding at some point, but this can be removed if need be.