### PR TITLE
Add Kumazawa Maruzen bookstore brands.

### DIFF
--- a/brands/shop/books.json
+++ b/brands/shop/books.json
@@ -471,6 +471,24 @@
       "shop": "books"
     }
   },
+  "shop/books|ジュンク堂書店": {
+    "countryCodes": ["jp"],
+    "matchNames": ["ジュンク"],
+    "tags": {
+      "brand": "ジュンク堂書店",
+      "brand:en": "Junkudo",
+      "brand:ja": "ジュンク堂書店",
+      "brand:wikidata": "Q1906012",
+      "brand:wikipedia": "ja:丸善雄松堂",
+      "name": "ジュンク堂書店",
+      "name:en": "Junkudo",
+      "name:ja": "ジュンク堂書店",
+      "official_name": "丸善ジュンク堂書店",
+      "official_name:en": "Maruzen Junkudo",
+      "official_name:ja": "丸善ジュンク堂書店",
+      "shop": "books"
+    }
+  },
   "shop/books|ブックオフ": {
     "countryCodes": ["jp"],
     "tags": {
@@ -529,6 +547,7 @@
   },
   "shop/books|丸善": {
     "countryCodes": ["jp"],
+    "matchNames": ["丸善書店"],
     "tags": {
       "brand": "丸善",
       "brand:en": "MARUZEN",
@@ -538,6 +557,9 @@
       "name": "丸善",
       "name:en": "MARUZEN",
       "name:ja": "丸善",
+      "official_name": "丸善雄松堂",
+      "official_name:en": "Maruzen Yushodo",
+      "official_name:ja": "丸善雄松堂",
       "shop": "books"
     }
   },

--- a/brands/shop/books.json
+++ b/brands/shop/books.json
@@ -544,7 +544,7 @@
   },
   "shop/books|丸善": {
     "countryCodes": ["jp"],
-    "matchNames": ["maruzen＆ジュンク", "丸善書店"],
+    "matchNames": ["丸善書店"],
     "tags": {
       "brand": "丸善",
       "brand:en": "MARUZEN",

--- a/brands/shop/books.json
+++ b/brands/shop/books.json
@@ -547,7 +547,7 @@
   },
   "shop/books|丸善": {
     "countryCodes": ["jp"],
-    "matchNames": ["丸善書店"],
+    "matchNames": ["maruzen＆ジュンク", "丸善書店"],
     "tags": {
       "brand": "丸善",
       "brand:en": "MARUZEN",

--- a/brands/shop/books.json
+++ b/brands/shop/books.json
@@ -427,6 +427,21 @@
       "shop": "books"
     }
   },
+  "shop/books|くまざわ書店": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "alt_name:en": "Kumabook",
+      "brand": "くまざわ書店",
+      "brand:en": "Kumazawa Books",
+      "brand:ja": "くまざわ書店",
+      "brand:wikidata": "Q11265517",
+      "brand:wikipedia": "ja:くまざわ",
+      "name": "くまざわ書店",
+      "name:en": "Kumazawa Books",
+      "name:ja": "くまざわ書店",
+      "shop": "books"
+    }
+  },
   "shop/books|とらのあな": {
     "countryCodes": ["jp"],
     "tags": {
@@ -509,6 +524,20 @@
       "name": "三省堂書店",
       "name:en": "Books Sanseido",
       "name:ja": "三省堂書店",
+      "shop": "books"
+    }
+  },
+  "shop/books|丸善": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "丸善",
+      "brand:en": "MARUZEN",
+      "brand:ja": "丸善",
+      "brand:wikidata": "Q1906012",
+      "brand:wikipedia": "ja:丸善雄松堂",
+      "name": "丸善",
+      "name:en": "MARUZEN",
+      "name:ja": "丸善",
       "shop": "books"
     }
   },

--- a/brands/shop/books.json
+++ b/brands/shop/books.json
@@ -483,9 +483,6 @@
       "name": "ジュンク堂書店",
       "name:en": "Junkudo",
       "name:ja": "ジュンク堂書店",
-      "official_name": "丸善ジュンク堂書店",
-      "official_name:en": "Maruzen Junkudo",
-      "official_name:ja": "丸善ジュンク堂書店",
       "shop": "books"
     }
   },

--- a/brands/shop/books.json
+++ b/brands/shop/books.json
@@ -479,7 +479,7 @@
       "brand:en": "Junkudo",
       "brand:ja": "ジュンク堂書店",
       "brand:wikidata": "Q1906012",
-      "brand:wikipedia": "ja:丸善雄松堂",
+      "brand:wikipedia": "ja:ジュンク堂書店",
       "name": "ジュンク堂書店",
       "name:en": "Junkudo",
       "name:ja": "ジュンク堂書店",

--- a/brands/shop/books.json
+++ b/brands/shop/books.json
@@ -478,7 +478,7 @@
       "brand": "ジュンク堂書店",
       "brand:en": "Junkudo",
       "brand:ja": "ジュンク堂書店",
-      "brand:wikidata": "Q1906012",
+      "brand:wikidata": "Q3190093",
       "brand:wikipedia": "ja:ジュンク堂書店",
       "name": "ジュンク堂書店",
       "name:en": "Junkudo",


### PR DESCRIPTION
This pull request adds Kumazawa and two Maruzen brands (with official names to identify current denominations, since Maruzen was divided into [other bookstore chains](https://ja.wikipedia.org/wiki/丸善CHIホールディングス), with M text in some stores).