### PR TITLE
Add Hack Drug for Welcia

### DIFF
--- a/brands/amenity/pharmacy.json
+++ b/brands/amenity/pharmacy.json
@@ -2314,10 +2314,14 @@
     "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "pharmacy",
-      "brand": "ハックドラッグ",
-      "brand:ja": "ハックドラッグ",
+      "brand": "ウエルシア",
+      "brand:en": "Welcia",
+      "brand:ja": "ウエルシア",
+      "brand:wikidata": "Q11288684",
+      "brand:wikipedia": "ja:ウエルシアホールディングス",
       "healthcare": "pharmacy",
       "name": "ハックドラッグ",
+      "name:en": "Hack Drug",
       "name:ja": "ハックドラッグ"
     }
   },


### PR DESCRIPTION
This pull request adds the Welcia brand. Since it was confirmed that in the coming years it will be merged with the pharmacy chain. At the moment it is officially available. See for example [this store with second brand](https://stores.welcia.co.jp/2026D).