### PR TITLE
Create anime.json with three brands

### DIFF
--- a/brands/shop/anime.json
+++ b/brands/shop/anime.json
@@ -1,0 +1,17 @@
+{
+  "shop/anime|ケイ・ブックス": {
+    "countryCodes": ["jp"],
+    "matchNames": ["k-books"],
+    "tags": {
+      "brand": "ケイ・ブックス",
+      "brand:en": "K-BOOKS",
+      "brand:ja": "ケイ・ブックス",
+      "brand:wikidata": "Q8061680",
+      "brand:wikipedia": "ja:K-BOOKS",
+      "name": "ケイ・ブックス",
+      "name:en": "K-BOOKS",
+      "name:ja": "ケイ・ブックス",
+      "shop": "anime"
+    }
+  }
+}

--- a/brands/shop/anime.json
+++ b/brands/shop/anime.json
@@ -13,6 +13,20 @@
       "shop": "anime"
     }
   },
+  "shop/anime|らしんばん": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "らしんばん",
+      "brand:en": "Lashinbang",
+      "brand:ja": "らしんばん",
+      "brand:wikidata": "Q11281322",
+      "brand:wikipedia": "ja:らしんばん",
+      "name": "らしんばん",
+      "name:en": "Lashinbang",
+      "name:ja": "らしんばん",
+      "shop": "anime"
+    }
+  },
   "shop/anime|ケイ・ブックス": {
     "countryCodes": ["jp"],
     "matchNames": ["k-books"],

--- a/brands/shop/anime.json
+++ b/brands/shop/anime.json
@@ -1,7 +1,22 @@
 {
+  "shop/anime|まんだらけ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "まんだらけ",
+      "brand:en": "Mandarake",
+      "brand:ja": "まんだらけ",
+      "brand:wikidata": "Q6747833",
+      "brand:wikipedia": "ja:まんだらけ",
+      "name": "まんだらけ",
+      "name:en": "Mandarake",
+      "name:ja": "まんだらけ",
+      "shop": "anime"
+    }
+  },
   "shop/anime|ケイ・ブックス": {
     "countryCodes": ["jp"],
     "matchNames": ["k-books"],
+    "matchTags": ["shop/books"],
     "tags": {
       "brand": "ケイ・ブックス",
       "brand:en": "K-BOOKS",


### PR DESCRIPTION
This pull request adds three brands of anime store: K-Book (with matchtag for books), Lashinbang  and Mandarake.