### PR TITLE
removal of dupe + incorrect entry for Q1640290

### DIFF
--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -3517,20 +3517,6 @@
       "name:ja": "エッソ"
     }
   },
-  "amenity/fuel|エネオス": {
-    "countryCodes": ["jp"],
-    "tags": {
-      "amenity": "fuel",
-      "brand": "エネオス",
-      "brand:en": "JXTG Nippon Oil & Energy",
-      "brand:ja": "エネオス",
-      "brand:wikidata": "Q1640290",
-      "brand:wikipedia": "en:JXTG Nippon Oil & Energy",
-      "name": "エネオス",
-      "name:en": "JXTG Nippon Oil & Energy",
-      "name:ja": "エネオス"
-    }
-  },
   "amenity/fuel|キグナス石油": {
     "countryCodes": ["jp"],
     "matchNames": ["キグナス"],


### PR DESCRIPTION
Came to this repository to update ENEOS gas station brand name in english. found duplicate with incorrect brand:en value and deleted it. "ENEOS" is the proper brand name in english.