### PR TITLE
Add matchname for FamilyMart

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -2621,6 +2621,7 @@
   },
   "shop/convenience|ファミリーマート": {
     "countryCodes": ["jp"],
+    "matchNames": ["ファミマ"],
     "tags": {
       "brand": "ファミリーマート",
       "brand:en": "FamilyMart",


### PR DESCRIPTION
This pull requests adds matchname for FamilyMart called Famima, it's colloquially called in some establishments.