### PR TITLE
Change Overpass Turbo link to include styles

### DIFF
--- a/app/src/CategoryRow.jsx
+++ b/app/src/CategoryRow.jsx
@@ -45,7 +45,7 @@ export default function CategoryRow(props) {
       </h3>
       <div className="nsikey"><pre>'{kvnd}'</pre></div>
       <div className="countries">{ countries(entry.countryCodes) }</div>
-      <div className="viewlink">{ overpassLink(k, v, tags.name) }</div>
+      <div className="viewlink">{ overpassLink(k, v, tags.name, tags['brand:wikidata']) }</div>
     </td>
     <td className="count">{count}</td>
     <td className="tags"><pre className="tags" dangerouslySetInnerHTML={ highlight(tt, displayTags(tags)) } /></td>
@@ -85,15 +85,32 @@ export default function CategoryRow(props) {
   }
 
 
-  function overpassLink(k, v, n) {
-    const q = encodeURIComponent(`[out:json][timeout:60];
-(nwr["${k}"="${v}"]["name"="${n}"];);
+  function overpassLink(k, v, n, w) {
+    // Build Overpass Turbo link:
+    const q = encodeURIComponent(`[out:json][timeout:100];
+(nwr["name"="${n}"];);
+{{style:
+node[name=${n}],
+way[name=${n}],
+relation[name=${n}]
+{ color:red; fill-color:red; }
+node[${k}=${v}][name=${n}],
+way[${k}=${v}][name=${n}],
+relation[${k}=${v}][name=${n}]
+{ color:yellow; fill-color:yellow; }
+node[${k}=${v}][name=${n}][brand=${n}][brand:wikidata=${w}],
+way[${k}=${v}][name=${n}][brand=${n}][brand:wikidata=${w}],
+relation[${k}=${v}][name=${n}][brand=${n}][brand:wikidata=${w}]
+{ color:green; fill-color:green; }
+}}
 out body;
 >;
 out skel qt;`);
+    
+    // Create Overpass Turbo link:
     const href = `https://overpass-turbo.eu/?Q=${q}&R`;
     return (
-      <a target="_blank" href={href}>View on Overpass Turbo</a>
+      <a target="_blank" href={href} title="View ${n} via Overpass Turbo">View ${n} via Overpass Turbo</a>
     );
   }
 

--- a/app/src/CategoryRow.jsx
+++ b/app/src/CategoryRow.jsx
@@ -89,6 +89,10 @@ export default function CategoryRow(props) {
     // Build Overpass Turbo link:
     const q = encodeURIComponent(`[out:json][timeout:100];
 (nwr["name"="${n}"];);
+out body;
+>;
+out skel qt;
+
 {{style:
 node[name=${n}],
 way[name=${n}],
@@ -102,10 +106,7 @@ node[${k}=${v}][name=${n}][brand=${n}][brand:wikidata=${w}],
 way[${k}=${v}][name=${n}][brand=${n}][brand:wikidata=${w}],
 relation[${k}=${v}][name=${n}][brand=${n}][brand:wikidata=${w}]
 { color:green; fill-color:green; }
-}}
-out body;
->;
-out skel qt;`);
+}}`);
     
     // Create Overpass Turbo link:
     const href = `https://overpass-turbo.eu/?Q=${q}&R`;


### PR DESCRIPTION
**Alter Overpass Turbo link on [nsi.guide](https://nsi.guide)**

This is a bit of a hack job as I'm using it as a bit of a learning curve, so I don't necessarily expect it to be pulled, but would like to use this pull request as a means of feedback and opinions for a suggested change to the Overpass Turbo link on [nsi.guide](https://nsi.guide).

The suggested change might not be suitable or wanted, or might need adjusting, but I thought it better to make some edits and submit a pull request so it A) helps me learn a bit and B) might make it clearer what I'm suggesting.

At the moment, on [nsi.guide](https://nsi.guide), each entry has a link to Overpass Turbo, which links to a search using the object name and type (in my example, the name is "Argos" and the type is "shop=catalogue").

There isn't anything wrong with the current method, but I think adding some styles to the link would help distinguish each result and highlight any objects that may be missing brand data, or that don't have the correct type assigned (such as an Argos marked up as a department store, or general building).

I think adding a "red, yellow & green" style would make the resulting Overpass Turbo query clearer to people using it that some of the objects they are looking for are missing data that could easily be added via the pre-existing NSI entry (i.e. the Argos entry in the NSI).

The Argos Overpass Turbo query I put together looks like this ([https://overpass-turbo.eu/s/ToE](https://overpass-turbo.eu/s/ToE)), and when run, should find any "Argos" entries by name only (not type), then, colour all those Argos entries as red, then any that has the correct type (shop=catalogue) as yellow, and finally any that has the brand name and brand:wikidata entry as green:

[out:json][timeout:100];
    // Search for any node, way, or relation for the name 'Argos'.
    (nwr["name"="Argos"];);
out body;
_>_;
out skel qt;

// Then, style the results in the following manner:
//
// Red: Matches name only, not type and brand data,
//      meaning the name may not be of the desired object,
//      or is missing brand and type data.
//
// Yellow: Matches name and type only, not brand data,
//         meaning the object might be correct, but is just
//         missing brand data.
//
// Green: Matches name, type and brand data (brand & brand:wikidata),
//        meaning the object is likely tagged correctly.

{{style:
node[name=Argos],
way[name=Argos],
relation[name=Argos]
{ color:red; fill-color:red; }
node[shop=catalogue][name=Argos],
way[shop=catalogue][name=Argos],
relation[shop=catalogue][name=Argos]
{ color:yellow; fill-color:yellow; }
node[shop=catalogue][name=Argos][brand=Argos][brand:wikidata=Q4789707],
way[shop=catalogue][name=Argos][brand=Argos][brand:wikidata=Q4789707],
relation[shop=catalogue][name=Argos][brand=Argos][brand:wikidata=Q4789707]
{ color:green; fill-color:green; }
}}

This differs from the current link that searches for name and type, but misses any "Argos" objects that have the wrong type, and doesn't highlight any brand data associated with the resulting objects.

The edit to "**/app/src/CategoryRow.jsx**" is, admittedly, a bit of a punt, a hack job, as this level of in depth editing is new to me, and so probably fails in some areas, or all, but was done hopefully to make it easier to see where my suggested edit for the Overpass Turbo link would result in.

I added to " overpassLink(k, v, tags.name, **tags['brand:wikidata']**)" which hopefully should pass the wikidata id along with the overpassLink() function, and in turn then captured this passed data as the variable "w" when the function is called (overpassLink(k, v, n, **w**)).

I then added the style data which hopefully calls the existing variables in the correct place and way. The brand uses the same **${n}** as the name, but ,this might be better done with the brand tag being passed into the function.

I finally changed the link text from "View in Overpass Turbo" to "View **name here** via Overpass Turbo", and added the **title** attribute to the link, just as a visual change.

None of the **// style comments** included above are part of the pull request, as I thought they might make the URL to long. I also extended the timeout to 100, but again, this might be unnecessary.