### PR TITLE
added insurance=health for some "Krankenkasse" presets in germany

### DIFF
--- a/brands/office/insurance.json
+++ b/brands/office/insurance.json
@@ -16,6 +16,7 @@
       "brand:wikidata": "Q87070013",
       "name": "A-Plan Insurance",
       "office": "insurance"
+      "insurance": "health"
     }
   },
   "office/insurance|AAA Insurance": {
@@ -210,6 +211,7 @@
       "brand:wikipedia": "de:DAK-Gesundheit",
       "name": "DAK",
       "office": "insurance"
+      "insurance": "health"
     }
   },
   "office/insurance|DEVK": {
@@ -394,6 +396,7 @@
       "brand:wikipedia": "de:Knappschaft (Krankenkasse)",
       "name": "Knappschaft",
       "office": "insurance"
+      "insurance": "health"
     }
   },
   "office/insurance|Kooperativa": {
@@ -638,6 +641,7 @@
       "brand:wikipedia": "de:Techniker Krankenkasse",
       "name": "Techniker Krankenkasse",
       "office": "insurance"
+      "insurance": "health"
     }
   },
   "office/insurance|The Co-operators": {


### PR DESCRIPTION
See #3854 - added insurance=health for specifying those insurances offices, which are specialized only on health insurances. In germany we have some brands of them and insurance=health is the proposed tag to add.