### PR TITLE
Fixing amenity/fuel

### DIFF
--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -1487,6 +1487,19 @@
       "name": "Kastrati"
     }
   },
+  "amenity/fuel|King Soopers": {
+    "countryCodes": ["us"],
+    "matchNames": ["king soopers fuel", "king soopers gas"],
+    "nomatch": ["shop/supermarket|King Soopers"],
+    "tags": {
+      "amenity": "fuel",
+      "brand": "King Soopers",
+      "brand:wikidata": "Q6412065",
+      "brand:wikipedia": "en:King Soopers",
+      "name": "King Soopers",
+      "official_name": "King Soopers Fuel Station"
+    }
+  },
   "amenity/fuel|Kobil": {
     "countryCodes": [
       "bi",

--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -247,9 +247,12 @@
     }
   },
   "amenity/fuel|Applegreen": {
+    "countryCodes": ["gb","ie","us"],
     "tags": {
       "amenity": "fuel",
       "brand": "Applegreen",
+      "brand:wikidata": "Q7178908",
+      "brand:wikipedia": "en:Applegreen",
       "name": "Applegreen"
     }
   },


### PR DESCRIPTION
Fixed Applegreen by adding the country codes of the UK, US, Ireland, addition of the Wikidata ID: Q7178908, and add the Wikipedia link of en:Applegreen