### PR TITLE
Add Radiowealth Finance

### DIFF
--- a/brands/shop/money_lender.json
+++ b/brands/shop/money_lender.json
@@ -119,5 +119,20 @@
       "official_name:en": "SMBC Consumer Finance",
       "shop": "money_lender"
     }
+  },
+  "shop/money_lender|Radiowealth Finance": {
+    "countryCodes": ["ph"],
+    "tags": {
+      "brand": "Radiowealth Finance",
+      "brand:en": "Radiowealth Finance",
+      "brand:wikidata": "Q94572570",
+      "name": "Radiowealth Finance",
+      "official_name": "Radiowealth Finance Company",
+      "name:abbr": "RFC",
+      "name:en": "Radiowealth Finance",
+      "shop": "money_lender",
+      "contact:email": "easyrfc@rfc.com.ph",
+      "contact:website": "https://rfc.com.ph"
+    }
   }
 }

--- a/brands/shop/money_lender.json
+++ b/brands/shop/money_lender.json
@@ -128,11 +128,9 @@
       "brand:wikidata": "Q94572570",
       "name": "Radiowealth Finance",
       "official_name": "Radiowealth Finance Company",
-      "name:abbr": "RFC",
+      "short_name": "RFC",
       "name:en": "Radiowealth Finance",
-      "shop": "money_lender",
-      "contact:email": "easyrfc@rfc.com.ph",
-      "contact:website": "https://rfc.com.ph"
+      "shop": "money_lender"
     }
   }
 }


### PR DESCRIPTION
Add item for Radiowealth Finance, a local chain of money lenders in the Philippines