### PR TITLE
FR: Add Vapostore (e-cigarette)

### DIFF
--- a/brands/shop/e-cigarette.json
+++ b/brands/shop/e-cigarette.json
@@ -15,6 +15,15 @@
       "shop": "e-cigarette"
     }
   },
+  "shop/e-cigarette|Vapostore": {
+    "countryCodes": ["fr"],
+    "tags": {
+      "brand": "Vapostore",
+      "brand:wikidata": "Q91257968",
+      "name": "Vapostore",
+      "shop": "e-cigarette"
+    }
+  },
   "shop/e-cigarette|Vardex": {
     "countryCodes": ["ru"],
     "tags": {


### PR DESCRIPTION
Added "Vapstore", e-cigarette shop in France to address issue #3750 