### PR TITLE
Add matchname for Daily Yamazaki

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -2591,6 +2591,7 @@
   },
   "shop/convenience|デイリーヤマザキ": {
     "countryCodes": ["jp"],
+    "matchNames": ["デイリーストア"],
     "tags": {
       "brand": "デイリーヤマザキ",
       "brand:en": "Daily Yamazaki",


### PR DESCRIPTION
In Japanse Wikipedia and [its website](http://www.daily-yamazaki.jp/information/), Daily Yamazaki is called Dailyshop. This pull request adds to matchname.