### PR TITLE
Add Molly Fantasy and add playground to matchGroups

### DIFF
--- a/brands/leisure/playground.json
+++ b/brands/leisure/playground.json
@@ -12,7 +12,6 @@
   },
   "leisure/playground|モーリーファンタジー": {
     "countryCodes": ["jp"],
-    "matchTags": ["leisure/amusement_arcade"],
     "tags": {
       "access": "customers",
       "brand": "モーリーファンタジー",

--- a/brands/leisure/playground.json
+++ b/brands/leisure/playground.json
@@ -12,6 +12,7 @@
   },
   "leisure/playground|モーリーファンタジー": {
     "countryCodes": ["jp"],
+    "matchTags": ["leisure/amusement_arcade"],
     "tags": {
       "access": "customers",
       "brand": "モーリーファンタジー",

--- a/brands/leisure/playground.json
+++ b/brands/leisure/playground.json
@@ -9,5 +9,19 @@
       "leisure": "playground",
       "name": "McDonald's PlayPlace"
     }
+  },
+  "leisure/playground|モーリーファンタジー": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "access": "customers",
+      "brand": "モーリーファンタジー",
+      "brand:en": "Molly Fantasy",
+      "brand:ja": "モーリーファンタジー",
+      "brand:wikidata": "Q92437201",
+      "leisure": "playground",
+      "name": "モーリーファンタジー",
+      "name:en": "Molly Fantasy",
+      "name:ja": "モーリーファンタジー"
+    }
   }
 }

--- a/config/match_groups.json
+++ b/config/match_groups.json
@@ -132,6 +132,11 @@
       "shop/outdoor",
       "shop/sports"
     ],
+    "playground": [
+      "amenity/theme_park",
+      "leisure/amusement_arcade",
+      "leisure/playground"
+    ],
     "rental": [
       "amenity/bicycle_rental",
       "amenity/boat_rental",


### PR DESCRIPTION
This pull request adds a playground brand in Aeon malls. Also, added playground to matchgroup since   they called are "theme parks" but they are very small for this tag, in addition to recreational rooms for "children only" (under 12 years old) and that usually include trampolines and others.