### PR TITLE
Add wiki tags for Pizza Capers

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -2208,6 +2208,8 @@
     "tags": {
       "amenity": "fast_food",
       "brand": "Pizza Capers",
+      "brand:wikidata": "Q17021875",
+      "brand:wikipedia": "en:Pizza Capers",
       "cuisine": "pizza",
       "name": "Pizza Capers",
       "takeaway": "yes"


### PR DESCRIPTION
Added wiki tags for Pizza Capers
Wikidata [link](https://www.wikidata.org/wiki/Q17021875)
Wikipedia [link](https://en.wikipedia.org/wiki/Pizza_Capers) 