### PR TITLE
Add matchname for KFC and Baskin-Robbins

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -3867,7 +3867,9 @@
   },
   "amenity/fast_food|ケンタッキーフライドチキン": {
     "countryCodes": ["jp"],
+    "matchNames": ["ケンタッキー"],
     "tags": {
+      "alt_name:en": "Kentucky Fried Chicken",
       "amenity": "fast_food",
       "brand": "ケンタッキーフライドチキン",
       "brand:en": "KFC",

--- a/brands/amenity/ice_cream.json
+++ b/brands/amenity/ice_cream.json
@@ -388,6 +388,7 @@
   },
   "amenity/ice_cream|サーティワンアイスクリーム": {
     "countryCodes": ["jp"],
+    "matchNames": ["サーティーワン"],
     "tags": {
       "amenity": "ice_cream",
       "brand": "バスキン・ロビンス",

--- a/brands/amenity/ice_cream.json
+++ b/brands/amenity/ice_cream.json
@@ -388,7 +388,7 @@
   },
   "amenity/ice_cream|サーティワンアイスクリーム": {
     "countryCodes": ["jp"],
-    "matchNames": ["サーティーワン"],
+    "matchNames": ["31アイスクリーム", "サーティーワン"],
     "tags": {
       "amenity": "ice_cream",
       "brand": "バスキン・ロビンス",


### PR DESCRIPTION
This edition consists of:

- Add alt_name:en for KFC (Japan).
- Add matchname of kentucky for KFC.
- Add unofficial names of Baskin-Robbins (Japan).
