### PR TITLE
Fixing incorrect EN name & adding EN brand name.

### DIFF
--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -3644,10 +3644,11 @@
       "brand": "出光",
       "brand:en": "Idemitsu Kosan",
       "brand:ja": "出光",
+      "brand:en": "Idemitsu",
       "brand:wikidata": "Q2216770",
       "brand:wikipedia": "en:Idemitsu Kosan",
       "name": "出光",
-      "name:en": "Idemitsu Kosan",
+      "name:en": "Idemitsu",
       "name:ja": "出光"
     }
   },


### PR DESCRIPTION
出光 = Idemitsu, which is the common name of the brand used in English signage (in Japan). 