### PR TITLE
Add TEPCO and KEPCO

### DIFF
--- a/brands/office/energy_supplier.json
+++ b/brands/office/energy_supplier.json
@@ -57,5 +57,34 @@
       "name": "Naturgy",
       "office": "energy_supplier"
     }
+  },
+  "office/energy_supplier|東京電力": {
+    "countryCodes": ["jp"],
+    "matchNames": ["東電"],
+    "tags": {
+      "brand": "東京電力",
+      "brand:en": "TEPCO",
+      "brand:ja": "東京電力",
+      "brand:wikidata": "Q333894",
+      "brand:wikipedia": "ja:東京電力ホールディングス",
+      "name": "東京電力",
+      "name:en": "TEPCO",
+      "name:ja": "東京電力",
+      "office": "energy_supplier"
+    }
+  },
+  "office/energy_supplier|関西電力": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "関西電力",
+      "brand:en": "KEPCO",
+      "brand:ja": "関西電力",
+      "brand:wikidata": "Q1365015",
+      "brand:wikipedia": "ja:関西電力",
+      "name": "関西電力",
+      "name:en": "KEPCO",
+      "name:ja": "関西電力",
+      "office": "energy_supplier"
+    }
   }
 }


### PR DESCRIPTION
This pull request adds two power companies. This tagged under office=energy_supplier. For example, TEPCO has [several offices](https://www.tepco.co.jp/about/office/) under Japan and other prefectures.