### PR TITLE
Specialty’s is closing

### DIFF
--- a/dist/dissolved.json
+++ b/dist/dissolved.json
@@ -24,6 +24,7 @@
     {"date": "2019-01-01T00:00:00.000Z", "upgrade": ["amenity/bank|Открытие"]}
   ],
   "amenity/bank|近畿大阪銀行": [{"date": "2019-03-31T00:00:00.000Z"}],
+  "amenity/fast_food|Specialty's": [{"date": "2020-05-20T00:00:00.000-07:00"}],
   "amenity/fuel|Agip": [{"date": "2008-01-01T00:00:00.000Z"}],
   "amenity/fuel|Ampol": [{"date": "1995-01-01T00:00:00.000Z"}],
   "amenity/fuel|CAMPSA": [{"date": "1992-01-01T00:00:00.000Z"}],


### PR DESCRIPTION
Specialty’s is [closing Tuesday](https://www.mercurynews.com/2020/05/17/all-specialtys-cafe-bakery-restaurants-will-close-permanently/) as another casualty of the COVID-19 pandemic. The [Wikidata item](https://www.wikidata.org/wiki/Q64339210) has been updated to note its closure, but this PR adds a line to the dissolved file just in case.