### PR TITLE
Add Japan newspaper brands

### DIFF
--- a/brands/shop/newsagent.json
+++ b/brands/shop/newsagent.json
@@ -170,6 +170,21 @@
       "shop": "newsagent"
     }
   },
+  "shop/newsagent|日本経済新聞": {
+    "countryCodes": ["jp"],
+    "matchNames": ["日経新聞"],
+    "tags": {
+      "brand": "日本経済新聞",
+      "brand:en": "The Nikkei",
+      "brand:ja": "日本経済新聞",
+      "brand:wikidata": "Q1077694",
+      "brand:wikipedia": "ja:日本経済新聞",
+      "name": "日本経済新聞",
+      "name:en": "The Nikkei",
+      "name:ja": "日本経済新聞",
+      "shop": "newsagent"
+    }
+  },
   "shop/newsagent|朝日新聞": {
     "tags": {
       "brand": "朝日新聞",

--- a/brands/shop/newsagent.json
+++ b/brands/shop/newsagent.json
@@ -198,6 +198,7 @@
   },
   "shop/newsagent|毎日新聞": {
     "countryCodes": ["jp"],
+    "matchNames": ["毎日ニュースポート"],
     "tags": {
       "brand": "毎日新聞",
       "brand:en": "Mainichi Shimbun",

--- a/brands/shop/newsagent.json
+++ b/brands/shop/newsagent.json
@@ -181,6 +181,35 @@
       "shop": "newsagent"
     }
   },
+  "shop/newsagent|毎日新聞": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "毎日新聞",
+      "brand:en": "Mainichi Shimbun",
+      "brand:ja": "毎日新聞",
+      "brand:wikidata": "Q1136866",
+      "brand:wikipedia": "ja:毎日新聞",
+      "name": "毎日新聞",
+      "name:en": "Mainichi Shimbun",
+      "name:ja": "毎日新聞",
+      "shop": "newsagent"
+    }
+  },
+  "shop/newsagent|産経新聞": {
+    "countryCodes": ["jp"],
+    "matchNames": ["サンケイ新聞"],
+    "tags": {
+      "brand": "産経新聞",
+      "brand:en": "Sankei Shimbun",
+      "brand:ja": "産経新聞",
+      "brand:wikidata": "Q1197261",
+      "brand:wikipedia": "ja:産経新聞",
+      "name": "産経新聞",
+      "name:en": "Sankei Shimbun",
+      "name:ja": "産経新聞",
+      "shop": "newsagent"
+    }
+  },
   "shop/newsagent|読売新聞": {
     "countryCodes": ["jp"],
     "tags": {


### PR DESCRIPTION
This pull request adds newsagent for other big six japanese newspapers.