### PR TITLE
Rename brand to "Steak gusto" and add S-Gusto

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -2844,6 +2844,22 @@
       "takeaway": "yes"
     }
   },
+  "amenity/fast_food|Sガスト": {
+    "countryCodes": ["jp"],
+    "nomatch": ["amenity/restaurant|ガスト"],
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "ガスト",
+      "brand:en": "Gusto",
+      "brand:ja": "ガスト",
+      "brand:wikidata": "Q87724117",
+      "cuisine": "western;japanese",
+      "name": "Sガスト",
+      "name:en": "S-Gusto",
+      "name:ja": "Sガスト",
+      "takeaway": "yes"
+    }
+  },
   "amenity/fast_food|Taco Bell": {
     "tags": {
       "amenity": "fast_food",

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -3011,7 +3011,6 @@
       "brand:en": "Steak Gusto",
       "brand:ja": "ステーキガスト",
       "brand:wikidata": "Q92599119",
-      "brand:wikipedia": "ja:すかいらーく",
       "cuisine": "steak",
       "name": "ステーキガスト",
       "name:en": "Steak Gusto",

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -2342,6 +2342,20 @@
       "name": "Swiss Chalet"
     }
   },
+  "amenity/restaurant|Sガスト": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "amenity": "restaurant",
+      "brand": "ガスト",
+      "brand:en": "Gusto",
+      "brand:ja": "ガスト",
+      "brand:wikidata": "Q87724117",
+      "cuisine": "western;japanese",
+      "name": "Sガスト",
+      "name:en": "S-Gusto",
+      "name:ja": "Sガスト"
+    }
+  },
   "amenity/restaurant|TGI Friday's": {
     "tags": {
       "amenity": "restaurant",
@@ -3007,13 +3021,13 @@
     "tags": {
       "amenity": "restaurant",
       "brand": "ステーキガスト",
-      "brand:en": "Skylark",
+      "brand:en": "Steak Gusto",
       "brand:ja": "ステーキガスト",
-      "brand:wikidata": "Q11253593",
+      "brand:wikidata": "Q92599119",
       "brand:wikipedia": "ja:すかいらーく",
       "cuisine": "steak",
       "name": "ステーキガスト",
-      "name:en": "Skylark",
+      "name:en": "Steak Gusto",
       "name:ja": "ステーキガスト"
     }
   },

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -2342,20 +2342,6 @@
       "name": "Swiss Chalet"
     }
   },
-  "amenity/restaurant|Sガスト": {
-    "countryCodes": ["jp"],
-    "tags": {
-      "amenity": "restaurant",
-      "brand": "ガスト",
-      "brand:en": "Gusto",
-      "brand:ja": "ガスト",
-      "brand:wikidata": "Q87724117",
-      "cuisine": "western;japanese",
-      "name": "Sガスト",
-      "name:en": "S-Gusto",
-      "name:ja": "Sガスト"
-    }
-  },
   "amenity/restaurant|TGI Friday's": {
     "tags": {
       "amenity": "restaurant",
@@ -2929,6 +2915,7 @@
   },
   "amenity/restaurant|ガスト": {
     "countryCodes": ["jp"],
+    "nomatch": ["amenity/fast_food|Sガスト"],
     "tags": {
       "amenity": "restaurant",
       "brand": "ガスト",


### PR DESCRIPTION
This pull request fix the "Steak Gusto" brand (because the previous name is its operator). Also, added S-Gusto (Speed Gusto).