### PR TITLE
amenity/college.json for SAE Institute and Akademie Deutsche POP

### DIFF
--- a/brands/amenity/college.json
+++ b/brands/amenity/college.json
@@ -1,7 +1,6 @@
 {
   "amenity/college|SAE Institute": {
     "tags": {
-      "brand": "SAE Institute",
       "brand:wikidata": "Q201438",
       "brand:wikipedia": "en:SAE Institute",
       "operator:wikidata": "Q201438",
@@ -13,7 +12,6 @@
   },
   "amenity/college|Akademie Deutsche POP": {
     "tags": {
-      "brand": "Akademie Deutsche POP",
       "brand:wikidata": "Q413887",
       "brand:wikipedia": "de:Akademie Deutsche POP",
       "operator:wikidata": "Q413887",

--- a/brands/amenity/college.json
+++ b/brands/amenity/college.json
@@ -3,6 +3,9 @@
     "tags": {
       "brand:wikidata": "Q201438",
       "brand:wikipedia": "en:SAE Institute",
+      "operator:wikidata": "Q201438",
+      "operator:wikipedia": "en:SAE Institute",
+      "operator:type": "private",
       "name": "SAE Institute",
       "amenity": "college",
     }

--- a/brands/amenity/college.json
+++ b/brands/amenity/college.json
@@ -13,7 +13,7 @@
       "brand": "Akademie Deutsche POP",
       "brand:wikidata": "Q413887",
       "brand:wikipedia": "de:Akademie Deutsche POP",
-      "name": "SAE Institute",
+      "name": "Akademie Deutsche POP",
       "amenity": "college"
     }
   }

--- a/brands/amenity/college.json
+++ b/brands/amenity/college.json
@@ -6,5 +6,13 @@
       "name": "SAE Institute",
       "amenity": "college",
     }
+  },
+  "amenity/college|Akademie Deutsche POP": {
+    "tags": {
+      "brand:wikidata": "Q413887",
+      "brand:wikipedia": "de:Akademie Deutsche POP",
+      "name": "SAE Institute",
+      "amenity": "college"
+    }
   }
 }

--- a/brands/amenity/college.json
+++ b/brands/amenity/college.json
@@ -14,6 +14,9 @@
     "tags": {
       "brand:wikidata": "Q413887",
       "brand:wikipedia": "de:Akademie Deutsche POP",
+      "operator:wikidata": "Q413887",
+      "operator:wikipedia": "de:Akademie Deutsche POP",
+      "operator:type": "private",
       "name": "SAE Institute",
       "amenity": "college"
     }

--- a/brands/amenity/college.json
+++ b/brands/amenity/college.json
@@ -1,6 +1,7 @@
 {
   "amenity/college|SAE Institute": {
     "tags": {
+      "brand": "SAE Institute",
       "brand:wikidata": "Q201438",
       "brand:wikipedia": "en:SAE Institute",
       "name": "SAE Institute",
@@ -9,6 +10,7 @@
   },
   "amenity/college|Akademie Deutsche POP": {
     "tags": {
+      "brand": "Akademie Deutsche POP",
       "brand:wikidata": "Q413887",
       "brand:wikipedia": "de:Akademie Deutsche POP",
       "name": "SAE Institute",

--- a/brands/amenity/college.json
+++ b/brands/amenity/college.json
@@ -7,7 +7,7 @@
       "operator:wikipedia": "en:SAE Institute",
       "operator:type": "private",
       "name": "SAE Institute",
-      "amenity": "college",
+      "amenity": "college"
     }
   },
   "amenity/college|Akademie Deutsche POP": {

--- a/brands/amenity/college.json
+++ b/brands/amenity/college.json
@@ -1,0 +1,10 @@
+{
+  "amenity/college|SAE Institute": {
+    "tags": {
+      "brand:wikidata": "Q201438",
+      "brand:wikipedia": "en:SAE Institute",
+      "name": "SAE Institute",
+      "amenity": "college",
+    }
+  }
+}

--- a/brands/amenity/college.json
+++ b/brands/amenity/college.json
@@ -11,9 +11,6 @@
     "tags": {
       "brand:wikidata": "Q413887",
       "brand:wikipedia": "de:Akademie Deutsche POP",
-      "operator:wikidata": "Q413887",
-      "operator:wikipedia": "de:Akademie Deutsche POP",
-      "operator:type": "private",
       "name": "SAE Institute",
       "amenity": "college"
     }

--- a/brands/amenity/college.json
+++ b/brands/amenity/college.json
@@ -3,9 +3,6 @@
     "tags": {
       "brand:wikidata": "Q201438",
       "brand:wikipedia": "en:SAE Institute",
-      "operator:wikidata": "Q201438",
-      "operator:wikipedia": "en:SAE Institute",
-      "operator:type": "private",
       "name": "SAE Institute",
       "amenity": "college"
     }

--- a/brands/amenity/college.json
+++ b/brands/amenity/college.json
@@ -1,6 +1,7 @@
 {
   "amenity/college|SAE Institute": {
     "tags": {
+      "brand": "SAE Institute",
       "brand:wikidata": "Q201438",
       "brand:wikipedia": "en:SAE Institute",
       "operator:wikidata": "Q201438",
@@ -12,6 +13,7 @@
   },
   "amenity/college|Akademie Deutsche POP": {
     "tags": {
+      "brand": "Akademie Deutsche POP",
       "brand:wikidata": "Q413887",
       "brand:wikipedia": "de:Akademie Deutsche POP",
       "operator:wikidata": "Q413887",


### PR DESCRIPTION
I would suggest a new `./brands/amenity/college.json` for SAE Institute and Akademie Deutsche POP. I am just not sure how the discussion on `operator` tagging went, so I made it four distinct commits.