### PR TITLE
Add Takarakuji (National Autonomous Lottery)

### DIFF
--- a/brands/shop/lottery.json
+++ b/brands/shop/lottery.json
@@ -26,7 +26,7 @@
       "shop": "lottery"
     }
   },
-  "shop/lottery|宝くじ~(Japan)": {
+  "shop/lottery|宝くじ": {
     "countryCodes": ["jp"],
     "matchNames": [
       "lotoロト",

--- a/brands/shop/lottery.json
+++ b/brands/shop/lottery.json
@@ -25,5 +25,29 @@
       "official_name": "Organización Nacional de Ciegos Españoles",
       "shop": "lottery"
     }
+  },
+  "shop/lottery|宝くじ~(Japan)": {
+    "countryCodes": ["jp"],
+    "matchNames": [
+      "lotoロト",
+      "lottery of japan",
+      "takarakuji",
+      "‎japan loto",
+      "全国自治宝くじ"
+    ],
+    "tags": {
+      "brand": "宝くじ",
+      "brand:en": "Takarakuji",
+      "brand:ja": "宝くじ",
+      "brand:wikidata": "Q87824893",
+      "brand:wikipedia": "ja:宝くじ",
+      "name": "宝くじ",
+      "name:en": "Takarakuji",
+      "name:ja": "宝くじ",
+      "official_name": "全国自治宝くじ",
+      "official_name:en": "National Autonomous Lottery",
+      "official_name:ja": "全国自治宝くじ",
+      "shop": "lottery"
+    }
   }
 }


### PR DESCRIPTION
This lottery stand is used for gambing activities in the country. Maybe, the only legally recognized brand.

Note: The "~(Japan)" is because in Wikidata there are two similar names, lottery, and other is related to lotteries from several countries. This avoids a conflict of adding a non-Japan POI.