### PR TITLE
Add Sotetsu Rosen

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -5704,6 +5704,20 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|相鉄ローゼン": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "相鉄ローゼン",
+      "brand:en": "Sotetsu Rosen",
+      "brand:ja": "相鉄ローゼン",
+      "brand:wikidata": "Q11582450",
+      "brand:wikipedia": "ja:相鉄ローゼン",
+      "name": "相鉄ローゼン",
+      "name:en": "Sotetsu Rosen",
+      "name:ja": "相鉄ローゼン",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|美廉社": {
     "countryCodes": ["tw"],
     "tags": {

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -5706,7 +5706,9 @@
   },
   "shop/supermarket|相鉄ローゼン": {
     "countryCodes": ["jp"],
+    "matchNames": ["そうてつローゼン"],
     "tags": {
+      "alt_name": "そうてつローゼン",
       "brand": "相鉄ローゼン",
       "brand:en": "Sotetsu Rosen",
       "brand:ja": "相鉄ローゼン",


### PR DESCRIPTION
This pull request adds Sotetsu Rosen, with alternative name, a japanese supermarket chain.