### PR TITLE
Add insurance office of Japan

### DIFF
--- a/brands/office/insurance.json
+++ b/brands/office/insurance.json
@@ -767,6 +767,20 @@
       "office": "insurance"
     }
   },
+  "office/insurance|明治安田生命": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "明治安田生命",
+      "brand:en": "Meiji Yasuda Life",
+      "brand:ja": "明治安田生命",
+      "brand:wikidata": "Q174081",
+      "brand:wikipedia": "ja:明治安田生命保険",
+      "name": "明治安田生命",
+      "name:en": "Meiji Yasuda Life",
+      "name:ja": "明治安田生命",
+      "office": "insurance"
+    }
+  },
   "office/insurance|第一生命": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/office/insurance.json
+++ b/brands/office/insurance.json
@@ -751,5 +751,34 @@
       "name:fa": "بیمه ایران",
       "office": "insurance"
     }
+  },
+  "office/insurance|日本生命": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "alt_name:en": "Nissay",
+      "brand": "日本生命",
+      "brand:en": "Nippon Life",
+      "brand:ja": "日本生命",
+      "brand:wikidata": "Q519611",
+      "brand:wikipedia": "ja:日本生命保険",
+      "name": "日本生命",
+      "name:en": "Nippon Life",
+      "name:ja": "日本生命",
+      "office": "insurance"
+    }
+  },
+  "office/insurance|第一生命": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "第一生命",
+      "brand:en": "Dai-ichi Life",
+      "brand:ja": "第一生命",
+      "brand:wikidata": "Q595475",
+      "brand:wikipedia": "ja:第一生命保険",
+      "name": "第一生命",
+      "name:en": "Dai-ichi Life",
+      "name:ja": "第一生命",
+      "office": "insurance"
+    }
   }
 }


### PR DESCRIPTION
This pull request adds 3 insurance brands: Nissay, Mieji Yasuda and Dai-ichi.