### PR TITLE
Set specific Wikidata for Ueshima Coffee House

### DIFF
--- a/brands/amenity/cafe.json
+++ b/brands/amenity/cafe.json
@@ -1761,9 +1761,10 @@
     "matchNames": ["上島珈琲"],
     "tags": {
       "amenity": "cafe",
-      "brand": "UCC",
-      "brand:wikidata": "Q1185060",
-      "brand:wikipedia": "ja:UCC上島珈琲",
+      "brand": "上島珈琲店",
+      "brand:en": "Ueshima Coffee House",
+      "brand:ja": "上島珈琲店",
+      "brand:wikidata": "Q96152143",
       "cuisine": "coffee_shop",
       "name": "上島珈琲店",
       "name:en": "Ueshima Coffee House",


### PR DESCRIPTION
This pull request edits the brand to a more specific one. Since a new Wikidata was created, I added specific information about coffee shops, in addition to using exclusive social networks. This replaces the old Wikidata with UCC.