### PR TITLE
BB&T and SunTrust merger to Truist Financial

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -459,7 +459,7 @@
       "amenity": "bank",
       "brand": "BB&T",
       "brand:wikidata": "Q795486",
-      "brand:wikipedia": "en:BB&T",
+      "brand:wikipedia": "en:Truist Financial",
       "name": "BB&T",
       "official_name": "Branch Banking and Trust Company"
     }
@@ -5896,8 +5896,8 @@
     "tags": {
       "amenity": "bank",
       "brand": "SunTrust",
-      "brand:wikidata": "Q181507",
-      "brand:wikipedia": "en:SunTrust Banks",
+      "brand:wikidata": "Q795486",
+      "brand:wikipedia": "en:Truist Financial",
       "name": "SunTrust"
     }
   },
@@ -6066,6 +6066,17 @@
       "brand:wikidata": "Q3520318",
       "brand:wikipedia": "en:The Co-operative Bank",
       "name": "The Co-operative Bank"
+    }
+  },
+  "amenity/bank|Truist Financial": {
+    "countryCodes": ["us"],
+    "matchNames": ["truist bank"],
+    "tags": {
+      "amenity": "bank",
+      "brand": "Truist",
+      "brand:wikidata": "Q795486",
+      "brand:wikipedia": "en:Truist Financial",
+      "name": "Truist Financial"
     }
   },
   "amenity/bank|Türkiye İş Bankası": {


### PR DESCRIPTION
BB&T and SunTrust recently merged into a single company now called Truist Financial.  The actual buildings haven't changed their branding, yet, but the wikipages have been merged.

I suggest changing the brand wikipage and wikidata to the current tags and add the Truist brand to future-proof the system.