### PR TITLE
Add German Sparkassen

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -2317,6 +2317,16 @@
       "name": "Beobank"
     }
   },
+  "amenity/bank|Berliner Sparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Berliner Sparkasse",
+      "brand:wikidata": "Q821760",
+      "brand:wikipedia": "de:Berliner Sparkasse",
+      "name": "Berliner Sparkasse"
+    }
+  },
   "amenity/bank|Berliner Volksbank": {
     "countryCodes": ["de"],
     "tags": {
@@ -2325,6 +2335,16 @@
       "brand:wikidata": "Q821855",
       "brand:wikipedia": "de:Berliner Volksbank",
       "name": "Berliner Volksbank"
+    }
+  },
+  "amenity/bank|Bezirkssparkasse Reichenau": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Bezirkssparkasse Reichenau",
+      "brand:wikidata": "Q18616717",
+      "brand:wikipedia": "de:Bezirkssparkasse Reichenau",
+      "name": "Bezirkssparkasse Reichenau"
     }
   },
   "amenity/bank|Bicentenario": {
@@ -2348,6 +2368,16 @@
       "name": "Bicici"
     }
   },
+  "amenity/bank|Bordesholmer Sparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Bordesholmer Sparkasse",
+      "brand:wikidata": "Q893433",
+      "brand:wikipedia": "de:Bordesholmer Sparkasse",
+      "name": "Bordesholmer Sparkasse"
+    }
+  },
   "amenity/bank|Bradesco": {
     "countryCodes": ["br"],
     "matchNames": ["banco bradesco"],
@@ -2357,6 +2387,16 @@
       "brand:wikidata": "Q806181",
       "brand:wikipedia": "en:Banco Bradesco",
       "name": "Bradesco"
+    }
+  },
+  "amenity/bank|Braunschweigische Landessparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Braunschweigische Landessparkasse",
+      "brand:wikidata": "Q902027",
+      "brand:wikipedia": "de:Braunschweigische Landessparkasse",
+      "name": "Braunschweigische Landessparkasse"
     }
   },
   "amenity/bank|Budapest Bank": {
@@ -3277,6 +3317,16 @@
       "name": "Erste Bank"
     }
   },
+  "amenity/bank|Erzgebirgssparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Erzgebirgssparkasse",
+      "brand:wikidata": "Q1366150",
+      "brand:wikipedia": "de:Erzgebirgssparkasse",
+      "name": "Erzgebirgssparkasse"
+    }
+  },
   "amenity/bank|EuroBic": {
     "countryCodes": ["pt"],
     "matchNames": ["banco bic"],
@@ -3541,6 +3591,16 @@
       "name": "First West Credit Union"
     }
   },
+  "amenity/bank|Frankfurter Sparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Frankfurter Sparkasse",
+      "brand:wikidata": "Q1445030",
+      "brand:wikipedia": "de:Frankfurter Sparkasse",
+      "name": "Frankfurter Sparkasse"
+    }
+  },
   "amenity/bank|Frost Bank": {
     "countryCodes": ["us"],
     "tags": {
@@ -3558,6 +3618,16 @@
       "brand": "Fulton Bank",
       "brand:wikidata": "Q16976594",
       "name": "Fulton Bank"
+    }
+  },
+  "amenity/bank|Förde Sparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Förde Sparkasse",
+      "brand:wikidata": "Q1479894",
+      "brand:wikipedia": "de:Förde Sparkasse",
+      "name": "Förde Sparkasse"
     }
   },
   "amenity/bank|GCB Bank": {
@@ -3761,6 +3831,16 @@
       "name": "Handelsbanken"
     }
   },
+  "amenity/bank|Harzsparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Harzsparkasse",
+      "brand:wikidata": "Q1268986",
+      "brand:wikipedia": "de:Harzsparkasse",
+      "name": "Harzsparkasse"
+    }
+  },
   "amenity/bank|Heritage Bank": {
     "tags": {
       "amenity": "bank",
@@ -3768,6 +3848,26 @@
       "brand:wikidata": "Q5738690",
       "brand:wikipedia": "en:Heritage Bank",
       "name": "Heritage Bank"
+    }
+  },
+  "amenity/bank|Herner Sparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Herner Sparkasse",
+      "brand:wikidata": "Q15709500",
+      "brand:wikipedia": "de:Herner Sparkasse",
+      "name": "Herner Sparkasse"
+    }
+  },
+  "amenity/bank|Hohenzollerische Landesbank Kreissparkasse Sigmaringen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Hohenzollerische Landesbank Kreissparkasse Sigmaringen",
+      "brand:wikidata": "Q1623858",
+      "brand:wikipedia": "de:Hohenzollerische Landesbank Kreissparkasse Sigmaringen",
+      "name": "Hohenzollerische Landesbank Kreissparkasse Sigmaringen"
     }
   },
   "amenity/bank|Hong Leong Bank": {
@@ -4021,6 +4121,16 @@
       "name": "Kasa Stefczyka"
     }
   },
+  "amenity/bank|Kasseler Sparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kasseler Sparkasse",
+      "brand:wikidata": "Q968300",
+      "brand:wikipedia": "de:Kasseler Sparkasse",
+      "name": "Kasseler Sparkasse"
+    }
+  },
   "amenity/bank|KeyBank": {
     "countryCodes": ["us"],
     "tags": {
@@ -4051,6 +4161,696 @@
       "name": "Kotak Mahindra Bank"
     }
   },
+  "amenity/bank|Kreis- und Stadtsparkasse Kaufbeuren": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreis- und Stadtsparkasse Kaufbeuren",
+      "brand:wikidata": "Q1787169",
+      "brand:wikipedia": "de:Kreis- und Stadtsparkasse Kaufbeuren",
+      "name": "Kreis- und Stadtsparkasse Kaufbeuren"
+    }
+  },
+  "amenity/bank|Kreis- und Stadtsparkasse Wasserburg am Inn": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreis- und Stadtsparkasse Wasserburg am Inn",
+      "brand:wikidata": "Q1787172",
+      "brand:wikipedia": "de:Kreis- und Stadtsparkasse Wasserburg am Inn",
+      "name": "Kreis- und Stadtsparkasse Wasserburg am Inn"
+    }
+  },
+  "amenity/bank|Kreis-Sparkasse Northeim": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreis-Sparkasse Northeim",
+      "brand:wikidata": "Q1787162",
+      "brand:wikipedia": "de:Kreis-Sparkasse Northeim",
+      "name": "Kreis-Sparkasse Northeim"
+    }
+  },
+  "amenity/bank|Kreissparkasse Ahrweiler": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Ahrweiler",
+      "brand:wikidata": "Q18022447",
+      "brand:wikipedia": "de:Kreissparkasse Ahrweiler",
+      "name": "Kreissparkasse Ahrweiler"
+    }
+  },
+  "amenity/bank|Kreissparkasse Anhalt-Bitterfeld": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Anhalt-Bitterfeld",
+      "brand:wikidata": "Q50682772",
+      "brand:wikipedia": "de:Kreissparkasse Anhalt-Bitterfeld",
+      "name": "Kreissparkasse Anhalt-Bitterfeld"
+    }
+  },
+  "amenity/bank|Kreissparkasse Augsburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Augsburg",
+      "brand:wikidata": "Q1787766",
+      "brand:wikipedia": "de:Kreissparkasse Augsburg",
+      "name": "Kreissparkasse Augsburg"
+    }
+  },
+  "amenity/bank|Kreissparkasse Bautzen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Bautzen",
+      "brand:wikidata": "Q1705051",
+      "brand:wikipedia": "de:Kreissparkasse Bautzen",
+      "name": "Kreissparkasse Bautzen"
+    }
+  },
+  "amenity/bank|Kreissparkasse Bersenbrück": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Bersenbrück",
+      "brand:wikidata": "Q1787768",
+      "brand:wikipedia": "de:Kreissparkasse Bersenbrück",
+      "name": "Kreissparkasse Bersenbrück"
+    }
+  },
+  "amenity/bank|Kreissparkasse Biberach": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Biberach",
+      "brand:wikidata": "Q1787769",
+      "brand:wikipedia": "de:Kreissparkasse Biberach",
+      "name": "Kreissparkasse Biberach"
+    }
+  },
+  "amenity/bank|Kreissparkasse Birkenfeld": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Birkenfeld",
+      "brand:wikidata": "Q1787770",
+      "brand:wikipedia": "de:Kreissparkasse Birkenfeld",
+      "name": "Kreissparkasse Birkenfeld"
+    }
+  },
+  "amenity/bank|Kreissparkasse Bitburg-Prüm": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Bitburg-Prüm",
+      "brand:wikidata": "Q18628329",
+      "brand:wikipedia": "de:Kreissparkasse Bitburg-Prüm",
+      "name": "Kreissparkasse Bitburg-Prüm"
+    }
+  },
+  "amenity/bank|Kreissparkasse Böblingen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Böblingen",
+      "brand:wikidata": "Q1290595",
+      "brand:wikipedia": "de:Kreissparkasse Böblingen",
+      "name": "Kreissparkasse Böblingen"
+    }
+  },
+  "amenity/bank|Kreissparkasse Börde": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Börde",
+      "brand:wikidata": "Q22674523",
+      "brand:wikipedia": "de:Kreissparkasse Börde",
+      "name": "Kreissparkasse Börde"
+    }
+  },
+  "amenity/bank|Kreissparkasse Döbeln": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Döbeln",
+      "brand:wikidata": "Q29019823",
+      "brand:wikipedia": "de:Kreissparkasse Döbeln",
+      "name": "Kreissparkasse Döbeln"
+    }
+  },
+  "amenity/bank|Kreissparkasse Düsseldorf": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Düsseldorf",
+      "brand:wikidata": "Q1787774",
+      "brand:wikipedia": "de:Kreissparkasse Düsseldorf",
+      "name": "Kreissparkasse Düsseldorf"
+    }
+  },
+  "amenity/bank|Kreissparkasse Eichsfeld": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Eichsfeld",
+      "brand:wikidata": "Q1691959",
+      "brand:wikipedia": "de:Kreissparkasse Eichsfeld",
+      "name": "Kreissparkasse Eichsfeld"
+    }
+  },
+  "amenity/bank|Kreissparkasse Esslingen-Nürtingen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Esslingen-Nürtingen",
+      "brand:wikidata": "Q1492852",
+      "brand:wikipedia": "de:Kreissparkasse Esslingen-Nürtingen",
+      "name": "Kreissparkasse Esslingen-Nürtingen"
+    }
+  },
+  "amenity/bank|Kreissparkasse Euskirchen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Euskirchen",
+      "brand:wikidata": "Q1787776",
+      "brand:wikipedia": "de:Kreissparkasse Euskirchen",
+      "name": "Kreissparkasse Euskirchen"
+    }
+  },
+  "amenity/bank|Kreissparkasse Freudenstadt": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Freudenstadt",
+      "brand:wikidata": "Q1787778",
+      "brand:wikipedia": "de:Kreissparkasse Freudenstadt",
+      "name": "Kreissparkasse Freudenstadt"
+    }
+  },
+  "amenity/bank|Kreissparkasse Garmisch-Partenkirchen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Garmisch-Partenkirchen",
+      "brand:wikidata": "Q1787777",
+      "brand:wikipedia": "de:Kreissparkasse Garmisch-Partenkirchen",
+      "name": "Kreissparkasse Garmisch-Partenkirchen"
+    }
+  },
+  "amenity/bank|Kreissparkasse Gelnhausen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Gelnhausen",
+      "brand:wikidata": "Q15117664",
+      "brand:wikipedia": "de:Kreissparkasse Gelnhausen",
+      "name": "Kreissparkasse Gelnhausen"
+    }
+  },
+  "amenity/bank|Kreissparkasse Gotha": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Gotha",
+      "brand:wikidata": "Q18287991",
+      "brand:wikipedia": "de:Kreissparkasse Gotha",
+      "name": "Kreissparkasse Gotha"
+    }
+  },
+  "amenity/bank|Kreissparkasse Grafschaft Bentheim zu Nordhorn": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Grafschaft Bentheim zu Nordhorn",
+      "brand:wikidata": "Q1683380",
+      "brand:wikipedia": "de:Kreissparkasse Grafschaft Bentheim zu Nordhorn",
+      "name": "Kreissparkasse Grafschaft Bentheim zu Nordhorn"
+    }
+  },
+  "amenity/bank|Kreissparkasse Grafschaft Diepholz": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Grafschaft Diepholz",
+      "brand:wikidata": "Q15117665",
+      "brand:wikipedia": "de:Kreissparkasse Grafschaft Diepholz",
+      "name": "Kreissparkasse Grafschaft Diepholz"
+    }
+  },
+  "amenity/bank|Kreissparkasse Groß-Gerau": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Groß-Gerau",
+      "brand:wikidata": "Q1559993",
+      "brand:wikipedia": "de:Kreissparkasse Groß-Gerau",
+      "name": "Kreissparkasse Groß-Gerau"
+    }
+  },
+  "amenity/bank|Kreissparkasse Göppingen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Göppingen",
+      "brand:wikidata": "Q1768338",
+      "brand:wikipedia": "de:Kreissparkasse Göppingen",
+      "name": "Kreissparkasse Göppingen"
+    }
+  },
+  "amenity/bank|Kreissparkasse Halle (Westf.)": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Halle (Westf.)",
+      "brand:wikidata": "Q18628330",
+      "brand:wikipedia": "de:Kreissparkasse Halle (Westf.)",
+      "name": "Kreissparkasse Halle (Westf.)"
+    }
+  },
+  "amenity/bank|Kreissparkasse Heidenheim": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Heidenheim",
+      "brand:wikidata": "Q37068918",
+      "brand:wikipedia": "de:Kreissparkasse Heidenheim",
+      "name": "Kreissparkasse Heidenheim"
+    }
+  },
+  "amenity/bank|Kreissparkasse Heilbronn": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Heilbronn",
+      "brand:wikidata": "Q1787781",
+      "brand:wikipedia": "de:Kreissparkasse Heilbronn",
+      "name": "Kreissparkasse Heilbronn"
+    }
+  },
+  "amenity/bank|Kreissparkasse Heinsberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Heinsberg",
+      "brand:wikidata": "Q1787782",
+      "brand:wikipedia": "de:Kreissparkasse Heinsberg",
+      "name": "Kreissparkasse Heinsberg"
+    }
+  },
+  "amenity/bank|Kreissparkasse Herzogtum Lauenburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Herzogtum Lauenburg",
+      "brand:wikidata": "Q1787780",
+      "brand:wikipedia": "de:Kreissparkasse Herzogtum Lauenburg",
+      "name": "Kreissparkasse Herzogtum Lauenburg"
+    }
+  },
+  "amenity/bank|Kreissparkasse Hildburghausen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Hildburghausen",
+      "brand:wikidata": "Q18287994",
+      "brand:wikipedia": "de:Kreissparkasse Hildburghausen",
+      "name": "Kreissparkasse Hildburghausen"
+    }
+  },
+  "amenity/bank|Kreissparkasse Kaiserslautern": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Kaiserslautern",
+      "brand:wikidata": "Q1787784",
+      "brand:wikipedia": "de:Kreissparkasse Kaiserslautern",
+      "name": "Kreissparkasse Kaiserslautern"
+    }
+  },
+  "amenity/bank|Kreissparkasse Kelheim": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Kelheim",
+      "brand:wikidata": "Q1521090",
+      "brand:wikipedia": "de:Kreissparkasse Kelheim",
+      "name": "Kreissparkasse Kelheim"
+    }
+  },
+  "amenity/bank|Kreissparkasse Kusel": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Kusel",
+      "brand:wikidata": "Q15824395",
+      "brand:wikipedia": "de:Kreissparkasse Kusel",
+      "name": "Kreissparkasse Kusel"
+    }
+  },
+  "amenity/bank|Kreissparkasse Köln": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Köln",
+      "brand:wikidata": "Q1787788",
+      "brand:wikipedia": "de:Kreissparkasse Köln",
+      "name": "Kreissparkasse Köln"
+    }
+  },
+  "amenity/bank|Kreissparkasse Limburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Limburg",
+      "brand:wikidata": "Q1787789",
+      "brand:wikipedia": "de:Kreissparkasse Limburg",
+      "name": "Kreissparkasse Limburg"
+    }
+  },
+  "amenity/bank|Kreissparkasse Ludwigsburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Ludwigsburg",
+      "brand:wikidata": "Q1787791",
+      "brand:wikipedia": "de:Kreissparkasse Ludwigsburg",
+      "name": "Kreissparkasse Ludwigsburg"
+    }
+  },
+  "amenity/bank|Kreissparkasse Mayen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Mayen",
+      "brand:wikidata": "Q1787792",
+      "brand:wikipedia": "de:Kreissparkasse Mayen",
+      "name": "Kreissparkasse Mayen"
+    }
+  },
+  "amenity/bank|Kreissparkasse Melle": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Melle",
+      "brand:wikidata": "Q1787794",
+      "brand:wikipedia": "de:Kreissparkasse Melle",
+      "name": "Kreissparkasse Melle"
+    }
+  },
+  "amenity/bank|Kreissparkasse Miesbach-Tegernsee": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Miesbach-Tegernsee",
+      "brand:wikidata": "Q1787796",
+      "brand:wikipedia": "de:Kreissparkasse Miesbach-Tegernsee",
+      "name": "Kreissparkasse Miesbach-Tegernsee"
+    }
+  },
+  "amenity/bank|Kreissparkasse München Starnberg Ebersberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse München Starnberg Ebersberg",
+      "brand:wikidata": "Q1787798",
+      "brand:wikipedia": "de:Kreissparkasse München Starnberg Ebersberg",
+      "name": "Kreissparkasse München Starnberg Ebersberg"
+    }
+  },
+  "amenity/bank|Kreissparkasse Nordhausen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Nordhausen",
+      "brand:wikidata": "Q18410516",
+      "brand:wikipedia": "de:Kreissparkasse Nordhausen",
+      "name": "Kreissparkasse Nordhausen"
+    }
+  },
+  "amenity/bank|Kreissparkasse Ostalb": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Ostalb",
+      "brand:wikidata": "Q1787800",
+      "brand:wikipedia": "de:Kreissparkasse Ostalb",
+      "name": "Kreissparkasse Ostalb"
+    }
+  },
+  "amenity/bank|Kreissparkasse Ravensburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Ravensburg",
+      "brand:wikidata": "Q1385106",
+      "brand:wikipedia": "de:Kreissparkasse Ravensburg",
+      "name": "Kreissparkasse Ravensburg"
+    }
+  },
+  "amenity/bank|Kreissparkasse Reutlingen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Reutlingen",
+      "brand:wikidata": "Q1787801",
+      "brand:wikipedia": "de:Kreissparkasse Reutlingen",
+      "name": "Kreissparkasse Reutlingen"
+    }
+  },
+  "amenity/bank|Kreissparkasse Rhein-Hunsrück": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Rhein-Hunsrück",
+      "brand:wikidata": "Q1525586",
+      "brand:wikipedia": "de:Kreissparkasse Rhein-Hunsrück",
+      "name": "Kreissparkasse Rhein-Hunsrück"
+    }
+  },
+  "amenity/bank|Kreissparkasse Rottweil": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Rottweil",
+      "brand:wikidata": "Q1787803",
+      "brand:wikipedia": "de:Kreissparkasse Rottweil",
+      "name": "Kreissparkasse Rottweil"
+    }
+  },
+  "amenity/bank|Kreissparkasse Saale-Orla": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Saale-Orla",
+      "brand:wikidata": "Q18287998",
+      "brand:wikipedia": "de:Kreissparkasse Saale-Orla",
+      "name": "Kreissparkasse Saale-Orla"
+    }
+  },
+  "amenity/bank|Kreissparkasse Saalfeld-Rudolstadt": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Saalfeld-Rudolstadt",
+      "brand:wikidata": "Q1787802",
+      "brand:wikipedia": "de:Kreissparkasse Saalfeld-Rudolstadt",
+      "name": "Kreissparkasse Saalfeld-Rudolstadt"
+    }
+  },
+  "amenity/bank|Kreissparkasse Saarlouis": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Saarlouis",
+      "brand:wikidata": "Q18628332",
+      "brand:wikipedia": "de:Kreissparkasse Saarlouis",
+      "name": "Kreissparkasse Saarlouis"
+    }
+  },
+  "amenity/bank|Kreissparkasse Saarpfalz": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Saarpfalz",
+      "brand:wikidata": "Q1787806",
+      "brand:wikipedia": "de:Kreissparkasse Saarpfalz",
+      "name": "Kreissparkasse Saarpfalz"
+    }
+  },
+  "amenity/bank|Kreissparkasse Schlüchtern": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Schlüchtern",
+      "brand:wikidata": "Q15117674",
+      "brand:wikipedia": "de:Kreissparkasse Schlüchtern",
+      "name": "Kreissparkasse Schlüchtern"
+    }
+  },
+  "amenity/bank|Kreissparkasse Schwalm-Eder": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Schwalm-Eder",
+      "brand:wikidata": "Q1787808",
+      "brand:wikipedia": "de:Kreissparkasse Schwalm-Eder",
+      "name": "Kreissparkasse Schwalm-Eder"
+    }
+  },
+  "amenity/bank|Kreissparkasse Soltau": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Soltau",
+      "brand:wikidata": "Q1787807",
+      "brand:wikipedia": "de:Kreissparkasse Soltau",
+      "name": "Kreissparkasse Soltau"
+    }
+  },
+  "amenity/bank|Kreissparkasse St. Wendel": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse St. Wendel",
+      "brand:wikidata": "Q1787809",
+      "brand:wikipedia": "de:Kreissparkasse St. Wendel",
+      "name": "Kreissparkasse St. Wendel"
+    }
+  },
+  "amenity/bank|Kreissparkasse Stade": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Stade",
+      "brand:wikidata": "Q1698040",
+      "brand:wikipedia": "de:Kreissparkasse Stade",
+      "name": "Kreissparkasse Stade"
+    }
+  },
+  "amenity/bank|Kreissparkasse Steinfurt": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Steinfurt",
+      "brand:wikidata": "Q15992040",
+      "brand:wikipedia": "de:Kreissparkasse Steinfurt",
+      "name": "Kreissparkasse Steinfurt"
+    }
+  },
+  "amenity/bank|Kreissparkasse Stendal": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Stendal",
+      "brand:wikidata": "Q56070842",
+      "brand:wikipedia": "de:Kreissparkasse Stendal",
+      "name": "Kreissparkasse Stendal"
+    }
+  },
+  "amenity/bank|Kreissparkasse Syke": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Syke",
+      "brand:wikidata": "Q1787810",
+      "brand:wikipedia": "de:Kreissparkasse Syke",
+      "name": "Kreissparkasse Syke"
+    }
+  },
+  "amenity/bank|Kreissparkasse Traunstein-Trostberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Traunstein-Trostberg",
+      "brand:wikidata": "Q1298364",
+      "brand:wikipedia": "de:Kreissparkasse Traunstein-Trostberg",
+      "name": "Kreissparkasse Traunstein-Trostberg"
+    }
+  },
+  "amenity/bank|Kreissparkasse Tuttlingen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Tuttlingen",
+      "brand:wikidata": "Q16832628",
+      "brand:wikipedia": "de:Kreissparkasse Tuttlingen",
+      "name": "Kreissparkasse Tuttlingen"
+    }
+  },
+  "amenity/bank|Kreissparkasse Tübingen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Tübingen",
+      "brand:wikidata": "Q1787813",
+      "brand:wikipedia": "de:Kreissparkasse Tübingen",
+      "name": "Kreissparkasse Tübingen"
+    }
+  },
+  "amenity/bank|Kreissparkasse Verden": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Verden",
+      "brand:wikidata": "Q1787815",
+      "brand:wikipedia": "de:Kreissparkasse Verden",
+      "name": "Kreissparkasse Verden"
+    }
+  },
+  "amenity/bank|Kreissparkasse Vulkaneifel": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Vulkaneifel",
+      "brand:wikidata": "Q18628333",
+      "brand:wikipedia": "de:Kreissparkasse Vulkaneifel",
+      "name": "Kreissparkasse Vulkaneifel"
+    }
+  },
+  "amenity/bank|Kreissparkasse Waiblingen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Waiblingen",
+      "brand:wikidata": "Q1787814",
+      "brand:wikipedia": "de:Kreissparkasse Waiblingen",
+      "name": "Kreissparkasse Waiblingen"
+    }
+  },
+  "amenity/bank|Kreissparkasse Walsrode": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Walsrode",
+      "brand:wikidata": "Q1787817",
+      "brand:wikipedia": "de:Kreissparkasse Walsrode",
+      "name": "Kreissparkasse Walsrode"
+    }
+  },
+  "amenity/bank|Kreissparkasse Weilburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Weilburg",
+      "brand:wikidata": "Q1787819",
+      "brand:wikipedia": "de:Kreissparkasse Weilburg",
+      "name": "Kreissparkasse Weilburg"
+    }
+  },
+  "amenity/bank|Kreissparkasse Wiedenbrück": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kreissparkasse Wiedenbrück",
+      "brand:wikidata": "Q1787821",
+      "brand:wikipedia": "de:Kreissparkasse Wiedenbrück",
+      "name": "Kreissparkasse Wiedenbrück"
+    }
+  },
   "amenity/bank|Kutxabank": {
     "countryCodes": ["es"],
     "tags": {
@@ -4069,6 +4869,16 @@
       "brand:wikidata": "Q6036058",
       "brand:wikipedia": "tr:Kuveyt Türk",
       "name": "Kuveyt Türk"
+    }
+  },
+  "amenity/bank|Kyffhäusersparkasse Artern-Sondershausen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Kyffhäusersparkasse Artern-Sondershausen",
+      "brand:wikidata": "Q18333732",
+      "brand:wikipedia": "de:Kyffhäusersparkasse Artern-Sondershausen",
+      "name": "Kyffhäusersparkasse Artern-Sondershausen"
     }
   },
   "amenity/bank|LCL": {
@@ -4146,6 +4956,16 @@
       "brand:wikidata": "Q6483872",
       "brand:wikipedia": "en:Land Bank of the Philippines",
       "name": "Landbank"
+    }
+  },
+  "amenity/bank|Landessparkasse zu Oldenburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Landessparkasse zu Oldenburg",
+      "brand:wikidata": "Q1802620",
+      "brand:wikipedia": "de:Landessparkasse zu Oldenburg",
+      "name": "Landessparkasse zu Oldenburg"
     }
   },
   "amenity/bank|Leeds Building Society": {
@@ -4365,7 +5185,8 @@
       "brand": "Mittelbrandenburgische Sparkasse",
       "brand:wikidata": "Q1940058",
       "brand:wikipedia": "de:Mittelbrandenburgische Sparkasse",
-      "name": "Mittelbrandenburgische Sparkasse"
+      "name": "Mittelbrandenburgische Sparkasse",
+      "short_name": "MBS"
     }
   },
   "amenity/bank|Monte dei Paschi di Siena": {
@@ -4396,6 +5217,16 @@
       "brand:wikidata": "Q6924862",
       "brand:wikipedia": "en:Mountain America Credit Union",
       "name": "Mountain America Credit Union"
+    }
+  },
+  "amenity/bank|Müritz-Sparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Müritz-Sparkasse",
+      "brand:wikidata": "Q1959286",
+      "brand:wikipedia": "de:Müritz-Sparkasse",
+      "name": "Müritz-Sparkasse"
     }
   },
   "amenity/bank|NAB": {
@@ -4435,6 +5266,16 @@
       "brand:wikidata": "Q12500189",
       "brand:wikipedia": "en:National Savings Bank (Sri Lanka)",
       "name": "NSB"
+    }
+  },
+  "amenity/bank|Nassauische Sparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Nassauische Sparkasse",
+      "brand:wikidata": "Q1751833",
+      "brand:wikipedia": "de:Nassauische Sparkasse",
+      "name": "Nassauische Sparkasse"
     }
   },
   "amenity/bank|NatWest": {
@@ -4495,6 +5336,27 @@
       "brand:wikidata": "Q2751701",
       "brand:wikipedia": "en:Nedbank",
       "name": "Nedbank"
+    }
+  },
+  "amenity/bank|Niederrheinische Sparkasse RheinLippe": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Niederrheinische Sparkasse RheinLippe",
+      "brand:wikidata": "Q22674731",
+      "brand:wikipedia": "de:Niederrheinische Sparkasse RheinLippe",
+      "name": "Niederrheinische Sparkasse RheinLippe",
+      "short_name": "Nispa"
+    }
+  },
+  "amenity/bank|Nord-Ostsee Sparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Nord-Ostsee Sparkasse",
+      "brand:wikidata": "Q1369016",
+      "brand:wikipedia": "de:Nord-Ostsee Sparkasse",
+      "name": "Nord-Ostsee Sparkasse"
     }
   },
   "amenity/bank|Nordea": {
@@ -4594,6 +5456,26 @@
       "brand:wikidata": "Q367008",
       "brand:wikipedia": "en:Oriental Bank of Commerce",
       "name": "Oriental Bank of Commerce"
+    }
+  },
+  "amenity/bank|OstseeSparkasse Rostock": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "OstseeSparkasse Rostock",
+      "brand:wikidata": "Q2036055",
+      "brand:wikipedia": "de:OstseeSparkasse Rostock",
+      "name": "OstseeSparkasse Rostock"
+    }
+  },
+  "amenity/bank|Ostsächsische Sparkasse Dresden": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Ostsächsische Sparkasse Dresden",
+      "brand:wikidata": "Q2036125",
+      "brand:wikipedia": "de:Ostsächsische Sparkasse Dresden",
+      "name": "Ostsächsische Sparkasse Dresden"
     }
   },
   "amenity/bank|Osuuspankki": {
@@ -5117,6 +5999,16 @@
       "name": "República"
     }
   },
+  "amenity/bank|Rhön-Rennsteig-Sparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Rhön-Rennsteig-Sparkasse",
+      "brand:wikidata": "Q2148396",
+      "brand:wikipedia": "de:Rhön-Rennsteig-Sparkasse",
+      "name": "Rhön-Rennsteig-Sparkasse"
+    }
+  },
   "amenity/bank|S-Pankki": {
     "countryCodes": ["fi"],
     "tags": {
@@ -5177,6 +6069,16 @@
       "name": "SNS Bank"
     }
   },
+  "amenity/bank|Saalesparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Saalesparkasse",
+      "brand:wikidata": "Q22674685",
+      "brand:wikipedia": "de:Saalesparkasse",
+      "name": "Saalesparkasse"
+    }
+  },
   "amenity/bank|Sacombank": {
     "tags": {
       "amenity": "bank",
@@ -5184,6 +6086,16 @@
       "brand:wikidata": "Q6123772",
       "brand:wikipedia": "vi:Ngân hàng thương mại cổ phần Sài Gòn Thương Tín",
       "name": "Sacombank"
+    }
+  },
+  "amenity/bank|Salzlandsparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Salzlandsparkasse",
+      "brand:wikidata": "Q15965171",
+      "brand:wikipedia": "de:Salzlandsparkasse",
+      "name": "Salzlandsparkasse"
     }
   },
   "amenity/bank|Sampath Bank": {
@@ -5457,6 +6369,2776 @@
       "name": "Sparda-Bank"
     }
   },
+  "amenity/bank|Sparkasse Aachen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Aachen",
+      "brand:wikidata": "Q2307270",
+      "brand:wikipedia": "de:Sparkasse Aachen",
+      "name": "Sparkasse Aachen"
+    }
+  },
+  "amenity/bank|Sparkasse Aichach-Schrobenhausen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Aichach-Schrobenhausen",
+      "brand:wikidata": "Q15848089",
+      "brand:wikipedia": "de:Sparkasse Aichach-Schrobenhausen",
+      "name": "Sparkasse Aichach-Schrobenhausen"
+    }
+  },
+  "amenity/bank|Sparkasse Allgäu": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Allgäu",
+      "brand:wikidata": "Q1337936",
+      "brand:wikipedia": "de:Sparkasse Allgäu",
+      "name": "Sparkasse Allgäu"
+    }
+  },
+  "amenity/bank|Sparkasse Altenburger Land": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Altenburger Land",
+      "brand:wikidata": "Q1650564",
+      "brand:wikipedia": "de:Sparkasse Altenburger Land",
+      "name": "Sparkasse Altenburger Land"
+    }
+  },
+  "amenity/bank|Sparkasse Altmark West": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Altmark West",
+      "brand:wikidata": "Q56070799",
+      "brand:wikipedia": "de:Sparkasse Altmark West",
+      "name": "Sparkasse Altmark West"
+    }
+  },
+  "amenity/bank|Sparkasse Altötting-Mühldorf": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Altötting-Mühldorf",
+      "brand:wikidata": "Q1795025",
+      "brand:wikipedia": "de:Sparkasse Altötting-Mühldorf",
+      "name": "Sparkasse Altötting-Mühldorf"
+    }
+  },
+  "amenity/bank|Sparkasse Amberg-Sulzbach": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Amberg-Sulzbach",
+      "brand:wikidata": "Q1565995",
+      "brand:wikipedia": "de:Sparkasse Amberg-Sulzbach",
+      "name": "Sparkasse Amberg-Sulzbach"
+    }
+  },
+  "amenity/bank|Sparkasse Ansbach": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Ansbach",
+      "brand:wikidata": "Q2514965",
+      "brand:wikipedia": "de:Sparkasse Ansbach",
+      "name": "Sparkasse Ansbach"
+    }
+  },
+  "amenity/bank|Sparkasse Arnsberg-Sundern": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Arnsberg-Sundern",
+      "brand:wikidata": "Q2307278",
+      "brand:wikipedia": "de:Sparkasse Arnsberg-Sundern",
+      "name": "Sparkasse Arnsberg-Sundern"
+    }
+  },
+  "amenity/bank|Sparkasse Arnstadt-Ilmenau": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Arnstadt-Ilmenau",
+      "brand:wikidata": "Q2307280",
+      "brand:wikipedia": "de:Sparkasse Arnstadt-Ilmenau",
+      "name": "Sparkasse Arnstadt-Ilmenau"
+    }
+  },
+  "amenity/bank|Sparkasse Aschaffenburg-Alzenau": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Aschaffenburg-Alzenau",
+      "brand:wikidata": "Q2307290",
+      "brand:wikipedia": "de:Sparkasse Aschaffenburg-Alzenau",
+      "name": "Sparkasse Aschaffenburg-Alzenau"
+    }
+  },
+  "amenity/bank|Sparkasse Attendorn-Lennestadt-Kirchhundem": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Attendorn-Lennestadt-Kirchhundem",
+      "brand:wikidata": "Q18413109",
+      "brand:wikipedia": "de:Sparkasse Attendorn-Lennestadt-Kirchhundem",
+      "name": "Sparkasse Attendorn-Lennestadt-Kirchhundem"
+    }
+  },
+  "amenity/bank|Sparkasse Aurich-Norden": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Aurich-Norden",
+      "brand:wikidata": "Q2307293",
+      "brand:wikipedia": "de:Sparkasse Aurich-Norden",
+      "name": "Sparkasse Aurich-Norden"
+    }
+  },
+  "amenity/bank|Sparkasse Bad Hersfeld-Rotenburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bad Hersfeld-Rotenburg",
+      "brand:wikidata": "Q2307301",
+      "brand:wikipedia": "de:Sparkasse Bad Hersfeld-Rotenburg",
+      "name": "Sparkasse Bad Hersfeld-Rotenburg"
+    }
+  },
+  "amenity/bank|Sparkasse Bad Kissingen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bad Kissingen",
+      "brand:wikidata": "Q2307302",
+      "brand:wikipedia": "de:Sparkasse Bad Kissingen",
+      "name": "Sparkasse Bad Kissingen"
+    }
+  },
+  "amenity/bank|Sparkasse Bad Neustadt a. d. Saale": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bad Neustadt a. d. Saale",
+      "brand:wikidata": "Q2307304",
+      "brand:wikipedia": "de:Sparkasse Bad Neustadt a. d. Saale",
+      "name": "Sparkasse Bad Neustadt a. d. Saale"
+    }
+  },
+  "amenity/bank|Sparkasse Bad Oeynhausen - Porta Westfalica": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bad Oeynhausen - Porta Westfalica",
+      "brand:wikidata": "Q2328084",
+      "brand:wikipedia": "de:Sparkasse Bad Oeynhausen - Porta Westfalica",
+      "name": "Sparkasse Bad Oeynhausen - Porta Westfalica"
+    }
+  },
+  "amenity/bank|Sparkasse Bad Tölz-Wolfratshausen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bad Tölz-Wolfratshausen",
+      "brand:wikidata": "Q2307310",
+      "brand:wikipedia": "de:Sparkasse Bad Tölz-Wolfratshausen",
+      "name": "Sparkasse Bad Tölz-Wolfratshausen"
+    }
+  },
+  "amenity/bank|Sparkasse Baden-Baden Gaggenau": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Baden-Baden Gaggenau",
+      "brand:wikidata": "Q19059957",
+      "brand:wikipedia": "de:Sparkasse Baden-Baden Gaggenau",
+      "name": "Sparkasse Baden-Baden Gaggenau"
+    }
+  },
+  "amenity/bank|Sparkasse Bamberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bamberg",
+      "brand:wikidata": "Q2307311",
+      "brand:wikipedia": "de:Sparkasse Bamberg",
+      "name": "Sparkasse Bamberg"
+    }
+  },
+  "amenity/bank|Sparkasse Barnim": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Barnim",
+      "brand:wikidata": "Q2307313",
+      "brand:wikipedia": "de:Sparkasse Barnim",
+      "name": "Sparkasse Barnim"
+    }
+  },
+  "amenity/bank|Sparkasse Battenberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Battenberg",
+      "brand:wikidata": "Q15128915",
+      "brand:wikipedia": "de:Sparkasse Battenberg",
+      "name": "Sparkasse Battenberg"
+    }
+  },
+  "amenity/bank|Sparkasse Bayreuth": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bayreuth",
+      "brand:wikidata": "Q1340647",
+      "brand:wikipedia": "de:Sparkasse Bayreuth",
+      "name": "Sparkasse Bayreuth"
+    }
+  },
+  "amenity/bank|Sparkasse Beckum-Wadersloh": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Beckum-Wadersloh",
+      "brand:wikidata": "Q15128916",
+      "brand:wikipedia": "de:Sparkasse Beckum-Wadersloh",
+      "name": "Sparkasse Beckum-Wadersloh"
+    }
+  },
+  "amenity/bank|Sparkasse Bensheim": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bensheim",
+      "brand:wikidata": "Q2307319",
+      "brand:wikipedia": "de:Sparkasse Bensheim",
+      "name": "Sparkasse Bensheim"
+    }
+  },
+  "amenity/bank|Sparkasse Berchtesgadener Land": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Berchtesgadener Land",
+      "brand:wikidata": "Q1644106",
+      "brand:wikipedia": "de:Sparkasse Berchtesgadener Land",
+      "name": "Sparkasse Berchtesgadener Land"
+    }
+  },
+  "amenity/bank|Sparkasse Bergkamen-Bönen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bergkamen-Bönen",
+      "brand:wikidata": "Q18413111",
+      "brand:wikipedia": "de:Sparkasse Bergkamen-Bönen",
+      "name": "Sparkasse Bergkamen-Bönen"
+    }
+  },
+  "amenity/bank|Sparkasse Bielefeld": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bielefeld",
+      "brand:wikidata": "Q1767965",
+      "brand:wikipedia": "de:Sparkasse Bielefeld",
+      "name": "Sparkasse Bielefeld"
+    }
+  },
+  "amenity/bank|Sparkasse Bochum": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bochum",
+      "brand:wikidata": "Q2307321",
+      "brand:wikipedia": "de:Sparkasse Bochum",
+      "name": "Sparkasse Bochum"
+    }
+  },
+  "amenity/bank|Sparkasse Bodensee": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bodensee",
+      "brand:wikidata": "Q2307325",
+      "brand:wikipedia": "de:Sparkasse Bodensee",
+      "name": "Sparkasse Bodensee"
+    }
+  },
+  "amenity/bank|Sparkasse Bonndorf-Stühlingen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bonndorf-Stühlingen",
+      "brand:wikidata": "Q2307330",
+      "brand:wikipedia": "de:Sparkasse Bonndorf-Stühlingen",
+      "name": "Sparkasse Bonndorf-Stühlingen"
+    }
+  },
+  "amenity/bank|Sparkasse Bottrop": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bottrop",
+      "brand:wikidata": "Q18630899",
+      "brand:wikipedia": "de:Sparkasse Bottrop",
+      "name": "Sparkasse Bottrop"
+    }
+  },
+  "amenity/bank|Sparkasse Bremen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bremen",
+      "brand:wikidata": "Q1643208",
+      "brand:wikipedia": "de:Sparkasse Bremen",
+      "name": "Sparkasse Bremen"
+    }
+  },
+  "amenity/bank|Sparkasse Burbach-Neunkirchen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Burbach-Neunkirchen",
+      "brand:wikidata": "Q18630901",
+      "brand:wikipedia": "de:Sparkasse Burbach-Neunkirchen",
+      "name": "Sparkasse Burbach-Neunkirchen"
+    }
+  },
+  "amenity/bank|Sparkasse Burgenlandkreis": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Burgenlandkreis",
+      "brand:wikidata": "Q1393306",
+      "brand:wikipedia": "de:Sparkasse Burgenlandkreis",
+      "name": "Sparkasse Burgenlandkreis"
+    }
+  },
+  "amenity/bank|Sparkasse Bühl": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Bühl",
+      "brand:wikidata": "Q26794521",
+      "brand:wikipedia": "de:Sparkasse Bühl",
+      "name": "Sparkasse Bühl"
+    }
+  },
+  "amenity/bank|Sparkasse Celle-Gifhorn-Wolfsburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Celle-Gifhorn-Wolfsburg",
+      "brand:wikidata": "Q2307429",
+      "brand:wikipedia": "de:Sparkasse Celle-Gifhorn-Wolfsburg",
+      "name": "Sparkasse Celle-Gifhorn-Wolfsburg"
+    }
+  },
+  "amenity/bank|Sparkasse Chemnitz": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Chemnitz",
+      "brand:wikidata": "Q2307340",
+      "brand:wikipedia": "de:Sparkasse Chemnitz",
+      "name": "Sparkasse Chemnitz"
+    }
+  },
+  "amenity/bank|Sparkasse Coburg - Lichtenfels": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Coburg - Lichtenfels",
+      "brand:wikidata": "Q2307342",
+      "brand:wikipedia": "de:Sparkasse Coburg - Lichtenfels",
+      "name": "Sparkasse Coburg - Lichtenfels"
+    }
+  },
+  "amenity/bank|Sparkasse Dachau": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Dachau",
+      "brand:wikidata": "Q2307347",
+      "brand:wikipedia": "de:Sparkasse Dachau",
+      "name": "Sparkasse Dachau"
+    }
+  },
+  "amenity/bank|Sparkasse Darmstadt": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Darmstadt",
+      "brand:wikidata": "Q2307349",
+      "brand:wikipedia": "de:Sparkasse Darmstadt",
+      "name": "Sparkasse Darmstadt"
+    }
+  },
+  "amenity/bank|Sparkasse Deggendorf": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Deggendorf",
+      "brand:wikidata": "Q2307353",
+      "brand:wikipedia": "de:Sparkasse Deggendorf",
+      "name": "Sparkasse Deggendorf"
+    }
+  },
+  "amenity/bank|Sparkasse Dieburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Dieburg",
+      "brand:wikidata": "Q2307358",
+      "brand:wikipedia": "de:Sparkasse Dieburg",
+      "name": "Sparkasse Dieburg"
+    }
+  },
+  "amenity/bank|Sparkasse Dillenburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Dillenburg",
+      "brand:wikidata": "Q18289500",
+      "brand:wikipedia": "de:Sparkasse Dillenburg",
+      "name": "Sparkasse Dillenburg"
+    }
+  },
+  "amenity/bank|Sparkasse Dillingen-Nördlingen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Dillingen-Nördlingen",
+      "brand:wikidata": "Q1656888",
+      "brand:wikipedia": "de:Sparkasse Dillingen-Nördlingen",
+      "name": "Sparkasse Dillingen-Nördlingen"
+    }
+  },
+  "amenity/bank|Sparkasse Donauwörth": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Donauwörth",
+      "brand:wikidata": "Q2307363",
+      "brand:wikipedia": "de:Sparkasse Donauwörth",
+      "name": "Sparkasse Donauwörth"
+    }
+  },
+  "amenity/bank|Sparkasse Donnersberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Donnersberg",
+      "brand:wikidata": "Q18630903",
+      "brand:wikipedia": "de:Sparkasse Donnersberg",
+      "name": "Sparkasse Donnersberg"
+    }
+  },
+  "amenity/bank|Sparkasse Dortmund": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Dortmund",
+      "brand:wikidata": "Q1493538",
+      "brand:wikipedia": "de:Sparkasse Dortmund",
+      "name": "Sparkasse Dortmund"
+    }
+  },
+  "amenity/bank|Sparkasse Duderstadt": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Duderstadt",
+      "brand:wikidata": "Q2307371",
+      "brand:wikipedia": "de:Sparkasse Duderstadt",
+      "name": "Sparkasse Duderstadt"
+    }
+  },
+  "amenity/bank|Sparkasse Duisburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Duisburg",
+      "brand:wikidata": "Q2307372",
+      "brand:wikipedia": "de:Sparkasse Duisburg",
+      "name": "Sparkasse Duisburg"
+    }
+  },
+  "amenity/bank|Sparkasse Düren": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Düren",
+      "brand:wikidata": "Q2307375",
+      "brand:wikipedia": "de:Sparkasse Düren",
+      "name": "Sparkasse Düren"
+    }
+  },
+  "amenity/bank|Sparkasse Einbeck": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Einbeck",
+      "brand:wikidata": "Q1230532",
+      "brand:wikipedia": "de:Sparkasse Einbeck",
+      "name": "Sparkasse Einbeck"
+    }
+  },
+  "amenity/bank|Sparkasse Elbe-Elster": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Elbe-Elster",
+      "brand:wikidata": "Q2307386",
+      "brand:wikipedia": "de:Sparkasse Elbe-Elster",
+      "name": "Sparkasse Elbe-Elster"
+    }
+  },
+  "amenity/bank|Sparkasse Elmshorn": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Elmshorn",
+      "brand:wikidata": "Q1347636",
+      "brand:wikipedia": "de:Sparkasse Elmshorn",
+      "name": "Sparkasse Elmshorn"
+    }
+  },
+  "amenity/bank|Sparkasse Emden": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Emden",
+      "brand:wikidata": "Q1389719",
+      "brand:wikipedia": "de:Sparkasse Emden",
+      "name": "Sparkasse Emden"
+    }
+  },
+  "amenity/bank|Sparkasse Emsland": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Emsland",
+      "brand:wikidata": "Q2307391",
+      "brand:wikipedia": "de:Sparkasse Emsland",
+      "name": "Sparkasse Emsland"
+    }
+  },
+  "amenity/bank|Sparkasse Engen-Gottmadingen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Engen-Gottmadingen",
+      "brand:wikidata": "Q56070863",
+      "brand:wikipedia": "de:Sparkasse Engen-Gottmadingen",
+      "name": "Sparkasse Engen-Gottmadingen"
+    }
+  },
+  "amenity/bank|Sparkasse Ennepetal-Breckerfeld": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Ennepetal-Breckerfeld",
+      "brand:wikidata": "Q18630905",
+      "brand:wikipedia": "de:Sparkasse Ennepetal-Breckerfeld",
+      "name": "Sparkasse Ennepetal-Breckerfeld"
+    }
+  },
+  "amenity/bank|Sparkasse Erding – Dorfen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Erding – Dorfen",
+      "brand:wikidata": "Q1787168",
+      "brand:wikipedia": "de:Sparkasse Erding – Dorfen",
+      "name": "Sparkasse Erding – Dorfen"
+    }
+  },
+  "amenity/bank|Sparkasse Erlangen Höchstadt Herzogenaurach": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Erlangen Höchstadt Herzogenaurach",
+      "brand:wikidata": "Q2326324",
+      "brand:wikipedia": "de:Sparkasse Erlangen Höchstadt Herzogenaurach",
+      "name": "Sparkasse Erlangen Höchstadt Herzogenaurach"
+    }
+  },
+  "amenity/bank|Sparkasse Essen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Essen",
+      "brand:wikidata": "Q2307400",
+      "brand:wikipedia": "de:Sparkasse Essen",
+      "name": "Sparkasse Essen"
+    }
+  },
+  "amenity/bank|Sparkasse Forchheim": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Forchheim",
+      "brand:wikidata": "Q2307408",
+      "brand:wikipedia": "de:Sparkasse Forchheim",
+      "name": "Sparkasse Forchheim"
+    }
+  },
+  "amenity/bank|Sparkasse Freiburg-Nördlicher Breisgau": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Freiburg-Nördlicher Breisgau",
+      "brand:wikidata": "Q15128927",
+      "brand:wikipedia": "de:Sparkasse Freiburg-Nördlicher Breisgau",
+      "name": "Sparkasse Freiburg-Nördlicher Breisgau"
+    }
+  },
+  "amenity/bank|Sparkasse Freising": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Freising",
+      "brand:wikidata": "Q1617919",
+      "brand:wikipedia": "de:Sparkasse Freising",
+      "name": "Sparkasse Freising"
+    }
+  },
+  "amenity/bank|Sparkasse Freyung-Grafenau": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Freyung-Grafenau",
+      "brand:wikidata": "Q2307413",
+      "brand:wikipedia": "de:Sparkasse Freyung-Grafenau",
+      "name": "Sparkasse Freyung-Grafenau"
+    }
+  },
+  "amenity/bank|Sparkasse Fulda": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Fulda",
+      "brand:wikidata": "Q1331819",
+      "brand:wikipedia": "de:Sparkasse Fulda",
+      "name": "Sparkasse Fulda"
+    }
+  },
+  "amenity/bank|Sparkasse Fürstenfeldbruck": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Fürstenfeldbruck",
+      "brand:wikidata": "Q1312801",
+      "brand:wikipedia": "de:Sparkasse Fürstenfeldbruck",
+      "name": "Sparkasse Fürstenfeldbruck"
+    }
+  },
+  "amenity/bank|Sparkasse Fürth": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Fürth",
+      "brand:wikidata": "Q2307414",
+      "brand:wikipedia": "de:Sparkasse Fürth",
+      "name": "Sparkasse Fürth"
+    }
+  },
+  "amenity/bank|Sparkasse Gelsenkirchen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Gelsenkirchen",
+      "brand:wikidata": "Q18630912",
+      "brand:wikipedia": "de:Sparkasse Gelsenkirchen",
+      "name": "Sparkasse Gelsenkirchen"
+    }
+  },
+  "amenity/bank|Sparkasse Gengenbach": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Gengenbach",
+      "brand:wikidata": "Q26794527",
+      "brand:wikipedia": "de:Sparkasse Gengenbach",
+      "name": "Sparkasse Gengenbach"
+    }
+  },
+  "amenity/bank|Sparkasse Gera-Greiz": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Gera-Greiz",
+      "brand:wikidata": "Q2307417",
+      "brand:wikipedia": "de:Sparkasse Gera-Greiz",
+      "name": "Sparkasse Gera-Greiz"
+    }
+  },
+  "amenity/bank|Sparkasse Germersheim-Kandel": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Germersheim-Kandel",
+      "brand:wikidata": "Q2307421",
+      "brand:wikipedia": "de:Sparkasse Germersheim-Kandel",
+      "name": "Sparkasse Germersheim-Kandel"
+    }
+  },
+  "amenity/bank|Sparkasse Geseke": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Geseke",
+      "brand:wikidata": "Q2307425",
+      "brand:wikipedia": "de:Sparkasse Geseke",
+      "name": "Sparkasse Geseke"
+    }
+  },
+  "amenity/bank|Sparkasse Gevelsberg-Wetter": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Gevelsberg-Wetter",
+      "brand:wikidata": "Q2328103",
+      "brand:wikipedia": "de:Sparkasse Gevelsberg-Wetter",
+      "name": "Sparkasse Gevelsberg-Wetter"
+    }
+  },
+  "amenity/bank|Sparkasse Gießen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Gießen",
+      "brand:wikidata": "Q2307427",
+      "brand:wikipedia": "de:Sparkasse Gießen",
+      "name": "Sparkasse Gießen"
+    }
+  },
+  "amenity/bank|Sparkasse Gladbeck": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Gladbeck",
+      "brand:wikidata": "Q18630914",
+      "brand:wikipedia": "de:Sparkasse Gladbeck",
+      "name": "Sparkasse Gladbeck"
+    }
+  },
+  "amenity/bank|Sparkasse Grünberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Grünberg",
+      "brand:wikidata": "Q18289502",
+      "brand:wikipedia": "de:Sparkasse Grünberg",
+      "name": "Sparkasse Grünberg"
+    }
+  },
+  "amenity/bank|Sparkasse Gummersbach": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Gummersbach",
+      "brand:wikidata": "Q15848090",
+      "brand:wikipedia": "de:Sparkasse Gummersbach",
+      "name": "Sparkasse Gummersbach"
+    }
+  },
+  "amenity/bank|Sparkasse Göttingen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Göttingen",
+      "brand:wikidata": "Q2307434",
+      "brand:wikipedia": "de:Sparkasse Göttingen",
+      "name": "Sparkasse Göttingen"
+    }
+  },
+  "amenity/bank|Sparkasse Günzburg-Krumbach": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Günzburg-Krumbach",
+      "brand:wikidata": "Q1425072",
+      "brand:wikipedia": "de:Sparkasse Günzburg-Krumbach",
+      "name": "Sparkasse Günzburg-Krumbach"
+    }
+  },
+  "amenity/bank|Sparkasse Gütersloh-Rietberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Gütersloh-Rietberg",
+      "brand:wikidata": "Q15128932",
+      "brand:wikipedia": "de:Sparkasse Gütersloh-Rietberg",
+      "name": "Sparkasse Gütersloh-Rietberg"
+    }
+  },
+  "amenity/bank|Sparkasse HagenHerdecke": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse HagenHerdecke",
+      "brand:wikidata": "Q1644724",
+      "brand:wikipedia": "de:Sparkasse HagenHerdecke",
+      "name": "Sparkasse HagenHerdecke"
+    }
+  },
+  "amenity/bank|Sparkasse Hameln-Weserbergland": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Hameln-Weserbergland",
+      "brand:wikidata": "Q22674568",
+      "brand:wikipedia": "de:Sparkasse Hameln-Weserbergland",
+      "name": "Sparkasse Hameln-Weserbergland"
+    }
+  },
+  "amenity/bank|Sparkasse Hamm": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Hamm",
+      "brand:wikidata": "Q18630921",
+      "brand:wikipedia": "de:Sparkasse Hamm",
+      "name": "Sparkasse Hamm"
+    }
+  },
+  "amenity/bank|Sparkasse Hanau": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Hanau",
+      "brand:wikidata": "Q2307440",
+      "brand:wikipedia": "de:Sparkasse Hanau",
+      "name": "Sparkasse Hanau"
+    }
+  },
+  "amenity/bank|Sparkasse Hanauerland": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Hanauerland",
+      "brand:wikidata": "Q2307444",
+      "brand:wikipedia": "de:Sparkasse Hanauerland",
+      "name": "Sparkasse Hanauerland"
+    }
+  },
+  "amenity/bank|Sparkasse Hannover": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Hannover",
+      "brand:wikidata": "Q2307451",
+      "brand:wikipedia": "de:Sparkasse Hannover",
+      "name": "Sparkasse Hannover"
+    }
+  },
+  "amenity/bank|Sparkasse Harburg-Buxtehude": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Harburg-Buxtehude",
+      "brand:wikidata": "Q2307455",
+      "brand:wikipedia": "de:Sparkasse Harburg-Buxtehude",
+      "name": "Sparkasse Harburg-Buxtehude"
+    }
+  },
+  "amenity/bank|Sparkasse Haslach-Zell": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Haslach-Zell",
+      "brand:wikidata": "Q26794526",
+      "brand:wikipedia": "de:Sparkasse Haslach-Zell",
+      "name": "Sparkasse Haslach-Zell"
+    }
+  },
+  "amenity/bank|Sparkasse Hattingen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Hattingen",
+      "brand:wikidata": "Q18630924",
+      "brand:wikipedia": "de:Sparkasse Hattingen",
+      "name": "Sparkasse Hattingen"
+    }
+  },
+  "amenity/bank|Sparkasse Hegau-Bodensee": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Hegau-Bodensee",
+      "brand:wikidata": "Q2307674",
+      "brand:wikipedia": "de:Sparkasse Hegau-Bodensee",
+      "name": "Sparkasse Hegau-Bodensee"
+    }
+  },
+  "amenity/bank|Sparkasse Heidelberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Heidelberg",
+      "brand:wikidata": "Q1443207",
+      "brand:wikipedia": "de:Sparkasse Heidelberg",
+      "name": "Sparkasse Heidelberg"
+    }
+  },
+  "amenity/bank|Sparkasse Herford": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Herford",
+      "brand:wikidata": "Q1682874",
+      "brand:wikipedia": "de:Sparkasse Herford",
+      "name": "Sparkasse Herford"
+    }
+  },
+  "amenity/bank|Sparkasse Hilden-Ratingen-Velbert": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Hilden-Ratingen-Velbert",
+      "brand:wikidata": "Q2307467",
+      "brand:wikipedia": "de:Sparkasse Hilden-Ratingen-Velbert",
+      "name": "Sparkasse Hilden-Ratingen-Velbert"
+    }
+  },
+  "amenity/bank|Sparkasse Hildesheim Goslar Peine": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Hildesheim Goslar Peine",
+      "brand:wikidata": "Q2307468",
+      "brand:wikipedia": "de:Sparkasse Hildesheim Goslar Peine",
+      "name": "Sparkasse Hildesheim Goslar Peine"
+    }
+  },
+  "amenity/bank|Sparkasse Hochfranken": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Hochfranken",
+      "brand:wikidata": "Q2307470",
+      "brand:wikipedia": "de:Sparkasse Hochfranken",
+      "name": "Sparkasse Hochfranken"
+    }
+  },
+  "amenity/bank|Sparkasse Hochrhein": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Hochrhein",
+      "brand:wikidata": "Q15848091",
+      "brand:wikipedia": "de:Sparkasse Hochrhein",
+      "name": "Sparkasse Hochrhein"
+    }
+  },
+  "amenity/bank|Sparkasse Hochsauerland": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Hochsauerland",
+      "brand:wikidata": "Q2307477",
+      "brand:wikipedia": "de:Sparkasse Hochsauerland",
+      "name": "Sparkasse Hochsauerland"
+    }
+  },
+  "amenity/bank|Sparkasse Hochschwarzwald": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Hochschwarzwald",
+      "brand:wikidata": "Q56070763",
+      "brand:wikipedia": "de:Sparkasse Hochschwarzwald",
+      "name": "Sparkasse Hochschwarzwald"
+    }
+  },
+  "amenity/bank|Sparkasse Hohenlohekreis": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Hohenlohekreis",
+      "brand:wikidata": "Q2307480",
+      "brand:wikipedia": "de:Sparkasse Hohenlohekreis",
+      "name": "Sparkasse Hohenlohekreis"
+    }
+  },
+  "amenity/bank|Sparkasse Holstein": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Holstein",
+      "brand:wikidata": "Q1439313",
+      "brand:wikipedia": "de:Sparkasse Holstein",
+      "name": "Sparkasse Holstein"
+    }
+  },
+  "amenity/bank|Sparkasse Höxter": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Höxter",
+      "brand:wikidata": "Q2307482",
+      "brand:wikipedia": "de:Sparkasse Höxter",
+      "name": "Sparkasse Höxter"
+    }
+  },
+  "amenity/bank|Sparkasse Ingolstadt Eichstätt": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Ingolstadt Eichstätt",
+      "brand:wikidata": "Q1698904",
+      "brand:wikipedia": "de:Sparkasse Ingolstadt Eichstätt",
+      "name": "Sparkasse Ingolstadt Eichstätt"
+    }
+  },
+  "amenity/bank|Sparkasse Iserlohn": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Iserlohn",
+      "brand:wikidata": "Q2307489",
+      "brand:wikipedia": "de:Sparkasse Iserlohn",
+      "name": "Sparkasse Iserlohn"
+    }
+  },
+  "amenity/bank|Sparkasse Jena-Saale-Holzland": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Jena-Saale-Holzland",
+      "brand:wikidata": "Q2307490",
+      "brand:wikipedia": "de:Sparkasse Jena-Saale-Holzland",
+      "name": "Sparkasse Jena-Saale-Holzland"
+    }
+  },
+  "amenity/bank|Sparkasse Jerichower Land": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Jerichower Land",
+      "brand:wikidata": "Q56070868",
+      "brand:wikipedia": "de:Sparkasse Jerichower Land",
+      "name": "Sparkasse Jerichower Land"
+    }
+  },
+  "amenity/bank|Sparkasse Karlsruhe": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Karlsruhe",
+      "brand:wikidata": "Q2307494",
+      "brand:wikipedia": "de:Sparkasse Karlsruhe",
+      "name": "Sparkasse Karlsruhe"
+    }
+  },
+  "amenity/bank|Sparkasse Kierspe-Meinerzhagen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Kierspe-Meinerzhagen",
+      "brand:wikidata": "Q18630927",
+      "brand:wikipedia": "de:Sparkasse Kierspe-Meinerzhagen",
+      "name": "Sparkasse Kierspe-Meinerzhagen"
+    }
+  },
+  "amenity/bank|Sparkasse Koblenz": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Koblenz",
+      "brand:wikidata": "Q2307510",
+      "brand:wikipedia": "de:Sparkasse Koblenz",
+      "name": "Sparkasse Koblenz"
+    }
+  },
+  "amenity/bank|Sparkasse Kraichgau": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Kraichgau",
+      "brand:wikidata": "Q1527770",
+      "brand:wikipedia": "de:Sparkasse Kraichgau",
+      "name": "Sparkasse Kraichgau"
+    }
+  },
+  "amenity/bank|Sparkasse Krefeld": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Krefeld",
+      "brand:wikidata": "Q15848092",
+      "brand:wikipedia": "de:Sparkasse Krefeld",
+      "name": "Sparkasse Krefeld"
+    }
+  },
+  "amenity/bank|Sparkasse Kulmbach-Kronach": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Kulmbach-Kronach",
+      "brand:wikidata": "Q2307514",
+      "brand:wikipedia": "de:Sparkasse Kulmbach-Kronach",
+      "name": "Sparkasse Kulmbach-Kronach"
+    }
+  },
+  "amenity/bank|Sparkasse KölnBonn": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse KölnBonn",
+      "brand:wikidata": "Q1681035",
+      "brand:wikipedia": "de:Sparkasse KölnBonn",
+      "name": "Sparkasse KölnBonn"
+    }
+  },
+  "amenity/bank|Sparkasse Landsberg-Dießen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Landsberg-Dießen",
+      "brand:wikidata": "Q2307525",
+      "brand:wikipedia": "de:Sparkasse Landsberg-Dießen",
+      "name": "Sparkasse Landsberg-Dießen"
+    }
+  },
+  "amenity/bank|Sparkasse Landshut": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Landshut",
+      "brand:wikidata": "Q2307526",
+      "brand:wikipedia": "de:Sparkasse Landshut",
+      "name": "Sparkasse Landshut"
+    }
+  },
+  "amenity/bank|Sparkasse Langen-Seligenstadt": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Langen-Seligenstadt",
+      "brand:wikidata": "Q1369089",
+      "brand:wikipedia": "de:Sparkasse Langen-Seligenstadt",
+      "name": "Sparkasse Langen-Seligenstadt"
+    }
+  },
+  "amenity/bank|Sparkasse Laubach-Hungen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Laubach-Hungen",
+      "brand:wikidata": "Q18289504",
+      "brand:wikipedia": "de:Sparkasse Laubach-Hungen",
+      "name": "Sparkasse Laubach-Hungen"
+    }
+  },
+  "amenity/bank|Sparkasse LeerWittmund": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse LeerWittmund",
+      "brand:wikidata": "Q2307529",
+      "brand:wikipedia": "de:Sparkasse LeerWittmund",
+      "name": "Sparkasse LeerWittmund"
+    }
+  },
+  "amenity/bank|Sparkasse Leipzig": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Leipzig",
+      "brand:wikidata": "Q2307533",
+      "brand:wikipedia": "de:Sparkasse Leipzig",
+      "name": "Sparkasse Leipzig"
+    }
+  },
+  "amenity/bank|Sparkasse Lemgo": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Lemgo",
+      "brand:wikidata": "Q2307536",
+      "brand:wikipedia": "de:Sparkasse Lemgo",
+      "name": "Sparkasse Lemgo"
+    }
+  },
+  "amenity/bank|Sparkasse Leverkusen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Leverkusen",
+      "brand:wikidata": "Q16856990",
+      "brand:wikipedia": "de:Sparkasse Leverkusen",
+      "name": "Sparkasse Leverkusen"
+    }
+  },
+  "amenity/bank|Sparkasse Lippstadt": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Lippstadt",
+      "brand:wikidata": "Q1573103",
+      "brand:wikipedia": "de:Sparkasse Lippstadt",
+      "name": "Sparkasse Lippstadt"
+    }
+  },
+  "amenity/bank|Sparkasse Lörrach-Rheinfelden": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Lörrach-Rheinfelden",
+      "brand:wikidata": "Q2307539",
+      "brand:wikipedia": "de:Sparkasse Lörrach-Rheinfelden",
+      "name": "Sparkasse Lörrach-Rheinfelden"
+    }
+  },
+  "amenity/bank|Sparkasse Lüdenscheid": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Lüdenscheid",
+      "brand:wikidata": "Q2307543",
+      "brand:wikipedia": "de:Sparkasse Lüdenscheid",
+      "name": "Sparkasse Lüdenscheid"
+    }
+  },
+  "amenity/bank|Sparkasse Lüneburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Lüneburg",
+      "brand:wikidata": "Q1499130",
+      "brand:wikipedia": "de:Sparkasse Lüneburg",
+      "name": "Sparkasse Lüneburg"
+    }
+  },
+  "amenity/bank|Sparkasse Mainfranken Würzburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Mainfranken Würzburg",
+      "brand:wikidata": "Q2307545",
+      "brand:wikipedia": "de:Sparkasse Mainfranken Würzburg",
+      "name": "Sparkasse Mainfranken Würzburg"
+    }
+  },
+  "amenity/bank|Sparkasse Mainz": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Mainz",
+      "brand:wikidata": "Q2307547",
+      "brand:wikipedia": "de:Sparkasse Mainz",
+      "name": "Sparkasse Mainz"
+    }
+  },
+  "amenity/bank|Sparkasse Mansfeld-Südharz": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Mansfeld-Südharz",
+      "brand:wikidata": "Q28484708",
+      "brand:wikipedia": "de:Sparkasse Mansfeld-Südharz",
+      "name": "Sparkasse Mansfeld-Südharz"
+    }
+  },
+  "amenity/bank|Sparkasse Marburg-Biedenkopf": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Marburg-Biedenkopf",
+      "brand:wikidata": "Q16294740",
+      "brand:wikipedia": "de:Sparkasse Marburg-Biedenkopf",
+      "name": "Sparkasse Marburg-Biedenkopf"
+    }
+  },
+  "amenity/bank|Sparkasse Markgräflerland": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Markgräflerland",
+      "brand:wikidata": "Q1430840",
+      "brand:wikipedia": "de:Sparkasse Markgräflerland",
+      "name": "Sparkasse Markgräflerland"
+    }
+  },
+  "amenity/bank|Sparkasse Mecklenburg-Nordwest": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Mecklenburg-Nordwest",
+      "brand:wikidata": "Q1535595",
+      "brand:wikipedia": "de:Sparkasse Mecklenburg-Nordwest",
+      "name": "Sparkasse Mecklenburg-Nordwest"
+    }
+  },
+  "amenity/bank|Sparkasse Mecklenburg-Schwerin": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Mecklenburg-Schwerin",
+      "brand:wikidata": "Q2307549",
+      "brand:wikipedia": "de:Sparkasse Mecklenburg-Schwerin",
+      "name": "Sparkasse Mecklenburg-Schwerin"
+    }
+  },
+  "amenity/bank|Sparkasse Mecklenburg-Strelitz": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Mecklenburg-Strelitz",
+      "brand:wikidata": "Q996764",
+      "brand:wikipedia": "de:Sparkasse Mecklenburg-Strelitz",
+      "name": "Sparkasse Mecklenburg-Strelitz"
+    }
+  },
+  "amenity/bank|Sparkasse Meißen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Meißen",
+      "brand:wikidata": "Q15128949",
+      "brand:wikipedia": "de:Sparkasse Meißen",
+      "name": "Sparkasse Meißen"
+    }
+  },
+  "amenity/bank|Sparkasse Memmingen-Lindau-Mindelheim": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Memmingen-Lindau-Mindelheim",
+      "brand:wikidata": "Q1693433",
+      "brand:wikipedia": "de:Sparkasse Memmingen-Lindau-Mindelheim",
+      "name": "Sparkasse Memmingen-Lindau-Mindelheim"
+    }
+  },
+  "amenity/bank|Sparkasse Merzig-Wadern": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Merzig-Wadern",
+      "brand:wikidata": "Q18630932",
+      "brand:wikipedia": "de:Sparkasse Merzig-Wadern",
+      "name": "Sparkasse Merzig-Wadern"
+    }
+  },
+  "amenity/bank|Sparkasse Miltenberg-Obernburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Miltenberg-Obernburg",
+      "brand:wikidata": "Q2307559",
+      "brand:wikipedia": "de:Sparkasse Miltenberg-Obernburg",
+      "name": "Sparkasse Miltenberg-Obernburg"
+    }
+  },
+  "amenity/bank|Sparkasse Minden-Lübbecke": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Minden-Lübbecke",
+      "brand:wikidata": "Q2307562",
+      "brand:wikipedia": "de:Sparkasse Minden-Lübbecke",
+      "name": "Sparkasse Minden-Lübbecke"
+    }
+  },
+  "amenity/bank|Sparkasse Mittelfranken-Süd": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Mittelfranken-Süd",
+      "brand:wikidata": "Q1669402",
+      "brand:wikipedia": "de:Sparkasse Mittelfranken-Süd",
+      "name": "Sparkasse Mittelfranken-Süd"
+    }
+  },
+  "amenity/bank|Sparkasse Mittelholstein": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Mittelholstein",
+      "brand:wikidata": "Q2307564",
+      "brand:wikipedia": "de:Sparkasse Mittelholstein",
+      "name": "Sparkasse Mittelholstein"
+    }
+  },
+  "amenity/bank|Sparkasse Mittelmosel - Eifel Mosel Hunsrück": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Mittelmosel - Eifel Mosel Hunsrück",
+      "brand:wikidata": "Q1562562",
+      "brand:wikipedia": "de:Sparkasse Mittelmosel - Eifel Mosel Hunsrück",
+      "name": "Sparkasse Mittelmosel - Eifel Mosel Hunsrück"
+    }
+  },
+  "amenity/bank|Sparkasse Mittelsachsen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Mittelsachsen",
+      "brand:wikidata": "Q18334179",
+      "brand:wikipedia": "de:Sparkasse Mittelsachsen",
+      "name": "Sparkasse Mittelsachsen"
+    }
+  },
+  "amenity/bank|Sparkasse Mittelthüringen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Mittelthüringen",
+      "brand:wikidata": "Q1645884",
+      "brand:wikipedia": "de:Sparkasse Mittelthüringen",
+      "name": "Sparkasse Mittelthüringen"
+    }
+  },
+  "amenity/bank|Sparkasse Mitten im Sauerland": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Mitten im Sauerland",
+      "brand:wikidata": "Q66058328",
+      "brand:wikipedia": "de:Sparkasse Mitten im Sauerland",
+      "name": "Sparkasse Mitten im Sauerland"
+    }
+  },
+  "amenity/bank|Sparkasse Muldental": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Muldental",
+      "brand:wikidata": "Q56070852",
+      "brand:wikipedia": "de:Sparkasse Muldental",
+      "name": "Sparkasse Muldental"
+    }
+  },
+  "amenity/bank|Sparkasse Märkisch-Oderland": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Märkisch-Oderland",
+      "brand:wikidata": "Q1645803",
+      "brand:wikipedia": "de:Sparkasse Märkisch-Oderland",
+      "name": "Sparkasse Märkisch-Oderland"
+    }
+  },
+  "amenity/bank|Sparkasse Märkisches Sauerland Hemer–Menden": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Märkisches Sauerland Hemer–Menden",
+      "brand:wikidata": "Q2307570",
+      "brand:wikipedia": "de:Sparkasse Märkisches Sauerland Hemer–Menden",
+      "name": "Sparkasse Märkisches Sauerland Hemer–Menden"
+    }
+  },
+  "amenity/bank|Sparkasse Mülheim an der Ruhr": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Mülheim an der Ruhr",
+      "brand:wikidata": "Q18630938",
+      "brand:wikipedia": "de:Sparkasse Mülheim an der Ruhr",
+      "name": "Sparkasse Mülheim an der Ruhr"
+    }
+  },
+  "amenity/bank|Sparkasse Münden": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Münden",
+      "brand:wikidata": "Q1446928",
+      "brand:wikipedia": "de:Sparkasse Münden",
+      "name": "Sparkasse Münden"
+    }
+  },
+  "amenity/bank|Sparkasse Münsterland Ost": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Münsterland Ost",
+      "brand:wikidata": "Q2307576",
+      "brand:wikipedia": "de:Sparkasse Münsterland Ost",
+      "name": "Sparkasse Münsterland Ost"
+    }
+  },
+  "amenity/bank|Sparkasse Neckartal-Odenwald": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Neckartal-Odenwald",
+      "brand:wikidata": "Q14912505",
+      "brand:wikipedia": "de:Sparkasse Neckartal-Odenwald",
+      "name": "Sparkasse Neckartal-Odenwald"
+    }
+  },
+  "amenity/bank|Sparkasse Neu-Ulm - Illertissen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Neu-Ulm - Illertissen",
+      "brand:wikidata": "Q1773361",
+      "brand:wikipedia": "de:Sparkasse Neu-Ulm - Illertissen",
+      "name": "Sparkasse Neu-Ulm - Illertissen"
+    }
+  },
+  "amenity/bank|Sparkasse Neubrandenburg-Demmin": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Neubrandenburg-Demmin",
+      "brand:wikidata": "Q1715498",
+      "brand:wikipedia": "de:Sparkasse Neubrandenburg-Demmin",
+      "name": "Sparkasse Neubrandenburg-Demmin"
+    }
+  },
+  "amenity/bank|Sparkasse Neuburg-Rain": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Neuburg-Rain",
+      "brand:wikidata": "Q1636321",
+      "brand:wikipedia": "de:Sparkasse Neuburg-Rain",
+      "name": "Sparkasse Neuburg-Rain"
+    }
+  },
+  "amenity/bank|Sparkasse Neumarkt i.d.OPf.-Parsberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Neumarkt i.d.OPf.-Parsberg",
+      "brand:wikidata": "Q1437820",
+      "brand:wikipedia": "de:Sparkasse Neumarkt i.d.OPf.-Parsberg",
+      "name": "Sparkasse Neumarkt i.d.OPf.-Parsberg"
+    }
+  },
+  "amenity/bank|Sparkasse Neunkirchen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Neunkirchen",
+      "brand:wikidata": "Q18630944",
+      "brand:wikipedia": "de:Sparkasse Neunkirchen (Saarland)",
+      "name": "Sparkasse Neunkirchen"
+    }
+  },
+  "amenity/bank|Sparkasse Neuss": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Neuss",
+      "brand:wikidata": "Q2307580",
+      "brand:wikipedia": "de:Sparkasse Neuss",
+      "name": "Sparkasse Neuss"
+    }
+  },
+  "amenity/bank|Sparkasse Neuwied": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Neuwied",
+      "brand:wikidata": "Q15848096",
+      "brand:wikipedia": "de:Sparkasse Neuwied",
+      "name": "Sparkasse Neuwied"
+    }
+  },
+  "amenity/bank|Sparkasse Niederbayern-Mitte": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Niederbayern-Mitte",
+      "brand:wikidata": "Q1491695",
+      "brand:wikipedia": "de:Sparkasse Niederbayern-Mitte",
+      "name": "Sparkasse Niederbayern-Mitte"
+    }
+  },
+  "amenity/bank|Sparkasse Niederlausitz": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Niederlausitz",
+      "brand:wikidata": "Q1288753",
+      "brand:wikipedia": "de:Sparkasse Niederlausitz",
+      "name": "Sparkasse Niederlausitz"
+    }
+  },
+  "amenity/bank|Sparkasse Nienburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Nienburg",
+      "brand:wikidata": "Q1392587",
+      "brand:wikipedia": "de:Sparkasse Nienburg",
+      "name": "Sparkasse Nienburg"
+    }
+  },
+  "amenity/bank|Sparkasse Nürnberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Nürnberg",
+      "brand:wikidata": "Q2307586",
+      "brand:wikipedia": "de:Sparkasse Nürnberg",
+      "name": "Sparkasse Nürnberg"
+    }
+  },
+  "amenity/bank|Sparkasse Oberhessen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Oberhessen",
+      "brand:wikidata": "Q1554198",
+      "brand:wikipedia": "de:Sparkasse Oberhessen",
+      "name": "Sparkasse Oberhessen"
+    }
+  },
+  "amenity/bank|Sparkasse Oberland": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Oberland",
+      "brand:wikidata": "Q1365877",
+      "brand:wikipedia": "de:Sparkasse Oberland",
+      "name": "Sparkasse Oberland"
+    }
+  },
+  "amenity/bank|Sparkasse Oberlausitz-Niederschlesien": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Oberlausitz-Niederschlesien",
+      "brand:wikidata": "Q1734365",
+      "brand:wikipedia": "de:Sparkasse Oberlausitz-Niederschlesien",
+      "name": "Sparkasse Oberlausitz-Niederschlesien"
+    }
+  },
+  "amenity/bank|Sparkasse Oberpfalz Nord": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Oberpfalz Nord",
+      "brand:wikidata": "Q1757112",
+      "brand:wikipedia": "de:Sparkasse Oberpfalz Nord",
+      "name": "Sparkasse Oberpfalz Nord"
+    }
+  },
+  "amenity/bank|Sparkasse Odenwaldkreis": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Odenwaldkreis",
+      "brand:wikidata": "Q18334182",
+      "brand:wikipedia": "de:Sparkasse Odenwaldkreis",
+      "name": "Sparkasse Odenwaldkreis"
+    }
+  },
+  "amenity/bank|Sparkasse Oder-Spree": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Oder-Spree",
+      "brand:wikidata": "Q2307594",
+      "brand:wikipedia": "de:Sparkasse Oder-Spree",
+      "name": "Sparkasse Oder-Spree"
+    }
+  },
+  "amenity/bank|Sparkasse Offenburg/Ortenau": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Offenburg/Ortenau",
+      "brand:wikidata": "Q2307590",
+      "brand:wikipedia": "de:Sparkasse Offenburg/Ortenau",
+      "name": "Sparkasse Offenburg/Ortenau"
+    }
+  },
+  "amenity/bank|Sparkasse Olpe-Drolshagen-Wenden": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Olpe-Drolshagen-Wenden",
+      "brand:wikidata": "Q18630947",
+      "brand:wikipedia": "de:Sparkasse Olpe-Drolshagen-Wenden",
+      "name": "Sparkasse Olpe-Drolshagen-Wenden"
+    }
+  },
+  "amenity/bank|Sparkasse Osnabrück": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Osnabrück",
+      "brand:wikidata": "Q2307597",
+      "brand:wikipedia": "de:Sparkasse Osnabrück",
+      "name": "Sparkasse Osnabrück"
+    }
+  },
+  "amenity/bank|Sparkasse Osterode am Harz": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Osterode am Harz",
+      "brand:wikidata": "Q2307600",
+      "brand:wikipedia": "de:Sparkasse Osterode am Harz",
+      "name": "Sparkasse Osterode am Harz"
+    }
+  },
+  "amenity/bank|Sparkasse Ostprignitz-Ruppin": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Ostprignitz-Ruppin",
+      "brand:wikidata": "Q56070775",
+      "brand:wikipedia": "de:Sparkasse Ostprignitz-Ruppin",
+      "name": "Sparkasse Ostprignitz-Ruppin"
+    }
+  },
+  "amenity/bank|Sparkasse Paderborn-Detmold": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Paderborn-Detmold",
+      "brand:wikidata": "Q2307609",
+      "brand:wikipedia": "de:Sparkasse Paderborn-Detmold",
+      "name": "Sparkasse Paderborn-Detmold"
+    }
+  },
+  "amenity/bank|Sparkasse Parchim-Lübz": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Parchim-Lübz",
+      "brand:wikidata": "Q2307612",
+      "brand:wikipedia": "de:Sparkasse Parchim-Lübz",
+      "name": "Sparkasse Parchim-Lübz"
+    }
+  },
+  "amenity/bank|Sparkasse Passau": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Passau",
+      "brand:wikidata": "Q2307613",
+      "brand:wikipedia": "de:Sparkasse Passau",
+      "name": "Sparkasse Passau"
+    }
+  },
+  "amenity/bank|Sparkasse Pfaffenhofen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Pfaffenhofen",
+      "brand:wikidata": "Q2307617",
+      "brand:wikipedia": "de:Sparkasse Pfaffenhofen",
+      "name": "Sparkasse Pfaffenhofen"
+    }
+  },
+  "amenity/bank|Sparkasse Pforzheim Calw": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Pforzheim Calw",
+      "brand:wikidata": "Q2307618",
+      "brand:wikipedia": "de:Sparkasse Pforzheim Calw",
+      "name": "Sparkasse Pforzheim Calw"
+    }
+  },
+  "amenity/bank|Sparkasse Pfullendorf-Meßkirch": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Pfullendorf-Meßkirch",
+      "brand:wikidata": "Q2307621",
+      "brand:wikipedia": "de:Sparkasse Pfullendorf-Meßkirch",
+      "name": "Sparkasse Pfullendorf-Meßkirch"
+    }
+  },
+  "amenity/bank|Sparkasse Prignitz": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Prignitz",
+      "brand:wikidata": "Q56199282",
+      "brand:wikipedia": "de:Sparkasse Prignitz",
+      "name": "Sparkasse Prignitz"
+    }
+  },
+  "amenity/bank|Sparkasse Radevormwald-Hückeswagen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Radevormwald-Hückeswagen",
+      "brand:wikidata": "Q2307633",
+      "brand:wikipedia": "de:Sparkasse Radevormwald-Hückeswagen",
+      "name": "Sparkasse Radevormwald-Hückeswagen"
+    }
+  },
+  "amenity/bank|Sparkasse Rastatt-Gernsbach": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Rastatt-Gernsbach",
+      "brand:wikidata": "Q26794524",
+      "brand:wikipedia": "de:Sparkasse Rastatt-Gernsbach",
+      "name": "Sparkasse Rastatt-Gernsbach"
+    }
+  },
+  "amenity/bank|Sparkasse Regen-Viechtach": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Regen-Viechtach",
+      "brand:wikidata": "Q1670662",
+      "brand:wikipedia": "de:Sparkasse Regen-Viechtach",
+      "name": "Sparkasse Regen-Viechtach"
+    }
+  },
+  "amenity/bank|Sparkasse Regensburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Regensburg",
+      "brand:wikidata": "Q1557248",
+      "brand:wikipedia": "de:Sparkasse Regensburg",
+      "name": "Sparkasse Regensburg"
+    }
+  },
+  "amenity/bank|Sparkasse Rhein Neckar Nord": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Rhein Neckar Nord",
+      "brand:wikidata": "Q2307642",
+      "brand:wikipedia": "de:Sparkasse Rhein Neckar Nord",
+      "name": "Sparkasse Rhein Neckar Nord"
+    }
+  },
+  "amenity/bank|Sparkasse Rhein-Haardt": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Rhein-Haardt",
+      "brand:wikidata": "Q2307638",
+      "brand:wikipedia": "de:Sparkasse Rhein-Haardt",
+      "name": "Sparkasse Rhein-Haardt"
+    }
+  },
+  "amenity/bank|Sparkasse Rhein-Maas": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Rhein-Maas",
+      "brand:wikidata": "Q2307502",
+      "brand:wikipedia": "de:Sparkasse Rhein-Maas",
+      "name": "Sparkasse Rhein-Maas"
+    }
+  },
+  "amenity/bank|Sparkasse Rhein-Nahe": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Rhein-Nahe",
+      "brand:wikidata": "Q1321477",
+      "brand:wikipedia": "de:Sparkasse Rhein-Nahe",
+      "name": "Sparkasse Rhein-Nahe"
+    }
+  },
+  "amenity/bank|Sparkasse Rosenheim-Bad Aibling": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Rosenheim-Bad Aibling",
+      "brand:wikidata": "Q1292095",
+      "brand:wikipedia": "de:Sparkasse Rosenheim-Bad Aibling",
+      "name": "Sparkasse Rosenheim-Bad Aibling"
+    }
+  },
+  "amenity/bank|Sparkasse Rotenburg Osterholz": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Rotenburg Osterholz",
+      "brand:wikidata": "Q2307645",
+      "brand:wikipedia": "de:Sparkasse Rotenburg Osterholz",
+      "name": "Sparkasse Rotenburg Osterholz"
+    }
+  },
+  "amenity/bank|Sparkasse Rottal-Inn": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Rottal-Inn",
+      "brand:wikidata": "Q2307651",
+      "brand:wikipedia": "de:Sparkasse Rottal-Inn",
+      "name": "Sparkasse Rottal-Inn"
+    }
+  },
+  "amenity/bank|Sparkasse Saarbrücken": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Saarbrücken",
+      "brand:wikidata": "Q2307655",
+      "brand:wikipedia": "de:Sparkasse Saarbrücken",
+      "name": "Sparkasse Saarbrücken"
+    }
+  },
+  "amenity/bank|Sparkasse Salem-Heiligenberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Salem-Heiligenberg",
+      "brand:wikidata": "Q2307658",
+      "brand:wikipedia": "de:Sparkasse Salem-Heiligenberg",
+      "name": "Sparkasse Salem-Heiligenberg"
+    }
+  },
+  "amenity/bank|Sparkasse Schaumburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Schaumburg",
+      "brand:wikidata": "Q1537492",
+      "brand:wikipedia": "de:Sparkasse Schaumburg",
+      "name": "Sparkasse Schaumburg"
+    }
+  },
+  "amenity/bank|Sparkasse Scheeßel": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Scheeßel",
+      "brand:wikidata": "Q2307659",
+      "brand:wikipedia": "de:Sparkasse Scheeßel",
+      "name": "Sparkasse Scheeßel"
+    }
+  },
+  "amenity/bank|Sparkasse Schwarzwald-Baar": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Schwarzwald-Baar",
+      "brand:wikidata": "Q33133663",
+      "brand:wikipedia": "de:Sparkasse Schwarzwald-Baar",
+      "name": "Sparkasse Schwarzwald-Baar"
+    }
+  },
+  "amenity/bank|Sparkasse Schweinfurt-Haßberge": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Schweinfurt-Haßberge",
+      "brand:wikidata": "Q2307665",
+      "brand:wikipedia": "de:Sparkasse Schweinfurt-Haßberge",
+      "name": "Sparkasse Schweinfurt-Haßberge"
+    }
+  },
+  "amenity/bank|Sparkasse Schwerte": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Schwerte",
+      "brand:wikidata": "Q18630952",
+      "brand:wikipedia": "de:Sparkasse Schwerte",
+      "name": "Sparkasse Schwerte"
+    }
+  },
+  "amenity/bank|Sparkasse Schwäbisch Hall-Crailsheim": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Schwäbisch Hall-Crailsheim",
+      "brand:wikidata": "Q1723179",
+      "brand:wikipedia": "de:Sparkasse Schwäbisch Hall-Crailsheim",
+      "name": "Sparkasse Schwäbisch Hall-Crailsheim"
+    }
+  },
+  "amenity/bank|Sparkasse Siegen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Siegen",
+      "brand:wikidata": "Q2307671",
+      "brand:wikipedia": "de:Sparkasse Siegen",
+      "name": "Sparkasse Siegen"
+    }
+  },
+  "amenity/bank|Sparkasse SoestWerl": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse SoestWerl",
+      "brand:wikidata": "Q47015238",
+      "brand:wikipedia": "de:Sparkasse SoestWerl",
+      "name": "Sparkasse SoestWerl"
+    }
+  },
+  "amenity/bank|Sparkasse Sonneberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Sonneberg",
+      "brand:wikidata": "Q18334184",
+      "brand:wikipedia": "de:Sparkasse Sonneberg",
+      "name": "Sparkasse Sonneberg"
+    }
+  },
+  "amenity/bank|Sparkasse Spree-Neiße": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Spree-Neiße",
+      "brand:wikidata": "Q2307681",
+      "brand:wikipedia": "de:Sparkasse Spree-Neiße",
+      "name": "Sparkasse Spree-Neiße"
+    }
+  },
+  "amenity/bank|Sparkasse St. Blasien": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse St. Blasien",
+      "brand:wikidata": "Q15128968",
+      "brand:wikipedia": "de:Sparkasse St. Blasien",
+      "name": "Sparkasse St. Blasien"
+    }
+  },
+  "amenity/bank|Sparkasse Stade-Altes Land": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Stade-Altes Land",
+      "brand:wikidata": "Q2307687",
+      "brand:wikipedia": "de:Sparkasse Stade-Altes Land",
+      "name": "Sparkasse Stade-Altes Land"
+    }
+  },
+  "amenity/bank|Sparkasse Starkenburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Starkenburg",
+      "brand:wikidata": "Q2307691",
+      "brand:wikipedia": "de:Sparkasse Starkenburg",
+      "name": "Sparkasse Starkenburg"
+    }
+  },
+  "amenity/bank|Sparkasse Staufen-Breisach": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Staufen-Breisach",
+      "brand:wikidata": "Q53968330",
+      "brand:wikipedia": "de:Sparkasse Staufen-Breisach",
+      "name": "Sparkasse Staufen-Breisach"
+    }
+  },
+  "amenity/bank|Sparkasse Südholstein": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Südholstein",
+      "brand:wikidata": "Q2307695",
+      "brand:wikipedia": "de:Sparkasse Südholstein",
+      "name": "Sparkasse Südholstein"
+    }
+  },
+  "amenity/bank|Sparkasse Südliche Weinstraße": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Südliche Weinstraße",
+      "brand:wikidata": "Q1656510",
+      "brand:wikipedia": "de:Sparkasse Südliche Weinstraße",
+      "name": "Sparkasse Südliche Weinstraße"
+    }
+  },
+  "amenity/bank|Sparkasse Südwestpfalz": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Südwestpfalz",
+      "brand:wikidata": "Q15128972",
+      "brand:wikipedia": "de:Sparkasse Südwestpfalz",
+      "name": "Sparkasse Südwestpfalz"
+    }
+  },
+  "amenity/bank|Sparkasse Tauberfranken": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Tauberfranken",
+      "brand:wikidata": "Q1566741",
+      "brand:wikipedia": "de:Sparkasse Tauberfranken",
+      "name": "Sparkasse Tauberfranken"
+    }
+  },
+  "amenity/bank|Sparkasse Trier": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Trier",
+      "brand:wikidata": "Q2307697",
+      "brand:wikipedia": "de:Sparkasse Trier",
+      "name": "Sparkasse Trier"
+    }
+  },
+  "amenity/bank|Sparkasse Uckermark": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Uckermark",
+      "brand:wikidata": "Q2307700",
+      "brand:wikipedia": "de:Sparkasse Uckermark",
+      "name": "Sparkasse Uckermark"
+    }
+  },
+  "amenity/bank|Sparkasse Uecker-Randow": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Uecker-Randow",
+      "brand:wikidata": "Q1686884",
+      "brand:wikipedia": "de:Sparkasse Uecker-Randow",
+      "name": "Sparkasse Uecker-Randow"
+    }
+  },
+  "amenity/bank|Sparkasse Uelzen Lüchow-Dannenberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Uelzen Lüchow-Dannenberg",
+      "brand:wikidata": "Q2307701",
+      "brand:wikipedia": "de:Sparkasse Uelzen Lüchow-Dannenberg",
+      "name": "Sparkasse Uelzen Lüchow-Dannenberg"
+    }
+  },
+  "amenity/bank|Sparkasse Ulm": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Ulm",
+      "brand:wikidata": "Q18630954",
+      "brand:wikipedia": "de:Sparkasse Ulm",
+      "name": "Sparkasse Ulm"
+    }
+  },
+  "amenity/bank|Sparkasse UnnaKamen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse UnnaKamen",
+      "brand:wikidata": "Q15848097",
+      "brand:wikipedia": "de:Sparkasse UnnaKamen",
+      "name": "Sparkasse UnnaKamen"
+    }
+  },
+  "amenity/bank|Sparkasse Unstrut-Hainich": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Unstrut-Hainich",
+      "brand:wikidata": "Q18334187",
+      "brand:wikipedia": "de:Sparkasse Unstrut-Hainich",
+      "name": "Sparkasse Unstrut-Hainich"
+    }
+  },
+  "amenity/bank|Sparkasse Vest Recklinghausen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Vest Recklinghausen",
+      "brand:wikidata": "Q18630956",
+      "brand:wikipedia": "de:Sparkasse Vest Recklinghausen",
+      "name": "Sparkasse Vest Recklinghausen"
+    }
+  },
+  "amenity/bank|Sparkasse Vogtland": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Vogtland",
+      "brand:wikidata": "Q1605249",
+      "brand:wikipedia": "de:Sparkasse Vogtland",
+      "name": "Sparkasse Vogtland"
+    }
+  },
+  "amenity/bank|Sparkasse Vorderpfalz": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Vorderpfalz",
+      "brand:wikidata": "Q15128975",
+      "brand:wikipedia": "de:Sparkasse Vorderpfalz",
+      "name": "Sparkasse Vorderpfalz"
+    }
+  },
+  "amenity/bank|Sparkasse Vorpommern": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Vorpommern",
+      "brand:wikidata": "Q2307709",
+      "brand:wikipedia": "de:Sparkasse Vorpommern",
+      "name": "Sparkasse Vorpommern"
+    }
+  },
+  "amenity/bank|Sparkasse Waldeck-Frankenberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Waldeck-Frankenberg",
+      "brand:wikidata": "Q15128978",
+      "brand:wikipedia": "de:Sparkasse Waldeck-Frankenberg",
+      "name": "Sparkasse Waldeck-Frankenberg"
+    }
+  },
+  "amenity/bank|Sparkasse Werra-Meißner": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Werra-Meißner",
+      "brand:wikidata": "Q1170839",
+      "brand:wikipedia": "de:Sparkasse Werra-Meißner",
+      "name": "Sparkasse Werra-Meißner"
+    }
+  },
+  "amenity/bank|Sparkasse Westerwald-Sieg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Westerwald-Sieg",
+      "brand:wikidata": "Q18022453",
+      "brand:wikipedia": "de:Sparkasse Westerwald-Sieg",
+      "name": "Sparkasse Westerwald-Sieg"
+    }
+  },
+  "amenity/bank|Sparkasse Westholstein": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Westholstein",
+      "brand:wikidata": "Q2307720",
+      "brand:wikipedia": "de:Sparkasse Westholstein",
+      "name": "Sparkasse Westholstein"
+    }
+  },
+  "amenity/bank|Sparkasse Westmünsterland": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Westmünsterland",
+      "brand:wikidata": "Q1567929",
+      "brand:wikipedia": "de:Sparkasse Westmünsterland",
+      "name": "Sparkasse Westmünsterland"
+    }
+  },
+  "amenity/bank|Sparkasse Wetzlar": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Wetzlar",
+      "brand:wikidata": "Q1748989",
+      "brand:wikipedia": "de:Sparkasse Wetzlar",
+      "name": "Sparkasse Wetzlar"
+    }
+  },
+  "amenity/bank|Sparkasse Wiesental": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Wiesental",
+      "brand:wikidata": "Q56070837",
+      "brand:wikipedia": "de:Sparkasse Wiesental",
+      "name": "Sparkasse Wiesental"
+    }
+  },
+  "amenity/bank|Sparkasse Wilhelmshaven": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Wilhelmshaven",
+      "brand:wikidata": "Q1230591",
+      "brand:wikipedia": "de:Sparkasse Wilhelmshaven",
+      "name": "Sparkasse Wilhelmshaven"
+    }
+  },
+  "amenity/bank|Sparkasse Witten": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Witten",
+      "brand:wikidata": "Q2307725",
+      "brand:wikipedia": "de:Sparkasse Witten",
+      "name": "Sparkasse Witten"
+    }
+  },
+  "amenity/bank|Sparkasse Wittenberg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Wittenberg",
+      "brand:wikidata": "Q54867473",
+      "brand:wikipedia": "de:Sparkasse Wittenberg",
+      "name": "Sparkasse Wittenberg"
+    }
+  },
+  "amenity/bank|Sparkasse Wittgenstein": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Wittgenstein",
+      "brand:wikidata": "Q2307728",
+      "brand:wikipedia": "de:Sparkasse Wittgenstein",
+      "name": "Sparkasse Wittgenstein"
+    }
+  },
+  "amenity/bank|Sparkasse Wolfach": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Wolfach",
+      "brand:wikidata": "Q26794525",
+      "brand:wikipedia": "de:Sparkasse Wolfach",
+      "name": "Sparkasse Wolfach"
+    }
+  },
+  "amenity/bank|Sparkasse Worms-Alzey-Ried": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Worms-Alzey-Ried",
+      "brand:wikidata": "Q1435829",
+      "brand:wikipedia": "de:Sparkasse Worms-Alzey-Ried",
+      "name": "Sparkasse Worms-Alzey-Ried"
+    }
+  },
+  "amenity/bank|Sparkasse Zollernalb": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Zollernalb",
+      "brand:wikidata": "Q2307734",
+      "brand:wikipedia": "de:Sparkasse Zollernalb",
+      "name": "Sparkasse Zollernalb"
+    }
+  },
+  "amenity/bank|Sparkasse Zwickau": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse Zwickau",
+      "brand:wikidata": "Q2307735",
+      "brand:wikipedia": "de:Sparkasse Zwickau",
+      "name": "Sparkasse Zwickau"
+    }
+  },
+  "amenity/bank|Sparkasse am Niederrhein": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse am Niederrhein",
+      "brand:wikidata": "Q1411585",
+      "brand:wikipedia": "de:Sparkasse am Niederrhein",
+      "name": "Sparkasse am Niederrhein"
+    }
+  },
+  "amenity/bank|Sparkasse an der Lippe": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse an der Lippe",
+      "brand:wikidata": "Q18630930",
+      "brand:wikipedia": "de:Sparkasse an der Lippe",
+      "name": "Sparkasse an der Lippe"
+    }
+  },
+  "amenity/bank|Sparkasse im Landkreis Cham": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse im Landkreis Cham",
+      "brand:wikidata": "Q2307747",
+      "brand:wikipedia": "de:Sparkasse im Landkreis Cham",
+      "name": "Sparkasse im Landkreis Cham"
+    }
+  },
+  "amenity/bank|Sparkasse im Landkreis Neustadt a. d. Aisch - Bad Windsheim": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse im Landkreis Neustadt a. d. Aisch - Bad Windsheim",
+      "brand:wikidata": "Q1401594",
+      "brand:wikipedia": "de:Sparkasse im Landkreis Neustadt a. d. Aisch - Bad Windsheim",
+      "name": "Sparkasse im Landkreis Neustadt a. d. Aisch - Bad Windsheim"
+    }
+  },
+  "amenity/bank|Sparkasse im Landkreis Schwandorf": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse im Landkreis Schwandorf",
+      "brand:wikidata": "Q2307750",
+      "brand:wikipedia": "de:Sparkasse im Landkreis Schwandorf",
+      "name": "Sparkasse im Landkreis Schwandorf"
+    }
+  },
+  "amenity/bank|Sparkasse zu Lübeck": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Sparkasse zu Lübeck",
+      "brand:wikidata": "Q2307753",
+      "brand:wikipedia": "de:Sparkasse zu Lübeck",
+      "name": "Sparkasse zu Lübeck"
+    }
+  },
+  "amenity/bank|Stadt- und Kreissparkasse Moosburg a.d. Isar": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadt- und Kreissparkasse Moosburg a.d. Isar",
+      "brand:wikidata": "Q2326327",
+      "brand:wikipedia": "de:Stadt- und Kreissparkasse Moosburg a.d. Isar",
+      "name": "Stadt- und Kreissparkasse Moosburg a.d. Isar"
+    }
+  },
+  "amenity/bank|Stadt-Sparkasse Haan (Rheinl.)": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadt-Sparkasse Haan (Rheinl.)",
+      "brand:wikidata": "Q18631055",
+      "brand:wikipedia": "de:Stadt-Sparkasse Haan (Rheinl.)",
+      "name": "Stadt-Sparkasse Haan (Rheinl.)"
+    }
+  },
+  "amenity/bank|Stadt-Sparkasse Langenfeld": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadt-Sparkasse Langenfeld",
+      "brand:wikidata": "Q18631056",
+      "brand:wikipedia": "de:Stadt-Sparkasse Langenfeld",
+      "name": "Stadt-Sparkasse Langenfeld"
+    }
+  },
+  "amenity/bank|Stadt-Sparkasse Solingen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadt-Sparkasse Solingen",
+      "brand:wikidata": "Q18631057",
+      "brand:wikipedia": "de:Stadt-Sparkasse Solingen",
+      "name": "Stadt-Sparkasse Solingen"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Augsburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Augsburg",
+      "brand:wikidata": "Q2328081",
+      "brand:wikipedia": "de:Stadtsparkasse Augsburg",
+      "name": "Stadtsparkasse Augsburg"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Bad Pyrmont": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Bad Pyrmont",
+      "brand:wikidata": "Q1586261",
+      "brand:wikipedia": "de:Stadtsparkasse Bad Pyrmont",
+      "name": "Stadtsparkasse Bad Pyrmont"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Barsinghausen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Barsinghausen",
+      "brand:wikidata": "Q2328088",
+      "brand:wikipedia": "de:Stadtsparkasse Barsinghausen",
+      "name": "Stadtsparkasse Barsinghausen"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Blomberg/Lippe": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Blomberg/Lippe",
+      "brand:wikidata": "Q1717096",
+      "brand:wikipedia": "de:Stadtsparkasse Blomberg/Lippe",
+      "name": "Stadtsparkasse Blomberg/Lippe"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Bocholt": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Bocholt",
+      "brand:wikidata": "Q1310641",
+      "brand:wikipedia": "de:Stadtsparkasse Bocholt",
+      "name": "Stadtsparkasse Bocholt"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Borken": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Borken",
+      "brand:wikidata": "Q2328091",
+      "brand:wikipedia": "de:Stadtsparkasse Borken",
+      "name": "Stadtsparkasse Borken"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Burgdorf": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Burgdorf",
+      "brand:wikidata": "Q1752351",
+      "brand:wikipedia": "de:Stadtsparkasse Burgdorf",
+      "name": "Stadtsparkasse Burgdorf"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Cuxhaven": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Cuxhaven",
+      "brand:wikidata": "Q1600996",
+      "brand:wikipedia": "de:Stadtsparkasse Cuxhaven",
+      "name": "Stadtsparkasse Cuxhaven"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Delbrück": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Delbrück",
+      "brand:wikidata": "Q18631074",
+      "brand:wikipedia": "de:Stadtsparkasse Delbrück",
+      "name": "Stadtsparkasse Delbrück"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Dessau": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Dessau",
+      "brand:wikidata": "Q56070848",
+      "brand:wikipedia": "de:Stadtsparkasse Dessau",
+      "name": "Stadtsparkasse Dessau"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Düsseldorf": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Düsseldorf",
+      "brand:wikidata": "Q1423788",
+      "brand:wikipedia": "de:Stadtsparkasse Düsseldorf",
+      "name": "Stadtsparkasse Düsseldorf"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Grebenstein": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Grebenstein",
+      "brand:wikidata": "Q15130149",
+      "brand:wikipedia": "de:Stadtsparkasse Grebenstein",
+      "name": "Stadtsparkasse Grebenstein"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Haltern am See": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Haltern am See",
+      "brand:wikidata": "Q18631076",
+      "brand:wikipedia": "de:Stadtsparkasse Haltern am See",
+      "name": "Stadtsparkasse Haltern am See"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Kaiserslautern": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Kaiserslautern",
+      "brand:wikidata": "Q2328109",
+      "brand:wikipedia": "de:Stadtsparkasse Kaiserslautern",
+      "name": "Stadtsparkasse Kaiserslautern"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Lengerich": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Lengerich",
+      "brand:wikidata": "Q18631079",
+      "brand:wikipedia": "de:Stadtsparkasse Lengerich",
+      "name": "Stadtsparkasse Lengerich"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Magdeburg": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Magdeburg",
+      "brand:wikidata": "Q56070793",
+      "brand:wikipedia": "de:Stadtsparkasse Magdeburg",
+      "name": "Stadtsparkasse Magdeburg"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Mönchengladbach": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Mönchengladbach",
+      "brand:wikidata": "Q18413199",
+      "brand:wikipedia": "de:Stadtsparkasse Mönchengladbach",
+      "name": "Stadtsparkasse Mönchengladbach"
+    }
+  },
+  "amenity/bank|Stadtsparkasse München": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse München",
+      "brand:wikidata": "Q1438593",
+      "brand:wikipedia": "de:Stadtsparkasse München",
+      "name": "Stadtsparkasse München"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Oberhausen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Oberhausen",
+      "brand:wikidata": "Q15130152",
+      "brand:wikipedia": "de:Stadtsparkasse Oberhausen",
+      "name": "Stadtsparkasse Oberhausen"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Rahden": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Rahden",
+      "brand:wikidata": "Q18631083",
+      "brand:wikipedia": "de:Stadtsparkasse Rahden",
+      "name": "Stadtsparkasse Rahden"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Remscheid": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Remscheid",
+      "brand:wikidata": "Q2328112",
+      "brand:wikipedia": "de:Stadtsparkasse Remscheid",
+      "name": "Stadtsparkasse Remscheid"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Rheine": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Rheine",
+      "brand:wikidata": "Q18631084",
+      "brand:wikipedia": "de:Stadtsparkasse Rheine",
+      "name": "Stadtsparkasse Rheine"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Schwalmstadt": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Schwalmstadt",
+      "brand:wikidata": "Q15130155",
+      "brand:wikipedia": "de:Stadtsparkasse Schwalmstadt",
+      "name": "Stadtsparkasse Schwalmstadt"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Schwedt": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Schwedt",
+      "brand:wikidata": "Q19964021",
+      "brand:wikipedia": "de:Stadtsparkasse Schwedt",
+      "name": "Stadtsparkasse Schwedt"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Sprockhövel": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Sprockhövel",
+      "brand:wikidata": "Q1752273",
+      "brand:wikipedia": "de:Stadtsparkasse Sprockhövel",
+      "name": "Stadtsparkasse Sprockhövel"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Versmold": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Versmold",
+      "brand:wikidata": "Q18631086",
+      "brand:wikipedia": "de:Stadtsparkasse Versmold",
+      "name": "Stadtsparkasse Versmold"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Wedel": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Wedel",
+      "brand:wikidata": "Q2328122",
+      "brand:wikipedia": "de:Stadtsparkasse Wedel",
+      "name": "Stadtsparkasse Wedel"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Wermelskirchen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Wermelskirchen",
+      "brand:wikidata": "Q2328127",
+      "brand:wikipedia": "de:Stadtsparkasse Wermelskirchen",
+      "name": "Stadtsparkasse Wermelskirchen"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Wunstorf": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Wunstorf",
+      "brand:wikidata": "Q2328132",
+      "brand:wikipedia": "de:Stadtsparkasse Wunstorf",
+      "name": "Stadtsparkasse Wunstorf"
+    }
+  },
+  "amenity/bank|Stadtsparkasse Wuppertal": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Stadtsparkasse Wuppertal",
+      "brand:wikidata": "Q1639934",
+      "brand:wikipedia": "de:Stadtsparkasse Wuppertal",
+      "name": "Stadtsparkasse Wuppertal"
+    }
+  },
   "amenity/bank|Stanbic Bank": {
     "tags": {
       "amenity": "bank",
@@ -5503,6 +9185,26 @@
       "brand:wikipedia": "en:State Employees Credit Union",
       "name": "State Employees Credit Union",
       "short_name": "SECU"
+    }
+  },
+  "amenity/bank|Städtische Sparkasse Offenbach am Main": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Städtische Sparkasse Offenbach am Main",
+      "brand:wikidata": "Q18334351",
+      "brand:wikipedia": "de:Städtische Sparkasse Offenbach am Main",
+      "name": "Städtische Sparkasse Offenbach am Main"
+    }
+  },
+  "amenity/bank|Städtische Sparkasse zu Schwelm": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Städtische Sparkasse zu Schwelm",
+      "brand:wikidata": "Q18631341",
+      "brand:wikipedia": "de:Städtische Sparkasse zu Schwelm",
+      "name": "Städtische Sparkasse zu Schwelm"
     }
   },
   "amenity/bank|Summit Bank": {
@@ -5664,6 +9366,16 @@
       "brand:wikidata": "Q1718069",
       "brand:wikipedia": "en:Tatra banka",
       "name": "Tatra banka"
+    }
+  },
+  "amenity/bank|Taunus Sparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Taunus Sparkasse",
+      "brand:wikidata": "Q1737542",
+      "brand:wikipedia": "de:Taunus Sparkasse",
+      "name": "Taunus Sparkasse"
     }
   },
   "amenity/bank|Taytay sa Kauswagan": {
@@ -5982,6 +9694,56 @@
       "name": "Veneto Banca"
     }
   },
+  "amenity/bank|Verbandssparkasse Goch-Kevelaer-Weeze": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Verbandssparkasse Goch-Kevelaer-Weeze",
+      "brand:wikidata": "Q1803570",
+      "brand:wikipedia": "de:Verbandssparkasse Goch-Kevelaer-Weeze",
+      "name": "Verbandssparkasse Goch-Kevelaer-Weeze"
+    }
+  },
+  "amenity/bank|Verbundsparkasse Emsdetten-Ochtrup": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Verbundsparkasse Emsdetten-Ochtrup",
+      "brand:wikidata": "Q18632340",
+      "brand:wikipedia": "de:Verbundsparkasse Emsdetten-Ochtrup",
+      "name": "Verbundsparkasse Emsdetten-Ochtrup"
+    }
+  },
+  "amenity/bank|Vereinigte Sparkasse im Märkischen Kreis": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Vereinigte Sparkasse im Märkischen Kreis",
+      "brand:wikidata": "Q16321084",
+      "brand:wikipedia": "de:Vereinigte Sparkasse im Märkischen Kreis",
+      "name": "Vereinigte Sparkasse im Märkischen Kreis"
+    }
+  },
+  "amenity/bank|Vereinigte Sparkassen Eschenbach i.d.OPf. Neustadt a.d.Waldnaab Vohenstrauß": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Vereinigte Sparkassen Eschenbach i.d.OPf. Neustadt a.d.Waldnaab Vohenstrauß",
+      "brand:wikidata": "Q2514962",
+      "brand:wikipedia": "de:Vereinigte Sparkassen Eschenbach i.d.OPf. Neustadt a.d.Waldnaab Vohenstrauß",
+      "name": "Vereinigte Sparkassen Eschenbach i.d.OPf. Neustadt a.d.Waldnaab Vohenstrauß"
+    }
+  },
+  "amenity/bank|Vereinigte Sparkassen Gunzenhausen": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Vereinigte Sparkassen Gunzenhausen",
+      "brand:wikidata": "Q2514964",
+      "brand:wikipedia": "de:Vereinigte Sparkassen Gunzenhausen",
+      "name": "Vereinigte Sparkassen Gunzenhausen"
+    }
+  },
   "amenity/bank|Vietcombank": {
     "countryCodes": ["vn"],
     "tags": {
@@ -6041,6 +9803,16 @@
       "name": "VÚB"
     }
   },
+  "amenity/bank|Wartburg-Sparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Wartburg-Sparkasse",
+      "brand:wikidata": "Q2549915",
+      "brand:wikipedia": "de:Wartburg-Sparkasse",
+      "name": "Wartburg-Sparkasse"
+    }
+  },
   "amenity/bank|Washington Federal": {
     "countryCodes": ["us"],
     "tags": {
@@ -6080,6 +9852,17 @@
       "brand:wikidata": "Q7983629",
       "brand:wikipedia": "en:WesBanco",
       "name": "WesBanco"
+    }
+  },
+  "amenity/bank|Weser-Elbe-Sparkasse": {
+    "countryCodes": ["de"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Weser-Elbe-Sparkasse",
+      "brand:wikidata": "Q1787820",
+      "brand:wikipedia": "de:Weser-Elbe-Sparkasse",
+      "name": "Weser-Elbe-Sparkasse",
+      "short_name": "WESPA"
     }
   },
   "amenity/bank|Western Union": {


### PR DESCRIPTION
> [Savings banks in German-speaking countries are called Sparkasse (pl: Sparkassen).](https://en.wikipedia.org/wiki/German_public_bank)

Two of them were already added, so I figured I might as well complete the list. The diff looks a bit strange on my end, but `amenity/bank|Mittelbrandenburgische Sparkasse` is the only entry I actually amended - all other changes are new entries.