### PR TITLE
Added East of Chicago Pizza, updated Gino's Pizza & Spaghetti House

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -818,6 +818,18 @@
       "takeaway": "yes"
     }
   },
+  "amenity/fast_food|East of Chicago Pizza": {
+    "countryCodes": ["us"],
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "East of Chicago Pizza",
+      "brand:wikidata": "Q5329751",
+      "brand:wikipedia": "en:East of Chicago Pizza",
+      "cuisine": "pizza",
+      "name": "East of Chicago Pizza",
+      "takeaway": "yes"
+    }
+  },
   "amenity/fast_food|EAT.": {
     "countryCodes": ["gb"],
     "tags": {
@@ -1033,15 +1045,15 @@
       "takeaway": "yes"
     }
   },
-  "amenity/fast_food|Gino's Pizza~(West Virginia)": {
+  "amenity/fast_food|Gino's Pizza & Spaghetti House~(West Virginia)": {
     "countryCodes": ["us"],
     "tags": {
       "amenity": "fast_food",
-      "brand": "Gino's Pizza",
+      "brand": "Gino's Pizza & Spaghetti House",
       "brand:wikidata": "Q5563205",
       "brand:wikipedia": "en:Gino's Pizza and Spaghetti",
       "cuisine": "pizza",
-      "name": "Gino's Pizza",
+      "name": "Gino's Pizza & Spaghetti House",
       "takeaway": "yes"
     }
   },

--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -1045,11 +1045,11 @@
       "takeaway": "yes"
     }
   },
-  "amenity/fast_food|Gino's Pizza & Spaghetti House~(West Virginia)": {
+  "amenity/fast_food|Gino's Pizza~(West Virginia)": {
     "countryCodes": ["us"],
     "tags": {
       "amenity": "fast_food",
-      "brand": "Gino's Pizza & Spaghetti House",
+      "brand": "Gino's Pizza",
       "brand:wikidata": "Q5563205",
       "brand:wikipedia": "en:Gino's Pizza and Spaghetti",
       "cuisine": "pizza",

--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -1053,7 +1053,8 @@
       "brand:wikidata": "Q5563205",
       "brand:wikipedia": "en:Gino's Pizza and Spaghetti",
       "cuisine": "pizza",
-      "name": "Gino's Pizza & Spaghetti House",
+      "name": "Gino's Pizza",
+      "official_name": "Gino's Pizza & Spaghetti House",
       "takeaway": "yes"
     }
   },


### PR DESCRIPTION
Gino's Pizza & Spaghetti House is consistently worded on all signs and logos that I can find, including the "& Spaghetti House" that was previously omitted from tags.

I added wikidata tags for EOCpizza for Twitter, FB, and website, so logo fetch should work.