### PR TITLE
added BankWest (US)

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -2173,6 +2173,15 @@
       "name": "Bankwest"
     }
   },
+   "amenity/bank|BankWest": {
+    "countryCodes": ["us"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "BankWest",
+      "brand:wikidata": "Q90386673",
+      "name": "BankWest"
+    }
+  }, 
   "amenity/bank|Banner Bank": {
     "countryCodes": ["us"],
     "tags": {


### PR DESCRIPTION
fixes #3690 
Disambiguation is not necessary cause of the US and AU country code also spelling is slightly different
with Bank**W**est and Bank**w**est