### PR TITLE
Fix Gyomu Super name

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -6291,11 +6291,13 @@
       "brand": "業務スーパー",
       "brand:en": "Gyomu Super",
       "brand:ja": "業務スーパー",
+      "brand:ja-Latn": "Gyōmu sūpā",
       "brand:wikidata": "Q11590183",
       "brand:wikipedia": "ja:神戸物産",
       "name": "業務スーパー",
-      "name:en": "Gyōmu sūpā",
+      "name:en": "Gyomu Super",
       "name:ja": "業務スーパー",
+      "name:ja-Latn": "Gyōmu sūpā",
       "shop": "supermarket"
     }
   },


### PR DESCRIPTION
This pull request adds "name:ja-Latn" for romanization. Also the ":en" sufix is "Gyomu Super".