### PR TITLE
Add Orell Füssli and remove Switzerland from Thalia

### DIFF
--- a/brands/shop/books.json
+++ b/brands/shop/books.json
@@ -199,6 +199,16 @@
       "shop": "books"
     }
   },
+  "shop/books|Orell Füssli": {
+    "countryCodes": ["ch"],
+    "tags": {
+      "brand": "Orell Füssli",
+      "brand:wikidata": "Q1511140",
+      "brand:wikipedia": "de:Orell Füssli",
+      "name": "Orell Füssli",
+      "shop": "books"
+    }
+  },
   "shop/books|Osiander": {
     "countryCodes": ["de"],
     "tags": {
@@ -276,7 +286,7 @@
     }
   },
   "shop/books|Thalia": {
-    "countryCodes": ["at", "ch", "de"],
+    "countryCodes": ["at", "de"],
     "tags": {
       "brand": "Thalia",
       "brand:wikidata": "Q2408854",


### PR DESCRIPTION
It looks like Thalia and Orell Füssli have a joint venture in Switzerland, and existing Thalia shops were converted to the Orell Füssli brand. The [source](https://www.badische-zeitung.de/nachrichten/suedwest/der-name-thalia-verschwindet) listed on Wikipedia is a bit older and speaks of Thalia shops disappearing in the future, and "thalia.ch" redirects to the [Orell Füssli](https://www.orellfuessli.ch/) website, but it might still be nice to get local knowledge about this. Maybe @habi can confirm this?