### PR TITLE
Add Karada Factory

### DIFF
--- a/brands/shop/massage.json
+++ b/brands/shop/massage.json
@@ -32,7 +32,6 @@
   },
   "shop/massage|カラダファクトリー": {
     "countryCodes": ["jp"],
-    "matchNames": ["ka・ra・da"],
     "tags": {
       "brand": "カラダファクトリー",
       "brand:en": "Karada Factory",

--- a/brands/shop/massage.json
+++ b/brands/shop/massage.json
@@ -29,5 +29,19 @@
       "name": "Massage Heights",
       "shop": "massage"
     }
+  },
+  "shop/massage|カラダファクトリー": {
+    "countryCodes": ["jp"],
+    "matchNames": ["ka・ra・da"],
+    "tags": {
+      "brand": "カラダファクトリー",
+      "brand:en": "Karada Factory",
+      "brand:ja": "カラダファクトリー",
+      "brand:wikidata": "Q87833239",
+      "name": "カラダファクトリー",
+      "name:en": "Karada Factory",
+      "name:ja": "カラダファクトリー",
+      "shop": "massage"
+    }
   }
 }


### PR DESCRIPTION
Karada is a japanese massage chain with 300 shops inside country. The japanese translation is "Body Factory", but its english name is keeped as "Karada Factory".