### PR TITLE
Add M Lhuillier (shop=pawnbroker)

### DIFF
--- a/brands/shop/pawnbroker.json
+++ b/brands/shop/pawnbroker.json
@@ -11,8 +11,7 @@
   "shop/pawnbroker|Cebuana Lhuillier": {
     "countryCodes": ["ph"],
     "matchNames": [
-      "agencia cebuana",
-      "m lhuillier"
+      "agencia cebuana"
     ],
     "tags": {
       "brand": "Cebuana Lhuillier",
@@ -28,6 +27,15 @@
     "tags": {
       "brand": "Loombard",
       "name": "Loombard",
+      "shop": "pawnbroker"
+    }
+  },
+  "shop/pawnbroker|M Lhuillier": {
+    "countryCodes": ["ph"],
+    "tags": {
+      "brand": "M Lhuillier",
+      "brand:wikidata": "Q83434356",
+      "name": "M Lhuillier",
       "shop": "pawnbroker"
     }
   },


### PR DESCRIPTION
Add the M Lhuillier chain of pawnshops in the Philippines and remove it as a match for Cebuana Lhuillier, which is a completely different chain of pawnshops and owned by an unrelated family. (Filipinos actually incorrectly assume that the two chains are related to each other.)

This wrong match has already resulted in a mistagging of a pawnshop due to iD's suggestion to upgrade tags: https://www.openstreetmap.org/node/6827462574/history