### PR TITLE
Add Tambunting (shop=pawnbroker)

### DIFF
--- a/brands/shop/pawnbroker.json
+++ b/brands/shop/pawnbroker.json
@@ -58,7 +58,7 @@
     "countryCodes": ["ph"],
     "tags": {
       "brand": "Tambunting",
-      "brand:wikidata": "Q93928644",
+      "brand:wikidata": "Q7681088",
       "name": "Tambunting",
       "shop": "pawnbroker"
     }

--- a/brands/shop/pawnbroker.json
+++ b/brands/shop/pawnbroker.json
@@ -59,6 +59,7 @@
     "tags": {
       "brand": "Tambunting",
       "brand:wikidata": "Q7681088",
+      "brand:wikipedia": "en:Tambunting",
       "name": "Tambunting",
       "shop": "pawnbroker"
     }

--- a/brands/shop/pawnbroker.json
+++ b/brands/shop/pawnbroker.json
@@ -54,6 +54,15 @@
       "shop": "pawnbroker"
     }
   },
+  "shop/pawnbroker|Tambunting": {
+    "countryCodes": ["ph"],
+    "tags": {
+      "brand": "Tambunting",
+      "brand:wikidata": "Q93928644",
+      "name": "Tambunting",
+      "shop": "pawnbroker"
+    }
+  },
   "shop/pawnbroker|Villarica Pawnshop": {
     "countryCodes": ["ph"],
     "tags": {


### PR DESCRIPTION
Add an entry for the Tambunting chain of pawnshops in the Philippines, update entries with correct Wikidata and Wikipedia items.