### PR TITLE
Several of finance and shop brands of Japan

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -7780,6 +7780,21 @@
       "name": "京城商業銀行"
     }
   },
+  "amenity/bank|京葉銀行": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "alt_name:en": "αBANK",
+      "amenity": "bank",
+      "brand": "京葉銀行",
+      "brand:en": "Keiyo Bank",
+      "brand:ja": "京葉銀行",
+      "brand:wikidata": "Q11374734",
+      "brand:wikipedia": "ja:京葉銀行",
+      "name": "京葉銀行",
+      "name:en": "Keiyo Bank",
+      "name:ja": "京葉銀行"
+    }
+  },
   "amenity/bank|京都中央信用金庫": {
     "countryCodes": ["jp"],
     "tags": {
@@ -7880,6 +7895,20 @@
       "name:en": "Hokkaido Bank"
     }
   },
+  "amenity/bank|千葉興業銀行": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "千葉興業銀行",
+      "brand:en": "Chiba Kogyo Bank",
+      "brand:ja": "千葉興業銀行",
+      "brand:wikidata": "Q11406742",
+      "brand:wikipedia": "ja:千葉興業銀行",
+      "name": "千葉興業銀行",
+      "name:en": "Chiba Kogyo Bank",
+      "name:ja": "千葉興業銀行"
+    }
+  },
   "amenity/bank|千葉銀行": {
     "countryCodes": ["jp"],
     "tags": {
@@ -7940,6 +7969,20 @@
       "brand:wikipedia": "en:Taiwan Cooperative Bank",
       "name": "合作金庫商業銀行",
       "name:en": "Taiwan Cooperative Bank"
+    }
+  },
+  "amenity/bank|商工中金": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "商工中金",
+      "brand:en": "Shoko Chukin Bank",
+      "brand:ja": "商工中金",
+      "brand:wikidata": "Q11418759",
+      "brand:wikipedia": "ja:商工中金",
+      "name": "商工中金",
+      "name:en": "Shoko Chukin Bank",
+      "name:ja": "商工中金"
     }
   },
   "amenity/bank|國泰世華商業銀行": {
@@ -8093,6 +8136,20 @@
       "name:en": "Bank of East Asia",
       "name:zh-Hans": "东亚银行",
       "name:zh-Hant": "東亞銀行"
+    }
+  },
+  "amenity/bank|東京ベイ信金": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "東京ベイ信金",
+      "brand:en": "Tokyo Bay Shinkin Bank",
+      "brand:ja": "東京ベイ信金",
+      "brand:wikidata": "Q11524392",
+      "brand:wikipedia": "ja:東京ベイ信金",
+      "name": "東京ベイ信金",
+      "name:en": "Tokyo Bay Shinkin Bank",
+      "name:ja": "東京ベイ信金"
     }
   },
   "amenity/bank|東日本銀行": {

--- a/brands/amenity/cafe.json
+++ b/brands/amenity/cafe.json
@@ -1720,7 +1720,7 @@
     }
   },
   "amenity/cafe|貢茶~(Japan)": {
-    "countryCodes": ["ja"],
+    "countryCodes": ["jp"],
     "tags": {
       "amenity": "cafe",
       "brand": "貢茶",

--- a/brands/office/estate_agent.json
+++ b/brands/office/estate_agent.json
@@ -401,6 +401,20 @@
       "office": "estate_agent"
     }
   },
+  "office/estate_agent|タウンハウジング": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "タウンハウジング",
+      "brand:en": "Townhousing",
+      "brand:ja": "タウンハウジング",
+      "brand:wikidata": "Q11315877",
+      "brand:wikipedia": "ja:タウンハウジング",
+      "name": "タウンハウジング",
+      "name:en": "Townhousing",
+      "name:ja": "タウンハウジング",
+      "office": "estate_agent"
+    }
+  },
   "office/estate_agent|ピタットハウス": {
     "countryCodes": ["jp"],
     "matchNames": ["ピタットハウスネットワーク"],

--- a/brands/shop/books.json
+++ b/brands/shop/books.json
@@ -427,6 +427,21 @@
       "shop": "books"
     }
   },
+  "shop/books|とらのあな": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "books": "comic",
+      "brand": "とらのあな",
+      "brand:en": "Toranoana",
+      "brand:ja": "とらのあな",
+      "brand:wikidata": "Q865297",
+      "brand:wikipedia": "ja:コミックとらのあな",
+      "name": "とらのあな",
+      "name:en": "Comic Toranoana",
+      "name:ja": "とらのあな",
+      "shop": "books"
+    }
+  },
   "shop/books|オリオン書房": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/shop/computer.json
+++ b/brands/shop/computer.json
@@ -42,5 +42,33 @@
       "name:ja": "じゃんぱら",
       "shop": "computer"
     }
+  },
+  "shop/computer|イオシス": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "イオシス",
+      "brand:en": "IOSYS",
+      "brand:ja": "イオシス",
+      "brand:wikidata": "Q17988651",
+      "brand:wikipedia": "ja:イオシス (株式会社)",
+      "name": "イオシス",
+      "name:en": "IOSYS",
+      "name:ja": "イオシス",
+      "shop": "computer"
+    }
+  },
+  "shop/computer|ツクモ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "ツクモ",
+      "brand:en": "TSUKUMO",
+      "brand:ja": "ツクモ",
+      "brand:wikidata": "Q29793996",
+      "brand:wikipedia": "ja:九十九電機",
+      "name": "ツクモ",
+      "name:en": "TSUKUMO",
+      "name:ja": "ツクモ",
+      "shop": "computer"
+    }
   }
 }

--- a/brands/shop/doityourself.json
+++ b/brands/shop/doityourself.json
@@ -598,6 +598,20 @@
       "shop": "doityourself"
     }
   },
+  "shop/doityourself|アマノ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "アマノ",
+      "brand:en": "Amano",
+      "brand:ja": "アマノ",
+      "brand:wikidata": "Q11284890",
+      "brand:wikipedia": "ja:アマノ",
+      "name": "アマノ",
+      "name:en": "Amano",
+      "name:ja": "アマノ",
+      "shop": "doityourself"
+    }
+  },
   "shop/doityourself|カインズホーム": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/shop/money_lender.json
+++ b/brands/shop/money_lender.json
@@ -103,5 +103,21 @@
       "name": "Moneytree",
       "shop": "money_lender"
     }
+  },
+  "shop/money_lender|プロミス": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "プロミス",
+      "brand:en": "Promise",
+      "brand:ja": "プロミス",
+      "brand:wikidata": "Q11243682",
+      "brand:wikipedia": "ja:SMBCコンシューマーファイナンス",
+      "name": "プロミス",
+      "name:en": "Promise",
+      "name:ja": "プロミス",
+      "official_name": "SMBCコンシューマーファイナンス",
+      "official_name:en": "SMBC Consumer Finance",
+      "shop": "money_lender"
+    }
   }
 }

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -5261,6 +5261,20 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|イオンマーケット": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "イオンマーケット",
+      "brand:en": "Aeon Market",
+      "brand:ja": "イオンマーケット",
+      "brand:wikidata": "Q11331715",
+      "brand:wikipedia": "ja:イオンマーケット",
+      "name": "イオンマーケット",
+      "name:en": "Aeon Market",
+      "name:ja": "イオンマーケット",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|イズミヤ": {
     "countryCodes": ["jp"],
     "matchNames": ["いづみや"],
@@ -5344,6 +5358,20 @@
       "name": "カスミ",
       "name:en": "Kasumi",
       "name:ja": "カスミ",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|キョーエイ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "キョーエイ",
+      "brand:en": "Kyoei",
+      "brand:ja": "キョーエイ",
+      "brand:wikidata": "Q11297581",
+      "brand:wikipedia": "ja:キョーエイ",
+      "name": "キョーエイ",
+      "name:en": "Kyoei",
+      "name:ja": "キョーエイ",
       "shop": "supermarket"
     }
   },
@@ -5503,6 +5531,20 @@
       "name": "ヤオコー",
       "name:en": "Yaoko",
       "name:ja": "ヤオコー",
+      "shop": "supermarket"
+    }
+  },
+  "shop/supermarket|ヤマナカ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "ヤマナカ",
+      "brand:en": "Yamanaka",
+      "brand:ja": "ヤマナカ",
+      "brand:wikidata": "Q11345199",
+      "brand:wikipedia": "ja:ヤマナカ",
+      "name": "ヤマナカ",
+      "name:en": "Yamanaka",
+      "name:ja": "ヤマナカ",
       "shop": "supermarket"
     }
   },

--- a/brands/shop/ticket.json
+++ b/brands/shop/ticket.json
@@ -36,5 +36,19 @@
       "name": "Минсктранс",
       "shop": "ticket"
     }
+  },
+  "shop/ticket|みどりの窓口": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "みどりの窓口",
+      "brand:en": "Midori-no-madoguchi",
+      "brand:ja": "みどりの窓口",
+      "brand:wikidata": "Q11279064",
+      "brand:wikipedia": "ja:みどりの窓口",
+      "name": "みどりの窓口",
+      "name:en": "JR Ticket Office",
+      "name:ja": "みどりの窓口",
+      "shop": "ticket"
+    }
   }
 }


### PR DESCRIPTION
Extension of: #3571

Now other brands from different financial entities are added. Fix little edit of "ja" tag to "jp". Also, added shops and ticket office.