### PR TITLE
use more specific Wikidata item for Rewe to Go

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -1595,7 +1595,6 @@
     "tags": {
       "brand": "Rewe To Go",
       "brand:wikidata": "Q85224313",
-      "brand:wikipedia": "en:REWE",
       "name": "Rewe To Go",
       "shop": "convenience"
     }

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -1594,7 +1594,7 @@
     ],
     "tags": {
       "brand": "Rewe To Go",
-      "brand:wikidata": "Q16968817",
+      "brand:wikidata": "Q85224313",
       "brand:wikipedia": "en:REWE",
       "name": "Rewe To Go",
       "shop": "convenience"


### PR DESCRIPTION
[Q16968817](http://www.wikidata.org/entity/Q16968817) is about Rewe as supermarket chain in general, while [Q85224313](http://www.wikidata.org/entity/Q85224313) the specific Rewe to Go chain represents. I therefore propose to use the more specific one. This way the fetched website and the from Wikidata fetched logo (and from Facebook) are specific to this brand and chain.