### PR TITLE
Add Parking brands of Japan

### DIFF
--- a/brands/amenity/parking.json
+++ b/brands/amenity/parking.json
@@ -11,13 +11,15 @@
   },
   "amenity/parking|NPC24H": {
     "countryCodes": ["jp"],
+    "matchNames": ["日本パーキング"],
     "tags": {
       "amenity": "parking",
       "brand": "NPC",
       "brand:wikidata": "Q11506782",
       "brand:wikipedia": "ja:日本パーキング",
       "fee": "yes",
-      "name": "NPC24H"
+      "name": "NPC24H",
+      "official_name": "日本パーキング"
     }
   },
   "amenity/parking|Parking Company of America": {

--- a/brands/amenity/parking.json
+++ b/brands/amenity/parking.json
@@ -70,6 +70,21 @@
       "name": "Wilson Parking"
     }
   },
+  "amenity/parking|アップルパーク": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "parking",
+      "brand": "アップルパーク",
+      "brand:en": "Apple Park",
+      "brand:ja": "アップルパーク",
+      "brand:wikidata": "Q30923801",
+      "brand:wikipedia": "ja:アップルパーク",
+      "fee": "yes",
+      "name": "アップルパーク",
+      "name:en": "Apple Park",
+      "name:ja": "アップルパーク"
+    }
+  },
   "amenity/parking|タイムズ": {
     "countryCodes": ["jp"],
     "matchNames": ["times 24th", "タイムズ24"],

--- a/brands/amenity/parking.json
+++ b/brands/amenity/parking.json
@@ -9,6 +9,17 @@
       "name": "Diamond Parking"
     }
   },
+  "amenity/parking|NPC24H": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "parking",
+      "brand": "NPC",
+      "brand:wikidata": "Q11506782",
+      "brand:wikipedia": "ja:日本パーキング",
+      "fee": "yes",
+      "name": "NPC24H"
+    }
+  },
   "amenity/parking|Parking Company of America": {
     "countryCodes": ["us"],
     "tags": {
@@ -71,6 +82,21 @@
       "name": "タイムズ",
       "name:en": "Times",
       "name:ja": "タイムズ"
+    }
+  },
+  "amenity/parking|パラカ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "parking",
+      "brand": "パラカ",
+      "brand:en": "Paraca",
+      "brand:ja": "パラカ",
+      "brand:wikidata": "Q11329318",
+      "brand:wikipedia": "ja:パラカ",
+      "fee": "yes",
+      "name": "パラカ",
+      "name:en": "Paraca",
+      "name:ja": "パラカ"
     }
   }
 }


### PR DESCRIPTION
This pull request adds three brands of parking in Japan: Apple Park, Paraca and NPC (Nippon Parking).