### PR TITLE
Add WiFi to Premier Inn preset

### DIFF
--- a/brands/tourism/hotel.json
+++ b/brands/tourism/hotel.json
@@ -808,6 +808,9 @@
       "brand": "Premier Inn",
       "brand:wikidata": "Q2108626",
       "brand:wikipedia": "en:Premier Inn",
+      "internet_access": "wlan",
+      "internet_access:fee": "customers",
+      "internet_access:ssid": "Premier Inn Free Wi-Fi",
       "name": "Premier Inn",
       "tourism": "hotel"
     }


### PR DESCRIPTION
As per #3905 add standard values to Premier Inn preset.

Note, I've not tested this, but I think you have CI set up.