### PR TITLE
Add matchgroups for adult gaming centre

### DIFF
--- a/config/match_groups.json
+++ b/config/match_groups.json
@@ -1,5 +1,10 @@
 {
   "matchGroups": {
+    "adult_gaming_centre": [
+      "amenity/casino",
+      "amenity/gambling",
+      "leisure/adult_gaming_centre"      
+    ],
     "beauty": [
       "shop/beauty",
       "shop/hairdresser_supply"


### PR DESCRIPTION
I think it is more of a proposal but perhaps it will be useful for recent pachinko saloons brands  (because they don't use cards). The brands taged as adult_gaming_centre are extended to amenity tags like amenity=gambling and amenity=casino. Also, that would avoid some confusion in POIs with slot machines or games that require paying money.