### PR TITLE
Add Ginza Cozy Corner

### DIFF
--- a/brands/shop/confectionery.json
+++ b/brands/shop/confectionery.json
@@ -145,5 +145,22 @@
       "name:ja": "不二家",
       "shop": "confectionery"
     }
+  },
+  "shop/confectionery|銀座コージーコーナー": {
+    "countryCodes": ["jp"],
+    "matchNames": ["コージーコーナー"],
+    "tags": {
+      "brand": "銀座コージーコーナー",
+      "brand:en": "Ginza Cozy Corner",
+      "brand:ja": "銀座コージーコーナー",
+      "brand:wikidata": "Q11649983",
+      "brand:wikipedia": "ja:銀座コージーコーナー",
+      "name": "銀座コージーコーナー",
+      "name:en": "Ginza Cozy Corner",
+      "name:ja": "銀座コージーコーナー",
+      "official_name": "銀座コージーコーナー",
+      "official_name:en": "銀座コージーコーナー",
+      "shop": "confectionery"
+    }
   }
 }


### PR DESCRIPTION
Add Ginza Cozy Corner, a japanese confectionery with Wikidata info.