### PR TITLE
Add Cooper Tire & Rubber Company to brand/shop/tyres

### DIFF
--- a/brands/shop/typres.json
+++ b/brands/shop/typres.json
@@ -1,0 +1,12 @@
+{
+  "shop/typres|Cooper Tire & Rubber Company": {
+    "countryCodes": ["us"],
+    "tags": {
+      "brand": "Cooper Tire & Rubber Company",
+      "brand:wikidata": "Q1129847",
+      "brand:wikipedia": "en:Cooper Tire & Rubber Company",
+      "name": "Cooper Tire & Rubber Company",
+      "shop": "tyres"
+    }
+  }
+}

--- a/brands/shop/tyres.json
+++ b/brands/shop/tyres.json
@@ -106,5 +106,15 @@
       "name": "Vianor",
       "shop": "tyres"
     }
+  },
+  "shop/typres|Cooper Tire & Rubber Company": {
+    "countryCodes": ["us"],
+    "tags": {
+      "brand": "Cooper Tire & Rubber Company",
+      "brand:wikidata": "Q1129847",
+      "brand:wikipedia": "en:Cooper Tire & Rubber Company",
+      "name": "Cooper Tire & Rubber Company",
+      "shop": "tyres"
+    }
   }
 }


### PR DESCRIPTION
**Add Cooper Tire & Rubber Company to brand/shop/tyres** 
First contribution

"brand": "Cooper Tire & Rubber Company",
"brand:wikidata": "Q1129847",
"brand:wikipedia": "en:Cooper Tire & Rubber Company",