### PR TITLE
Add Kagi110-Key Ambulancy Association

### DIFF
--- a/brands/shop/locksmith.json
+++ b/brands/shop/locksmith.json
@@ -1,0 +1,28 @@
+{
+  "shop/locksmith|カギの110番": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "カギの110番",
+      "brand:en": "Kagi110",
+      "brand:ja": "カギの110番",
+      "brand:wikidata": "Q94551271",
+      "name": "カギの110番",
+      "name:en": "Kagi110",
+      "name:ja": "カギの110番",
+      "shop": "locksmith"
+    }
+  },
+  "shop/locksmith|カギの救急車": {
+    "countryCodes": ["jp"],
+    "tags": {
+      "brand": "カギの救急車",
+      "brand:en": "Key Ambulancy",
+      "brand:ja": "カギの救急車",
+      "brand:wikidata": "Q94551271",
+      "name": "カギの救急車",
+      "name:en": "Key Ambulancy",
+      "name:ja": "カギの救急車",
+      "shop": "locksmith"
+    }
+  }
+}


### PR DESCRIPTION
This company operates two locksmith shop brands. Two brands share the same logo, SNS and  website. Store names differ only by name.