### PR TITLE
Add official name for Shimamura and Avail

### DIFF
--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -4107,6 +4107,19 @@
       "shop": "clothes"
     }
   },
+  "shop/clothes|アベイル": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "アベイル",
+      "brand:en": "Avail",
+      "brand:ja": "アベイル",
+      "brand:wikidata": "Q11284759",
+      "name": "アベイル",
+      "name:en": "Avail",
+      "name:ja": "アベイル",
+      "shop": "clothes"
+    }
+  },
   "shop/clothes|コナカ": {
     "countryCodes": ["jp"],
     "tags": {

--- a/brands/shop/clothes.json
+++ b/brands/shop/clothes.json
@@ -4087,6 +4087,9 @@
       "name": "しまむら",
       "name:en": "Shimamura",
       "name:ja": "しまむら",
+      "official_name": "ファッションセンターしまむら",
+      "official_name:en": "Fashion Center Shimamura",
+      "official_name:ja": "ファッションセンターしまむら",
       "shop": "clothes"
     }
   },


### PR DESCRIPTION
Shimamura has a official name for "Fashion Center Shimamura". The name explains why and it's named in SNS (social media). Also, added its "other brand", Avail.