### PR TITLE
Fix English and Japanese locales for Times parking

### DIFF
--- a/brands/amenity/parking.json
+++ b/brands/amenity/parking.json
@@ -69,8 +69,8 @@
       "brand:wikipedia": "ja:パーク24",
       "fee": "yes",
       "name": "Times",
-      "name:en": "タイムズ",
-      "name:ja": "Times"
+      "name:en": "Times",
+      "name:ja": "タイムズ"
     }
   }
 }


### PR DESCRIPTION
Was originally:

```
name:ja=Times
name:en=タイムズ
```

and now changed to match the correct language:


```
name:ja=タイムズ
name:en=Times
```

Now fixes the correct file per conversation here: https://github.com/osmlab/name-suggestion-index/pull/3502