### PR TITLE
Add J&T Banka

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -4138,6 +4138,16 @@
       "name": "Jyske Bank"
     }
   },
+  "amenity/bank|J&T Banka": {
+    "countryCodes": ["cz", "sk"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "J&T Banka",
+      "brand:wikidata": "Q12022160",
+      "brand:wikipedia": "sk:J & T BANKA",
+      "name": "J&T Banka"
+    }
+  },
   "amenity/bank|K&H Bank": {
     "countryCodes": ["hu"],
     "tags": {


### PR DESCRIPTION
Added brand of network of banks in the Czech Republic and Slovakia called J&T Banka.