### PR TITLE
Add Tambunting (shop=pawnbroker)

### DIFF
--- a/brands/shop/pawnbroker.json
+++ b/brands/shop/pawnbroker.json
@@ -54,6 +54,15 @@
       "shop": "pawnbroker"
     }
   },
+  "shop/pawnbroker|Tambunting": {
+    "countryCodes": ["ph"],
+    "tags": {
+      "brand": "Tambunting",
+      "brand:wikidata": "Q93928644",
+      "name": "Tambunting",
+      "shop": "pawnbroker"
+    }
+  },
   "shop/pawnbroker|Villarica Pawnshop": {
     "countryCodes": ["ph"],
     "tags": {


### PR DESCRIPTION
Add an entry for the Tambunting chain of pawnshops in the Philippines.