### PR TITLE
Edit Pony Cleaning, add Young Dry and Dia Cleaning

### DIFF
--- a/brands/shop/dry_cleaning.json
+++ b/brands/shop/dry_cleaning.json
@@ -93,7 +93,7 @@
       "shop": "dry_cleaning"
     }
   },
-  "shop/dry_cleaning|ポニークリーニング": {
+  "shop/dry_cleaning|ポニー": {
     "countryCodes": ["jp"],
     "matchNames": ["ポニー"],
     "tags": {
@@ -101,9 +101,12 @@
       "brand:en": "Pony",
       "brand:ja": "ポニー",
       "brand:wikidata": "Q88012241",
-      "name": "ポニークリーニング",
-      "name:en": "Pony Cleaning",
-      "name:ja": "ポニークリーニング",
+      "name": "ポニー",
+      "name:en": "Pony",
+      "name:ja": "ポニー",
+      "official_name": "ポニークリーニング",
+      "official_name:en": "Pony Cleaning",
+      "official_name:ja": "ポニークリーニング",
       "shop": "dry_cleaning"
     }
   },

--- a/brands/shop/dry_cleaning.json
+++ b/brands/shop/dry_cleaning.json
@@ -79,15 +79,17 @@
       "shop": "dry_cleaning"
     }
   },
-  "shop/dry_cleaning|ポニー": {
+  "shop/dry_cleaning|ポニークリーニング": {
     "countryCodes": ["jp"],
+    "matchNames": ["ポニー"],
     "tags": {
       "brand": "ポニー",
-      "brand:en": "Pony Cleaning",
+      "brand:en": "Pony",
       "brand:ja": "ポニー",
-      "name": "ポニー",
+      "brand:wikidata": "Q88012241",
+      "name": "ポニークリーニング",
       "name:en": "Pony Cleaning",
-      "name:ja": "ポニー",
+      "name:ja": "ポニークリーニング",
       "shop": "dry_cleaning"
     }
   },

--- a/brands/shop/dry_cleaning.json
+++ b/brands/shop/dry_cleaning.json
@@ -93,6 +93,19 @@
       "shop": "dry_cleaning"
     }
   },
+  "shop/dry_cleaning|ヤングドライ": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "ヤングドライ",
+      "brand:en": "Young Dry",
+      "brand:ja": "ヤングドライ",
+      "brand:wikidata": "Q11345434",
+      "name": "ヤングドライ",
+      "name:en": "Young Dry",
+      "name:ja": "ヤングドライ",
+      "shop": "dry_cleaning"
+    }
+  },
   "shop/dry_cleaning|白洋舎": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/shop/dry_cleaning.json
+++ b/brands/shop/dry_cleaning.json
@@ -114,6 +114,7 @@
       "brand:en": "Young Dry",
       "brand:ja": "ヤングドライ",
       "brand:wikidata": "Q11345434",
+      "brand:wikipedia": "ja:ヤングドライ",
       "name": "ヤングドライ",
       "name:en": "Young Dry",
       "name:ja": "ヤングドライ",

--- a/brands/shop/dry_cleaning.json
+++ b/brands/shop/dry_cleaning.json
@@ -65,6 +65,20 @@
       "shop": "dry_cleaning"
     }
   },
+  "shop/dry_cleaning|ダイヤクリーニング": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "ダイヤクリーニング",
+      "brand:en": "Dia Cleaning",
+      "brand:ja": "ダイヤクリーニング",
+      "brand:wikidata": "Q11316968",
+      "brand:wikipedia": "ja:ダイヤクリーニング",
+      "name": "ダイヤクリーニング",
+      "name:en": "Dia Cleaning",
+      "name:ja": "ダイヤクリーニング",
+      "shop": "dry_cleaning"
+    }
+  },
   "shop/dry_cleaning|ホワイト急便": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/shop/dry_cleaning.json
+++ b/brands/shop/dry_cleaning.json
@@ -83,8 +83,10 @@
     "countryCodes": ["jp"],
     "tags": {
       "brand": "ポニー",
+      "brand:en": "Pony Cleaning",
       "brand:ja": "ポニー",
       "name": "ポニー",
+      "name:en": "Pony Cleaning",
       "name:ja": "ポニー",
       "shop": "dry_cleaning"
     }


### PR DESCRIPTION
This pull request update Pony Cleaning, a japense dry cleaning brand. With Wikidata and matchname. Also, added Young Dry (for Osaka area) and Dia Cleaning.