### PR TITLE
Fix Rimi supermarket entry

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -3539,8 +3539,7 @@
     "countryCodes": ["ee", "lt", "lv"],
     "tags": {
       "brand": "Rimi",
-      "brand:wikidata": "Q7334456",
-      "brand:wikipedia": "en:Rimi (Norway)",
+      "brand:wikipedia": "en:Rimi Baltic",
       "name": "Rimi",
       "shop": "supermarket"
     }

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -3539,6 +3539,7 @@
     "countryCodes": ["ee", "lt", "lv"],
     "tags": {
       "brand": "Rimi",
+      "brand:wikidata": "Q3741108",
       "brand:wikipedia": "en:Rimi Baltic",
       "name": "Rimi",
       "shop": "supermarket"


### PR DESCRIPTION
* Fix brand wikipedia reference
* Remove incorrect wikidata entry (pointing at the defunct Norwegian chain entry; there does not seem to be an entry for the Baltic one)