### PR TITLE
Add Japan vending machines (part 2)

### DIFF
--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -153,6 +153,19 @@
       "vending": "ice_cubes"
     }
   },
+  "amenity/vending_machine|JT": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "JT",
+      "brand:wikidata": "Q898568",
+      "brand:wikipedia": "ja:日本たばこ産業",
+      "name": "JT",
+      "official_name": "日本たばこ産業",
+      "official_name:en": "Japan Tobacco",
+      "vending": "cigarettes"
+    }
+  },
   "amenity/vending_machine|KKM": {
     "countryCodes": ["pl"],
     "tags": {
@@ -280,6 +293,21 @@
       "vending": "cigarettes"
     }
   },
+  "amenity/vending_machine|UCC": {
+    "countryCodes": ["jp"],
+    "matchNames": ["ucc上島珈琲"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "UCC",
+      "brand:wikidata": "Q1185060",
+      "brand:wikipedia": "ja:UCC上島珈琲",
+      "name": "UCC",
+      "official_name": "上島珈琲",
+      "official_name:en": "Ueshima Coffee",
+      "official_name:ja": "上島珈琲",
+      "vending": "coffee"
+    }
+  },
   "amenity/vending_machine|VVO Fahrausweise": {
     "countryCodes": ["de"],
     "tags": {
@@ -317,6 +345,22 @@
       "vending": "drinks"
     }
   },
+  "amenity/vending_machine|だし道楽": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "だし道楽",
+      "brand:en": "Dashi Douraku",
+      "brand:ja": "だし道楽",
+      "brand:wikidata": "Q60989429",
+      "brand:wikipedia": "ja:だし道楽",
+      "drink:brewery": "yes",
+      "name": "だし道楽",
+      "name:en": "Dashi Douraku",
+      "name:ja": "だし道楽",
+      "vending": "food"
+    }
+  },
   "amenity/vending_machine|はこぽす": {
     "countryCodes": ["jp"],
     "matchTags": ["amenity/post_box"],
@@ -333,6 +377,21 @@
       "vending": "parcel_pickup"
     }
   },
+  "amenity/vending_machine|アキュア": {
+    "countryCodes": ["jp"],
+    "matchNames": ["acureの自販機"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "アキュア",
+      "brand:en": "Acure",
+      "brand:ja": "アキュア",
+      "brand:wikidata": "Q11226260",
+      "brand:wikipedia": "ja:JR東日本ウォータービジネス",
+      "name": "アキュア",
+      "name:en": "Acure",
+      "name:ja": "アキュア"
+    }
+  },
   "amenity/vending_machine|アサヒビール": {
     "countryCodes": ["jp"],
     "tags": {
@@ -347,6 +406,21 @@
       "name:en": "Asahi Breweries",
       "name:ja": "アサヒビール",
       "vending": "drinks"
+    }
+  },
+  "amenity/vending_machine|アペックス": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "アペックス",
+      "brand:en": "Apex",
+      "brand:ja": "アペックス",
+      "brand:wikidata": "Q11284782",
+      "brand:wikipedia": "ja:アペックス (企業)",
+      "name": "アペックス",
+      "name:en": "Apex",
+      "name:ja": "アペックス",
+      "vending": "coffee"
     }
   },
   "amenity/vending_machine|カップヌードル": {
@@ -448,6 +522,36 @@
       "vending": "drinks"
     }
   },
+  "amenity/vending_machine|ジョージア": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "ジョージア",
+      "brand:en": "Georgia",
+      "brand:ja": "ジョージア",
+      "brand:wikidata": "Q5547323",
+      "brand:wikipedia": "ja:ジョージア (缶コーヒー)",
+      "name": "ジョージア",
+      "name:en": "Georgia",
+      "name:ja": "ジョージア",
+      "vending": "coffee"
+    }
+  },
+  "amenity/vending_machine|セブンティーンアイス": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "セブンティーンアイス",
+      "brand:en": "Seventeen Ice",
+      "brand:ja": "セブンティーンアイス",
+      "brand:wikidata": "Q11314427",
+      "brand:wikipedia": "ja:セブンティーンアイス",
+      "name": "セブンティーンアイス",
+      "name:en": "Seventeen Ice",
+      "name:ja": "セブンティーンアイス",
+      "vending": "ice_cream"
+    }
+  },
   "amenity/vending_machine|ダイドードリンコ": {
     "countryCodes": ["jp"],
     "matchNames": ["dydoドリンコ", "ダイドー"],
@@ -481,6 +585,37 @@
       "vending": "drinks"
     }
   },
+  "amenity/vending_machine|ドール": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "ドール",
+      "brand:en": "Dole",
+      "brand:ja": "ドール",
+      "brand:wikidata": "Q492747",
+      "brand:wikipedia": "ja:ドール・フード・カンパニー",
+      "name": "ドール",
+      "name:en": "Dole",
+      "name:ja": "ドール",
+      "vending": "food"
+    }
+  },
+  "amenity/vending_machine|ニチレイフーズ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "alt_name:en": "Nichirei 24 Hour Hot Menu Casual Frozen Foods",
+      "amenity": "vending_machine",
+      "brand": "ニチレイフーズ",
+      "brand:en": "Nichirei Foods",
+      "brand:ja": "ニチレイフーズ",
+      "brand:wikidata": "Q4921527",
+      "brand:wikipedia": "ja:ニチレイ",
+      "name": "ニチレイフーズ",
+      "name:en": "Nichirei Foods",
+      "name:ja": "ニチレイフーズ",
+      "vending": "food"
+    }
+  },
   "amenity/vending_machine|ポッカサッポロ": {
     "countryCodes": ["jp"],
     "matchNames": ["pokka sapporo"],
@@ -495,6 +630,53 @@
       "name:en": "Pokka Sapporo",
       "name:ja": "ポッカサッポロ",
       "vending": "water;food"
+    }
+  },
+  "amenity/vending_machine|メトロの缶詰": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "alt_name:en": "Metocan Shop",
+      "amenity": "vending_machine",
+      "brand": "メトロの缶詰",
+      "brand:en": "Metro Commerce",
+      "brand:ja": "メトロの缶詰",
+      "brand:wikidata": "Q11343895",
+      "brand:wikipedia": "ja:メトロコマース",
+      "name": "メトロの缶詰",
+      "name:en": "Metro Commerce",
+      "name:ja": "メトロの缶詰",
+      "vending": "gift"
+    }
+  },
+  "amenity/vending_machine|ヤクルト": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "ヤクルト",
+      "brand:en": "Yakult",
+      "brand:ja": "ヤクルト",
+      "brand:wikidata": "Q16172223",
+      "brand:wikipedia": "ja:ヤクルト本社",
+      "drink:milk": "yes",
+      "name": "ヤクルト",
+      "name:en": "Yakult",
+      "name:ja": "ヤクルト",
+      "vending": "milk"
+    }
+  },
+  "amenity/vending_machine|ロッテアイス": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "ロッテアイス",
+      "brand:en": "Lotte Ice Cream",
+      "brand:ja": "ロッテアイス",
+      "brand:wikidata": "Q24886018",
+      "brand:wikipedia": "ja:ロッテアイス",
+      "name": "ロッテアイス",
+      "name:en": "Lotte Ice Cream",
+      "name:ja": "ロッテアイス",
+      "vending": "ice_cream"
     }
   },
   "amenity/vending_machine|伊藤園": {


### PR DESCRIPTION
Extension of: #3571

Several of the most popular vending machines because of the nearly 5 millions that exist in 2014 were also added. For example: Acure (JR). In addition to adding sources about the brands for easy edition (since first web searching generates more confusion for the user like: "list of crazy...").