### PR TITLE
Add Yamaha Ongaku Kyōshitsu

### DIFF
--- a/brands/amenity/music_school.json
+++ b/brands/amenity/music_school.json
@@ -1,0 +1,18 @@
+{
+  "amenity/music_school|ヤマハ音楽教室": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "music_school",
+      "brand": "ヤマハ音楽教室",
+      "brand:en": "Yamaha Music School",
+      "brand:ja": "ヤマハ音楽教室",
+      "brand:ja-Latn": "Yamaha Ongaku Kyōshitsu",
+      "brand:wikidata": "Q90327852",
+      "name": "ヤマハ音楽教室",
+      "name:en": "Yamaha Music School",
+      "name:ja": "ヤマハ音楽教室",
+      "name:ja-Hira": "イーオン",
+      "name:ja-Latn": "Yamaha Ongaku Kyōshitsu"
+    }
+  }
+}

--- a/brands/amenity/music_school.json
+++ b/brands/amenity/music_school.json
@@ -11,7 +11,6 @@
       "name": "ヤマハ音楽教室",
       "name:en": "Yamaha Music School",
       "name:ja": "ヤマハ音楽教室",
-      "name:ja-Hira": "イーオン",
       "name:ja-Latn": "Yamaha Ongaku Kyōshitsu"
     }
   }


### PR DESCRIPTION
This pull request adds Yamaha Ongaku Kyōshitsu, a japanese brand of music school in Japan. Also, this creates a new file "music_school".