### PR TITLE
Add Hachijuni Bank and Iyo Bank

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -8084,6 +8084,21 @@
       "name:en": "Bank of Kyoto"
     }
   },
+  "amenity/bank|伊予銀行": {
+    "countryCodes": ["jp"],
+    "matchNames": ["いよぎん"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "伊予銀行",
+      "brand:en": "Iyo Bank",
+      "brand:ja": "伊予銀行",
+      "brand:wikidata": "Q2895314",
+      "brand:wikipedia": "ja:伊予銀行",
+      "name": "伊予銀行",
+      "name:en": "Iyo Bank",
+      "name:ja": "伊予銀行"
+    }
+  },
   "amenity/bank|元大商業銀行": {
     "countryCodes": ["tw"],
     "tags": {
@@ -8106,6 +8121,21 @@
       "brand:wikipedia": "en:Mega International Commercial Bank",
       "name": "兆豐國際商業銀行",
       "name:en": "Mega International Commercial Bank"
+    }
+  },
+  "amenity/bank|八十二銀行": {
+    "countryCodes": ["jp"],
+    "matchNames": ["82銀行"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "八十二銀行",
+      "brand:en": "Hachijuni Bank",
+      "brand:ja": "八十二銀行",
+      "brand:wikidata": "Q11390608",
+      "brand:wikipedia": "ja:八十二銀行",
+      "name": "八十二銀行",
+      "name:en": "Hachijuni Bank",
+      "name:ja": "八十二銀行"
     }
   },
   "amenity/bank|兴业银行": {


### PR DESCRIPTION
This pull request adds two banks of Japan with alternative names, because a number is also part of the corporate identity.