### PR TITLE
Add Prvá stavebná sporiteľňa

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -5013,6 +5013,16 @@
       "name": "Provincial"
     }
   },
+    "amenity/bank|Prvá stavebná sporiteľňa": {
+    "countryCodes": ["sk"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Prvá stavebná sporiteľňa",
+      "brand:wikidata": "Q29054618",
+      "brand:wikipedia": "sk:Prvá stavebná sporiteľňa",
+      "name": "Prvá stavebná sporiteľňa"
+    }
+  },
   "amenity/bank|Public Bank~(Malaysia)": {
     "matchNames": ["public bank berhad"],
     "tags": {


### PR DESCRIPTION
Added brand of savings bank in Slovakia called Prvá stavebná sporiteľňa.