### PR TITLE
Add tyres brand & fix missing tags in restaurant

### DIFF
--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -3218,7 +3218,7 @@
     "tags": {
       "amenity": "restaurant",
       "brand": "弘爺漢堡",
-      "cuisine": "american",
+      "cuisine": "american;breakfast",
       "name": "弘爺漢堡",
       "name:en": "Hong Ya Hambuger"
     }
@@ -3306,10 +3306,13 @@
     }
   },
   "amenity/restaurant|麥味登": {
+    "countryCodes": ["tw"],
     "tags": {
       "amenity": "restaurant",
       "brand": "麥味登",
-      "name": "麥味登"
+      "cuisine": "american;breakfast",
+      "name": "麥味登",
+      "name:en": "My Warn Day Care & Brunch"
     }
   },
   "amenity/restaurant|바다횟집": {

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -127,7 +127,14 @@
     }
   },
   "amenity/restaurant|Benihana": {
-    "countryCodes": ["aw", "br", "ca", "pa", "sv", "us"],
+    "countryCodes": [
+      "aw",
+      "br",
+      "ca",
+      "pa",
+      "sv",
+      "us"
+    ],
     "matchNames": ["benihana of tokyo"],
     "tags": {
       "amenity": "restaurant",
@@ -209,7 +216,13 @@
     }
   },
   "amenity/restaurant|Blaze Pizza": {
-    "countryCodes": ["bh", "ca", "kw", "sa", "us"],
+    "countryCodes": [
+      "bh",
+      "ca",
+      "kw",
+      "sa",
+      "us"
+    ],
     "tags": {
       "amenity": "restaurant",
       "brand": "Blaze Pizza",
@@ -242,7 +255,17 @@
     }
   },
   "amenity/restaurant|Bonchon Chicken": {
-    "countryCodes": ["bh", "kh", "kr", "kw", "my", "ph", "sg", "th", "us"],
+    "countryCodes": [
+      "bh",
+      "kh",
+      "kr",
+      "kw",
+      "my",
+      "ph",
+      "sg",
+      "th",
+      "us"
+    ],
     "tags": {
       "amenity": "restaurant",
       "brand": "Bonchon Chicken",
@@ -625,7 +648,10 @@
   },
   "amenity/restaurant|Cora~(non-Quebec)": {
     "countryCodes": ["ca"],
-    "nomatch": ["amenity/restaurant|Cora~(Quebec)", "shop/supermarket|Cora"],
+    "nomatch": [
+      "amenity/restaurant|Cora~(Quebec)",
+      "shop/supermarket|Cora"
+    ],
     "tags": {
       "amenity": "restaurant",
       "brand": "Cora",
@@ -964,7 +990,10 @@
   },
   "amenity/restaurant|Golden Corral": {
     "countryCodes": ["us"],
-    "matchNames": ["golden corral buffet", "golden corral buffet and grill"],
+    "matchNames": [
+      "golden corral buffet",
+      "golden corral buffet and grill"
+    ],
     "tags": {
       "amenity": "restaurant",
       "brand": "Golden Corral",
@@ -1128,7 +1157,10 @@
   },
   "amenity/restaurant|Husky House": {
     "countryCodes": ["ca"],
-    "nomatch": ["amenity/fuel|Husky", "shop/convenience|Husky"],
+    "nomatch": [
+      "amenity/fuel|Husky",
+      "shop/convenience|Husky"
+    ],
     "tags": {
       "amenity": "restaurant",
       "brand": "Husky",
@@ -1139,7 +1171,9 @@
     }
   },
   "amenity/restaurant|IHOP": {
-    "matchNames": ["international house of pancakes"],
+    "matchNames": [
+      "international house of pancakes"
+    ],
     "tags": {
       "amenity": "restaurant",
       "brand": "IHOP",
@@ -1287,7 +1321,15 @@
     }
   },
   "amenity/restaurant|L'Osteria": {
-    "countryCodes": ["at", "ch", "cz", "de", "fr", "gb", "nl"],
+    "countryCodes": [
+      "at",
+      "ch",
+      "cz",
+      "de",
+      "fr",
+      "gb",
+      "nl"
+    ],
     "tags": {
       "amenity": "restaurant",
       "brand": "L'Osteria",
@@ -1476,7 +1518,11 @@
   },
   "amenity/restaurant|Marie Callender's": {
     "countryCodes": ["mx", "us"],
-    "matchNames": ["marie calendar", "marie calendar's", "marie callendar's"],
+    "matchNames": [
+      "marie calendar",
+      "marie calendar's",
+      "marie callendar's"
+    ],
     "tags": {
       "amenity": "restaurant",
       "brand": "Marie Callender's",
@@ -1511,7 +1557,10 @@
   },
   "amenity/restaurant|McCormick & Schmick's": {
     "countryCodes": ["us"],
-    "matchNames": ["mccormick and schmick", "mccormick and schmicks grill"],
+    "matchNames": [
+      "mccormick and schmick",
+      "mccormick and schmicks grill"
+    ],
     "tags": {
       "amenity": "restaurant",
       "brand": "McCormick & Schmick's",
@@ -1646,7 +1695,11 @@
   },
   "amenity/restaurant|Noodles & Company": {
     "countryCodes": ["us"],
-    "matchNames": ["noodles and co", "noodles co", "noodles company"],
+    "matchNames": [
+      "noodles and co",
+      "noodles co",
+      "noodles company"
+    ],
     "tags": {
       "amenity": "restaurant",
       "brand": "Noodles & Company",
@@ -1842,7 +1895,15 @@
     }
   },
   "amenity/restaurant|Phở Hòa": {
-    "countryCodes": ["ca", "id", "kr", "ms", "ph", "tw", "us"],
+    "countryCodes": [
+      "ca",
+      "id",
+      "kr",
+      "ms",
+      "ph",
+      "tw",
+      "us"
+    ],
     "tags": {
       "alt_name": "Phở Hoà",
       "alt_name:en": "Pho Hoa",
@@ -1891,7 +1952,9 @@
     }
   },
   "amenity/restaurant|Pizza Hut": {
-    "nomatch": ["amenity/fast_food|Pizza Hut Express"],
+    "nomatch": [
+      "amenity/fast_food|Pizza Hut Express"
+    ],
     "tags": {
       "amenity": "restaurant",
       "brand": "Pizza Hut",
@@ -1934,7 +1997,13 @@
     }
   },
   "amenity/restaurant|Ponderosa Steakhouse": {
-    "countryCodes": ["ae", "eg", "qa", "tw", "us"],
+    "countryCodes": [
+      "ae",
+      "eg",
+      "qa",
+      "tw",
+      "us"
+    ],
     "matchNames": ["ponderosa"],
     "tags": {
       "amenity": "restaurant",
@@ -2209,7 +2278,9 @@
   },
   "amenity/restaurant|St-Hubert": {
     "countryCodes": ["ca"],
-    "nomatch": ["amenity/fast_food|St-Hubert Express"],
+    "nomatch": [
+      "amenity/fast_food|St-Hubert Express"
+    ],
     "tags": {
       "amenity": "restaurant",
       "brand": "St-Hubert",
@@ -2597,7 +2668,13 @@
     }
   },
   "amenity/restaurant|Zambrero": {
-    "countryCodes": ["au", "ie", "nl", "th", "us"],
+    "countryCodes": [
+      "au",
+      "ie",
+      "nl",
+      "th",
+      "us"
+    ],
     "tags": {
       "amenity": "restaurant",
       "brand": "Zambrero",
@@ -2630,7 +2707,13 @@
     }
   },
   "amenity/restaurant|dean&david": {
-    "countryCodes": ["at", "ch", "de", "lu", "qa"],
+    "countryCodes": [
+      "at",
+      "ch",
+      "de",
+      "lu",
+      "qa"
+    ],
     "tags": {
       "amenity": "restaurant",
       "brand": "dean&david",
@@ -3131,10 +3214,11 @@
     }
   },
   "amenity/restaurant|弘爺漢堡": {
-    "countryCode": "tw",
+    "countryCodes": ["tw"],
     "tags": {
       "amenity": "restaurant",
       "brand": "弘爺漢堡",
+      "cuisine": "american",
       "name": "弘爺漢堡",
       "name:en": "Hong Ya Hambuger"
     }

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -3010,7 +3010,7 @@
       "brand": "三媽臭臭鍋",
       "cuisine": "taiwanese",
       "name": "三媽臭臭鍋",
-      "name:tw": "三媽臭臭鍋"
+      "name:zh": "三媽臭臭鍋"
     }
   },
   "amenity/restaurant|丸亀製麺": {
@@ -3131,10 +3131,12 @@
     }
   },
   "amenity/restaurant|弘爺漢堡": {
+    "countryCode": "tw",
     "tags": {
       "amenity": "restaurant",
       "brand": "弘爺漢堡",
-      "name": "弘爺漢堡"
+      "name": "弘爺漢堡",
+      "name:en": "Hong Ya Hambuger"
     }
   },
   "amenity/restaurant|木曽路": {

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -127,14 +127,7 @@
     }
   },
   "amenity/restaurant|Benihana": {
-    "countryCodes": [
-      "aw",
-      "br",
-      "ca",
-      "pa",
-      "sv",
-      "us"
-    ],
+    "countryCodes": ["aw", "br", "ca", "pa", "sv", "us"],
     "matchNames": ["benihana of tokyo"],
     "tags": {
       "amenity": "restaurant",
@@ -216,13 +209,7 @@
     }
   },
   "amenity/restaurant|Blaze Pizza": {
-    "countryCodes": [
-      "bh",
-      "ca",
-      "kw",
-      "sa",
-      "us"
-    ],
+    "countryCodes": ["bh", "ca", "kw", "sa", "us"],
     "tags": {
       "amenity": "restaurant",
       "brand": "Blaze Pizza",
@@ -255,17 +242,7 @@
     }
   },
   "amenity/restaurant|Bonchon Chicken": {
-    "countryCodes": [
-      "bh",
-      "kh",
-      "kr",
-      "kw",
-      "my",
-      "ph",
-      "sg",
-      "th",
-      "us"
-    ],
+    "countryCodes": ["bh", "kh", "kr", "kw", "my", "ph", "sg", "th", "us"],
     "tags": {
       "amenity": "restaurant",
       "brand": "Bonchon Chicken",
@@ -648,10 +625,7 @@
   },
   "amenity/restaurant|Cora~(non-Quebec)": {
     "countryCodes": ["ca"],
-    "nomatch": [
-      "amenity/restaurant|Cora~(Quebec)",
-      "shop/supermarket|Cora"
-    ],
+    "nomatch": ["amenity/restaurant|Cora~(Quebec)", "shop/supermarket|Cora"],
     "tags": {
       "amenity": "restaurant",
       "brand": "Cora",
@@ -990,10 +964,7 @@
   },
   "amenity/restaurant|Golden Corral": {
     "countryCodes": ["us"],
-    "matchNames": [
-      "golden corral buffet",
-      "golden corral buffet and grill"
-    ],
+    "matchNames": ["golden corral buffet", "golden corral buffet and grill"],
     "tags": {
       "amenity": "restaurant",
       "brand": "Golden Corral",
@@ -1157,10 +1128,7 @@
   },
   "amenity/restaurant|Husky House": {
     "countryCodes": ["ca"],
-    "nomatch": [
-      "amenity/fuel|Husky",
-      "shop/convenience|Husky"
-    ],
+    "nomatch": ["amenity/fuel|Husky", "shop/convenience|Husky"],
     "tags": {
       "amenity": "restaurant",
       "brand": "Husky",
@@ -1171,9 +1139,7 @@
     }
   },
   "amenity/restaurant|IHOP": {
-    "matchNames": [
-      "international house of pancakes"
-    ],
+    "matchNames": ["international house of pancakes"],
     "tags": {
       "amenity": "restaurant",
       "brand": "IHOP",
@@ -1321,15 +1287,7 @@
     }
   },
   "amenity/restaurant|L'Osteria": {
-    "countryCodes": [
-      "at",
-      "ch",
-      "cz",
-      "de",
-      "fr",
-      "gb",
-      "nl"
-    ],
+    "countryCodes": ["at", "ch", "cz", "de", "fr", "gb", "nl"],
     "tags": {
       "amenity": "restaurant",
       "brand": "L'Osteria",
@@ -1518,11 +1476,7 @@
   },
   "amenity/restaurant|Marie Callender's": {
     "countryCodes": ["mx", "us"],
-    "matchNames": [
-      "marie calendar",
-      "marie calendar's",
-      "marie callendar's"
-    ],
+    "matchNames": ["marie calendar", "marie calendar's", "marie callendar's"],
     "tags": {
       "amenity": "restaurant",
       "brand": "Marie Callender's",
@@ -1557,10 +1511,7 @@
   },
   "amenity/restaurant|McCormick & Schmick's": {
     "countryCodes": ["us"],
-    "matchNames": [
-      "mccormick and schmick",
-      "mccormick and schmicks grill"
-    ],
+    "matchNames": ["mccormick and schmick", "mccormick and schmicks grill"],
     "tags": {
       "amenity": "restaurant",
       "brand": "McCormick & Schmick's",
@@ -1695,11 +1646,7 @@
   },
   "amenity/restaurant|Noodles & Company": {
     "countryCodes": ["us"],
-    "matchNames": [
-      "noodles and co",
-      "noodles co",
-      "noodles company"
-    ],
+    "matchNames": ["noodles and co", "noodles co", "noodles company"],
     "tags": {
       "amenity": "restaurant",
       "brand": "Noodles & Company",
@@ -1895,15 +1842,7 @@
     }
   },
   "amenity/restaurant|Phở Hòa": {
-    "countryCodes": [
-      "ca",
-      "id",
-      "kr",
-      "ms",
-      "ph",
-      "tw",
-      "us"
-    ],
+    "countryCodes": ["ca", "id", "kr", "ms", "ph", "tw", "us"],
     "tags": {
       "alt_name": "Phở Hoà",
       "alt_name:en": "Pho Hoa",
@@ -1952,9 +1891,7 @@
     }
   },
   "amenity/restaurant|Pizza Hut": {
-    "nomatch": [
-      "amenity/fast_food|Pizza Hut Express"
-    ],
+    "nomatch": ["amenity/fast_food|Pizza Hut Express"],
     "tags": {
       "amenity": "restaurant",
       "brand": "Pizza Hut",
@@ -1997,13 +1934,7 @@
     }
   },
   "amenity/restaurant|Ponderosa Steakhouse": {
-    "countryCodes": [
-      "ae",
-      "eg",
-      "qa",
-      "tw",
-      "us"
-    ],
+    "countryCodes": ["ae", "eg", "qa", "tw", "us"],
     "matchNames": ["ponderosa"],
     "tags": {
       "amenity": "restaurant",
@@ -2278,9 +2209,7 @@
   },
   "amenity/restaurant|St-Hubert": {
     "countryCodes": ["ca"],
-    "nomatch": [
-      "amenity/fast_food|St-Hubert Express"
-    ],
+    "nomatch": ["amenity/fast_food|St-Hubert Express"],
     "tags": {
       "amenity": "restaurant",
       "brand": "St-Hubert",
@@ -2668,13 +2597,7 @@
     }
   },
   "amenity/restaurant|Zambrero": {
-    "countryCodes": [
-      "au",
-      "ie",
-      "nl",
-      "th",
-      "us"
-    ],
+    "countryCodes": ["au", "ie", "nl", "th", "us"],
     "tags": {
       "amenity": "restaurant",
       "brand": "Zambrero",
@@ -2707,13 +2630,7 @@
     }
   },
   "amenity/restaurant|dean&david": {
-    "countryCodes": [
-      "at",
-      "ch",
-      "de",
-      "lu",
-      "qa"
-    ],
+    "countryCodes": ["at", "ch", "de", "lu", "qa"],
     "tags": {
       "amenity": "restaurant",
       "brand": "dean&david",
@@ -3087,10 +3004,13 @@
     }
   },
   "amenity/restaurant|三媽臭臭鍋": {
+    "countryCodes": ["tw"],
     "tags": {
       "amenity": "restaurant",
       "brand": "三媽臭臭鍋",
-      "name": "三媽臭臭鍋"
+      "cuisine": "taiwanese",
+      "name": "三媽臭臭鍋",
+      "name:tw": "三媽臭臭鍋"
     }
   },
   "amenity/restaurant|丸亀製麺": {

--- a/brands/shop/typres.json
+++ b/brands/shop/typres.json
@@ -1,0 +1,12 @@
+{
+  "shop/typres|Cooper Tire & Rubber Company": {
+    "countryCodes": ["us"],
+    "tags": {
+      "brand": "Cooper Tire & Rubber Company",
+      "brand:wikidata": "Q1129847",
+      "brand:wikipedia": "en:Cooper Tire & Rubber Company",
+      "name": "Cooper Tire & Rubber Company",
+      "shop": "tyres"
+    }
+  }
+}

--- a/brands/shop/tyres.json
+++ b/brands/shop/tyres.json
@@ -107,13 +107,21 @@
       "shop": "tyres"
     }
   },
-  "shop/typres|Cooper Tire & Rubber Company": {
-    "countryCodes": ["us"],
+  "shop/tyres|Alliance Tire Company": {
     "tags": {
-      "brand": "Cooper Tire & Rubber Company",
-      "brand:wikidata": "Q1129847",
-      "brand:wikipedia": "en:Cooper Tire & Rubber Company",
-      "name": "Cooper Tire & Rubber Company",
+      "brand": "Alliance",
+      "brand:wikidata": "Q420541",
+      "brand:wikipedia": "en:Alliance Tire Company Ltd",
+      "name": "Alliance Tire Company",
+      "shop": "tyres"
+    }
+  },
+  "shop/tyres|Apollo Tyres": {
+    "tags": {
+      "brand": "Apollo Tyres",
+      "brand:wikidata": "Q4780362",
+      "brand:wikipedia": "en:Apollo Tyres",
+      "name": "Apollo Tyres",
       "shop": "tyres"
     }
   }

--- a/brands/shop/tyres.json
+++ b/brands/shop/tyres.json
@@ -133,5 +133,14 @@
       "name": "Continental AG",
       "shop": "tyres"
     }
+  },
+  "shop/typres|Cooper Tire & Rubber Company": {
+    "tags": {
+      "brand": "Cooper Tire & Rubber Company",
+      "brand:wikidata": "Q1129847",
+      "brand:wikipedia": "en:Cooper Tire & Rubber Company",
+      "name": "Cooper Tire & Rubber Company",
+      "shop": "tyres"
+    }
   }
 }

--- a/brands/shop/tyres.json
+++ b/brands/shop/tyres.json
@@ -124,5 +124,14 @@
       "name": "Apollo Tyres",
       "shop": "tyres"
     }
+  },
+  "shop/tyres|Continental AG": {
+    "tags": {
+      "brand": "Continental AG",
+      "brand:wikidata": "Q163241",
+      "brand:wikipedia": "en:Continental AG",
+      "name": "Continental AG",
+      "shop": "tyres"
+    }
   }
 }

--- a/brands/shop/tyres.json
+++ b/brands/shop/tyres.json
@@ -106,5 +106,15 @@
       "name": "Vianor",
       "shop": "tyres"
     }
+  },
+  "shop/typres|Cooper Tire & Rubber Company": {
+    "countryCodes": ["us"],
+    "tags": {
+      "brand": "Cooper Tire & Rubber Company",
+      "brand:wikidata": "Q1129847",
+      "brand:wikipedia": "en:Cooper Tire & Rubber Company",
+      "name": "Cooper Tire & Rubber Company",
+      "shop": "tyres"
+    }
   }
 }


### PR DESCRIPTION
_This is my first contribution. My preemptive apology if there are any mistakes and shortcomings. Much appreciated._

**Added new brands in tyres:**
- Alliance
- Apollo
- Cooper Tire

**Fixed missing tags in restaurants:**
Added cuisine tag, English name and countryCodes.
- 三媽臭臭鍋
- 麥味登
- 弘爺漢堡
