### PR TITLE
Split First State Bank

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -3539,11 +3539,147 @@
       "name": "First National Bank"
     }
   },
-  "amenity/bank|First State Bank": {
+  "amenity/bank|First State Bank Nebraska": {
     "countryCodes": ["us"],
+    "nomatch": [
+      "amenity/bank|First State Bank~(Florida)",
+      "amenity/bank|First State Bank~(Illinois)",
+      "amenity/bank|First State Bank~(Michigan)",
+      "amenity/bank|First State Bank~(Mississippi)",
+      "amenity/bank|First State Bank~(Nebraska)",
+      "amenity/bank|First State Bank~(Ohio)",
+      "amenity/bank|First State Bank~(Texas)"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "First State Bank",
+      "brand:wikidata": "Q87646525",
+      "name": "First State Bank"
+    }
+  },
+  "amenity/bank|First State Bank~(Florida)": {
+    "countryCodes": ["us"],
+    "nomatch": [
+      "amenity/bank|First State Bank Nebraska",
+      "amenity/bank|First State Bank~(Illinois)",
+      "amenity/bank|First State Bank~(Michigan)",
+      "amenity/bank|First State Bank~(Mississippi)",
+      "amenity/bank|First State Bank~(Nebraska)",
+      "amenity/bank|First State Bank~(Ohio)",
+      "amenity/bank|First State Bank~(Texas)"
+    ],
+    "tags": {
+      "amenity": "bank",
+      "brand": "First State Bank",
+      "brand:wikidata": "Q87647395",
+      "name": "First State Bank"
+    }
+  },
+  "amenity/bank|First State Bank~(Illinois)": {
+    "countryCodes": ["us"],
+    "nomatch": [
+      "amenity/bank|First State Bank Nebraska",
+      "amenity/bank|First State Bank~(Florida)",
+      "amenity/bank|First State Bank~(Michigan)",
+      "amenity/bank|First State Bank~(Mississippi)",
+      "amenity/bank|First State Bank~(Nebraska)",
+      "amenity/bank|First State Bank~(Ohio)",
+      "amenity/bank|First State Bank~(Texas)"
+    ],
+    "tags": {
+      "amenity": "bank",
+      "brand": "First State Bank",
+      "brand:wikidata": "Q87647340",
+      "name": "First State Bank"
+    }
+  },
+  "amenity/bank|First State Bank~(Michigan)": {
+    "countryCodes": ["us"],
+    "nomatch": [
+      "amenity/bank|First State Bank Nebraska",
+      "amenity/bank|First State Bank~(Florida)",
+      "amenity/bank|First State Bank~(Illinois)",
+      "amenity/bank|First State Bank~(Mississippi)",
+      "amenity/bank|First State Bank~(Nebraska)",
+      "amenity/bank|First State Bank~(Ohio)",
+      "amenity/bank|First State Bank~(Texas)"
+    ],
+    "tags": {
+      "amenity": "bank",
+      "brand": "First State Bank",
+      "brand:wikidata": "Q87647479",
+      "name": "First State Bank"
+    }
+  },
+  "amenity/bank|First State Bank~(Mississippi)": {
+    "countryCodes": ["us"],
+    "nomatch": [
+      "amenity/bank|First State Bank Nebraska",
+      "amenity/bank|First State Bank~(Florida)",
+      "amenity/bank|First State Bank~(Illinois)",
+      "amenity/bank|First State Bank~(Michigan)",
+      "amenity/bank|First State Bank~(Nebraska)",
+      "amenity/bank|First State Bank~(Ohio)",
+      "amenity/bank|First State Bank~(Texas)"
+    ],
+    "tags": {
+      "amenity": "bank",
+      "brand": "First State Bank",
+      "brand:wikidata": "Q87647452",
+      "name": "First State Bank"
+    }
+  },
+  "amenity/bank|First State Bank~(Nebraska)": {
+    "countryCodes": ["us"],
+    "nomatch": [
+      "amenity/bank|First State Bank Nebraska",
+      "amenity/bank|First State Bank~(Florida)",
+      "amenity/bank|First State Bank~(Illinois)",
+      "amenity/bank|First State Bank~(Michigan)",
+      "amenity/bank|First State Bank~(Mississippi)",
+      "amenity/bank|First State Bank~(Ohio)",
+      "amenity/bank|First State Bank~(Texas)"
+    ],
+    "tags": {
+      "amenity": "bank",
+      "brand": "First State Bank",
+      "brand:wikidata": "Q5453817",
+      "name": "First State Bank"
+    }
+  },
+  "amenity/bank|First State Bank~(Ohio)": {
+    "countryCodes": ["us"],
+    "nomatch": [
+      "amenity/bank|First State Bank Nebraska",
+      "amenity/bank|First State Bank~(Florida)",
+      "amenity/bank|First State Bank~(Illinois)",
+      "amenity/bank|First State Bank~(Michigan)",
+      "amenity/bank|First State Bank~(Mississippi)",
+      "amenity/bank|First State Bank~(Nebraska)",
+      "amenity/bank|First State Bank~(Texas)"
+    ],
+    "tags": {
+      "amenity": "bank",
+      "brand": "First State Bank",
+      "brand:wikidata": "Q87647374",
+      "name": "First State Bank"
+    }
+  },
+  "amenity/bank|First State Bank~(Texas)": {
+    "countryCodes": ["us"],
+    "nomatch": [
+      "amenity/bank|First State Bank Nebraska",
+      "amenity/bank|First State Bank~(Florida)",
+      "amenity/bank|First State Bank~(Illinois)",
+      "amenity/bank|First State Bank~(Michigan)",
+      "amenity/bank|First State Bank~(Mississippi)",
+      "amenity/bank|First State Bank~(Nebraska)",
+      "amenity/bank|First State Bank~(Ohio)"
+    ],
+    "tags": {
+      "amenity": "bank",
+      "brand": "First State Bank",
+      "brand:wikidata": "Q87647065",
       "name": "First State Bank"
     }
   },


### PR DESCRIPTION
First State Bank is splitted into multiple entities. This request related to https://github.com/osmlab/name-suggestion-index/issues/3599. 

I am unsure about how to add this ones:
Q5453817 - Nebraska
Q87646525 - Nebraska.
The first one I named "amenity/bank|First State Bank~(Nebraska)"
The second one I named "amenity/bank|First State Bank Nebraska"

If I did this in a wrong way, correct me, please. I'm new here.