### PR TITLE
Add Côté Nature

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -981,6 +981,16 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Côté Nature": {
+    "countryCodes": ["fr"],
+    "tags": {
+      "brand": "Côté Nature",
+      "brand:wikidata": "Q90016283",
+      "name": "Côté Nature",
+      "organic": "only",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|D'Agostino": {
     "countryCodes": ["us"],
     "tags": {


### PR DESCRIPTION
[French brand of organic supermarkets.](https://www.wikidata.org/wiki/Q90016283)