### PR TITLE
Add and update france fuel amenities and supermarkets

### DIFF
--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -260,6 +260,7 @@
     }
   },
   "amenity/fuel|Avia": {
+    "countryCodes": ["at", "be", "bg", "ch", "cz", "de", "es", "fr", "hu", "it", "nl", "pl", "pt", "rs", "ua"],
     "matchNames": ["station avia"],
     "tags": {
       "amenity": "fuel",

--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -215,6 +215,18 @@
       "name": "Arco"
     }
   },
+  "amenity/fuel|AS 24": {
+    "countryCodes": ["at", "be", "bg", "cz", "de", "dk", "es", "fr", "gb", "ge", "gr", "hr",
+      "hu", "ie", "it", "lt", "lu", "mk", "nl", "pl", "pt", "ro", "rs", "se", "si", "sk", "ua"],
+    "tags": {
+      "amenity": "fuel",
+      "brand": "AS 24",
+      "brand:wikidata": "Q2819394",
+      "brand:wikipedia": "fr:AS 24 (entreprise)",
+      "hgv": "only",
+      "name": "AS 24"
+    }
+  },
   "amenity/fuel|Asda": {
     "countryCodes": ["gb"],
     "nomatch": [

--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -338,6 +338,14 @@
       "name": "BHPetrol"
     }
   },
+  "amenity/fuel|bi1": {
+    "countryCodes": ["fr"],
+    "nomatch": ["shop/supermarket|bi1"],
+    "tags": {
+      "amenity": "fuel",
+      "name": "bi1"
+    }
+  },
   "amenity/fuel|BP": {
     "matchNames": ["bp gas station"],
     "nomatch": ["shop/convenience|BP Shop"],

--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -821,6 +821,16 @@
       "name": "Domo"
     }
   },
+  "amenity/fuel|Dyneff": {
+    "countryCodes": ["es", "fr"],
+    "tags": {
+      "amenity": "fuel",
+      "brand": "Dyneff",
+      "brand:wikidata": "Q16630266",
+      "brand:wikipedia": "fr:Dyneff",
+      "name": "Dyneff"
+    }
+  },
   "amenity/fuel|EKO~(Canada)": {
     "countryCodes": ["ca"],
     "nomatch": [

--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -30,6 +30,16 @@
       "name": "76"
     }
   },
+    "amenity/fuel|8 à Huit": {
+    "countryCodes": ["fr"],
+    "nomatch": ["shop/supermarket|8 à Huit", "shop/convenience|8 à Huit"],
+    "tags": {
+      "amenity": "fuel",
+      "brand": "8 à Huit",
+      "brand:wikidata": "Q2818601",
+      "brand:wikipedia": "fr:8 à Huit",
+      "name": "8 à Huit"
+    },
   "amenity/fuel|ABC": {
     "countryCodes": ["fi"],
     "nomatch": ["shop/convenience|ABC"],

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -65,7 +65,7 @@
   },
   "shop/convenience|8 à Huit": {
     "countryCodes": ["fr"],
-    "nomatch": ["shop/supermarket|8 à Huit"],
+    "nomatch": ["shop/supermarket|8 à Huit", "amenity/fuel|8 à Huit"],
     "tags": {
       "brand": "8 à Huit",
       "brand:wikidata": "Q2818601",

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -1,6 +1,6 @@
 {
   "shop/supermarket|8 à Huit": {
-    "nomatch": ["shop/convenience|8 à Huit"],
+    "nomatch": ["shop/convenience|8 à Huit", "amenity/fuel|8 à Huit"],
     "tags": {
       "brand": "8 à Huit",
       "brand:wikidata": "Q2818601",

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -275,6 +275,15 @@
       "shop": "supermarket"
     }
   },
+    "shop/supermarket|bi1": {
+    "countryCodes": ["fr"],
+    "nomatch": ["amenity/fuel|bi1"],
+    "tags": {
+      "brand": "bi1",
+      "name": "bi1",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|BM": {
     "countryCodes": ["es"],
     "tags": {


### PR DESCRIPTION
Add and update some fuels and supermarkets :
- _8 à Huit :_ Add fuel amenities and add nomatch tags on 8 à Huit conveniences and supermarkets
- _Avia :_ Add countries where it is operatring (from Avia's website)
- _AS 24 :_ Add fuel amenities
- _bi1 :_ Add fuel amenities and supermarkets (only 5 in France)
- _Dyneff :_ Add fuel amenities. It is operating mainly in France. Some fuel stations in Spain