### PR TITLE
Add Sabeco group brands (spanish filial from Auchan group)

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -1787,7 +1787,6 @@
   },
   "shop/convenience|Simply Basic": {
     "locationSet": {"include": ["es"]},
-    "matchNames": ["simply"],
     "tags": {
       "brand": "Simply Basic",
       "brand:wikidata": "Q5643014",
@@ -1798,7 +1797,6 @@
   },
   "shop/convenience|Simply City": {
     "locationSet": {"include": ["es"]},
-    "matchNames": ["simply"],
     "tags": {
       "brand": "Simply City",
       "brand:wikidata": "Q5643014",
@@ -1809,7 +1807,6 @@
   },
   "shop/convenience|Simply Store": {
     "locationSet": {"include": ["es"]},
-    "matchNames": ["simply"],
     "tags": {
       "brand": "Simply Store",
       "brand:wikidata": "Q5643014",

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -1785,6 +1785,39 @@
       "shop": "convenience"
     }
   },
+  "shop/convenience|Simply Basic": {
+    "locationSet": {"include": ["es"]},
+    "matchNames": ["simply"],
+    "tags": {
+      "brand": "Simply Basic",
+      "brand:wikidata": "Q11893827",
+      "brand:wikipedia": "es:Sabeco",
+      "name": "Simply Basic",
+      "shop": "convenience"
+    }
+  },
+  "shop/convenience|Simply City": {
+    "locationSet": {"include": ["es"]},
+    "matchNames": ["simply"],
+    "tags": {
+      "brand": "Simply City",
+      "brand:wikidata": "Q11893827",
+      "brand:wikipedia": "es:Sabeco",
+      "name": "Simply City",
+      "shop": "convenience"
+    }
+  },
+  "shop/convenience|Simply Store": {
+    "locationSet": {"include": ["es"]},
+    "matchNames": ["simply"],
+    "tags": {
+      "brand": "Simply Store",
+      "brand:wikidata": "Q11893827",
+      "brand:wikipedia": "es:Sabeco",
+      "name": "Simply Store",
+      "shop": "convenience"
+    }
+  },
   "shop/convenience|Siwa": {
     "locationSet": {"include": ["fi"]},
     "tags": {

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -1790,7 +1790,7 @@
     "matchNames": ["simply"],
     "tags": {
       "brand": "Simply Basic",
-      "brand:wikidata": "Q11893827",
+      "brand:wikidata": "Q5643014",
       "brand:wikipedia": "es:Sabeco",
       "name": "Simply Basic",
       "shop": "convenience"
@@ -1801,7 +1801,7 @@
     "matchNames": ["simply"],
     "tags": {
       "brand": "Simply City",
-      "brand:wikidata": "Q11893827",
+      "brand:wikidata": "Q5643014",
       "brand:wikipedia": "es:Sabeco",
       "name": "Simply City",
       "shop": "convenience"
@@ -1812,7 +1812,7 @@
     "matchNames": ["simply"],
     "tags": {
       "brand": "Simply Store",
-      "brand:wikidata": "Q11893827",
+      "brand:wikidata": "Q5643014",
       "brand:wikipedia": "es:Sabeco",
       "name": "Simply Store",
       "shop": "convenience"

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -2015,7 +2015,7 @@
     "matchNames": ["simply"],
     "tags": {
       "brand": "Hiper Simply",
-      "brand:wikidata": "Q11893827",
+      "brand:wikidata": "Q5643014",
       "brand:wikipedia": "es:Sabeco",
       "name": "Hiper Simply",
       "shop": "supermarket"

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -2012,7 +2012,6 @@
   },
   "shop/supermarket|Hiper Simply": {
     "locationSet": {"include": ["es"]},
-    "matchNames": ["simply"],
     "tags": {
       "brand": "Hiper Simply",
       "brand:wikidata": "Q5643014",

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -2010,6 +2010,17 @@
       "shop": "supermarket"
     }
   },
+  "shop/supermarket|Hiper Simply": {
+    "locationSet": {"include": ["es"]},
+    "matchNames": ["simply"],
+    "tags": {
+      "brand": "Hiper Simply",
+      "brand:wikidata": "Q11893827",
+      "brand:wikipedia": "es:Sabeco",
+      "name": "Hiper Simply",
+      "shop": "supermarket"
+    }
+  },
   "shop/supermarket|Hipermaxi": {
     "locationSet": {"include": ["bo"]},
     "tags": {


### PR DESCRIPTION
Sabeco group involves also _Simply Market_, who is already included in the guide as a worldwide brand. That's OK and the establishment is the same, but the other brands are regional scoped since they belong to the Sabeco group, who operates only in spain

Further info (in spanish):
- https://es.wikipedia.org/wiki/Sabeco#Tipos_de_establecimientos
- https://www.simply.es/pagEstatica.aspx?id=7