### PR TITLE
Osmose now uses the nsi

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Currently used in:
 - iD (see above)
 - [Vespucci](http://vespucci.io/tutorials/name_suggestions/)
 - [JOSM presets](https://josm.openstreetmap.de/wiki/Help/Preferences/Map#TaggingPresets) available
+- [Osmose](http://osmose.openstreetmap.fr/en/errors/?item=3130)  
 
 ### Participate!
 


### PR DESCRIPTION
Since a few weeks, Osmose uses the OSM frequent names extracted by the name-suggestion-index to detect brand candidates in existing OSM objects.

If they correspond to known brands in the nsi, it then suggests to add some tags.

![Screenshot_2020-05-16 Osmose - Carte](https://user-images.githubusercontent.com/919962/82230808-85c34880-992c-11ea-9589-181c66029d9c.png)

http://osmose.openstreetmap.fr/en/map/?item=3130 / https://github.com/osm-fr/osmose-backend/pull/874