### PR TITLE
Added supermarket chain: Smatch

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -3736,6 +3736,16 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Smatch": {
+    "countryCodes": ["be", "lu"],
+    "tags": {
+      "brand": "Smatch",
+      "brand:wikidata": "Q5185959",
+      "brand:wikipedia": "fr:Smatch",
+      "name": "Smatch",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|Smith's": {
     "countryCodes": ["ca", "us"],
     "nomatch": ["amenity/fuel|Smith's"],


### PR DESCRIPTION
Hi,
I noticed that the supermarket chain "Smatch" does not yet exist in the NSI. "Smatch" and "Match" are two different brands owned by the same group (they have different logos as well).