### PR TITLE
Changed TagInfo reference to "release"

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -12,7 +12,7 @@ const BRANDS = `${DIST}/brands.json`;
 const WIKIDATA = `${DIST}/wikidata.json`;
 
 // We can use iD's taginfo file to pick icons
-const TAGINFO = "https://raw.githubusercontent.com/openstreetmap/iD/master/data/taginfo.json";
+const TAGINFO = "https://raw.githubusercontent.com/openstreetmap/iD/release/data/taginfo.json";
 
 
 export default function App() {


### PR DESCRIPTION
Changed TagInfo reference to "release" in place of the former "master" branch of iD, which no longer exists.