### PR TITLE
Add sport=10pin to ROUND1

### DIFF
--- a/brands/leisure/bowling_alley.json
+++ b/brands/leisure/bowling_alley.json
@@ -30,7 +30,8 @@
       "leisure": "bowling_alley",
       "name": "ラウンドワン",
       "name:en": "ROUND1",
-      "name:ja": "ラウンドワン"
+      "name:ja": "ラウンドワン",
+      "sport": "10pin"
     }
   }
 }


### PR DESCRIPTION
In this pull request, I'm sure that all the bowling chain are playing with 10pin. For example, in [this video](https://youtu.be/QCs5EifsDSw?t=275) indicates "10ピン".