### PR TITLE
Add wikidata to RHB and CNEP

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -5131,6 +5131,7 @@
     "tags": {
       "amenity": "bank",
       "brand": "RHB Bank",
+      "brand:wikidata": "Q4207443",
       "brand:wikipedia": "ms:RHB Bank",
       "name": "RHB Bank"
     }
@@ -7274,6 +7275,7 @@
     "tags": {
       "amenity": "bank",
       "brand": "الصندوق الوطني للتوفير والاحتياط",
+      "brand:wikidata": "Q2931752",
       "name": "الصندوق الوطني للتوفير والاحتياط"
     }
   },


### PR DESCRIPTION
Added wikidata identifiers to banks:

RHB bank [link](https://www.wikidata.org/wiki/Q4207443)
الصندوق الوطني للتوفير والاحتياط (CNEP-Bank) [link](https://www.wikidata.org/wiki/Q2931752)