### PR TITLE
Add vending machines (part 2) plus several brands of Japan

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -8095,6 +8095,20 @@
       "name:zh-Hant": "東亞銀行"
     }
   },
+  "amenity/bank|東京ベイ信金": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "東京ベイ信金",
+      "brand:en": "Tokyo Bay Shinkin Bank",
+      "brand:ja": "東京ベイ信金",
+      "brand:wikidata": "Q11524392",
+      "brand:wikipedia": "ja:東京ベイ信金",
+      "name": "東京ベイ信金",
+      "name:en": "Tokyo Bay Shinkin Bank",
+      "name:ja": "東京ベイ信金"
+    }
+  },
   "amenity/bank|東日本銀行": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -7780,6 +7780,21 @@
       "name": "京城商業銀行"
     }
   },
+  "amenity/bank|京葉銀行": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "alt_name:en": "αBANK",
+      "amenity": "bank",
+      "brand": "京葉銀行",
+      "brand:en": "Keiyo Bank",
+      "brand:ja": "京葉銀行",
+      "brand:wikidata": "Q11374734",
+      "brand:wikipedia": "ja:京葉銀行",
+      "name": "京葉銀行",
+      "name:en": "Keiyo Bank",
+      "name:ja": "京葉銀行"
+    }
+  },
   "amenity/bank|京都中央信用金庫": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -7880,6 +7880,20 @@
       "name:en": "Hokkaido Bank"
     }
   },
+  "amenity/bank|千葉興業銀行": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "千葉興業銀行",
+      "brand:en": "Chiba Kogyo Bank",
+      "brand:ja": "千葉興業銀行",
+      "brand:wikidata": "Q11406742",
+      "brand:wikipedia": "ja:千葉興業銀行",
+      "name": "千葉興業銀行",
+      "name:en": "Chiba Kogyo Bank",
+      "name:ja": "千葉興業銀行"
+    }
+  },
   "amenity/bank|千葉銀行": {
     "countryCodes": ["jp"],
     "tags": {
@@ -7940,6 +7954,20 @@
       "brand:wikipedia": "en:Taiwan Cooperative Bank",
       "name": "合作金庫商業銀行",
       "name:en": "Taiwan Cooperative Bank"
+    }
+  },
+  "amenity/bank|商工中金": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "商工中金",
+      "brand:en": "Shoko Chukin Bank",
+      "brand:ja": "商工中金",
+      "brand:wikidata": "Q11418759",
+      "brand:wikipedia": "ja:商工中金",
+      "name": "商工中金",
+      "name:en": "Shoko Chukin Bank",
+      "name:ja": "商工中金"
     }
   },
   "amenity/bank|國泰世華商業銀行": {

--- a/brands/amenity/cafe.json
+++ b/brands/amenity/cafe.json
@@ -1720,7 +1720,7 @@
     }
   },
   "amenity/cafe|貢茶~(Japan)": {
-    "countryCodes": ["ja"],
+    "countryCodes": ["jp"],
     "tags": {
       "amenity": "cafe",
       "brand": "貢茶",

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -648,18 +648,18 @@
       "vending": "milk"
     }
   },
-  "amenity/vending_machine|ロッテ": {
+  "amenity/vending_machine|ロッテアイス": {
     "countryCodes": ["jp"],
     "tags": {
       "amenity": "vending_machine",
-      "brand": "ロッテ",
-      "brand:en": "Lotte",
-      "brand:ja": "ロッテ",
+      "brand": "ロッテアイス",
+      "brand:en": "Lotte Ice Cream",
+      "brand:ja": "ロッテアイス",
       "brand:wikidata": "Q24886018",
-      "brand:wikipedia": "ja:ロッテ",
-      "name": "ロッテ",
-      "name:en": "Lotte",
-      "name:ja": "ロッテ",
+      "brand:wikipedia": "ja:ロッテアイス",
+      "name": "ロッテアイス",
+      "name:en": "Lotte Ice Cream",
+      "name:ja": "ロッテアイス",
       "vending": "ice_cream"
     }
   },

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -293,6 +293,21 @@
       "vending": "cigarettes"
     }
   },
+  "amenity/vending_machine|UCC": {
+    "countryCodes": ["jp"],
+    "matchNames": ["ucc上島珈琲"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "UCC",
+      "brand:wikidata": "Q1185060",
+      "brand:wikipedia": "ja:UCC上島珈琲",
+      "name": "UCC",
+      "official_name": "上島珈琲",
+      "official_name:en": "Ueshima Coffee",
+      "official_name:ja": "上島珈琲",
+      "vending": "coffee"
+    }
+  },
   "amenity/vending_machine|VVO Fahrausweise": {
     "countryCodes": ["de"],
     "tags": {

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -603,7 +603,7 @@
   "amenity/vending_machine|ニチレイフーズ": {
     "countryCodes": ["jp"],
     "tags": {
-      "alt_name:en": "Nichirei 24 Hour Hot Menu Casual Frozen Foods ",
+      "alt_name:en": "Nichirei 24 Hour Hot Menu Casual Frozen Foods",
       "amenity": "vending_machine",
       "brand": "ニチレイフーズ",
       "brand:en": "Nichirei Foods",

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -600,6 +600,22 @@
       "vending": "food"
     }
   },
+  "amenity/vending_machine|ニチレイフーズ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "alt_name:en": "Nichirei Casual Frozen Foods",
+      "amenity": "vending_machine",
+      "brand": "ニチレイフーズ",
+      "brand:en": "Nichirei Foods",
+      "brand:ja": "ニチレイフーズ",
+      "brand:wikidata": "Q4921527",
+      "brand:wikipedia": "ja:ニチレイ",
+      "name": "ニチレイフーズ",
+      "name:en": "Nichirei Foods",
+      "name:ja": "ニチレイフーズ",
+      "vending": "food"
+    }
+  },
   "amenity/vending_machine|ポッカサッポロ": {
     "countryCodes": ["jp"],
     "matchNames": ["pokka sapporo"],

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -616,6 +616,22 @@
       "vending": "water;food"
     }
   },
+  "amenity/vending_machine|メトロの缶詰": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "alt_name:en": "Metocan Shop",
+      "amenity": "vending_machine",
+      "brand": "メトロの缶詰",
+      "brand:en": "Metro Commerce",
+      "brand:ja": "メトロの缶詰",
+      "brand:wikidata": "Q11343895",
+      "brand:wikipedia": "ja:メトロコマース",
+      "name": "メトロの缶詰",
+      "name:en": "Metro Commerce",
+      "name:ja": "メトロの缶詰",
+      "vending": "gift"
+    }
+  },
   "amenity/vending_machine|ヤクルト": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -153,6 +153,19 @@
       "vending": "ice_cubes"
     }
   },
+  "amenity/vending_machine|JT": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "JT",
+      "brand:wikidata": "Q898568",
+      "brand:wikipedia": "ja:日本たばこ産業",
+      "name": "JT",
+      "official_name": "日本たばこ産業",
+      "official_name:en": "Japan Tobacco",
+      "vending": "cigarettes"
+    }
+  },
   "amenity/vending_machine|KKM": {
     "countryCodes": ["pl"],
     "tags": {
@@ -446,6 +459,21 @@
       "name:en": "Suntory",
       "name:ja": "サントリー",
       "vending": "drinks"
+    }
+  },
+  "amenity/vending_machine|ジョージア": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "ジョージア",
+      "brand:en": "Georgia",
+      "brand:ja": "ジョージア",
+      "brand:wikidata": "Q5547323",
+      "brand:wikipedia": "ja:ジョージア (缶コーヒー)",
+      "name": "ジョージア",
+      "name:en": "Georgia",
+      "name:ja": "ジョージア",
+      "vending": "coffee"
     }
   },
   "amenity/vending_machine|セブンティーンアイス": {

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -448,6 +448,21 @@
       "vending": "drinks"
     }
   },
+  "amenity/vending_machine|セブンティーンアイス": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "セブンティーンアイス",
+      "brand:en": "Seventeen Ice",
+      "brand:ja": "セブンティーンアイス",
+      "brand:wikidata": "Q11314427",
+      "brand:wikipedia": "ja:セブンティーンアイス",
+      "name": "セブンティーンアイス",
+      "name:en": "Seventeen Ice",
+      "name:ja": "セブンティーンアイス",
+      "vending": "ice_cream"
+    }
+  },
   "amenity/vending_machine|ダイドードリンコ": {
     "countryCodes": ["jp"],
     "matchNames": ["dydoドリンコ", "ダイドー"],

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -361,6 +361,21 @@
       "vending": "parcel_pickup"
     }
   },
+  "amenity/vending_machine|アキュア": {
+    "countryCodes": ["jp"],
+    "matchNames": ["acureの自販機"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "アキュア",
+      "brand:en": "Acure",
+      "brand:ja": "アキュア",
+      "brand:wikidata": "Q11226260",
+      "brand:wikipedia": "ja:JR東日本ウォータービジネス",
+      "name": "アキュア",
+      "name:en": "Acure",
+      "name:ja": "アキュア"
+    }
+  },
   "amenity/vending_machine|アサヒビール": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -345,6 +345,22 @@
       "vending": "drinks"
     }
   },
+  "amenity/vending_machine|だし道楽": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "だし道楽",
+      "brand:en": "Dashi Douraku",
+      "brand:ja": "だし道楽",
+      "brand:wikidata": "Q60989429",
+      "brand:wikipedia": "ja:だし道楽",
+      "drink:brewery": "yes",
+      "name": "だし道楽",
+      "name:en": "Dashi Douraku",
+      "name:ja": "だし道楽",
+      "vending": "food"
+    }
+  },
   "amenity/vending_machine|はこぽす": {
     "countryCodes": ["jp"],
     "matchTags": ["amenity/post_box"],

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -408,6 +408,21 @@
       "vending": "drinks"
     }
   },
+  "amenity/vending_machine|アペックス": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "アペックス",
+      "brand:en": "Apex",
+      "brand:ja": "アペックス",
+      "brand:wikidata": "Q11284782",
+      "brand:wikipedia": "ja:アペックス (企業)",
+      "name": "アペックス",
+      "name:en": "Apex",
+      "name:ja": "アペックス",
+      "vending": "coffee"
+    }
+  },
   "amenity/vending_machine|カップヌードル": {
     "countryCodes": ["jp"],
     "tags": {
@@ -599,6 +614,22 @@
       "name:en": "Pokka Sapporo",
       "name:ja": "ポッカサッポロ",
       "vending": "water;food"
+    }
+  },
+  "amenity/vending_machine|ヤクルト": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "ヤクルト",
+      "brand:en": "Yakult",
+      "brand:ja": "ヤクルト",
+      "brand:wikidata": "Q16172223",
+      "brand:wikipedia": "ja:ヤクルト本社",
+      "drink:milk": "yes",
+      "name": "ヤクルト",
+      "name:en": "Yakult",
+      "name:ja": "ヤクルト",
+      "vending": "milk"
     }
   },
   "amenity/vending_machine|伊藤園": {

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -554,6 +554,21 @@
       "vending": "drinks"
     }
   },
+  "amenity/vending_machine|ドール": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "ドール",
+      "brand:en": "Dole",
+      "brand:ja": "ドール",
+      "brand:wikidata": "Q492747",
+      "brand:wikipedia": "ja:ドール・フード・カンパニー",
+      "name": "ドール",
+      "name:en": "Dole",
+      "name:ja": "ドール",
+      "vending": "food"
+    }
+  },
   "amenity/vending_machine|ポッカサッポロ": {
     "countryCodes": ["jp"],
     "matchNames": ["pokka sapporo"],

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -632,6 +632,21 @@
       "vending": "milk"
     }
   },
+  "amenity/vending_machine|ロッテ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "ロッテ",
+      "brand:en": "Lotte",
+      "brand:ja": "ロッテ",
+      "brand:wikidata": "Q24886018",
+      "brand:wikipedia": "ja:ロッテ",
+      "name": "ロッテ",
+      "name:en": "Lotte",
+      "name:ja": "ロッテ",
+      "vending": "ice_cream"
+    }
+  },
   "amenity/vending_machine|伊藤園": {
     "countryCodes": ["jp"],
     "matchNames": ["ito en"],

--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -603,7 +603,7 @@
   "amenity/vending_machine|ニチレイフーズ": {
     "countryCodes": ["jp"],
     "tags": {
-      "alt_name:en": "Nichirei Casual Frozen Foods",
+      "alt_name:en": "Nichirei 24 Hour Hot Menu Casual Frozen Foods ",
       "amenity": "vending_machine",
       "brand": "ニチレイフーズ",
       "brand:en": "Nichirei Foods",

--- a/brands/office/estate_agent.json
+++ b/brands/office/estate_agent.json
@@ -401,6 +401,20 @@
       "office": "estate_agent"
     }
   },
+  "office/estate_agent|タウンハウジング": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "タウンハウジング",
+      "brand:en": "Townhousing",
+      "brand:ja": "タウンハウジング",
+      "brand:wikidata": "Q11315877",
+      "brand:wikipedia": "ja:タウンハウジング",
+      "name": "タウンハウジング",
+      "name:en": "Townhousing",
+      "name:ja": "タウンハウジング",
+      "office": "estate_agent"
+    }
+  },
   "office/estate_agent|ピタットハウス": {
     "countryCodes": ["jp"],
     "matchNames": ["ピタットハウスネットワーク"],

--- a/brands/shop/books.json
+++ b/brands/shop/books.json
@@ -427,6 +427,21 @@
       "shop": "books"
     }
   },
+  "shop/books|とらのあな": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "books": "comic",
+      "brand": "とらのあな",
+      "brand:en": "Toranoana",
+      "brand:ja": "とらのあな",
+      "brand:wikidata": "Q865297",
+      "brand:wikipedia": "ja:コミックとらのあな",
+      "name": "とらのあな",
+      "name:en": "Comic Toranoana",
+      "name:ja": "とらのあな",
+      "shop": "books"
+    }
+  },
   "shop/books|オリオン書房": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/shop/computer.json
+++ b/brands/shop/computer.json
@@ -42,5 +42,19 @@
       "name:ja": "じゃんぱら",
       "shop": "computer"
     }
+  },
+  "shop/computer|イオシス": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "イオシス",
+      "brand:en": "IOSYS",
+      "brand:ja": "イオシス",
+      "brand:wikidata": "Q17988651",
+      "brand:wikipedia": "ja:イオシス (株式会社)",
+      "name": "イオシス",
+      "name:en": "IOSYS",
+      "name:ja": "イオシス",
+      "shop": "computer"
+    }
   }
 }

--- a/brands/shop/computer.json
+++ b/brands/shop/computer.json
@@ -56,5 +56,19 @@
       "name:ja": "イオシス",
       "shop": "computer"
     }
+  },
+  "shop/computer|ツクモ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "ツクモ",
+      "brand:en": "TSUKUMO",
+      "brand:ja": "ツクモ",
+      "brand:wikidata": "Q29793996",
+      "brand:wikipedia": "ja:九十九電機",
+      "name": "ツクモ",
+      "name:en": "TSUKUMO",
+      "name:ja": "ツクモ",
+      "shop": "computer"
+    }
   }
 }

--- a/brands/shop/doityourself.json
+++ b/brands/shop/doityourself.json
@@ -598,6 +598,20 @@
       "shop": "doityourself"
     }
   },
+  "shop/doityourself|アマノ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "アマノ",
+      "brand:en": "Amano",
+      "brand:ja": "アマノ",
+      "brand:wikidata": "Q11284890",
+      "brand:wikipedia": "ja:アマノ",
+      "name": "アマノ",
+      "name:en": "Amano",
+      "name:ja": "アマノ",
+      "shop": "doityourself"
+    }
+  },
   "shop/doityourself|カインズホーム": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/shop/money_lender.json
+++ b/brands/shop/money_lender.json
@@ -103,5 +103,21 @@
       "name": "Moneytree",
       "shop": "money_lender"
     }
+  },
+  "shop/money_lender|プロミス": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "プロミス",
+      "brand:en": "Promise",
+      "brand:ja": "プロミス",
+      "brand:wikidata": "Q11243682",
+      "brand:wikipedia": "ja:SMBCコンシューマーファイナンス",
+      "name": "プロミス",
+      "name:en": "Promise",
+      "name:ja": "プロミス",
+      "official_name": "SMBCコンシューマーファイナンス",
+      "official_name:en": "SMBC Consumer Finance",
+      "shop": "money_lender"
+    }
   }
 }

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -5361,6 +5361,20 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|キョーエイ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "キョーエイ",
+      "brand:en": "Kyoei",
+      "brand:ja": "キョーエイ",
+      "brand:wikidata": "Q11297581",
+      "brand:wikipedia": "ja:キョーエイ",
+      "name": "キョーエイ",
+      "name:en": "Kyoei",
+      "name:ja": "キョーエイ",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|コープ": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -5534,6 +5534,20 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|ヤマナカ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "ヤマナカ",
+      "brand:en": "Yamanaka",
+      "brand:ja": "ヤマナカ",
+      "brand:wikidata": "Q11345199",
+      "brand:wikipedia": "ja:ヤマナカ",
+      "name": "ヤマナカ",
+      "name:en": "Yamanaka",
+      "name:ja": "ヤマナカ",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|ヨークベニマル": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -5261,6 +5261,20 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|イオンマーケット": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "イオンマーケット",
+      "brand:en": "Aeon Market",
+      "brand:ja": "イオンマーケット",
+      "brand:wikidata": "Q11331715",
+      "brand:wikipedia": "ja:イオンマーケット",
+      "name": "イオンマーケット",
+      "name:en": "Aeon Market",
+      "name:ja": "イオンマーケット",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|イズミヤ": {
     "countryCodes": ["jp"],
     "matchNames": ["いづみや"],

--- a/brands/shop/ticket.json
+++ b/brands/shop/ticket.json
@@ -36,5 +36,19 @@
       "name": "Минсктранс",
       "shop": "ticket"
     }
+  },
+  "shop/ticket|みどりの窓口": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "みどりの窓口",
+      "brand:en": "Midori-no-madoguchi",
+      "brand:ja": "みどりの窓口",
+      "brand:wikidata": "Q11279064",
+      "brand:wikipedia": "ja:みどりの窓口",
+      "name": "みどりの窓口",
+      "name:en": "JR Ticket Office",
+      "name:ja": "みどりの窓口",
+      "shop": "ticket"
+    }
   }
 }


### PR DESCRIPTION
Extension of: #3571

Now other brands from different financial entities are added. Several of the most popular vending machines because of the nearly 5 millions that exist in 2014 were also added. For example: Acure (JR).

I am trying to avoid any conflict with pull requests. In addition to adding sources about the brands (since first web searching generates more confusion like: "list of crazy..."). Exception is a little edit of "ja" tag to "jp".