### PR TITLE
Update Mix Markt

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -1159,7 +1159,7 @@
     "tags": {
       "brand": "Mini Mix",
       "brand:wikidata": "Q327854",
-      "brand:wikipedia": "de:Mix Markt",
+      "brand:wikipedia": "en:Mix Markt",
       "name": "Mini Mix",
       "shop": "convenience"
     }

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -2843,7 +2843,7 @@
     "tags": {
       "brand": "Mix Markt",
       "brand:wikidata": "Q327854",
-      "brand:wikipedia": "de:Mix Markt",
+      "brand:wikipedia": "en:Mix Markt",
       "name": "Mix Markt",
       "shop": "supermarket"
     }


### PR DESCRIPTION
Change the brand's Wikipedia link from German to English Wikipedia, which didn't exist at the time.