### PR TITLE
corrected the AWG brandname to AWG-Modecenter and added wikipedia and…

### DIFF
--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -21,12 +21,14 @@
       "shop": "clothes"
     }
   },
-  "shop/clothes|AWG": {
+  "shop/clothes|AWG-Modecenter": {
     "countryCodes": ["bg", "de"],
     "tags": {
-      "brand": "AWG",
-      "name": "AWG",
-      "shop": "clothes"
+      "brand": "AWG-Modecenter",
+      "name": "AWG-Modecenter",
+      "shop": "clothes",
+      "brand:wikipedia": "de:AWG-Modecenter",
+      "brand:wikidata": "Q300220"
     }
   },
   "shop/clothes|Abercrombie & Fitch": {


### PR DESCRIPTION
… wikidata information

fix to issue - https://github.com/osmlab/name-suggestion-index/issues/3552