### PR TITLE
Rename Amazon Hub Locker

### DIFF
--- a/brands/amenity/vending_machine.json
+++ b/brands/amenity/vending_machine.json
@@ -1,4 +1,20 @@
 {
+  "amenity/vending_machine|Amazon Hub ロッカー": {
+    "countryCodes": ["jp"],
+    "matchNames": ["amazon ロッカー", "アマゾン・ハブ・ロッカー"],
+    "tags": {
+      "amenity": "vending_machine",
+      "brand": "Amazon Hub ロッカー",
+      "brand:en": "Amazon Hub Locker",
+      "brand:ja": "Amazon Hub ロッカー",
+      "brand:wikidata": "Q16974764",
+      "brand:wikipedia": "ja:Amazonロッカー",
+      "name": "Amazon Hub ロッカー",
+      "name:en": "Amazon Hub Locker",
+      "name:ja": "Amazon Hub ロッカー",
+      "vending": "parcel_pickup"
+    }
+  },
   "amenity/vending_machine|Amazon Locker": {
     "countryCodes": ["de", "gb", "us"],
     "tags": {
@@ -7,23 +23,6 @@
       "brand:wikidata": "Q16974764",
       "brand:wikipedia": "en:Amazon Locker",
       "name": "Amazon Locker",
-      "vending": "parcel_pickup"
-    }
-  },
-  "amenity/vending_machine|Amazonロッカー": {
-    "countryCodes": ["jp"],
-    "matchNames": ["アマゾン・ロッカー"],
-    "tags": {
-      "alt_name": "アマゾン・ロッカー",
-      "amenity": "vending_machine",
-      "brand": "Amazonロッカー",
-      "brand:en": "Amazon Locker",
-      "brand:ja": "Amazonロッカー",
-      "brand:wikidata": "Q16974764",
-      "brand:wikipedia": "ja:Amazonロッカー",
-      "name": "Amazonロッカー",
-      "name:en": "Amazon Locker",
-      "name:ja": "Amazonロッカー",
       "vending": "parcel_pickup"
     }
   },


### PR DESCRIPTION
This pull request renews the japanese service name to Amazon Hub, according to [this press release](https://www.watch.impress.co.jp/docs/news/1207906.html).