### PR TITLE
Added Taziki's to fast_food.json

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -2880,6 +2880,18 @@
       "takeaway": "yes"
     }
   },
+  "amenity/fast_food|Taziki's Mediterranean Cafe": {
+    "countryCodes": ["us"],
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "Taziki's Mediterranean Cafe",
+      "brand:wikidata": "Q19849840",
+      "brand:wikipedia": "en:Taziki's Mediterranean Café",
+      "cuisine": "mediterranean",
+      "name": "Taziki's Mediterranean Cafe",
+      "short_name": "Taziki's"
+    }
+  },
   "amenity/fast_food|Ted's Hot Dogs": {
     "countryCodes": ["us"],
     "tags": {

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -2290,16 +2290,16 @@
       "name": "Swiss Chalet"
     }
   },
-  "amenity/restaurant|Taziki's Mediterranean Café": {
+  "amenity/restaurant|Taziki's Mediterranean Cafe": {
     "countryCodes": ["us"],
     "matchTags": ["amenity/cafe"],
     "tags": {
       "amenity": "restaurant",
-      "brand": "Taziki's Mediterranean Café",
+      "brand": "Taziki's Mediterranean Cafe",
       "brand:wikidata": "Q19849840",
-      "brand:wikipedia": "en:Taziki's Mediterranean Café",
+      "brand:wikipedia": "en:Taziki's Mediterranean Cafe",
       "cuisine": "mediterranean",
-      "name": "Taziki's Mediterranean Café"
+      "name": "Taziki's Mediterranean Cafe"
     }
   },
   "amenity/restaurant|TGI Friday's": {

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -2290,6 +2290,18 @@
       "name": "Swiss Chalet"
     }
   },
+  "amenity/restaurant|Taziki's Mediterranean Café": {
+    "countryCodes": ["us"],
+    "matchTags": ["amenity/cafe"],
+    "tags": {
+      "amenity": "restaurant",
+      "brand": "Taziki's Mediterranean Café",
+      "brand:wikidata": "Q19849840",
+      "brand:wikipedia": "en:Taziki's Mediterranean Café",
+      "cuisine": "mediterranean",
+      "name": "Taziki's Mediterranean Café"
+    }
+  },
   "amenity/restaurant|TGI Friday's": {
     "tags": {
       "amenity": "restaurant",

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -2290,18 +2290,6 @@
       "name": "Swiss Chalet"
     }
   },
-  "amenity/restaurant|Taziki's Mediterranean Cafe": {
-    "countryCodes": ["us"],
-    "matchTags": ["amenity/cafe"],
-    "tags": {
-      "amenity": "restaurant",
-      "brand": "Taziki's Mediterranean Cafe",
-      "brand:wikidata": "Q19849840",
-      "brand:wikipedia": "en:Taziki's Mediterranean Cafe",
-      "cuisine": "mediterranean",
-      "name": "Taziki's Mediterranean Cafe"
-    }
-  },
   "amenity/restaurant|TGI Friday's": {
     "tags": {
       "amenity": "restaurant",


### PR DESCRIPTION
Added "_Taziki's Mediterranean Cafe_" to **/brand/amenity/restaurant.json** as per #3545 but have done so as a pull request so others from the US can check it before committing.

The entry includes a matchTags for "_amenity/cafe_" which might not be needed, and the name might be better suited to just "_Taziki's_".
