### PR TITLE
Re-edited Gino's to reflect name on the ground, specific to WV.

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -1035,6 +1035,18 @@
       "takeaway": "yes"
     }
   },
+  "amenity/fast_food|Gino's Pizza & Spaghetti House~(West Virginia)": {
+    "countryCodes": ["us"],
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "Gino's Pizza & Spaghetti House",
+      "brand:wikidata": "Q5563205",
+      "brand:wikipedia": "en:Gino's Pizza and Spaghetti",
+      "cuisine": "pizza",
+      "name": "Gino's Pizza & Spaghetti House",
+      "takeaway": "yes"
+    }
+  },
   "amenity/fast_food|Gino's Pizza~(Canada)": {
     "countryCodes": ["ca"],
     "tags": {
@@ -1043,19 +1055,6 @@
       "brand:wikidata": "Q84029134",
       "cuisine": "pizza",
       "name": "Gino's Pizza",
-      "takeaway": "yes"
-    }
-  },
-  "amenity/fast_food|Gino's Pizza~(West Virginia)": {
-    "countryCodes": ["us"],
-    "tags": {
-      "amenity": "fast_food",
-      "brand": "Gino's Pizza",
-      "brand:wikidata": "Q5563205",
-      "brand:wikipedia": "en:Gino's Pizza and Spaghetti",
-      "cuisine": "pizza",
-      "name": "Gino's Pizza",
-      "official_name": "Gino's Pizza & Spaghetti House",
       "takeaway": "yes"
     }
   },


### PR DESCRIPTION
I looked into this brand some more, because it was bugging me from my last PR. I want to map what's on the ground, and every restaurant of this brand I've seen fully writes out the whole name of Gino's Pizza & Spaghetti House.

A comment from last PR was that many instances of the restaurant only use "Gino's Pizza". Here's the output of that search—there are only three in WV:
![image](https://user-images.githubusercontent.com/7786285/80233103-f88a1e00-8623-11ea-8ba7-9b1009b92765.png)

The search for the full name shows this:
![image](https://user-images.githubusercontent.com/7786285/80233052-e1e3c700-8623-11ea-9dfc-08e56bd1e63d.png)

Most of the ones with the full name were not added by me (6/9), so there's no personal bias here. (2 of the "Gino's Pizza" in the WV area were mine added with the current NSI tags.)

Here's the location page from their website: http://ginospizza.com/locations.aspx