### PR TITLE
Added Santander UK

### DIFF
--- a/brands/shop/charity.json
+++ b/brands/shop/charity.json
@@ -92,6 +92,15 @@
       "shop": "charity"
     }
   },
+  "shop/charity|Haven House Children's Hospice": {
+    "countryCodes" : ["gb"],
+    "tags": {
+      "brand": "Haven House",
+      "brand:wikidata": "Q92542889",
+      "name": "Haven House",
+      "shop": "charity"
+    }
+  },
   "shop/charity|Humana": {
     "matchNames": ["humana people to people"],
     "matchTags": [
@@ -243,6 +252,14 @@
       "brand:wikidata": "Q7434435",
       "brand:wikipedia": "en:Scope (charity)",
       "name": "Scope",
+      "shop": "charity"
+    }
+  },
+  "shop/charity|Sense, The National Deafblind And Rubella Association": {
+    "countryCodes": ["gb"],
+    "tags": {"brand": "Sense",
+      "brand:wikidata": "Q92552497",
+      "name": "Sense",
       "shop": "charity"
     }
   },


### PR DESCRIPTION
Current listing only shows Banco Santander/Santander for tagging company banks under Spanish division. I have added Santander UK to the list of banks, as the name "Santander" still appears on the high street the brand is "Santander UK" but the name is "Santander"