### PR TITLE
Add Chiyoda Sushi

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -3795,6 +3795,23 @@
       "takeaway": "yes"
     }
   },
+  "amenity/fast_food|ちよだ鮨": {
+    "countryCodes": ["jp"],
+    "matchTags": ["shop/deli"],
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "ちよだ鮨",
+      "brand:en": "Chiyoda Sushi",
+      "brand:ja": "ちよだ鮨",
+      "brand:wikidata": "Q11272065",
+      "brand:wikipedia": "ja:ちよだ鮨",
+      "cuisine": "sushi",
+      "name": "ちよだ鮨",
+      "name:en": "Chiyoda Sushi",
+      "name:ja": "ちよだ鮨",
+      "takeaway": "only"
+    }
+  },
   "amenity/fast_food|てんや": {
     "countryCodes": ["jp"],
     "tags": {


### PR DESCRIPTION
This pull request adds a fresh takeover food. Unlike Kyotaru, I think that more deli that fast food but this brand sells sushi preparated and packed only. So I added a matchtag.