### PR TITLE
NPM Run Build Error Fixes. 

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -3999,8 +3999,6 @@
     "tags": {
       "amenity": "bank",
       "brand": "Groupama",
-      "brand:wikidata": "Q3083531",
-      "brand:wikipedia": "en:Groupama",
       "name": "Groupama"
     }
   },

--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -5667,14 +5667,12 @@
     }
   },
   "amenity/bank|Santander": {
-    "locationSet": {"include": ["001"]},
-    "matchNames": ["santander consumer bank"],
-    "nomatch": ["amenity/bank|Banco Santander"],
+    "locationSet": {"include": ["gb"]},
     "tags": {
       "amenity": "bank",
       "brand": "Santander",
-      "brand:wikidata": "Q5835668",
-      "brand:wikipedia": "en:Santander Bank",
+      "brand:wikidata": "Q7420065",
+      "brand:wikipedia": "en:Santander UK",
       "name": "Santander"
     }
   },
@@ -5696,16 +5694,6 @@
       "brand:wikidata": "Q4854116",
       "brand:wikipedia": "pt:Banco Santander Portugal",
       "name": "Santander Totta"
-    }
-  },
-  "amenity/bank|Santander~(UK)": {
-    "locationSet": {"include": ["gb"]},
-    "tags": {
-      "amenity": "bank",
-      "brand": "Santander",
-      "brand:wikidata": "Q7420065",
-      "brand:wikipedia": "en:Santander UK",
-      "name": "Santander"
     }
   },
   "amenity/bank|Sberbank": {

--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -1,6 +1,6 @@
 {
   "amenity/bank|ABANCA": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "ABANCA",
@@ -11,7 +11,7 @@
     }
   },
   "amenity/bank|ABN AMRO": {
-    "locationSet": { "include": ["nl"] },
+    "locationSet": {"include": ["nl"]},
     "tags": {
       "amenity": "bank",
       "brand": "ABN AMRO",
@@ -22,7 +22,7 @@
     }
   },
   "amenity/bank|ABSA": {
-    "locationSet": { "include": ["za"] },
+    "locationSet": {"include": ["za"]},
     "tags": {
       "amenity": "bank",
       "brand": "ABSA",
@@ -32,7 +32,7 @@
     }
   },
   "amenity/bank|ACBA": {
-    "locationSet": { "include": ["am"] },
+    "locationSet": {"include": ["am"]},
     "tags": {
       "amenity": "bank",
       "brand": "ACBA",
@@ -42,8 +42,11 @@
     }
   },
   "amenity/bank|AIB": {
-    "locationSet": { "include": ["gb", "ie"] },
-    "matchNames": ["aib bank", "allied irish bank"],
+    "locationSet": {"include": ["gb", "ie"]},
+    "matchNames": [
+      "aib bank",
+      "allied irish bank"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "AIB",
@@ -54,7 +57,7 @@
     }
   },
   "amenity/bank|AMP": {
-    "locationSet": { "include": ["au", "nz"] },
+    "locationSet": {"include": ["au", "nz"]},
     "matchNames": ["amp bank"],
     "tags": {
       "amenity": "bank",
@@ -66,7 +69,7 @@
     }
   },
   "amenity/bank|ANZ": {
-    "locationSet": { "include": ["au", "nz"] },
+    "locationSet": {"include": ["au", "nz"]},
     "matchNames": ["anz bank"],
     "tags": {
       "amenity": "bank",
@@ -78,7 +81,7 @@
     }
   },
   "amenity/bank|ASB Bank": {
-    "locationSet": { "include": ["nz"] },
+    "locationSet": {"include": ["nz"]},
     "tags": {
       "amenity": "bank",
       "brand": "ASB Bank",
@@ -88,7 +91,7 @@
     }
   },
   "amenity/bank|ATB Financial": {
-    "locationSet": { "include": ["ca"] },
+    "locationSet": {"include": ["ca"]},
     "tags": {
       "amenity": "bank",
       "brand": "ATB Financial",
@@ -99,7 +102,7 @@
     }
   },
   "amenity/bank|AXA": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "nomatch": ["office/insurance|AXA"],
     "tags": {
       "amenity": "bank",
@@ -110,7 +113,7 @@
     }
   },
   "amenity/bank|Access Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Access Bank",
@@ -120,7 +123,7 @@
     }
   },
   "amenity/bank|ActivoBank": {
-    "locationSet": { "include": ["pt"] },
+    "locationSet": {"include": ["pt"]},
     "tags": {
       "amenity": "bank",
       "brand": "ActivoBank",
@@ -142,7 +145,7 @@
     }
   },
   "amenity/bank|Affin Bank": {
-    "locationSet": { "include": ["my"] },
+    "locationSet": {"include": ["my"]},
     "tags": {
       "amenity": "bank",
       "brand": "Affin Bank",
@@ -152,7 +155,7 @@
     }
   },
   "amenity/bank|Affinity Credit Union": {
-    "locationSet": { "include": ["ca"] },
+    "locationSet": {"include": ["ca"]},
     "matchNames": ["affinity"],
     "tags": {
       "amenity": "bank",
@@ -163,7 +166,7 @@
     }
   },
   "amenity/bank|Agribank~(USA)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Agribank",
@@ -173,7 +176,7 @@
     }
   },
   "amenity/bank|Agribank~(Vietnam)": {
-    "locationSet": { "include": ["vn"] },
+    "locationSet": {"include": ["vn"]},
     "tags": {
       "amenity": "bank",
       "brand": "Agribank",
@@ -185,7 +188,7 @@
     }
   },
   "amenity/bank|Agribank~(Zimbabwe)": {
-    "locationSet": { "include": ["zw"] },
+    "locationSet": {"include": ["zw"]},
     "tags": {
       "amenity": "bank",
       "brand": "Agribank",
@@ -195,7 +198,7 @@
     }
   },
   "amenity/bank|Agrobank": {
-    "locationSet": { "include": ["my"] },
+    "locationSet": {"include": ["my"]},
     "tags": {
       "amenity": "bank",
       "brand": "Agrobank",
@@ -205,7 +208,7 @@
     }
   },
   "amenity/bank|Akbank": {
-    "locationSet": { "include": ["tr"] },
+    "locationSet": {"include": ["tr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Akbank",
@@ -215,7 +218,7 @@
     }
   },
   "amenity/bank|Aktia": {
-    "locationSet": { "include": ["fi"] },
+    "locationSet": {"include": ["fi"]},
     "tags": {
       "amenity": "bank",
       "brand": "Aktia",
@@ -225,7 +228,7 @@
     }
   },
   "amenity/bank|Alior Bank": {
-    "locationSet": { "include": ["pl"] },
+    "locationSet": {"include": ["pl"]},
     "tags": {
       "amenity": "bank",
       "brand": "Alior Bank",
@@ -235,7 +238,7 @@
     }
   },
   "amenity/bank|Allahabad Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Allahabad Bank",
@@ -245,7 +248,7 @@
     }
   },
   "amenity/bank|Alliance Bank": {
-    "locationSet": { "include": ["my"] },
+    "locationSet": {"include": ["my"]},
     "tags": {
       "amenity": "bank",
       "brand": "Alliance Bank",
@@ -255,7 +258,7 @@
     }
   },
   "amenity/bank|Allied Bank~(Pakistan)": {
-    "locationSet": { "include": ["pk"] },
+    "locationSet": {"include": ["pk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Allied Bank",
@@ -265,7 +268,7 @@
     }
   },
   "amenity/bank|Allied Bank~(defunct bank in Philipiness)": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "tags": {
       "amenity": "bank",
       "brand": "Allied Bank",
@@ -275,7 +278,7 @@
     }
   },
   "amenity/bank|Alpha Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Alpha Bank",
@@ -285,7 +288,7 @@
     }
   },
   "amenity/bank|Alterna Savings": {
-    "locationSet": { "include": ["ca"] },
+    "locationSet": {"include": ["ca"]},
     "tags": {
       "amenity": "bank",
       "brand": "Alterna Savings",
@@ -295,7 +298,7 @@
     }
   },
   "amenity/bank|AmBank": {
-    "locationSet": { "include": ["my"] },
+    "locationSet": {"include": ["my"]},
     "tags": {
       "amenity": "bank",
       "brand": "AmBank",
@@ -305,7 +308,7 @@
     }
   },
   "amenity/bank|America First Credit Union": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "America First Credit Union",
@@ -316,7 +319,7 @@
     }
   },
   "amenity/bank|Andhra Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Andhra Bank",
@@ -326,7 +329,7 @@
     }
   },
   "amenity/bank|Antonveneta": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Antonveneta",
@@ -336,7 +339,7 @@
     }
   },
   "amenity/bank|Apple Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "nomatch": ["shop/electronics|Apple Store"],
     "tags": {
       "amenity": "bank",
@@ -359,7 +362,7 @@
     }
   },
   "amenity/bank|Arvest Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Arvest Bank",
@@ -369,7 +372,7 @@
     }
   },
   "amenity/bank|Asia United Bank": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "tags": {
       "amenity": "bank",
       "brand": "Asia United Bank",
@@ -379,7 +382,7 @@
     }
   },
   "amenity/bank|Askari Bank": {
-    "locationSet": { "include": ["pk"] },
+    "locationSet": {"include": ["pk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Askari Bank",
@@ -389,7 +392,7 @@
     }
   },
   "amenity/bank|Associated Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Associated Bank",
@@ -399,7 +402,7 @@
     }
   },
   "amenity/bank|Attijariwafa Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Attijariwafa Bank",
@@ -409,7 +412,7 @@
     }
   },
   "amenity/bank|Axis Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Axis Bank",
@@ -419,7 +422,7 @@
     }
   },
   "amenity/bank|BAC Credomatic": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "matchNames": ["bac"],
     "tags": {
       "amenity": "bank",
@@ -430,8 +433,10 @@
     }
   },
   "amenity/bank|BAI": {
-    "locationSet": { "include": ["ao"] },
-    "matchNames": ["banco africano de investimentos"],
+    "locationSet": {"include": ["ao"]},
+    "matchNames": [
+      "banco africano de investimentos"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "BAI",
@@ -442,7 +447,7 @@
     }
   },
   "amenity/bank|BAWAG PSK": {
-    "locationSet": { "include": ["at"] },
+    "locationSet": {"include": ["at"]},
     "tags": {
       "amenity": "bank",
       "brand": "BAWAG PSK",
@@ -452,7 +457,7 @@
     }
   },
   "amenity/bank|BB&T": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "BB&T",
@@ -462,7 +467,7 @@
     }
   },
   "amenity/bank|BBBank": {
-    "locationSet": { "include": ["de"] },
+    "locationSet": {"include": ["de"]},
     "tags": {
       "amenity": "bank",
       "brand": "BBBank",
@@ -472,7 +477,7 @@
     }
   },
   "amenity/bank|BBVA": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "BBVA",
@@ -483,7 +488,7 @@
     }
   },
   "amenity/bank|BBVA Bancomer": {
-    "locationSet": { "include": ["mx"] },
+    "locationSet": {"include": ["mx"]},
     "tags": {
       "amenity": "bank",
       "brand": "BBVA Bancomer",
@@ -493,7 +498,7 @@
     }
   },
   "amenity/bank|BBVA Compass": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "BBVA Compass",
@@ -504,7 +509,7 @@
     }
   },
   "amenity/bank|BBVA Continental": {
-    "locationSet": { "include": ["pe"] },
+    "locationSet": {"include": ["pe"]},
     "tags": {
       "amenity": "bank",
       "brand": "BBVA Continental",
@@ -514,7 +519,7 @@
     }
   },
   "amenity/bank|BBVA Francés": {
-    "locationSet": { "include": ["ar"] },
+    "locationSet": {"include": ["ar"]},
     "tags": {
       "amenity": "bank",
       "brand": "BBVA Francés",
@@ -528,7 +533,7 @@
     }
   },
   "amenity/bank|BCA": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "matchNames": ["bank bca"],
     "tags": {
       "amenity": "bank",
@@ -540,7 +545,7 @@
     }
   },
   "amenity/bank|BCEE": {
-    "locationSet": { "include": ["lu"] },
+    "locationSet": {"include": ["lu"]},
     "tags": {
       "amenity": "bank",
       "brand": "BCEE",
@@ -551,7 +556,7 @@
     }
   },
   "amenity/bank|BCI": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "matchNames": ["banco bci"],
     "tags": {
       "amenity": "bank",
@@ -565,7 +570,7 @@
     }
   },
   "amenity/bank|BCP~(Bolivia)": {
-    "locationSet": { "include": ["bo"] },
+    "locationSet": {"include": ["bo"]},
     "matchNames": ["banco de crédito", "bcp"],
     "nomatch": [
       "amenity/bank|BCP~(France)",
@@ -582,7 +587,7 @@
     }
   },
   "amenity/bank|BCP~(France)": {
-    "locationSet": { "include": ["fr"] },
+    "locationSet": {"include": ["fr"]},
     "matchNames": ["banque bcp", "bcp"],
     "nomatch": [
       "amenity/bank|BCP~(Bolivia)",
@@ -598,7 +603,7 @@
     }
   },
   "amenity/bank|BCP~(Luxembourg)": {
-    "locationSet": { "include": ["lu"] },
+    "locationSet": {"include": ["lu"]},
     "matchNames": ["banque bcp", "bcp"],
     "nomatch": [
       "amenity/bank|BCP~(Bolivia)",
@@ -614,7 +619,7 @@
     }
   },
   "amenity/bank|BCP~(Peru)": {
-    "locationSet": { "include": ["pe"] },
+    "locationSet": {"include": ["pe"]},
     "matchNames": ["banco de crédito del perú"],
     "nomatch": [
       "amenity/bank|BCP~(Bolivia)",
@@ -633,7 +638,7 @@
     }
   },
   "amenity/bank|BCR~(Banca Comercială Română)": {
-    "locationSet": { "include": ["ro"] },
+    "locationSet": {"include": ["ro"]},
     "matchNames": ["banca comercială română"],
     "tags": {
       "amenity": "bank",
@@ -647,7 +652,7 @@
     }
   },
   "amenity/bank|BCR~(Costa Rica)": {
-    "locationSet": { "include": ["cr"] },
+    "locationSet": {"include": ["cr"]},
     "matchNames": ["banco de costa rica"],
     "tags": {
       "amenity": "bank",
@@ -661,7 +666,7 @@
     }
   },
   "amenity/bank|BDM": {
-    "locationSet": { "include": ["ml"] },
+    "locationSet": {"include": ["ml"]},
     "tags": {
       "amenity": "bank",
       "brand": "BDM",
@@ -674,7 +679,7 @@
     }
   },
   "amenity/bank|BDO": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "tags": {
       "alt_name": "Banco de Oro",
       "amenity": "bank",
@@ -685,7 +690,7 @@
     }
   },
   "amenity/bank|BECU": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "BECU",
@@ -695,7 +700,7 @@
     }
   },
   "amenity/bank|BGL BNP Paribas": {
-    "locationSet": { "include": ["lu"] },
+    "locationSet": {"include": ["lu"]},
     "nomatch": ["amenity/bank|BGŻ BNP Paribas"],
     "tags": {
       "amenity": "bank",
@@ -706,7 +711,7 @@
     }
   },
   "amenity/bank|BGŻ BNP Paribas": {
-    "locationSet": { "include": ["pl"] },
+    "locationSet": {"include": ["pl"]},
     "tags": {
       "amenity": "bank",
       "brand": "BGŻ BNP Paribas",
@@ -716,7 +721,7 @@
     }
   },
   "amenity/bank|BIAT": {
-    "locationSet": { "include": ["tn"] },
+    "locationSet": {"include": ["tn"]},
     "tags": {
       "amenity": "bank",
       "brand": "BIAT",
@@ -729,7 +734,7 @@
     }
   },
   "amenity/bank|BIDV": {
-    "locationSet": { "include": ["vn"] },
+    "locationSet": {"include": ["vn"]},
     "tags": {
       "amenity": "bank",
       "brand": "BIDV",
@@ -742,7 +747,7 @@
     }
   },
   "amenity/bank|BIL": {
-    "locationSet": { "include": ["lu"] },
+    "locationSet": {"include": ["lu"]},
     "tags": {
       "amenity": "bank",
       "brand": "BIL",
@@ -755,7 +760,7 @@
     }
   },
   "amenity/bank|BMCE Bank": {
-    "locationSet": { "include": ["ma"] },
+    "locationSet": {"include": ["ma"]},
     "matchNames": ["bmce"],
     "tags": {
       "amenity": "bank",
@@ -769,7 +774,7 @@
     }
   },
   "amenity/bank|BMCI": {
-    "locationSet": { "include": ["ma"] },
+    "locationSet": {"include": ["ma"]},
     "matchNames": ["bmci bank"],
     "tags": {
       "amenity": "bank",
@@ -780,7 +785,7 @@
     }
   },
   "amenity/bank|BMN": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "BMN",
@@ -791,7 +796,7 @@
     }
   },
   "amenity/bank|BMO Harris Bank~(USA)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "matchNames": [
       "bank of montreal",
       "bmo",
@@ -808,7 +813,7 @@
     }
   },
   "amenity/bank|BMO~(Canada)": {
-    "locationSet": { "include": ["ca"] },
+    "locationSet": {"include": ["ca"]},
     "matchNames": [
       "bank of montreal",
       "banque de montréal",
@@ -826,7 +831,7 @@
     }
   },
   "amenity/bank|BNA~(Algeria)": {
-    "locationSet": { "include": ["dz"] },
+    "locationSet": {"include": ["dz"]},
     "tags": {
       "amenity": "bank",
       "brand": "BNA",
@@ -839,7 +844,7 @@
     }
   },
   "amenity/bank|BNA~(Tunisia)": {
-    "locationSet": { "include": ["tn"] },
+    "locationSet": {"include": ["tn"]},
     "tags": {
       "amenity": "bank",
       "brand": "BNA",
@@ -849,7 +854,7 @@
     }
   },
   "amenity/bank|BNDA": {
-    "locationSet": { "include": ["ml"] },
+    "locationSet": {"include": ["ml"]},
     "tags": {
       "amenity": "bank",
       "brand": "BNDA",
@@ -860,7 +865,7 @@
     }
   },
   "amenity/bank|BNI": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "matchNames": ["bank bni"],
     "tags": {
       "amenity": "bank",
@@ -874,7 +879,7 @@
     }
   },
   "amenity/bank|BNL": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "BNL",
@@ -887,7 +892,7 @@
     }
   },
   "amenity/bank|BNP Paribas": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "BNP Paribas",
@@ -897,7 +902,7 @@
     }
   },
   "amenity/bank|BNP Paribas Fortis": {
-    "locationSet": { "include": ["be"] },
+    "locationSet": {"include": ["be"]},
     "tags": {
       "amenity": "bank",
       "brand": "BNP Paribas Fortis",
@@ -907,7 +912,7 @@
     }
   },
   "amenity/bank|BOC": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "BOC",
@@ -918,7 +923,7 @@
     }
   },
   "amenity/bank|BOM": {
-    "locationSet": { "include": ["au"] },
+    "locationSet": {"include": ["au"]},
     "tags": {
       "amenity": "bank",
       "brand": "BOM",
@@ -929,7 +934,7 @@
     }
   },
   "amenity/bank|BOQ": {
-    "locationSet": { "include": ["au"] },
+    "locationSet": {"include": ["au"]},
     "tags": {
       "amenity": "bank",
       "brand": "BOQ",
@@ -940,7 +945,7 @@
     }
   },
   "amenity/bank|BPC": {
-    "locationSet": { "include": ["ao"] },
+    "locationSet": {"include": ["ao"]},
     "tags": {
       "amenity": "bank",
       "brand": "BPC",
@@ -951,7 +956,7 @@
     }
   },
   "amenity/bank|BPER Banca": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "BPER Banca",
@@ -962,7 +967,7 @@
     }
   },
   "amenity/bank|BPI Family Savings Bank": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "tags": {
       "amenity": "bank",
       "brand": "BPI Family Savings Bank",
@@ -971,8 +976,10 @@
     }
   },
   "amenity/bank|BPI~(Global)": {
-    "locationSet": { "include": ["001"] },
-    "nomatch": ["amenity/bank|Banco BPI~(Portugal)"],
+    "locationSet": {"include": ["001"]},
+    "nomatch": [
+      "amenity/bank|Banco BPI~(Portugal)"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "BPI",
@@ -983,7 +990,7 @@
     }
   },
   "amenity/bank|BRD": {
-    "locationSet": { "include": ["ro"] },
+    "locationSet": {"include": ["ro"]},
     "tags": {
       "amenity": "bank",
       "brand": "BRD",
@@ -993,7 +1000,7 @@
     }
   },
   "amenity/bank|BRED": {
-    "locationSet": { "include": ["fr"] },
+    "locationSet": {"include": ["fr"]},
     "tags": {
       "amenity": "bank",
       "brand": "BRED",
@@ -1006,7 +1013,7 @@
     }
   },
   "amenity/bank|BRI": {
-    "locationSet": { "include": ["id"] },
+    "locationSet": {"include": ["id"]},
     "matchNames": ["bank bri"],
     "tags": {
       "amenity": "bank",
@@ -1020,7 +1027,7 @@
     }
   },
   "amenity/bank|BTN": {
-    "locationSet": { "include": ["id"] },
+    "locationSet": {"include": ["id"]},
     "tags": {
       "amenity": "bank",
       "brand": "BTN",
@@ -1037,7 +1044,7 @@
     }
   },
   "amenity/bank|BW-Bank": {
-    "locationSet": { "include": ["de"] },
+    "locationSet": {"include": ["de"]},
     "matchNames": ["baden-württembergische bank"],
     "tags": {
       "amenity": "bank",
@@ -1052,7 +1059,7 @@
     }
   },
   "amenity/bank|Banamex": {
-    "locationSet": { "include": ["mx"] },
+    "locationSet": {"include": ["mx"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banamex",
@@ -1065,7 +1072,7 @@
     }
   },
   "amenity/bank|Banca Intesa": {
-    "locationSet": { "include": ["it", "rs"] },
+    "locationSet": {"include": ["it", "rs"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banca Intesa",
@@ -1077,7 +1084,7 @@
     }
   },
   "amenity/bank|Banca March": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banca March",
@@ -1087,7 +1094,7 @@
     }
   },
   "amenity/bank|Banca Mediolanum": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banca Mediolanum",
@@ -1097,7 +1104,7 @@
     }
   },
   "amenity/bank|Banca Popolare di Bari": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banca Popolare di Bari",
@@ -1107,7 +1114,7 @@
     }
   },
   "amenity/bank|Banca Popolare di Milano": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "matchNames": ["bpm"],
     "tags": {
       "amenity": "bank",
@@ -1122,7 +1129,7 @@
     }
   },
   "amenity/bank|Banca Popolare di Novara": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banca Popolare di Novara",
@@ -1136,7 +1143,7 @@
     }
   },
   "amenity/bank|Banca Popolare di Sondrio": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banca Popolare di Sondrio",
@@ -1150,7 +1157,7 @@
     }
   },
   "amenity/bank|Banca Popolare di Verona": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banca Popolare di Verona",
@@ -1164,7 +1171,7 @@
     }
   },
   "amenity/bank|Banca Popolare di Vicenza": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banca Popolare di Vicenza",
@@ -1178,7 +1185,7 @@
     }
   },
   "amenity/bank|Banca Românească": {
-    "locationSet": { "include": ["ro"] },
+    "locationSet": {"include": ["ro"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banca Românească",
@@ -1192,7 +1199,7 @@
     }
   },
   "amenity/bank|Banca Sella": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banca Sella",
@@ -1206,7 +1213,7 @@
     }
   },
   "amenity/bank|Banca Transilvania": {
-    "locationSet": { "include": ["ro"] },
+    "locationSet": {"include": ["ro"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banca Transilvania",
@@ -1220,7 +1227,7 @@
     }
   },
   "amenity/bank|Bancaribe": {
-    "locationSet": { "include": ["ve"] },
+    "locationSet": {"include": ["ve"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bancaribe",
@@ -1230,7 +1237,7 @@
     }
   },
   "amenity/bank|Banco AV Villas": {
-    "locationSet": { "include": ["co"] },
+    "locationSet": {"include": ["co"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco AV Villas",
@@ -1244,7 +1251,7 @@
     }
   },
   "amenity/bank|Banco Agrario": {
-    "locationSet": { "include": ["co"] },
+    "locationSet": {"include": ["co"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Agrario",
@@ -1260,7 +1267,7 @@
     }
   },
   "amenity/bank|Banco Azteca": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Azteca",
@@ -1274,7 +1281,7 @@
     }
   },
   "amenity/bank|Banco BISA": {
-    "locationSet": { "include": ["bo"] },
+    "locationSet": {"include": ["bo"]},
     "matchNames": ["bisa"],
     "tags": {
       "amenity": "bank",
@@ -1285,7 +1292,7 @@
     }
   },
   "amenity/bank|Banco BPI~(Portugal)": {
-    "locationSet": { "include": ["pt"] },
+    "locationSet": {"include": ["pt"]},
     "nomatch": ["amenity/bank|BPI~(Global)"],
     "tags": {
       "amenity": "bank",
@@ -1298,7 +1305,7 @@
     }
   },
   "amenity/bank|Banco BPM": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco BPM",
@@ -1312,7 +1319,7 @@
     }
   },
   "amenity/bank|Banco CTT": {
-    "locationSet": { "include": ["pt"] },
+    "locationSet": {"include": ["pt"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco CTT",
@@ -1322,7 +1329,7 @@
     }
   },
   "amenity/bank|Banco Caja Social": {
-    "locationSet": { "include": ["co"] },
+    "locationSet": {"include": ["co"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Caja Social",
@@ -1336,7 +1343,7 @@
     }
   },
   "amenity/bank|Banco Ciudad": {
-    "locationSet": { "include": ["ar"] },
+    "locationSet": {"include": ["ar"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Ciudad",
@@ -1353,7 +1360,7 @@
     }
   },
   "amenity/bank|Banco Continental~(Paraguay)": {
-    "locationSet": { "include": ["py"] },
+    "locationSet": {"include": ["py"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Continental",
@@ -1366,7 +1373,7 @@
     }
   },
   "amenity/bank|Banco Continental~(Peru)": {
-    "locationSet": { "include": ["pe"] },
+    "locationSet": {"include": ["pe"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Continental",
@@ -1380,7 +1387,7 @@
     }
   },
   "amenity/bank|Banco Económico": {
-    "locationSet": { "include": ["bo"] },
+    "locationSet": {"include": ["bo"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Económico",
@@ -1390,7 +1397,7 @@
     }
   },
   "amenity/bank|Banco Estado": {
-    "locationSet": { "include": ["cl"] },
+    "locationSet": {"include": ["cl"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Estado",
@@ -1410,7 +1417,9 @@
     "locationSet": {
       "include": ["cl", "co", "pe"]
     },
-    "nomatch": ["shop/department_store|Falabella"],
+    "nomatch": [
+      "shop/department_store|Falabella"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "Banco Falabella",
@@ -1424,7 +1433,7 @@
     }
   },
   "amenity/bank|Banco Fassil": {
-    "locationSet": { "include": ["bo"] },
+    "locationSet": {"include": ["bo"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Fassil",
@@ -1433,7 +1442,7 @@
     }
   },
   "amenity/bank|Banco Fie": {
-    "locationSet": { "include": ["bo"] },
+    "locationSet": {"include": ["bo"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Fie",
@@ -1443,7 +1452,7 @@
     }
   },
   "amenity/bank|Banco Fortaleza": {
-    "locationSet": { "include": ["bo"] },
+    "locationSet": {"include": ["bo"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Fortaleza",
@@ -1452,7 +1461,7 @@
     }
   },
   "amenity/bank|Banco G&T Continental": {
-    "locationSet": { "include": ["gt", "sv"] },
+    "locationSet": {"include": ["gt", "sv"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco G&T Continental",
@@ -1466,7 +1475,7 @@
     }
   },
   "amenity/bank|Banco Ganadero": {
-    "locationSet": { "include": ["bo"] },
+    "locationSet": {"include": ["bo"]},
     "matchNames": ["bg"],
     "tags": {
       "amenity": "bank",
@@ -1477,7 +1486,7 @@
     }
   },
   "amenity/bank|Banco General": {
-    "locationSet": { "include": ["cr", "pa"] },
+    "locationSet": {"include": ["cr", "pa"]},
     "tags": {
       "amenity": "bank",
       "brand": "BW-Bank",
@@ -1491,7 +1500,7 @@
     }
   },
   "amenity/bank|Banco Industrial": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Industrial",
@@ -1505,7 +1514,7 @@
     }
   },
   "amenity/bank|Banco Internacional~(Chile)": {
-    "locationSet": { "include": ["cl"] },
+    "locationSet": {"include": ["cl"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Internacional",
@@ -1519,7 +1528,7 @@
     }
   },
   "amenity/bank|Banco Internacional~(Ecuador)": {
-    "locationSet": { "include": ["ec"] },
+    "locationSet": {"include": ["ec"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Internacional",
@@ -1533,7 +1542,7 @@
     }
   },
   "amenity/bank|Banco Mercantil": {
-    "locationSet": { "include": ["bo"] },
+    "locationSet": {"include": ["bo"]},
     "matchNames": ["bmsc"],
     "nomatch": ["amenity/bank|Mercantil"],
     "tags": {
@@ -1546,7 +1555,7 @@
     }
   },
   "amenity/bank|Banco Metropolitano": {
-    "locationSet": { "include": ["cu"] },
+    "locationSet": {"include": ["cu"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Metropolitano",
@@ -1559,7 +1568,7 @@
     }
   },
   "amenity/bank|Banco Nacional": {
-    "locationSet": { "include": ["cr", "pa"] },
+    "locationSet": {"include": ["cr", "pa"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Nacional de Costa Rica",
@@ -1577,7 +1586,7 @@
     }
   },
   "amenity/bank|Banco Nacional de Bolivia": {
-    "locationSet": { "include": ["bo"] },
+    "locationSet": {"include": ["bo"]},
     "matchNames": ["bnb"],
     "tags": {
       "amenity": "bank",
@@ -1589,7 +1598,7 @@
     }
   },
   "amenity/bank|Banco Nación": {
-    "locationSet": { "include": ["ar"] },
+    "locationSet": {"include": ["ar"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Nación",
@@ -1606,7 +1615,7 @@
     }
   },
   "amenity/bank|Banco Pastor": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Pastor",
@@ -1639,7 +1648,7 @@
     }
   },
   "amenity/bank|Banco Popular de Ahorro": {
-    "locationSet": { "include": ["cu"] },
+    "locationSet": {"include": ["cu"]},
     "matchNames": ["bpa"],
     "tags": {
       "amenity": "bank",
@@ -1653,7 +1662,7 @@
     }
   },
   "amenity/bank|Banco Provincia": {
-    "locationSet": { "include": ["ar"] },
+    "locationSet": {"include": ["ar"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Provincia",
@@ -1670,7 +1679,7 @@
     }
   },
   "amenity/bank|Banco Sabadell": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "matchNames": ["banc sabadell", "sabadell"],
     "tags": {
       "amenity": "bank",
@@ -1686,7 +1695,7 @@
     }
   },
   "amenity/bank|Banco Santa Fe": {
-    "locationSet": { "include": ["ar"] },
+    "locationSet": {"include": ["ar"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Santa Fe",
@@ -1703,7 +1712,7 @@
     }
   },
   "amenity/bank|Banco Santander": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "nomatch": ["amenity/bank|Santander"],
     "tags": {
       "amenity": "bank",
@@ -1719,7 +1728,7 @@
     }
   },
   "amenity/bank|Banco Sol~(Angola)": {
-    "locationSet": { "include": ["ao"] },
+    "locationSet": {"include": ["ao"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Sol",
@@ -1732,7 +1741,7 @@
     }
   },
   "amenity/bank|Banco Sol~(Bolivia)": {
-    "locationSet": { "include": ["bo"] },
+    "locationSet": {"include": ["bo"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco Sol",
@@ -1742,7 +1751,7 @@
     }
   },
   "amenity/bank|Banco Unión": {
-    "locationSet": { "include": ["bo"] },
+    "locationSet": {"include": ["bo"]},
     "nomatch": [
       "amenity/bank|UnionBank",
       "amenity/money_transfer|Express Union"
@@ -1756,7 +1765,7 @@
     }
   },
   "amenity/bank|Banco de Bogotá": {
-    "locationSet": { "include": ["co"] },
+    "locationSet": {"include": ["co"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco de Bogotá",
@@ -1770,7 +1779,7 @@
     }
   },
   "amenity/bank|Banco de Chile": {
-    "locationSet": { "include": ["cl"] },
+    "locationSet": {"include": ["cl"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco de Chile",
@@ -1784,7 +1793,7 @@
     }
   },
   "amenity/bank|Banco de Desarrollo Banrural": {
-    "locationSet": { "include": ["gt"] },
+    "locationSet": {"include": ["gt"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco de Desarrollo Banrural",
@@ -1798,7 +1807,7 @@
     }
   },
   "amenity/bank|Banco de Fomento Angola (BFA)": {
-    "locationSet": { "include": ["ao"] },
+    "locationSet": {"include": ["ao"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco de Fomento Angola (BFA)",
@@ -1812,7 +1821,7 @@
     }
   },
   "amenity/bank|Banco de Occidente": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco de Occidente",
@@ -1822,7 +1831,7 @@
     }
   },
   "amenity/bank|Banco de Venezuela": {
-    "locationSet": { "include": ["ve"] },
+    "locationSet": {"include": ["ve"]},
     "matchNames": ["de venezuela", "venezuela"],
     "tags": {
       "amenity": "bank",
@@ -1833,7 +1842,7 @@
     }
   },
   "amenity/bank|Banco de la Nación~(Argentina)": {
-    "locationSet": { "include": ["ar"] },
+    "locationSet": {"include": ["ar"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco de la Nación",
@@ -1843,7 +1852,7 @@
     }
   },
   "amenity/bank|Banco de la Nación~(Peru)": {
-    "locationSet": { "include": ["pe"] },
+    "locationSet": {"include": ["pe"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco de la Nación",
@@ -1853,7 +1862,7 @@
     }
   },
   "amenity/bank|Banco del Austro": {
-    "locationSet": { "include": ["ec"] },
+    "locationSet": {"include": ["ec"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco del Austro",
@@ -1862,7 +1871,7 @@
     }
   },
   "amenity/bank|Banco di Napoli": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco di Napoli",
@@ -1872,7 +1881,7 @@
     }
   },
   "amenity/bank|Banco di Sardegna": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco di Sardegna",
@@ -1882,7 +1891,7 @@
     }
   },
   "amenity/bank|Banco di Sicilia": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco di Sicilia",
@@ -1892,7 +1901,7 @@
     }
   },
   "amenity/bank|Banco do Brasil": {
-    "locationSet": { "include": ["br"] },
+    "locationSet": {"include": ["br"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco do Brasil",
@@ -1902,7 +1911,7 @@
     }
   },
   "amenity/bank|Banco do Nordeste": {
-    "locationSet": { "include": ["br"] },
+    "locationSet": {"include": ["br"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banco do Nordeste",
@@ -1912,7 +1921,7 @@
     }
   },
   "amenity/bank|Bancolombia": {
-    "locationSet": { "include": ["co"] },
+    "locationSet": {"include": ["co"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bancolombia",
@@ -1922,7 +1931,7 @@
     }
   },
   "amenity/bank|Bancomer": {
-    "locationSet": { "include": ["mx"] },
+    "locationSet": {"include": ["mx"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bancomer",
@@ -1932,7 +1941,7 @@
     }
   },
   "amenity/bank|Bancpost": {
-    "locationSet": { "include": ["ro"] },
+    "locationSet": {"include": ["ro"]},
     "nomatch": ["amenity/bank|Postbank"],
     "tags": {
       "amenity": "bank",
@@ -1943,7 +1952,7 @@
     }
   },
   "amenity/bank|Banesco": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banesco",
@@ -1953,7 +1962,7 @@
     }
   },
   "amenity/bank|Bangkok Bank": {
-    "locationSet": { "include": ["th"] },
+    "locationSet": {"include": ["th"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bangkok Bank",
@@ -1963,7 +1972,7 @@
     }
   },
   "amenity/bank|Bank Al Habib": {
-    "locationSet": { "include": ["pk"] },
+    "locationSet": {"include": ["pk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank Al Habib",
@@ -1973,7 +1982,7 @@
     }
   },
   "amenity/bank|Bank Alfalah": {
-    "locationSet": { "include": ["pk"] },
+    "locationSet": {"include": ["pk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank Alfalah",
@@ -1983,7 +1992,7 @@
     }
   },
   "amenity/bank|Bank Austria": {
-    "locationSet": { "include": ["at"] },
+    "locationSet": {"include": ["at"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank Austria",
@@ -1993,7 +2002,7 @@
     }
   },
   "amenity/bank|Bank Danamon": {
-    "locationSet": { "include": ["id"] },
+    "locationSet": {"include": ["id"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank Danamon",
@@ -2003,7 +2012,7 @@
     }
   },
   "amenity/bank|Bank Islam": {
-    "locationSet": { "include": ["my"] },
+    "locationSet": {"include": ["my"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank Islam",
@@ -2013,7 +2022,7 @@
     }
   },
   "amenity/bank|Bank Mandiri": {
-    "locationSet": { "include": ["id"] },
+    "locationSet": {"include": ["id"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank Mandiri",
@@ -2023,7 +2032,7 @@
     }
   },
   "amenity/bank|Bank Mandiri Syariah": {
-    "locationSet": { "include": ["id"] },
+    "locationSet": {"include": ["id"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank Mandiri Syariah",
@@ -2033,7 +2042,7 @@
     }
   },
   "amenity/bank|Bank Mega": {
-    "locationSet": { "include": ["id"] },
+    "locationSet": {"include": ["id"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank Mega",
@@ -2043,7 +2052,7 @@
     }
   },
   "amenity/bank|Bank Muamalat": {
-    "locationSet": { "include": ["id", "my"] },
+    "locationSet": {"include": ["id", "my"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank Muamalat",
@@ -2053,7 +2062,7 @@
     }
   },
   "amenity/bank|Bank Pekao": {
-    "locationSet": { "include": ["pl"] },
+    "locationSet": {"include": ["pl"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank Pekao",
@@ -2063,7 +2072,7 @@
     }
   },
   "amenity/bank|Bank Rakyat": {
-    "locationSet": { "include": ["my"] },
+    "locationSet": {"include": ["my"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank Rakyat",
@@ -2073,7 +2082,7 @@
     }
   },
   "amenity/bank|Bank Simpanan Nasional": {
-    "locationSet": { "include": ["my"] },
+    "locationSet": {"include": ["my"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank Simpanan Nasional",
@@ -2084,7 +2093,7 @@
     }
   },
   "amenity/bank|Bank of Africa": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Africa",
@@ -2095,7 +2104,7 @@
     }
   },
   "amenity/bank|Bank of America": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank of America",
@@ -2105,7 +2114,7 @@
     }
   },
   "amenity/bank|Bank of Baroda": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Baroda",
@@ -2115,7 +2124,7 @@
     }
   },
   "amenity/bank|Bank of Ceylon": {
-    "locationSet": { "include": ["lk"] },
+    "locationSet": {"include": ["lk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Ceylon",
@@ -2125,7 +2134,7 @@
     }
   },
   "amenity/bank|Bank of Commerce": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Commerce",
@@ -2135,7 +2144,7 @@
     }
   },
   "amenity/bank|Bank of Cyprus": {
-    "locationSet": { "include": ["cy", "gr"] },
+    "locationSet": {"include": ["cy", "gr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Cyprus",
@@ -2145,7 +2154,7 @@
     }
   },
   "amenity/bank|Bank of India": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank of India",
@@ -2155,7 +2164,7 @@
     }
   },
   "amenity/bank|Bank of Ireland": {
-    "locationSet": { "include": ["gb", "ie"] },
+    "locationSet": {"include": ["gb", "ie"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Ireland",
@@ -2165,7 +2174,7 @@
     }
   },
   "amenity/bank|Bank of Maharashtra": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Maharashtra",
@@ -2175,7 +2184,7 @@
     }
   },
   "amenity/bank|Bank of New Zealand": {
-    "locationSet": { "include": ["nz"] },
+    "locationSet": {"include": ["nz"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank of New Zealand",
@@ -2185,7 +2194,7 @@
     }
   },
   "amenity/bank|Bank of Scotland": {
-    "locationSet": { "include": ["gb"] },
+    "locationSet": {"include": ["gb"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Scotland",
@@ -2195,7 +2204,7 @@
     }
   },
   "amenity/bank|Bank of the West": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bank of the West",
@@ -2205,8 +2214,10 @@
     }
   },
   "amenity/bank|BankWest~(USA)": {
-    "locationSet": { "include": ["us"] },
-    "nomatch": ["amenity/bank|Bankwest~(Australia)"],
+    "locationSet": {"include": ["us"]},
+    "nomatch": [
+      "amenity/bank|Bankwest~(Australia)"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "BankWest",
@@ -2215,7 +2226,7 @@
     }
   },
   "amenity/bank|Bankia": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bankia",
@@ -2225,7 +2236,7 @@
     }
   },
   "amenity/bank|Bankinter": {
-    "locationSet": { "include": ["es", "pt"] },
+    "locationSet": {"include": ["es", "pt"]},
     "nomatch": ["amenity/bank|Interbank"],
     "tags": {
       "amenity": "bank",
@@ -2236,7 +2247,7 @@
     }
   },
   "amenity/bank|Bankwest~(Australia)": {
-    "locationSet": { "include": ["au"] },
+    "locationSet": {"include": ["au"]},
     "nomatch": ["amenity/bank|Bankwest~(USA)"],
     "tags": {
       "amenity": "bank",
@@ -2247,7 +2258,7 @@
     }
   },
   "amenity/bank|Banner Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banner Bank",
@@ -2257,7 +2268,7 @@
     }
   },
   "amenity/bank|Banorte": {
-    "locationSet": { "include": ["mx"] },
+    "locationSet": {"include": ["mx"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banorte",
@@ -2267,7 +2278,7 @@
     }
   },
   "amenity/bank|Banpais": {
-    "locationSet": { "include": ["hn"] },
+    "locationSet": {"include": ["hn"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banpais",
@@ -2275,7 +2286,7 @@
     }
   },
   "amenity/bank|Banque Atlantique": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banque Atlantique",
@@ -2285,7 +2296,7 @@
     }
   },
   "amenity/bank|Banque Dupuy de Parseval": {
-    "locationSet": { "include": ["fr"] },
+    "locationSet": {"include": ["fr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banque Dupuy de Parseval",
@@ -2295,7 +2306,7 @@
     }
   },
   "amenity/bank|Banque Laurentienne": {
-    "locationSet": { "include": ["ca"] },
+    "locationSet": {"include": ["ca"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banque Laurentienne",
@@ -2305,7 +2316,7 @@
     }
   },
   "amenity/bank|Banque Populaire~(France)": {
-    "locationSet": { "include": ["fr"] },
+    "locationSet": {"include": ["fr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banque Populaire",
@@ -2327,7 +2338,7 @@
     }
   },
   "amenity/bank|Banque de France": {
-    "locationSet": { "include": ["fr"] },
+    "locationSet": {"include": ["fr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banque de France",
@@ -2337,7 +2348,7 @@
     }
   },
   "amenity/bank|Banque de l'Habitat du Mali": {
-    "locationSet": { "include": ["ml"] },
+    "locationSet": {"include": ["ml"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banque de l'Habitat du Mali",
@@ -2347,7 +2358,7 @@
     }
   },
   "amenity/bank|Banrisul": {
-    "locationSet": { "include": ["br"] },
+    "locationSet": {"include": ["br"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banrisul",
@@ -2357,7 +2368,7 @@
     }
   },
   "amenity/bank|Banrural": {
-    "locationSet": { "include": ["gt", "hn"] },
+    "locationSet": {"include": ["gt", "hn"]},
     "tags": {
       "amenity": "bank",
       "brand": "Banrural",
@@ -2367,7 +2378,7 @@
     }
   },
   "amenity/bank|Bantierra": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bantierra",
@@ -2377,7 +2388,7 @@
     }
   },
   "amenity/bank|Barclays": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "matchNames": ["barclays bank"],
     "tags": {
       "amenity": "bank",
@@ -2388,7 +2399,7 @@
     }
   },
   "amenity/bank|Bcc": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bcc",
@@ -2398,7 +2409,7 @@
     }
   },
   "amenity/bank|Belfius": {
-    "locationSet": { "include": ["be"] },
+    "locationSet": {"include": ["be"]},
     "tags": {
       "amenity": "bank",
       "brand": "Belfius",
@@ -2408,7 +2419,7 @@
     }
   },
   "amenity/bank|Bendigo Bank": {
-    "locationSet": { "include": ["au"] },
+    "locationSet": {"include": ["au"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bendigo Bank",
@@ -2418,7 +2429,7 @@
     }
   },
   "amenity/bank|Beobank": {
-    "locationSet": { "include": ["be"] },
+    "locationSet": {"include": ["be"]},
     "tags": {
       "amenity": "bank",
       "brand": "Beobank",
@@ -2428,7 +2439,7 @@
     }
   },
   "amenity/bank|Berliner Volksbank": {
-    "locationSet": { "include": ["de"] },
+    "locationSet": {"include": ["de"]},
     "tags": {
       "amenity": "bank",
       "brand": "Berliner Volksbank",
@@ -2438,7 +2449,7 @@
     }
   },
   "amenity/bank|Bicentenario": {
-    "locationSet": { "include": ["ve"] },
+    "locationSet": {"include": ["ve"]},
     "tags": {
       "amenity": "bank",
       "brand": "Bicentenario",
@@ -2448,7 +2459,7 @@
     }
   },
   "amenity/bank|Bicici": {
-    "locationSet": { "include": ["ci"] },
+    "locationSet": {"include": ["ci"]},
     "matchNames": ["agence bicici"],
     "tags": {
       "amenity": "bank",
@@ -2459,7 +2470,7 @@
     }
   },
   "amenity/bank|Bradesco": {
-    "locationSet": { "include": ["br"] },
+    "locationSet": {"include": ["br"]},
     "matchNames": ["banco bradesco"],
     "tags": {
       "amenity": "bank",
@@ -2470,7 +2481,7 @@
     }
   },
   "amenity/bank|Budapest Bank": {
-    "locationSet": { "include": ["hu"] },
+    "locationSet": {"include": ["hu"]},
     "tags": {
       "amenity": "bank",
       "brand": "Budapest Bank",
@@ -2480,7 +2491,7 @@
     }
   },
   "amenity/bank|CBAO": {
-    "locationSet": { "include": ["sn"] },
+    "locationSet": {"include": ["sn"]},
     "tags": {
       "amenity": "bank",
       "brand": "CBAO",
@@ -2490,7 +2501,7 @@
     }
   },
   "amenity/bank|CEC Bank": {
-    "locationSet": { "include": ["ro"] },
+    "locationSet": {"include": ["ro"]},
     "tags": {
       "amenity": "bank",
       "brand": "CEC Bank",
@@ -2500,7 +2511,7 @@
     }
   },
   "amenity/bank|CIB Bank": {
-    "locationSet": { "include": ["hu"] },
+    "locationSet": {"include": ["hu"]},
     "tags": {
       "amenity": "bank",
       "brand": "CIB Bank",
@@ -2510,7 +2521,7 @@
     }
   },
   "amenity/bank|CIBC": {
-    "locationSet": { "include": ["ca"] },
+    "locationSet": {"include": ["ca"]},
     "matchNames": ["cibc banking centre"],
     "tags": {
       "amenity": "bank",
@@ -2521,7 +2532,7 @@
     }
   },
   "amenity/bank|CIC": {
-    "locationSet": { "include": ["fr"] },
+    "locationSet": {"include": ["fr"]},
     "tags": {
       "amenity": "bank",
       "brand": "CIC",
@@ -2531,7 +2542,7 @@
     }
   },
   "amenity/bank|CIH Bank": {
-    "locationSet": { "include": ["ma"] },
+    "locationSet": {"include": ["ma"]},
     "tags": {
       "amenity": "bank",
       "brand": "CIH Bank",
@@ -2541,7 +2552,7 @@
     }
   },
   "amenity/bank|CIMB Bank": {
-    "locationSet": { "include": ["my"] },
+    "locationSet": {"include": ["my"]},
     "tags": {
       "amenity": "bank",
       "brand": "CIMB Bank",
@@ -2551,7 +2562,7 @@
     }
   },
   "amenity/bank|CIMB Niaga": {
-    "locationSet": { "include": ["id"] },
+    "locationSet": {"include": ["id"]},
     "tags": {
       "amenity": "bank",
       "brand": "CIMB Niaga",
@@ -2561,7 +2572,7 @@
     }
   },
   "amenity/bank|CNEP": {
-    "locationSet": { "include": ["dz"] },
+    "locationSet": {"include": ["dz"]},
     "tags": {
       "amenity": "bank",
       "brand": "CNEP",
@@ -2571,7 +2582,7 @@
     }
   },
   "amenity/bank|CRDB Bank": {
-    "locationSet": { "include": ["tz"] },
+    "locationSet": {"include": ["tz"]},
     "tags": {
       "amenity": "bank",
       "brand": "CRDB Bank",
@@ -2581,7 +2592,7 @@
     }
   },
   "amenity/bank|Caisse d'Épargne": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Caisse d'Épargne",
@@ -2591,7 +2602,7 @@
     }
   },
   "amenity/bank|Caixa Econômica Federal~(Brazil)": {
-    "locationSet": { "include": ["br"] },
+    "locationSet": {"include": ["br"]},
     "matchNames": ["caixa", "caixabank"],
     "nomatch": ["amenity/bank|Caixabank~(Spain)"],
     "tags": {
@@ -2615,8 +2626,10 @@
     }
   },
   "amenity/bank|Caixabank~(Spain)": {
-    "locationSet": { "include": ["es"] },
-    "nomatch": ["amenity/bank|Caixa Econômica Federal~(Brazil)"],
+    "locationSet": {"include": ["es"]},
+    "nomatch": [
+      "amenity/bank|Caixa Econômica Federal~(Brazil)"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "Caixabank",
@@ -2626,7 +2639,7 @@
     }
   },
   "amenity/bank|Caja Duero": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "Caja Duero",
@@ -2636,7 +2649,7 @@
     }
   },
   "amenity/bank|Caja España": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "Caja España",
@@ -2646,7 +2659,7 @@
     }
   },
   "amenity/bank|Caja Rural": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "Caja Rural",
@@ -2656,7 +2669,7 @@
     }
   },
   "amenity/bank|Caja Rural de Jaén": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "Caja Rural de Jaén",
@@ -2666,7 +2679,7 @@
     }
   },
   "amenity/bank|CajaSur": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "CajaSur",
@@ -2676,7 +2689,7 @@
     }
   },
   "amenity/bank|Cajamar": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "Cajamar",
@@ -2686,7 +2699,7 @@
     }
   },
   "amenity/bank|California Coast Credit Union": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "California Coast Credit Union",
@@ -2696,7 +2709,7 @@
     }
   },
   "amenity/bank|Canara Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Canara Bank",
@@ -2706,7 +2719,7 @@
     }
   },
   "amenity/bank|Capital Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Capital Bank",
@@ -2716,7 +2729,7 @@
     }
   },
   "amenity/bank|Capital One": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "matchNames": ["capital one bank"],
     "tags": {
       "amenity": "bank",
@@ -2727,7 +2740,7 @@
     }
   },
   "amenity/bank|Carige": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Carige",
@@ -2737,7 +2750,7 @@
     }
   },
   "amenity/bank|Cariparma": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Cariparma",
@@ -2747,7 +2760,7 @@
     }
   },
   "amenity/bank|Carisbo": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Carisbo",
@@ -2757,7 +2770,7 @@
     }
   },
   "amenity/bank|Casden": {
-    "locationSet": { "include": ["fr"] },
+    "locationSet": {"include": ["fr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Casden",
@@ -2767,7 +2780,7 @@
     }
   },
   "amenity/bank|Cassa di Risparmio del Veneto": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Cassa di Risparmio del Veneto",
@@ -2777,7 +2790,7 @@
     }
   },
   "amenity/bank|CatalunyaCaixa": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "CatalunyaCaixa",
@@ -2799,7 +2812,7 @@
     }
   },
   "amenity/bank|Catholic Syrian Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Catholic Syrian Bank",
@@ -2807,7 +2820,7 @@
     }
   },
   "amenity/bank|Centennial Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Centennial Bank",
@@ -2816,7 +2829,7 @@
     }
   },
   "amenity/bank|Central Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Central Bank",
@@ -2824,7 +2837,7 @@
     }
   },
   "amenity/bank|Central Bank of India": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Central Bank of India",
@@ -2834,7 +2847,7 @@
     }
   },
   "amenity/bank|Chase": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "matchNames": ["chase bank"],
     "tags": {
       "amenity": "bank",
@@ -2845,7 +2858,7 @@
     }
   },
   "amenity/bank|Chemical Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Chemical Bank",
@@ -2854,7 +2867,7 @@
     }
   },
   "amenity/bank|China Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "China Bank",
@@ -2864,7 +2877,7 @@
     }
   },
   "amenity/bank|China Bank Savings": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "tags": {
       "amenity": "bank",
       "brand": "China Bank Savings",
@@ -2874,7 +2887,7 @@
     }
   },
   "amenity/bank|China Construction Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "China Construction Bank",
@@ -2885,7 +2898,7 @@
     }
   },
   "amenity/bank|Citibank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Citibank",
@@ -2896,7 +2909,7 @@
     }
   },
   "amenity/bank|Citizens Bank~(Eastern USA)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Citizens Bank",
@@ -2907,7 +2920,7 @@
     }
   },
   "amenity/bank|Citizens Bank~(Kentucky)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "alt_name": "Citizens Bank of Kentucky",
       "amenity": "bank",
@@ -2920,7 +2933,7 @@
     }
   },
   "amenity/bank|Citizens Bank~(Nepal)": {
-    "locationSet": { "include": ["np"] },
+    "locationSet": {"include": ["np"]},
     "tags": {
       "amenity": "bank",
       "brand": "Citizens Bank International",
@@ -2932,7 +2945,7 @@
     }
   },
   "amenity/bank|City National Bank~(California)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "City National Bank",
@@ -2942,7 +2955,7 @@
     }
   },
   "amenity/bank|City National Bank~(Florida)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "City National Bank",
@@ -2953,7 +2966,7 @@
     }
   },
   "amenity/bank|City National Bank~(West Virginia)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "City National Bank",
@@ -2962,7 +2975,7 @@
     }
   },
   "amenity/bank|Clydesdale Bank": {
-    "locationSet": { "include": ["gb"] },
+    "locationSet": {"include": ["gb"]},
     "tags": {
       "amenity": "bank",
       "brand": "Clydesdale Bank",
@@ -2972,8 +2985,11 @@
     }
   },
   "amenity/bank|Coast Capital Savings": {
-    "locationSet": { "include": ["ca"] },
-    "matchNames": ["coast capital", "coast capital savings credit union"],
+    "locationSet": {"include": ["ca"]},
+    "matchNames": [
+      "coast capital",
+      "coast capital savings credit union"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "Coast Capital Savings",
@@ -2984,7 +3000,7 @@
     }
   },
   "amenity/bank|Columbia Bank~(New Jersey)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "nomatch": [
       "amenity/bank|Columbia Bank~(Washington)",
       "shop/clothes|Columbia"
@@ -2997,7 +3013,7 @@
     }
   },
   "amenity/bank|Columbia Bank~(Washington)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "nomatch": [
       "amenity/bank|Columbia Bank~(New Jersey)",
       "shop/clothes|Columbia"
@@ -3010,7 +3026,7 @@
     }
   },
   "amenity/bank|Comerica Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Comerica Bank",
@@ -3020,7 +3036,7 @@
     }
   },
   "amenity/bank|Commerce Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Commerce Bank",
@@ -3030,7 +3046,7 @@
     }
   },
   "amenity/bank|Commercial Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Commercial Bank",
@@ -3038,7 +3054,7 @@
     }
   },
   "amenity/bank|Commercial Bank of Ceylon PLC": {
-    "locationSet": { "include": ["lk"] },
+    "locationSet": {"include": ["lk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Commercial Bank of Ceylon PLC",
@@ -3048,7 +3064,7 @@
     }
   },
   "amenity/bank|Commerzbank": {
-    "locationSet": { "include": ["de"] },
+    "locationSet": {"include": ["de"]},
     "tags": {
       "amenity": "bank",
       "brand": "Commerzbank",
@@ -3058,7 +3074,7 @@
     }
   },
   "amenity/bank|Commonwealth Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Commonwealth Bank",
@@ -3068,7 +3084,7 @@
     }
   },
   "amenity/bank|Community Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Community Bank",
@@ -3078,7 +3094,7 @@
     }
   },
   "amenity/bank|Corporation Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Corporation Bank",
@@ -3088,7 +3104,7 @@
     }
   },
   "amenity/bank|Credem": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Credem",
@@ -3098,7 +3114,7 @@
     }
   },
   "amenity/bank|Credicoop": {
-    "locationSet": { "include": ["ar"] },
+    "locationSet": {"include": ["ar"]},
     "tags": {
       "amenity": "bank",
       "brand": "Credicoop",
@@ -3108,7 +3124,7 @@
     }
   },
   "amenity/bank|Credit Suisse": {
-    "locationSet": { "include": ["ch"] },
+    "locationSet": {"include": ["ch"]},
     "tags": {
       "amenity": "bank",
       "brand": "Credit Suisse",
@@ -3118,7 +3134,7 @@
     }
   },
   "amenity/bank|Credito Valtellinese": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Credito Valtellinese",
@@ -3128,7 +3144,7 @@
     }
   },
   "amenity/bank|Crelan": {
-    "locationSet": { "include": ["be"] },
+    "locationSet": {"include": ["be"]},
     "tags": {
       "amenity": "bank",
       "brand": "Crelan",
@@ -3138,7 +3154,7 @@
     }
   },
   "amenity/bank|Crédit Agricole": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Crédit Agricole",
@@ -3148,7 +3164,7 @@
     }
   },
   "amenity/bank|Crédit Maritime": {
-    "locationSet": { "include": ["fr"] },
+    "locationSet": {"include": ["fr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Crédit Maritime",
@@ -3158,7 +3174,7 @@
     }
   },
   "amenity/bank|Crédit Mutuel": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Crédit Mutuel",
@@ -3168,7 +3184,7 @@
     }
   },
   "amenity/bank|Crédit Mutuel de Bretagne": {
-    "locationSet": { "include": ["fr"] },
+    "locationSet": {"include": ["fr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Crédit Mutuel de Bretagne",
@@ -3178,7 +3194,7 @@
     }
   },
   "amenity/bank|Crédit du Nord": {
-    "locationSet": { "include": ["fr"] },
+    "locationSet": {"include": ["fr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Crédit du Nord",
@@ -3188,7 +3204,7 @@
     }
   },
   "amenity/bank|Crédito Agrícola": {
-    "locationSet": { "include": ["pt"] },
+    "locationSet": {"include": ["pt"]},
     "tags": {
       "amenity": "bank",
       "brand": "Crédito Agrícola",
@@ -3199,7 +3215,14 @@
   },
   "amenity/bank|Danske Bank": {
     "locationSet": {
-      "include": ["dk", "fi", "gb", "lt", "no", "se"]
+      "include": [
+        "dk",
+        "fi",
+        "gb",
+        "lt",
+        "no",
+        "se"
+      ]
     },
     "tags": {
       "amenity": "bank",
@@ -3223,7 +3246,7 @@
     }
   },
   "amenity/bank|Degussa": {
-    "locationSet": { "include": ["de"] },
+    "locationSet": {"include": ["de"]},
     "tags": {
       "amenity": "bank",
       "brand": "Degussa",
@@ -3233,7 +3256,7 @@
     }
   },
   "amenity/bank|Denizbank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Denizbank",
@@ -3243,7 +3266,7 @@
     }
   },
   "amenity/bank|Desjardins": {
-    "locationSet": { "include": ["ca"] },
+    "locationSet": {"include": ["ca"]},
     "matchNames": ["caisse desjardins"],
     "tags": {
       "amenity": "bank",
@@ -3254,7 +3277,7 @@
     }
   },
   "amenity/bank|Deutsche Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Deutsche Bank",
@@ -3264,7 +3287,7 @@
     }
   },
   "amenity/bank|Dollar Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "nomatch": [
       "amenity/car_rental|Dollar",
       "shop/variety_store|Dollar General",
@@ -3281,7 +3304,7 @@
     }
   },
   "amenity/bank|Dubai Islamic Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Dubai Islamic Bank",
@@ -3291,7 +3314,7 @@
     }
   },
   "amenity/bank|EastWest Unibank": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "matchNames": ["eastwest bank"],
     "tags": {
       "amenity": "bank",
@@ -3302,7 +3325,7 @@
     }
   },
   "amenity/bank|Ecobank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "matchNames": ["agence ecobank"],
     "tags": {
       "amenity": "bank",
@@ -3313,7 +3336,7 @@
     }
   },
   "amenity/bank|Emirates NBD": {
-    "locationSet": { "include": ["ae"] },
+    "locationSet": {"include": ["ae"]},
     "tags": {
       "amenity": "bank",
       "brand": "Emirates NBD",
@@ -3323,7 +3346,7 @@
     }
   },
   "amenity/bank|Equity Bank~(Congo)": {
-    "locationSet": { "include": ["cd"] },
+    "locationSet": {"include": ["cd"]},
     "tags": {
       "amenity": "bank",
       "brand": "Equity Bank",
@@ -3333,7 +3356,7 @@
     }
   },
   "amenity/bank|Equity Bank~(Kenya)": {
-    "locationSet": { "include": ["ke"] },
+    "locationSet": {"include": ["ke"]},
     "tags": {
       "amenity": "bank",
       "brand": "Equity Bank",
@@ -3343,7 +3366,7 @@
     }
   },
   "amenity/bank|Equity Bank~(Rwanda)": {
-    "locationSet": { "include": ["rw"] },
+    "locationSet": {"include": ["rw"]},
     "tags": {
       "amenity": "bank",
       "brand": "Equity Bank",
@@ -3353,7 +3376,7 @@
     }
   },
   "amenity/bank|Equity Bank~(South Sudan)": {
-    "locationSet": { "include": ["ss"] },
+    "locationSet": {"include": ["ss"]},
     "tags": {
       "amenity": "bank",
       "brand": "Equity Bank",
@@ -3363,7 +3386,7 @@
     }
   },
   "amenity/bank|Equity Bank~(Tanzania)": {
-    "locationSet": { "include": ["tz"] },
+    "locationSet": {"include": ["tz"]},
     "tags": {
       "amenity": "bank",
       "brand": "Equity Bank",
@@ -3373,7 +3396,7 @@
     }
   },
   "amenity/bank|Equity Bank~(USA)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Equity Bank",
@@ -3383,7 +3406,7 @@
     }
   },
   "amenity/bank|Equity Bank~(Uganda)": {
-    "locationSet": { "include": ["ug"] },
+    "locationSet": {"include": ["ug"]},
     "tags": {
       "amenity": "bank",
       "brand": "Equity Bank",
@@ -3405,7 +3428,7 @@
     }
   },
   "amenity/bank|EuroBic": {
-    "locationSet": { "include": ["pt"] },
+    "locationSet": {"include": ["pt"]},
     "matchNames": ["banco bic"],
     "tags": {
       "amenity": "bank",
@@ -3417,7 +3440,7 @@
     }
   },
   "amenity/bank|Eurobank~(Greece)": {
-    "locationSet": { "include": ["gr"] },
+    "locationSet": {"include": ["gr"]},
     "matchNames": ["eurobank ergasias"],
     "tags": {
       "amenity": "bank",
@@ -3428,7 +3451,7 @@
     }
   },
   "amenity/bank|Eurobank~(Poland)": {
-    "locationSet": { "include": ["pl"] },
+    "locationSet": {"include": ["pl"]},
     "tags": {
       "amenity": "bank",
       "brand": "Eurobank",
@@ -3438,7 +3461,7 @@
     }
   },
   "amenity/bank|Eurobank~(Serbia)": {
-    "locationSet": { "include": ["rs"] },
+    "locationSet": {"include": ["rs"]},
     "tags": {
       "amenity": "bank",
       "brand": "Eurobank",
@@ -3449,7 +3472,14 @@
   },
   "amenity/bank|FNB~(South Africa)": {
     "locationSet": {
-      "include": ["bw", "mz", "na", "us", "za", "zm"]
+      "include": [
+        "bw",
+        "mz",
+        "na",
+        "us",
+        "za",
+        "zm"
+      ]
     },
     "tags": {
       "amenity": "bank",
@@ -3461,7 +3491,7 @@
     }
   },
   "amenity/bank|Faysal Bank": {
-    "locationSet": { "include": ["pk"] },
+    "locationSet": {"include": ["pk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Faysal Bank",
@@ -3471,7 +3501,7 @@
     }
   },
   "amenity/bank|Federal Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Federal Bank",
@@ -3482,7 +3512,14 @@
   },
   "amenity/bank|Ficohsa": {
     "locationSet": {
-      "include": ["es", "gt", "hn", "ni", "pa", "us"]
+      "include": [
+        "es",
+        "gt",
+        "hn",
+        "ni",
+        "pa",
+        "us"
+      ]
     },
     "matchNames": ["banco ficohsa"],
     "tags": {
@@ -3494,7 +3531,7 @@
     }
   },
   "amenity/bank|Fidelity Bank~(Ghana)": {
-    "locationSet": { "include": ["gh"] },
+    "locationSet": {"include": ["gh"]},
     "tags": {
       "amenity": "bank",
       "brand": "Fidelity Bank",
@@ -3504,7 +3541,7 @@
     }
   },
   "amenity/bank|Fidelity Bank~(Nigeria)": {
-    "locationSet": { "include": ["ng"] },
+    "locationSet": {"include": ["ng"]},
     "tags": {
       "amenity": "bank",
       "brand": "Fidelity Bank",
@@ -3514,7 +3551,7 @@
     }
   },
   "amenity/bank|Fidelity Bank~(USA)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Fidelity Bank",
@@ -3524,7 +3561,7 @@
     }
   },
   "amenity/bank|Fifth Third Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "matchNames": ["5/3"],
     "tags": {
       "amenity": "bank",
@@ -3536,7 +3573,7 @@
     }
   },
   "amenity/bank|Finansbank": {
-    "locationSet": { "include": ["tr"] },
+    "locationSet": {"include": ["tr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Finansbank",
@@ -3546,7 +3583,7 @@
     }
   },
   "amenity/bank|Fio banka": {
-    "locationSet": { "include": ["cz", "sk"] },
+    "locationSet": {"include": ["cz", "sk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Fio banka",
@@ -3556,8 +3593,12 @@
     }
   },
   "amenity/bank|First Bank~(North and South Carolina)": {
-    "locationSet": { "include": ["us"] },
-    "matchNames": ["1st bancorp", "1st bank", "first bancorp"],
+    "locationSet": {"include": ["us"]},
+    "matchNames": [
+      "1st bancorp",
+      "1st bank",
+      "first bancorp"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "First Bank",
@@ -3567,8 +3608,12 @@
     }
   },
   "amenity/bank|First Bank~(Puerto Rico)": {
-    "locationSet": { "include": ["us"] },
-    "matchNames": ["1st bancorp", "1st bank", "first bancorp"],
+    "locationSet": {"include": ["us"]},
+    "matchNames": [
+      "1st bancorp",
+      "1st bank",
+      "first bancorp"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "First Bank",
@@ -3578,7 +3623,7 @@
     }
   },
   "amenity/bank|First Bank~(Western USA)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "matchNames": ["1st bank"],
     "tags": {
       "amenity": "bank",
@@ -3590,7 +3635,7 @@
     }
   },
   "amenity/bank|First Citizens Bank~(Trinidad and Tobago)": {
-    "locationSet": { "include": ["bb", "tt"] },
+    "locationSet": {"include": ["bb", "tt"]},
     "matchNames": ["1st citizens bank"],
     "tags": {
       "amenity": "bank",
@@ -3601,7 +3646,7 @@
     }
   },
   "amenity/bank|First Citizens Bank~(USA)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "matchNames": ["1st citizens bank"],
     "tags": {
       "amenity": "bank",
@@ -3612,7 +3657,7 @@
     }
   },
   "amenity/bank|First Financial Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "matchNames": ["1st financial bank"],
     "tags": {
       "amenity": "bank",
@@ -3623,7 +3668,7 @@
     }
   },
   "amenity/bank|First Interstate Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "matchNames": [
       "1st interstate",
       "1st interstate bancsystem",
@@ -3640,7 +3685,7 @@
     }
   },
   "amenity/bank|First Midwest Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "First Midwest Bank",
@@ -3650,7 +3695,7 @@
     }
   },
   "amenity/bank|First National Bank~(USA)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "First National Bank",
@@ -3660,7 +3705,7 @@
     }
   },
   "amenity/bank|First State Bank Nebraska": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "nomatch": [
       "amenity/bank|First State Bank~(Florida)",
       "amenity/bank|First State Bank~(Illinois)",
@@ -3678,7 +3723,7 @@
     }
   },
   "amenity/bank|First State Bank~(Florida)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "nomatch": [
       "amenity/bank|First State Bank Nebraska",
       "amenity/bank|First State Bank~(Illinois)",
@@ -3696,7 +3741,7 @@
     }
   },
   "amenity/bank|First State Bank~(Illinois)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "nomatch": [
       "amenity/bank|First State Bank Nebraska",
       "amenity/bank|First State Bank~(Florida)",
@@ -3714,7 +3759,7 @@
     }
   },
   "amenity/bank|First State Bank~(Michigan)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "nomatch": [
       "amenity/bank|First State Bank Nebraska",
       "amenity/bank|First State Bank~(Florida)",
@@ -3732,7 +3777,7 @@
     }
   },
   "amenity/bank|First State Bank~(Mississippi)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "nomatch": [
       "amenity/bank|First State Bank Nebraska",
       "amenity/bank|First State Bank~(Florida)",
@@ -3750,7 +3795,7 @@
     }
   },
   "amenity/bank|First State Bank~(Nebraska)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "nomatch": [
       "amenity/bank|First State Bank Nebraska",
       "amenity/bank|First State Bank~(Florida)",
@@ -3768,7 +3813,7 @@
     }
   },
   "amenity/bank|First State Bank~(Ohio)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "nomatch": [
       "amenity/bank|First State Bank Nebraska",
       "amenity/bank|First State Bank~(Florida)",
@@ -3786,7 +3831,7 @@
     }
   },
   "amenity/bank|First State Bank~(Texas)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "nomatch": [
       "amenity/bank|First State Bank Nebraska",
       "amenity/bank|First State Bank~(Florida)",
@@ -3804,8 +3849,12 @@
     }
   },
   "amenity/bank|First Tech Credit Union": {
-    "locationSet": { "include": ["us"] },
-    "matchNames": ["1st tech", "1st tech credit union", "first tech"],
+    "locationSet": {"include": ["us"]},
+    "matchNames": [
+      "1st tech",
+      "1st tech credit union",
+      "first tech"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "First Tech Credit Union",
@@ -3815,7 +3864,7 @@
     }
   },
   "amenity/bank|First West Credit Union": {
-    "locationSet": { "include": ["ca"] },
+    "locationSet": {"include": ["ca"]},
     "tags": {
       "alt_name": "First West",
       "amenity": "bank",
@@ -3826,7 +3875,7 @@
     }
   },
   "amenity/bank|Frost Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Frost Bank",
@@ -3836,7 +3885,7 @@
     }
   },
   "amenity/bank|Fulton Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Fulton Bank",
@@ -3845,7 +3894,7 @@
     }
   },
   "amenity/bank|GCB Bank": {
-    "locationSet": { "include": ["gh"] },
+    "locationSet": {"include": ["gh"]},
     "tags": {
       "amenity": "bank",
       "brand": "GCB Bank",
@@ -3856,7 +3905,18 @@
   },
   "amenity/bank|GT Bank": {
     "locationSet": {
-      "include": ["ci", "gb", "gh", "gm", "ke", "lr", "ng", "rw", "tz", "ug"]
+      "include": [
+        "ci",
+        "gb",
+        "gh",
+        "gm",
+        "ke",
+        "lr",
+        "ng",
+        "rw",
+        "tz",
+        "ug"
+      ]
     },
     "tags": {
       "amenity": "bank",
@@ -3868,7 +3928,7 @@
     }
   },
   "amenity/bank|Galicia": {
-    "locationSet": { "include": ["ar"] },
+    "locationSet": {"include": ["ar"]},
     "tags": {
       "amenity": "bank",
       "brand": "Galicia",
@@ -3878,7 +3938,7 @@
     }
   },
   "amenity/bank|Garanti": {
-    "locationSet": { "include": ["tr"] },
+    "locationSet": {"include": ["tr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Garanti",
@@ -3888,7 +3948,7 @@
     }
   },
   "amenity/bank|Garanti Bankası": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Garanti Bankası",
@@ -3898,7 +3958,7 @@
     }
   },
   "amenity/bank|Getin Bank": {
-    "locationSet": { "include": ["pl"] },
+    "locationSet": {"include": ["pl"]},
     "tags": {
       "amenity": "bank",
       "brand": "Getin Bank",
@@ -3908,7 +3968,7 @@
     }
   },
   "amenity/bank|Golden 1 Credit Union": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "matchNames": [
       "golden 1",
       "golden one",
@@ -3925,7 +3985,7 @@
     }
   },
   "amenity/bank|Great Western Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Great Western Bank",
@@ -3935,7 +3995,7 @@
     }
   },
   "amenity/bank|Groupama": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Groupama",
@@ -3945,7 +4005,7 @@
     }
   },
   "amenity/bank|HBL Bank": {
-    "locationSet": { "include": ["pk"] },
+    "locationSet": {"include": ["pk"]},
     "matchNames": ["hbl"],
     "tags": {
       "amenity": "bank",
@@ -3956,7 +4016,7 @@
     }
   },
   "amenity/bank|HDFC Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "HDFC Bank",
@@ -3966,7 +4026,7 @@
     }
   },
   "amenity/bank|HNB": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "HNB",
@@ -3976,7 +4036,7 @@
     }
   },
   "amenity/bank|HSBC UK~(UK)": {
-    "locationSet": { "include": ["gb"] },
+    "locationSet": {"include": ["gb"]},
     "matchNames": ["hsbc"],
     "tags": {
       "amenity": "bank",
@@ -3986,7 +4046,7 @@
     }
   },
   "amenity/bank|HSBC~(Global)": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "HSBC",
@@ -3996,7 +4056,7 @@
     }
   },
   "amenity/bank|Halifax": {
-    "locationSet": { "include": ["gb"] },
+    "locationSet": {"include": ["gb"]},
     "tags": {
       "amenity": "bank",
       "brand": "Halifax",
@@ -4006,7 +4066,7 @@
     }
   },
   "amenity/bank|Halkbank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Halkbank",
@@ -4016,7 +4076,7 @@
     }
   },
   "amenity/bank|Hamburger Sparkasse": {
-    "locationSet": { "include": ["de"] },
+    "locationSet": {"include": ["de"]},
     "tags": {
       "amenity": "bank",
       "brand": "Hamburger Sparkasse",
@@ -4039,7 +4099,7 @@
     }
   },
   "amenity/bank|Heritage Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Heritage Bank",
@@ -4049,7 +4109,7 @@
     }
   },
   "amenity/bank|Hong Leong Bank": {
-    "locationSet": { "include": ["my"] },
+    "locationSet": {"include": ["my"]},
     "tags": {
       "amenity": "bank",
       "brand": "Hong Leong Bank",
@@ -4061,7 +4121,7 @@
     }
   },
   "amenity/bank|Hrvatska poštanska banka": {
-    "locationSet": { "include": ["hr"] },
+    "locationSet": {"include": ["hr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Hrvatska poštanska banka",
@@ -4071,7 +4131,7 @@
     }
   },
   "amenity/bank|Huntington Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Huntington Bank",
@@ -4081,7 +4141,7 @@
     }
   },
   "amenity/bank|HypoVereinsbank": {
-    "locationSet": { "include": ["de"] },
+    "locationSet": {"include": ["de"]},
     "tags": {
       "amenity": "bank",
       "brand": "HypoVereinsbank",
@@ -4091,7 +4151,7 @@
     }
   },
   "amenity/bank|ICBC": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "ICBC",
@@ -4113,7 +4173,7 @@
     }
   },
   "amenity/bank|IDBI Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "IDBI Bank",
@@ -4123,7 +4183,7 @@
     }
   },
   "amenity/bank|ING": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "matchNames": ["ing bank"],
     "tags": {
       "amenity": "bank",
@@ -4134,7 +4194,7 @@
     }
   },
   "amenity/bank|ING Bank Śląski": {
-    "locationSet": { "include": ["pl"] },
+    "locationSet": {"include": ["pl"]},
     "tags": {
       "amenity": "bank",
       "brand": "ING Bank Śląski",
@@ -4144,7 +4204,7 @@
     }
   },
   "amenity/bank|Ibercaja": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "Ibercaja",
@@ -4154,7 +4214,7 @@
     }
   },
   "amenity/bank|Indian Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Indian Bank",
@@ -4164,7 +4224,7 @@
     }
   },
   "amenity/bank|Indian Overseas Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Indian Overseas Bank",
@@ -4174,7 +4234,7 @@
     }
   },
   "amenity/bank|Interbank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "nomatch": ["amenity/bank|Bankinter"],
     "tags": {
       "amenity": "bank",
@@ -4185,7 +4245,7 @@
     }
   },
   "amenity/bank|Intesa Sanpaolo": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Intesa Sanpaolo",
@@ -4195,7 +4255,7 @@
     }
   },
   "amenity/bank|Investors Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Investors Bank",
@@ -4205,7 +4265,7 @@
     }
   },
   "amenity/bank|Itaú~(Brazil)": {
-    "locationSet": { "include": ["br"] },
+    "locationSet": {"include": ["br"]},
     "matchNames": ["banco itau"],
     "nomatch": ["amenity/bank|Itaú~(Chile)"],
     "tags": {
@@ -4217,7 +4277,7 @@
     }
   },
   "amenity/bank|Itaú~(Chile)": {
-    "locationSet": { "include": ["cl"] },
+    "locationSet": {"include": ["cl"]},
     "matchNames": ["banco itau"],
     "nomatch": ["amenity/bank|Itaú~(Brazil)"],
     "tags": {
@@ -4229,7 +4289,7 @@
     }
   },
   "amenity/bank|J&T Banka": {
-    "locationSet": { "include": ["cz", "sk"] },
+    "locationSet": {"include": ["cz", "sk"]},
     "tags": {
       "amenity": "bank",
       "brand": "J&T Banka",
@@ -4239,7 +4299,7 @@
     }
   },
   "amenity/bank|JAバンク": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "matchNames": ["ja", "ジェイエイバンク"],
     "nomatch": ["amenity/fuel|JA-SS"],
     "tags": {
@@ -4256,7 +4316,7 @@
     }
   },
   "amenity/bank|JS Bank": {
-    "locationSet": { "include": ["pk"] },
+    "locationSet": {"include": ["pk"]},
     "tags": {
       "amenity": "bank",
       "brand": "JS Bank",
@@ -4266,7 +4326,7 @@
     }
   },
   "amenity/bank|Jyske Bank": {
-    "locationSet": { "include": ["dk"] },
+    "locationSet": {"include": ["dk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Jyske Bank",
@@ -4276,7 +4336,7 @@
     }
   },
   "amenity/bank|K&H Bank": {
-    "locationSet": { "include": ["hu"] },
+    "locationSet": {"include": ["hu"]},
     "tags": {
       "amenity": "bank",
       "brand": "K&H Bank",
@@ -4286,7 +4346,7 @@
     }
   },
   "amenity/bank|KBC": {
-    "locationSet": { "include": ["be", "ie"] },
+    "locationSet": {"include": ["be", "ie"]},
     "tags": {
       "amenity": "bank",
       "brand": "KBC",
@@ -4296,7 +4356,7 @@
     }
   },
   "amenity/bank|KBZ Bank": {
-    "locationSet": { "include": ["mm"] },
+    "locationSet": {"include": ["mm"]},
     "tags": {
       "amenity": "bank",
       "brand": "KBZ Bank",
@@ -4306,7 +4366,7 @@
     }
   },
   "amenity/bank|Karnataka Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Karnataka Bank",
@@ -4316,7 +4376,7 @@
     }
   },
   "amenity/bank|Karur Vysya Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Karur Vysya Bank",
@@ -4326,7 +4386,7 @@
     }
   },
   "amenity/bank|Kasa Stefczyka": {
-    "locationSet": { "include": ["pl"] },
+    "locationSet": {"include": ["pl"]},
     "tags": {
       "amenity": "bank",
       "brand": "Kasa Stefczyka",
@@ -4335,7 +4395,7 @@
     }
   },
   "amenity/bank|Kerala Gramin Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Kerala Gramin Bank",
@@ -4345,7 +4405,7 @@
     }
   },
   "amenity/bank|KeyBank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "KeyBank",
@@ -4355,7 +4415,7 @@
     }
   },
   "amenity/bank|Komerční banka": {
-    "locationSet": { "include": ["cz"] },
+    "locationSet": {"include": ["cz"]},
     "tags": {
       "amenity": "bank",
       "brand": "Komerční banka",
@@ -4365,7 +4425,7 @@
     }
   },
   "amenity/bank|Kotak Mahindra Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Kotak Mahindra Bank",
@@ -4375,7 +4435,7 @@
     }
   },
   "amenity/bank|Kutxabank": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "Kutxabank",
@@ -4385,7 +4445,7 @@
     }
   },
   "amenity/bank|Kuveyt Türk": {
-    "locationSet": { "include": ["tr"] },
+    "locationSet": {"include": ["tr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Kuveyt Türk",
@@ -4395,7 +4455,7 @@
     }
   },
   "amenity/bank|LCL": {
-    "locationSet": { "include": ["fr"] },
+    "locationSet": {"include": ["fr"]},
     "tags": {
       "amenity": "bank",
       "brand": "LCL",
@@ -4405,7 +4465,7 @@
     }
   },
   "amenity/bank|LCNB": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "alt_name": "Lebanon Citizens National Bank",
       "amenity": "bank",
@@ -4416,7 +4476,7 @@
     }
   },
   "amenity/bank|La Banque Postale": {
-    "locationSet": { "include": ["fr"] },
+    "locationSet": {"include": ["fr"]},
     "tags": {
       "amenity": "bank",
       "brand": "La Banque Postale",
@@ -4426,7 +4486,7 @@
     }
   },
   "amenity/bank|La Caixa": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "La Caixa",
@@ -4436,7 +4496,7 @@
     }
   },
   "amenity/bank|Laboral Kutxa": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "Laboral Kutxa",
@@ -4446,7 +4506,7 @@
     }
   },
   "amenity/bank|Lake Michigan Credit Union": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Lake Michigan Credit Union",
@@ -4457,7 +4517,7 @@
     }
   },
   "amenity/bank|Landbank": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "matchNames": [
       "bangko sa lupa ng pilipinas",
       "land bank of the philippines",
@@ -4472,7 +4532,7 @@
     }
   },
   "amenity/bank|Leeds Building Society": {
-    "locationSet": { "include": ["gb"] },
+    "locationSet": {"include": ["gb"]},
     "tags": {
       "amenity": "bank",
       "brand": "Leeds Building Society",
@@ -4482,7 +4542,7 @@
     }
   },
   "amenity/bank|Liberbank": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "Liberbank",
@@ -4492,7 +4552,7 @@
     }
   },
   "amenity/bank|Liberty Bank~(Connecticut)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "nomatch": ["amenity/fuel|Liberty"],
     "tags": {
       "amenity": "bank",
@@ -4503,7 +4563,7 @@
     }
   },
   "amenity/bank|Lloyds Bank": {
-    "locationSet": { "include": ["gb", "im"] },
+    "locationSet": {"include": ["gb", "im"]},
     "matchNames": ["lloyds", "lloyds tsb"],
     "tags": {
       "amenity": "bank",
@@ -4514,7 +4574,7 @@
     }
   },
   "amenity/bank|M&T Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "M&T Bank",
@@ -4524,7 +4584,7 @@
     }
   },
   "amenity/bank|MCB": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "matchNames": ["mcb bank"],
     "tags": {
       "amenity": "bank",
@@ -4535,7 +4595,7 @@
     }
   },
   "amenity/bank|MONETA Money Bank": {
-    "locationSet": { "include": ["cz"] },
+    "locationSet": {"include": ["cz"]},
     "tags": {
       "amenity": "bank",
       "brand": "MONETA Money Bank",
@@ -4545,7 +4605,7 @@
     }
   },
   "amenity/bank|Macro": {
-    "locationSet": { "include": ["ar"] },
+    "locationSet": {"include": ["ar"]},
     "tags": {
       "amenity": "bank",
       "brand": "Macro",
@@ -4555,7 +4615,7 @@
     }
   },
   "amenity/bank|Maybank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Maybank",
@@ -4565,7 +4625,7 @@
     }
   },
   "amenity/bank|Meezan Bank": {
-    "locationSet": { "include": ["pk"] },
+    "locationSet": {"include": ["pk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Meezan Bank",
@@ -4575,7 +4635,7 @@
     }
   },
   "amenity/bank|Mercantil": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Mercantil",
@@ -4585,7 +4645,7 @@
     }
   },
   "amenity/bank|Meridian Credit Union": {
-    "locationSet": { "include": ["ca"] },
+    "locationSet": {"include": ["ca"]},
     "tags": {
       "alt_name": "Meridian",
       "amenity": "bank",
@@ -4596,7 +4656,7 @@
     }
   },
   "amenity/bank|Metro Bank~(UK)": {
-    "locationSet": { "include": ["gb"] },
+    "locationSet": {"include": ["gb"]},
     "nomatch": [
       "amenity/bank|Metrobank~(Philippines)",
       "shop/mobile_phone|MetroPCS",
@@ -4614,7 +4674,7 @@
     }
   },
   "amenity/bank|Metrobank~(Philippines)": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "nomatch": [
       "amenity/bank|Metro Bank~(UK)",
       "shop/mobile_phone|MetroPCS",
@@ -4632,7 +4692,7 @@
     }
   },
   "amenity/bank|Mibanco": {
-    "locationSet": { "include": ["pe"] },
+    "locationSet": {"include": ["pe"]},
     "tags": {
       "amenity": "bank",
       "brand": "Mibanco",
@@ -4641,7 +4701,7 @@
     }
   },
   "amenity/bank|MidFirst Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "MidFirst Bank",
@@ -4651,7 +4711,7 @@
     }
   },
   "amenity/bank|Millennium Bank": {
-    "locationSet": { "include": ["pl"] },
+    "locationSet": {"include": ["pl"]},
     "matchNames": ["bank millennium"],
     "tags": {
       "amenity": "bank",
@@ -4662,7 +4722,7 @@
     }
   },
   "amenity/bank|Millennium bcp": {
-    "locationSet": { "include": ["pt"] },
+    "locationSet": {"include": ["pt"]},
     "tags": {
       "amenity": "bank",
       "brand": "Millennium bcp",
@@ -4675,7 +4735,7 @@
     }
   },
   "amenity/bank|Mission Federal Credit Union": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Mission Federal Credit Union",
@@ -4685,7 +4745,7 @@
     }
   },
   "amenity/bank|Mittelbrandenburgische Sparkasse": {
-    "locationSet": { "include": ["de"] },
+    "locationSet": {"include": ["de"]},
     "tags": {
       "amenity": "bank",
       "brand": "Mittelbrandenburgische Sparkasse",
@@ -4695,7 +4755,7 @@
     }
   },
   "amenity/bank|Monte dei Paschi di Siena": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Monte dei Paschi di Siena",
@@ -4705,7 +4765,7 @@
     }
   },
   "amenity/bank|Montepio": {
-    "locationSet": { "include": ["pt"] },
+    "locationSet": {"include": ["pt"]},
     "tags": {
       "amenity": "bank",
       "brand": "Montepio",
@@ -4715,7 +4775,7 @@
     }
   },
   "amenity/bank|Mountain America Credit Union": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Mountain America Credit Union",
@@ -4725,7 +4785,7 @@
     }
   },
   "amenity/bank|NAB": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "NAB",
@@ -4735,7 +4795,7 @@
     }
   },
   "amenity/bank|NASA Federal Credit Union": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "NASA Federal Credit Union",
@@ -4745,7 +4805,7 @@
     }
   },
   "amenity/bank|NLB": {
-    "locationSet": { "include": ["si"] },
+    "locationSet": {"include": ["si"]},
     "tags": {
       "amenity": "bank",
       "brand": "NLB",
@@ -4755,7 +4815,7 @@
     }
   },
   "amenity/bank|NSB": {
-    "locationSet": { "include": ["lk"] },
+    "locationSet": {"include": ["lk"]},
     "matchNames": ["national savings bank"],
     "tags": {
       "amenity": "bank",
@@ -4766,7 +4826,7 @@
     }
   },
   "amenity/bank|NatWest": {
-    "locationSet": { "include": ["gb", "gg"] },
+    "locationSet": {"include": ["gb", "gg"]},
     "tags": {
       "amenity": "bank",
       "brand": "NatWest",
@@ -4776,8 +4836,11 @@
     }
   },
   "amenity/bank|National Bank": {
-    "locationSet": { "include": ["ca"] },
-    "matchNames": ["banque nationale", "banque nationale du canada"],
+    "locationSet": {"include": ["ca"]},
+    "matchNames": [
+      "banque nationale",
+      "banque nationale du canada"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "National Bank",
@@ -4794,7 +4857,7 @@
     }
   },
   "amenity/bank|Nationwide": {
-    "locationSet": { "include": ["gb"] },
+    "locationSet": {"include": ["gb"]},
     "nomatch": ["office/insurance|Nationwide"],
     "tags": {
       "amenity": "bank",
@@ -4805,7 +4868,7 @@
     }
   },
   "amenity/bank|Navy Federal Credit Union": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Navy Federal Credit Union",
@@ -4815,7 +4878,7 @@
     }
   },
   "amenity/bank|Nedbank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Nedbank",
@@ -4825,7 +4888,7 @@
     }
   },
   "amenity/bank|Nest Bank": {
-    "locationSet": { "include": ["pl"] },
+    "locationSet": {"include": ["pl"]},
     "tags": {
       "amenity": "bank",
       "brand": "Nest Bank",
@@ -4835,7 +4898,7 @@
     }
   },
   "amenity/bank|Nordea": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Nordea",
@@ -4845,7 +4908,7 @@
     }
   },
   "amenity/bank|Novo Banco": {
-    "locationSet": { "include": ["es", "pt"] },
+    "locationSet": {"include": ["es", "pt"]},
     "tags": {
       "amenity": "bank",
       "brand": "Novo Banco",
@@ -4855,7 +4918,7 @@
     }
   },
   "amenity/bank|OCBC Bank": {
-    "locationSet": { "include": ["my", "sg"] },
+    "locationSet": {"include": ["my", "sg"]},
     "tags": {
       "amenity": "bank",
       "brand": "OCBC Bank",
@@ -4867,7 +4930,7 @@
     }
   },
   "amenity/bank|OLB": {
-    "locationSet": { "include": ["de"] },
+    "locationSet": {"include": ["de"]},
     "tags": {
       "amenity": "bank",
       "brand": "OLB",
@@ -4877,7 +4940,7 @@
     }
   },
   "amenity/bank|OTP": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "matchNames": ["otp bank"],
     "tags": {
       "amenity": "bank",
@@ -4900,7 +4963,7 @@
     }
   },
   "amenity/bank|Occidental de Descuento": {
-    "locationSet": { "include": ["ve"] },
+    "locationSet": {"include": ["ve"]},
     "tags": {
       "amenity": "bank",
       "brand": "Occidental de Descuento",
@@ -4910,7 +4973,7 @@
     }
   },
   "amenity/bank|Old National Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Old National Bank",
@@ -4918,7 +4981,7 @@
     }
   },
   "amenity/bank|Oldenburgische Landesbank": {
-    "locationSet": { "include": ["de"] },
+    "locationSet": {"include": ["de"]},
     "tags": {
       "amenity": "bank",
       "brand": "Oldenburgische Landesbank",
@@ -4928,7 +4991,7 @@
     }
   },
   "amenity/bank|One Network Bank": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "tags": {
       "amenity": "bank",
       "brand": "One Network Bank",
@@ -4938,7 +5001,7 @@
     }
   },
   "amenity/bank|Oriental": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "alt_name": "Oriental Bank",
       "amenity": "bank",
@@ -4948,7 +5011,7 @@
     }
   },
   "amenity/bank|Oriental Bank of Commerce": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Oriental Bank of Commerce",
@@ -4958,7 +5021,7 @@
     }
   },
   "amenity/bank|Osuuspankki": {
-    "locationSet": { "include": ["fi"] },
+    "locationSet": {"include": ["fi"]},
     "tags": {
       "amenity": "bank",
       "brand": "Osuuspankki",
@@ -4968,7 +5031,7 @@
     }
   },
   "amenity/bank|PBZ": {
-    "locationSet": { "include": ["hr"] },
+    "locationSet": {"include": ["hr"]},
     "tags": {
       "amenity": "bank",
       "brand": "PBZ",
@@ -4978,7 +5041,7 @@
     }
   },
   "amenity/bank|PKO BP": {
-    "locationSet": { "include": ["pl"] },
+    "locationSet": {"include": ["pl"]},
     "matchNames": ["pko bank polski"],
     "tags": {
       "amenity": "bank",
@@ -4989,7 +5052,7 @@
     }
   },
   "amenity/bank|PNB": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "tags": {
       "amenity": "bank",
       "brand": "PNB",
@@ -5000,7 +5063,7 @@
     }
   },
   "amenity/bank|PNC Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "matchNames": ["pnc"],
     "tags": {
       "amenity": "bank",
@@ -5011,7 +5074,7 @@
     }
   },
   "amenity/bank|PSBank": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "tags": {
       "amenity": "bank",
       "brand": "PSBank",
@@ -5021,7 +5084,7 @@
     }
   },
   "amenity/bank|Panin Bank": {
-    "locationSet": { "include": ["id"] },
+    "locationSet": {"include": ["id"]},
     "tags": {
       "amenity": "bank",
       "brand": "Panin Bank",
@@ -5031,7 +5094,7 @@
     }
   },
   "amenity/bank|Patagonia": {
-    "locationSet": { "include": ["ar"] },
+    "locationSet": {"include": ["ar"]},
     "tags": {
       "amenity": "bank",
       "brand": "Patagonia",
@@ -5041,7 +5104,7 @@
     }
   },
   "amenity/bank|Pekao SA": {
-    "locationSet": { "include": ["pl"] },
+    "locationSet": {"include": ["pl"]},
     "tags": {
       "amenity": "bank",
       "brand": "Pekao SA",
@@ -5051,7 +5114,7 @@
     }
   },
   "amenity/bank|PenFed Credit Union": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "alt_name": "Pentagon Federal Credit Union",
       "amenity": "bank",
@@ -5063,7 +5126,7 @@
     }
   },
   "amenity/bank|People's United Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "People's United Bank",
@@ -5073,7 +5136,7 @@
     }
   },
   "amenity/bank|Peoples Bank~(Flemingsburg, Kentucky)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Peoples Bank",
@@ -5082,7 +5145,7 @@
     }
   },
   "amenity/bank|Peoples Bank~(Ohio)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Peoples Bank",
@@ -5091,7 +5154,7 @@
     }
   },
   "amenity/bank|Peoples Bank~(Washington)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Peoples Bank",
@@ -5101,7 +5164,7 @@
     }
   },
   "amenity/bank|Permanent TSB": {
-    "locationSet": { "include": ["ie"] },
+    "locationSet": {"include": ["ie"]},
     "tags": {
       "amenity": "bank",
       "brand": "Permanent TSB",
@@ -5123,7 +5186,7 @@
     }
   },
   "amenity/bank|Popular": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "matchNames": ["popular bank"],
     "nomatch": ["shop/books|Popular"],
     "tags": {
@@ -5145,7 +5208,7 @@
     }
   },
   "amenity/bank|Postbank~(Bulgaria)": {
-    "locationSet": { "include": ["bg"] },
+    "locationSet": {"include": ["bg"]},
     "nomatch": ["amenity/bank|Bancpost"],
     "tags": {
       "amenity": "bank",
@@ -5156,7 +5219,7 @@
     }
   },
   "amenity/bank|Postbank~(Germany)": {
-    "locationSet": { "include": ["de"] },
+    "locationSet": {"include": ["de"]},
     "matchNames": ["postbank finanzcenter"],
     "nomatch": ["amenity/bank|Bancpost"],
     "tags": {
@@ -5168,7 +5231,7 @@
     }
   },
   "amenity/bank|Poštová banka": {
-    "locationSet": { "include": ["sk"] },
+    "locationSet": {"include": ["sk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Poštová banka",
@@ -5178,7 +5241,7 @@
     }
   },
   "amenity/bank|Prima banka": {
-    "locationSet": { "include": ["sk"] },
+    "locationSet": {"include": ["sk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Prima banka",
@@ -5188,7 +5251,7 @@
     }
   },
   "amenity/bank|Privatbanka": {
-    "locationSet": { "include": ["sk"] },
+    "locationSet": {"include": ["sk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Privatbanka",
@@ -5198,7 +5261,7 @@
     }
   },
   "amenity/bank|Promerica": {
-    "locationSet": { "include": ["cr", "hn"] },
+    "locationSet": {"include": ["cr", "hn"]},
     "matchNames": ["banco promerica"],
     "tags": {
       "amenity": "bank",
@@ -5207,7 +5270,7 @@
     }
   },
   "amenity/bank|Prosperity Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Prosperity Bank",
@@ -5215,7 +5278,7 @@
     }
   },
   "amenity/bank|Provincial": {
-    "locationSet": { "include": ["ve"] },
+    "locationSet": {"include": ["ve"]},
     "matchNames": ["bbva provincial"],
     "tags": {
       "amenity": "bank",
@@ -5226,7 +5289,7 @@
     }
   },
   "amenity/bank|Prvá stavebná sporiteľňa": {
-    "locationSet": { "include": ["sk"] },
+    "locationSet": {"include": ["sk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Prvá stavebná sporiteľňa",
@@ -5236,7 +5299,7 @@
     }
   },
   "amenity/bank|Public Bank~(Malaysia)": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "matchNames": ["public bank berhad"],
     "tags": {
       "amenity": "bank",
@@ -5249,7 +5312,7 @@
     }
   },
   "amenity/bank|Punjab National Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Punjab National Bank",
@@ -5259,8 +5322,12 @@
     }
   },
   "amenity/bank|RBC": {
-    "locationSet": { "include": ["001"] },
-    "matchNames": ["rbc financial group", "rbc royal bank", "royal bank"],
+    "locationSet": {"include": ["001"]},
+    "matchNames": [
+      "rbc financial group",
+      "rbc royal bank",
+      "royal bank"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "RBC",
@@ -5284,7 +5351,7 @@
     }
   },
   "amenity/bank|RCBC": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "matchNames": ["rcbc savings bank"],
     "tags": {
       "amenity": "bank",
@@ -5320,7 +5387,7 @@
     }
   },
   "amenity/bank|Raiffeisen Polbank": {
-    "locationSet": { "include": ["de", "pl"] },
+    "locationSet": {"include": ["de", "pl"]},
     "nomatch": [
       "amenity/bank|Raiffeisenbank~(Albania)",
       "amenity/bank|Raiffeisenbank~(Bulgaria)",
@@ -5340,7 +5407,7 @@
     }
   },
   "amenity/bank|Raiffeisenbank~(Albania)": {
-    "locationSet": { "include": ["al"] },
+    "locationSet": {"include": ["al"]},
     "matchNames": ["raiffeisen"],
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
@@ -5361,7 +5428,7 @@
     }
   },
   "amenity/bank|Raiffeisenbank~(Bulgaria)": {
-    "locationSet": { "include": ["bg"] },
+    "locationSet": {"include": ["bg"]},
     "matchNames": ["raiffeisen"],
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
@@ -5382,8 +5449,11 @@
     }
   },
   "amenity/bank|Raiffeisenbank~(Czech Republic)": {
-    "locationSet": { "include": ["cz"] },
-    "matchNames": ["raiffeisen", "raiffeisenkasse"],
+    "locationSet": {"include": ["cz"]},
+    "matchNames": [
+      "raiffeisen",
+      "raiffeisenkasse"
+    ],
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
       "amenity/bank|Raiffeisenbank~(Albania)",
@@ -5403,7 +5473,7 @@
     }
   },
   "amenity/bank|Raiffeisenbank~(Romania)": {
-    "locationSet": { "include": ["ro"] },
+    "locationSet": {"include": ["ro"]},
     "matchNames": ["raiffeisen"],
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
@@ -5424,7 +5494,7 @@
     }
   },
   "amenity/bank|Raiffeisenbank~(Serbia)": {
-    "locationSet": { "include": ["rs"] },
+    "locationSet": {"include": ["rs"]},
     "matchNames": ["raiffeisen"],
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
@@ -5445,7 +5515,7 @@
     }
   },
   "amenity/bank|Raiffeisen~(Luxembourg)": {
-    "locationSet": { "include": ["lu"] },
+    "locationSet": {"include": ["lu"]},
     "matchNames": ["raiffeisen"],
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
@@ -5467,7 +5537,7 @@
     }
   },
   "amenity/bank|Regions Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Regions Bank",
@@ -5489,7 +5559,7 @@
     }
   },
   "amenity/bank|Republic Bank~(USA)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Republic Bank",
@@ -5500,7 +5570,7 @@
     }
   },
   "amenity/bank|República": {
-    "locationSet": { "include": ["uy"] },
+    "locationSet": {"include": ["uy"]},
     "tags": {
       "amenity": "bank",
       "brand": "República",
@@ -5510,7 +5580,7 @@
     }
   },
   "amenity/bank|S-Pankki": {
-    "locationSet": { "include": ["fi"] },
+    "locationSet": {"include": ["fi"]},
     "tags": {
       "amenity": "bank",
       "brand": "S-Pankki",
@@ -5520,7 +5590,7 @@
     }
   },
   "amenity/bank|SC제일은행": {
-    "locationSet": { "include": ["kr"] },
+    "locationSet": {"include": ["kr"]},
     "tags": {
       "amenity": "bank",
       "brand": "SC제일은행",
@@ -5544,7 +5614,7 @@
     }
   },
   "amenity/bank|SMBC信託銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "SMBC信託銀行",
@@ -5556,7 +5626,7 @@
     }
   },
   "amenity/bank|SNS Bank": {
-    "locationSet": { "include": ["nl"] },
+    "locationSet": {"include": ["nl"]},
     "tags": {
       "amenity": "bank",
       "brand": "SNS Bank",
@@ -5566,7 +5636,7 @@
     }
   },
   "amenity/bank|Sacombank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Sacombank",
@@ -5576,7 +5646,7 @@
     }
   },
   "amenity/bank|Sampath Bank": {
-    "locationSet": { "include": ["lk"] },
+    "locationSet": {"include": ["lk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Sampath Bank",
@@ -5586,7 +5656,7 @@
     }
   },
   "amenity/bank|San Diego County Credit Union": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "San Diego County Credit Union",
@@ -5597,7 +5667,7 @@
     }
   },
   "amenity/bank|Santander": {
-    "locationSet": { "include": ["gb"] },
+    "locationSet": {"include": ["gb"]},
     "tags": {
       "amenity": "bank",
       "brand": "Santander",
@@ -5607,7 +5677,7 @@
     }
   },
   "amenity/bank|Santander Río": {
-    "locationSet": { "include": ["ar"] },
+    "locationSet": {"include": ["ar"]},
     "tags": {
       "amenity": "bank",
       "brand": "Santander Río",
@@ -5617,7 +5687,7 @@
     }
   },
   "amenity/bank|Santander Totta": {
-    "locationSet": { "include": ["pt"] },
+    "locationSet": {"include": ["pt"]},
     "tags": {
       "amenity": "bank",
       "brand": "Santander Totta",
@@ -5627,7 +5697,7 @@
     }
   },
   "amenity/bank|Sberbank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Sberbank",
@@ -5637,7 +5707,7 @@
     }
   },
   "amenity/bank|Scotiabank~(Québec)": {
-    "locationSet": { "include": ["ca"] },
+    "locationSet": {"include": ["ca"]},
     "matchNames": ["scotia"],
     "nomatch": ["amenity/bank|Scotiabank"],
     "tags": {
@@ -5649,9 +5719,11 @@
     }
   },
   "amenity/bank|Scotiabank~(non-Québec)": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "matchNames": ["scotia"],
-    "nomatch": ["amenity/bank|Scotiabank~(Québec)"],
+    "nomatch": [
+      "amenity/bank|Scotiabank~(Québec)"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "Scotiabank",
@@ -5661,7 +5733,7 @@
     }
   },
   "amenity/bank|Security Bank": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "tags": {
       "amenity": "bank",
       "brand": "Security Bank",
@@ -5671,7 +5743,7 @@
     }
   },
   "amenity/bank|Security Service Federal Credit Union": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "matchNames": ["security service fcu"],
     "tags": {
       "amenity": "bank",
@@ -5683,7 +5755,7 @@
     }
   },
   "amenity/bank|Service Credit Union": {
-    "locationSet": { "include": ["de", "us"] },
+    "locationSet": {"include": ["de", "us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Service Credit Union",
@@ -5693,7 +5765,7 @@
     }
   },
   "amenity/bank|Servus Credit Union": {
-    "locationSet": { "include": ["ca"] },
+    "locationSet": {"include": ["ca"]},
     "tags": {
       "alt_name": "Servus",
       "amenity": "bank",
@@ -5704,7 +5776,7 @@
     }
   },
   "amenity/bank|Seylan Bank": {
-    "locationSet": { "include": ["lk"] },
+    "locationSet": {"include": ["lk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Seylan Bank",
@@ -5714,7 +5786,7 @@
     }
   },
   "amenity/bank|Siam Commercial Bank": {
-    "locationSet": { "include": ["th"] },
+    "locationSet": {"include": ["th"]},
     "tags": {
       "amenity": "bank",
       "brand": "Siam Commercial Bank",
@@ -5724,7 +5796,7 @@
     }
   },
   "amenity/bank|Sicoob": {
-    "locationSet": { "include": ["br"] },
+    "locationSet": {"include": ["br"]},
     "tags": {
       "amenity": "bank",
       "brand": "Sicoob",
@@ -5734,7 +5806,7 @@
     }
   },
   "amenity/bank|Sicredi": {
-    "locationSet": { "include": ["br"] },
+    "locationSet": {"include": ["br"]},
     "tags": {
       "amenity": "bank",
       "brand": "Sicredi",
@@ -5744,7 +5816,7 @@
     }
   },
   "amenity/bank|Simmons Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Simmons Bank",
@@ -5754,7 +5826,7 @@
     }
   },
   "amenity/bank|Skipton Building Society": {
-    "locationSet": { "include": ["gb"] },
+    "locationSet": {"include": ["gb"]},
     "tags": {
       "amenity": "bank",
       "brand": "Skipton Building Society",
@@ -5764,7 +5836,7 @@
     }
   },
   "amenity/bank|Slovenská sporiteľňa": {
-    "locationSet": { "include": ["sk"] },
+    "locationSet": {"include": ["sk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Slovenská sporiteľňa",
@@ -5774,7 +5846,7 @@
     }
   },
   "amenity/bank|Société Générale": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Société Générale",
@@ -5784,7 +5856,7 @@
     }
   },
   "amenity/bank|Société Marseillaise de Crédit": {
-    "locationSet": { "include": ["fr"] },
+    "locationSet": {"include": ["fr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Société Marseillaise de Crédit",
@@ -5794,7 +5866,7 @@
     }
   },
   "amenity/bank|Société générale Côte d’Ivoire": {
-    "locationSet": { "include": ["ci"] },
+    "locationSet": {"include": ["ci"]},
     "matchNames": ["agence sgbci", "sgbci"],
     "tags": {
       "amenity": "bank",
@@ -5807,7 +5879,7 @@
     }
   },
   "amenity/bank|South Indian Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "South Indian Bank",
@@ -5817,7 +5889,7 @@
     }
   },
   "amenity/bank|South State Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "South State Bank",
@@ -5827,7 +5899,7 @@
     }
   },
   "amenity/bank|Southern Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Southern Bank",
@@ -5837,7 +5909,7 @@
     }
   },
   "amenity/bank|Sparda-Bank": {
-    "locationSet": { "include": ["at", "de"] },
+    "locationSet": {"include": ["at", "de"]},
     "tags": {
       "amenity": "bank",
       "brand": "Sparda-Bank",
@@ -5847,7 +5919,7 @@
     }
   },
   "amenity/bank|Stanbic Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Stanbic Bank",
@@ -5857,7 +5929,7 @@
     }
   },
   "amenity/bank|Standard Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Standard Bank",
@@ -5867,7 +5939,7 @@
     }
   },
   "amenity/bank|Standard Chartered": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "matchNames": ["standard chartered bank"],
     "tags": {
       "amenity": "bank",
@@ -5878,7 +5950,7 @@
     }
   },
   "amenity/bank|State Bank of India": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "State Bank of India",
@@ -5888,7 +5960,7 @@
     }
   },
   "amenity/bank|State Employees Credit Union": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "State Employees Credit Union",
@@ -5899,7 +5971,7 @@
     }
   },
   "amenity/bank|Summit Bank": {
-    "locationSet": { "include": ["pk"] },
+    "locationSet": {"include": ["pk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Summit Bank",
@@ -5909,7 +5981,7 @@
     }
   },
   "amenity/bank|SunTrust": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "matchNames": ["suntrust bank"],
     "tags": {
       "amenity": "bank",
@@ -5920,7 +5992,7 @@
     }
   },
   "amenity/bank|Suncorp": {
-    "locationSet": { "include": ["au"] },
+    "locationSet": {"include": ["au"]},
     "tags": {
       "amenity": "bank",
       "brand": "Suncorp",
@@ -5930,7 +6002,7 @@
     }
   },
   "amenity/bank|Supervielle": {
-    "locationSet": { "include": ["ar"] },
+    "locationSet": {"include": ["ar"]},
     "tags": {
       "amenity": "bank",
       "brand": "Supervielle",
@@ -5952,7 +6024,7 @@
     }
   },
   "amenity/bank|Syndicate Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Syndicate Bank",
@@ -5962,7 +6034,7 @@
     }
   },
   "amenity/bank|Synovus": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Synovus",
@@ -5972,7 +6044,7 @@
     }
   },
   "amenity/bank|TCF Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "TCF Bank",
@@ -5982,7 +6054,7 @@
     }
   },
   "amenity/bank|TD Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "TD Bank",
@@ -5992,7 +6064,7 @@
     }
   },
   "amenity/bank|TD Canada Trust": {
-    "locationSet": { "include": ["ca"] },
+    "locationSet": {"include": ["ca"]},
     "tags": {
       "amenity": "bank",
       "brand": "TD Canada Trust",
@@ -6002,7 +6074,7 @@
     }
   },
   "amenity/bank|TEB": {
-    "locationSet": { "include": ["tr"] },
+    "locationSet": {"include": ["tr"]},
     "tags": {
       "amenity": "bank",
       "brand": "TEB",
@@ -6012,7 +6084,7 @@
     }
   },
   "amenity/bank|TSB": {
-    "locationSet": { "include": ["gb"] },
+    "locationSet": {"include": ["gb"]},
     "tags": {
       "amenity": "bank",
       "brand": "TSB",
@@ -6022,7 +6094,7 @@
     }
   },
   "amenity/bank|Takarékszövetkezet": {
-    "locationSet": { "include": ["hu"] },
+    "locationSet": {"include": ["hu"]},
     "tags": {
       "amenity": "bank",
       "brand": "Takarékszövetkezet",
@@ -6032,7 +6104,7 @@
     }
   },
   "amenity/bank|Tangerine": {
-    "locationSet": { "include": ["ca"] },
+    "locationSet": {"include": ["ca"]},
     "tags": {
       "amenity": "bank",
       "brand": "Tangerine",
@@ -6042,7 +6114,7 @@
     }
   },
   "amenity/bank|Targobank": {
-    "locationSet": { "include": ["de", "es"] },
+    "locationSet": {"include": ["de", "es"]},
     "tags": {
       "amenity": "bank",
       "brand": "Targobank",
@@ -6052,7 +6124,7 @@
     }
   },
   "amenity/bank|Tatra banka": {
-    "locationSet": { "include": ["sk"] },
+    "locationSet": {"include": ["sk"]},
     "tags": {
       "amenity": "bank",
       "brand": "Tatra banka",
@@ -6062,7 +6134,7 @@
     }
   },
   "amenity/bank|Taytay sa Kauswagan": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "tags": {
       "amenity": "bank",
       "brand": "Taytay sa Kauswagan",
@@ -6071,7 +6143,7 @@
     }
   },
   "amenity/bank|Tesoro": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "nomatch": ["amenity/fuel|Tesoro"],
     "tags": {
       "amenity": "bank",
@@ -6080,7 +6152,7 @@
     }
   },
   "amenity/bank|The Co-operative Bank": {
-    "locationSet": { "include": ["gb"] },
+    "locationSet": {"include": ["gb"]},
     "matchNames": ["co-op bank"],
     "tags": {
       "amenity": "bank",
@@ -6091,8 +6163,11 @@
     }
   },
   "amenity/bank|Truist": {
-    "locationSet": { "include": ["us"] },
-    "matchNames": ["truist bank", "truist financial"],
+    "locationSet": {"include": ["us"]},
+    "matchNames": [
+      "truist bank",
+      "truist financial"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "Truist",
@@ -6102,7 +6177,7 @@
     }
   },
   "amenity/bank|Türkiye İş Bankası": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Türkiye İş Bankası",
@@ -6112,7 +6187,7 @@
     }
   },
   "amenity/bank|U.S. Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "U.S. Bank",
@@ -6122,7 +6197,7 @@
     }
   },
   "amenity/bank|UBA": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "UBA",
@@ -6133,7 +6208,7 @@
     }
   },
   "amenity/bank|UBI Banca": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "UBI Banca",
@@ -6143,7 +6218,7 @@
     }
   },
   "amenity/bank|UBL": {
-    "locationSet": { "include": ["pk"] },
+    "locationSet": {"include": ["pk"]},
     "matchNames": ["ubl bank"],
     "tags": {
       "amenity": "bank",
@@ -6156,7 +6231,7 @@
     }
   },
   "amenity/bank|UBS": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "UBS",
@@ -6166,7 +6241,7 @@
     }
   },
   "amenity/bank|UCO Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "UCO Bank",
@@ -6176,7 +6251,7 @@
     }
   },
   "amenity/bank|UCPB": {
-    "locationSet": { "include": ["ph"] },
+    "locationSet": {"include": ["ph"]},
     "tags": {
       "amenity": "bank",
       "brand": "UCPB",
@@ -6186,7 +6261,7 @@
     }
   },
   "amenity/bank|UIB": {
-    "locationSet": { "include": ["tn"] },
+    "locationSet": {"include": ["tn"]},
     "tags": {
       "amenity": "bank",
       "brand": "UIB",
@@ -6197,7 +6272,7 @@
     }
   },
   "amenity/bank|UMB Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "UMB Bank",
@@ -6207,8 +6282,11 @@
     }
   },
   "amenity/bank|UNI": {
-    "locationSet": { "include": ["ca"] },
-    "matchNames": ["caisse populaire", "caisse populaire acadienne"],
+    "locationSet": {"include": ["ca"]},
+    "matchNames": [
+      "caisse populaire",
+      "caisse populaire acadienne"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "UNI",
@@ -6219,7 +6297,7 @@
     }
   },
   "amenity/bank|UOB": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "UOB",
@@ -6231,7 +6309,7 @@
     }
   },
   "amenity/bank|USAA": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "USAA",
@@ -6242,7 +6320,7 @@
     }
   },
   "amenity/bank|Ulster Bank": {
-    "locationSet": { "include": ["gb", "ie"] },
+    "locationSet": {"include": ["gb", "ie"]},
     "tags": {
       "amenity": "bank",
       "brand": "Ulster Bank",
@@ -6252,7 +6330,7 @@
     }
   },
   "amenity/bank|Umpqua Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Umpqua Bank",
@@ -6262,8 +6340,11 @@
     }
   },
   "amenity/bank|UniCredit Bank": {
-    "locationSet": { "include": ["001"] },
-    "matchNames": ["unicredit", "unicredit banca"],
+    "locationSet": {"include": ["001"]},
+    "matchNames": [
+      "unicredit",
+      "unicredit banca"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "UniCredit Bank",
@@ -6273,7 +6354,7 @@
     }
   },
   "amenity/bank|Unicaja Banco": {
-    "locationSet": { "include": ["es"] },
+    "locationSet": {"include": ["es"]},
     "tags": {
       "amenity": "bank",
       "brand": "Unicaja Banco",
@@ -6284,7 +6365,7 @@
     }
   },
   "amenity/bank|Union Bank of India": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Union Bank of India",
@@ -6294,8 +6375,11 @@
     }
   },
   "amenity/bank|Union Bank~(USA)": {
-    "locationSet": { "include": ["us"] },
-    "matchNames": ["mufg union bank", "union bank of california"],
+    "locationSet": {"include": ["us"]},
+    "matchNames": [
+      "mufg union bank",
+      "union bank of california"
+    ],
     "nomatch": [
       "amenity/bank|Banco Unión",
       "amenity/money_transfer|Express Union"
@@ -6310,8 +6394,10 @@
     }
   },
   "amenity/bank|UnionBank~(Philippines)": {
-    "locationSet": { "include": ["ph"] },
-    "matchNames": ["union bank of the philippines"],
+    "locationSet": {"include": ["ph"]},
+    "matchNames": [
+      "union bank of the philippines"
+    ],
     "nomatch": [
       "amenity/bank|Banco Unión",
       "amenity/money_transfer|Express Union"
@@ -6325,7 +6411,7 @@
     }
   },
   "amenity/bank|United Bank~(Connecticut)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "nomatch": [
       "amenity/bank|United Bank~(West Virginia)",
       "amenity/fuel|United",
@@ -6339,7 +6425,7 @@
     }
   },
   "amenity/bank|United Bank~(West Virginia)": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "nomatch": [
       "amenity/bank|United Bank~(Connecticut)",
       "amenity/fuel|United",
@@ -6354,7 +6440,7 @@
     }
   },
   "amenity/bank|United Community Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "United Community Bank",
@@ -6364,7 +6450,7 @@
     }
   },
   "amenity/bank|VTB": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "VTB",
@@ -6372,7 +6458,7 @@
     }
   },
   "amenity/bank|Vakıfbank": {
-    "locationSet": { "include": ["tr"] },
+    "locationSet": {"include": ["tr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Vakıfbank",
@@ -6382,7 +6468,7 @@
     }
   },
   "amenity/bank|Vancity": {
-    "locationSet": { "include": ["ca"] },
+    "locationSet": {"include": ["ca"]},
     "matchNames": ["vancouver city savings"],
     "tags": {
       "amenity": "bank",
@@ -6394,7 +6480,7 @@
     }
   },
   "amenity/bank|Veneto Banca": {
-    "locationSet": { "include": ["it"] },
+    "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
       "brand": "Veneto Banca",
@@ -6404,7 +6490,7 @@
     }
   },
   "amenity/bank|Vietcombank": {
-    "locationSet": { "include": ["vn"] },
+    "locationSet": {"include": ["vn"]},
     "tags": {
       "amenity": "bank",
       "brand": "Vietcombank",
@@ -6414,7 +6500,7 @@
     }
   },
   "amenity/bank|VietinBank": {
-    "locationSet": { "include": ["vn"] },
+    "locationSet": {"include": ["vn"]},
     "tags": {
       "amenity": "bank",
       "brand": "VietinBank",
@@ -6424,7 +6510,7 @@
     }
   },
   "amenity/bank|Vijaya Bank": {
-    "locationSet": { "include": ["in"] },
+    "locationSet": {"include": ["in"]},
     "tags": {
       "amenity": "bank",
       "brand": "Vijaya Bank",
@@ -6434,7 +6520,7 @@
     }
   },
   "amenity/bank|Virgin Money": {
-    "locationSet": { "include": ["gb"] },
+    "locationSet": {"include": ["gb"]},
     "tags": {
       "amenity": "bank",
       "brand": "Virgin Money",
@@ -6444,7 +6530,7 @@
     }
   },
   "amenity/bank|Volksbank Köln Bonn eG": {
-    "locationSet": { "include": ["de"] },
+    "locationSet": {"include": ["de"]},
     "tags": {
       "amenity": "bank",
       "brand": "Volksbank Köln Bonn eG",
@@ -6454,7 +6540,7 @@
     }
   },
   "amenity/bank|VÚB": {
-    "locationSet": { "include": ["sk"] },
+    "locationSet": {"include": ["sk"]},
     "tags": {
       "amenity": "bank",
       "brand": "VÚB",
@@ -6464,7 +6550,7 @@
     }
   },
   "amenity/bank|Washington Federal": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Washington Federal",
@@ -6474,7 +6560,7 @@
     }
   },
   "amenity/bank|Webster Bank": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Webster Bank",
@@ -6484,7 +6570,7 @@
     }
   },
   "amenity/bank|Wells Fargo": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "matchNames": ["wells fargo bank"],
     "tags": {
       "amenity": "bank",
@@ -6495,7 +6581,7 @@
     }
   },
   "amenity/bank|WesBanco": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "WesBanco",
@@ -6505,8 +6591,10 @@
     }
   },
   "amenity/bank|Western Union": {
-    "locationSet": { "include": ["001"] },
-    "nomatch": ["amenity/money_transfer|Western Union"],
+    "locationSet": {"include": ["001"]},
+    "nomatch": [
+      "amenity/money_transfer|Western Union"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "Western Union",
@@ -6516,7 +6604,7 @@
     }
   },
   "amenity/bank|Westpac": {
-    "locationSet": { "include": ["au", "nz"] },
+    "locationSet": {"include": ["au", "nz"]},
     "tags": {
       "amenity": "bank",
       "brand": "Westpac",
@@ -6526,7 +6614,7 @@
     }
   },
   "amenity/bank|Wings Financial Credit Union": {
-    "locationSet": { "include": ["us"] },
+    "locationSet": {"include": ["us"]},
     "tags": {
       "amenity": "bank",
       "brand": "Wings Financial Credit Union",
@@ -6536,7 +6624,7 @@
     }
   },
   "amenity/bank|Yapı Kredi": {
-    "locationSet": { "include": ["tr"] },
+    "locationSet": {"include": ["tr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Yapı Kredi",
@@ -6546,7 +6634,7 @@
     }
   },
   "amenity/bank|Yorkshire Bank": {
-    "locationSet": { "include": ["gb"] },
+    "locationSet": {"include": ["gb"]},
     "tags": {
       "amenity": "bank",
       "brand": "Yorkshire Bank",
@@ -6556,7 +6644,7 @@
     }
   },
   "amenity/bank|Yorkshire Building Society": {
-    "locationSet": { "include": ["gb"] },
+    "locationSet": {"include": ["gb"]},
     "tags": {
       "amenity": "bank",
       "brand": "Yorkshire Building Society",
@@ -6566,7 +6654,7 @@
     }
   },
   "amenity/bank|Zagrebačka banka": {
-    "locationSet": { "include": ["hr"] },
+    "locationSet": {"include": ["hr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Zagrebačka banka",
@@ -6577,7 +6665,14 @@
   },
   "amenity/bank|Zenith Bank": {
     "locationSet": {
-      "include": ["gb", "gh", "gm", "ng", "sl", "za"]
+      "include": [
+        "gb",
+        "gh",
+        "gm",
+        "ng",
+        "sl",
+        "za"
+      ]
     },
     "tags": {
       "amenity": "bank",
@@ -6588,7 +6683,7 @@
     }
   },
   "amenity/bank|Zions Bank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Zions Bank",
@@ -6597,7 +6692,7 @@
     }
   },
   "amenity/bank|Ziraat Bankası": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Ziraat Bankası",
@@ -6607,7 +6702,7 @@
     }
   },
   "amenity/bank|bank99": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "bank99",
@@ -6615,7 +6710,7 @@
     }
   },
   "amenity/bank|mBank": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "mBank",
@@ -6625,7 +6720,7 @@
     }
   },
   "amenity/bank|st.george": {
-    "locationSet": { "include": ["au"] },
+    "locationSet": {"include": ["au"]},
     "matchNames": ["st.george bank"],
     "tags": {
       "amenity": "bank",
@@ -6636,7 +6731,7 @@
     }
   },
   "amenity/bank|Ålandsbanken": {
-    "locationSet": { "include": ["fi"] },
+    "locationSet": {"include": ["fi"]},
     "tags": {
       "amenity": "bank",
       "brand": "Ålandsbanken",
@@ -6646,7 +6741,7 @@
     }
   },
   "amenity/bank|ČSOB": {
-    "locationSet": { "include": ["cz", "sk"] },
+    "locationSet": {"include": ["cz", "sk"]},
     "tags": {
       "amenity": "bank",
       "brand": "ČSOB",
@@ -6656,7 +6751,7 @@
     }
   },
   "amenity/bank|Česká spořitelna": {
-    "locationSet": { "include": ["cz"] },
+    "locationSet": {"include": ["cz"]},
     "tags": {
       "amenity": "bank",
       "brand": "Česká spořitelna",
@@ -6666,7 +6761,7 @@
     }
   },
   "amenity/bank|İş Bankası": {
-    "locationSet": { "include": ["tr"] },
+    "locationSet": {"include": ["tr"]},
     "tags": {
       "amenity": "bank",
       "brand": "İş Bankası",
@@ -6676,7 +6771,7 @@
     }
   },
   "amenity/bank|Εθνική Τράπεζα": {
-    "locationSet": { "include": ["gr"] },
+    "locationSet": {"include": ["gr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Εθνική Τράπεζα",
@@ -6690,7 +6785,7 @@
     }
   },
   "amenity/bank|Τράπεζα Πειραιώς": {
-    "locationSet": { "include": ["gr"] },
+    "locationSet": {"include": ["gr"]},
     "tags": {
       "amenity": "bank",
       "brand": "Τράπεζα Πειραιώς",
@@ -6707,7 +6802,7 @@
     }
   },
   "amenity/bank|А-Банк": {
-    "locationSet": { "include": ["ua"] },
+    "locationSet": {"include": ["ua"]},
     "tags": {
       "amenity": "bank",
       "brand": "А-Банк",
@@ -6717,7 +6812,7 @@
     }
   },
   "amenity/bank|Авангард": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Авангард",
@@ -6726,7 +6821,7 @@
     }
   },
   "amenity/bank|Ак Барс Банк": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "Ак Барс Банк",
@@ -6750,7 +6845,7 @@
     }
   },
   "amenity/bank|Альфа-Банк~(Украина)": {
-    "locationSet": { "include": ["ua"] },
+    "locationSet": {"include": ["ua"]},
     "tags": {
       "amenity": "bank",
       "brand": "Альфа-Банк",
@@ -6765,7 +6860,7 @@
     }
   },
   "amenity/bank|БПС-Сбербанк": {
-    "locationSet": { "include": ["by"] },
+    "locationSet": {"include": ["by"]},
     "tags": {
       "amenity": "bank",
       "brand": "БПС-Сбербанк",
@@ -6775,7 +6870,7 @@
     }
   },
   "amenity/bank|Банк Дабрабыт": {
-    "locationSet": { "include": ["by"] },
+    "locationSet": {"include": ["by"]},
     "tags": {
       "amenity": "bank",
       "brand": "Банк Дабрабыт",
@@ -6784,7 +6879,7 @@
     }
   },
   "amenity/bank|Банка ДСК": {
-    "locationSet": { "include": ["bg"] },
+    "locationSet": {"include": ["bg"]},
     "tags": {
       "amenity": "bank",
       "brand": "Банка ДСК",
@@ -6798,7 +6893,7 @@
     }
   },
   "amenity/bank|Белагропромбанк": {
-    "locationSet": { "include": ["by"] },
+    "locationSet": {"include": ["by"]},
     "tags": {
       "amenity": "bank",
       "brand": "Белагропромбанк",
@@ -6810,7 +6905,7 @@
     }
   },
   "amenity/bank|Беларусбанк": {
-    "locationSet": { "include": ["by"] },
+    "locationSet": {"include": ["by"]},
     "matchTags": ["amenity/bureau_de_change"],
     "tags": {
       "amenity": "bank",
@@ -6823,7 +6918,7 @@
     }
   },
   "amenity/bank|Белинвестбанк": {
-    "locationSet": { "include": ["by"] },
+    "locationSet": {"include": ["by"]},
     "tags": {
       "amenity": "bank",
       "brand": "Белинвестбанк",
@@ -6833,7 +6928,7 @@
     }
   },
   "amenity/bank|Бинбанк": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Бинбанк",
@@ -6845,7 +6940,7 @@
     }
   },
   "amenity/bank|ВТБ~(Россия)": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "matchNames": ["втб банк москвы"],
     "tags": {
       "amenity": "bank",
@@ -6858,7 +6953,7 @@
     }
   },
   "amenity/bank|ВТБ~(Украина)": {
-    "locationSet": { "include": ["ua"] },
+    "locationSet": {"include": ["ua"]},
     "matchNames": ["втб банк"],
     "tags": {
       "amenity": "bank",
@@ -6871,7 +6966,7 @@
     }
   },
   "amenity/bank|Возрождение": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Возрождение",
@@ -6881,7 +6976,7 @@
     }
   },
   "amenity/bank|Газпромбанк": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Газпромбанк",
@@ -6893,7 +6988,7 @@
     }
   },
   "amenity/bank|Генбанк": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Генбанк",
@@ -6902,7 +6997,7 @@
     }
   },
   "amenity/bank|Зенит": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Зенит",
@@ -6916,7 +7011,7 @@
     }
   },
   "amenity/bank|Казкоммерцбанк": {
-    "locationSet": { "include": ["kz"] },
+    "locationSet": {"include": ["kz"]},
     "tags": {
       "amenity": "bank",
       "brand": "Казкоммерцбанк",
@@ -6928,7 +7023,7 @@
     }
   },
   "amenity/bank|Московский индустриальный банк": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Московский индустриальный банк",
@@ -6940,7 +7035,7 @@
     }
   },
   "amenity/bank|Мособлбанк": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Мособлбанк",
@@ -6964,7 +7059,7 @@
     }
   },
   "amenity/bank|ОТП Банк": {
-    "locationSet": { "include": ["ru", "ua"] },
+    "locationSet": {"include": ["ru", "ua"]},
     "tags": {
       "amenity": "bank",
       "brand": "ОТП Банк",
@@ -6976,7 +7071,7 @@
     }
   },
   "amenity/bank|Обединена Българска Банка": {
-    "locationSet": { "include": ["bg"] },
+    "locationSet": {"include": ["bg"]},
     "tags": {
       "amenity": "bank",
       "brand": "Обединена Българска Банка",
@@ -6988,7 +7083,7 @@
     }
   },
   "amenity/bank|Открытие": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "matchNames": ["банк открытие"],
     "tags": {
       "amenity": "bank",
@@ -6999,7 +7094,7 @@
     }
   },
   "amenity/bank|Ощадбанк": {
-    "locationSet": { "include": ["ua"] },
+    "locationSet": {"include": ["ua"]},
     "tags": {
       "amenity": "bank",
       "brand": "Ощадбанк",
@@ -7011,7 +7106,7 @@
     }
   },
   "amenity/bank|ПУМБ": {
-    "locationSet": { "include": ["ua"] },
+    "locationSet": {"include": ["ua"]},
     "tags": {
       "amenity": "bank",
       "brand": "ПУМБ",
@@ -7023,7 +7118,7 @@
     }
   },
   "amenity/bank|Почта Банк": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Почта Банк",
@@ -7035,7 +7130,7 @@
     }
   },
   "amenity/bank|Пощенска банка": {
-    "locationSet": { "include": ["bg"] },
+    "locationSet": {"include": ["bg"]},
     "tags": {
       "amenity": "bank",
       "brand": "Пощенска банка",
@@ -7046,7 +7141,7 @@
     }
   },
   "amenity/bank|ПриватБанк": {
-    "locationSet": { "include": ["ua"] },
+    "locationSet": {"include": ["ua"]},
     "matchTags": ["amenity/payment_terminal"],
     "tags": {
       "amenity": "bank",
@@ -7059,7 +7154,7 @@
     }
   },
   "amenity/bank|Приднестровский Сбербанк": {
-    "locationSet": { "include": ["md"] },
+    "locationSet": {"include": ["md"]},
     "matchNames": ["приднестровский cбербанк"],
     "tags": {
       "amenity": "bank",
@@ -7074,7 +7169,7 @@
     }
   },
   "amenity/bank|Приорбанк": {
-    "locationSet": { "include": ["by"] },
+    "locationSet": {"include": ["by"]},
     "tags": {
       "amenity": "bank",
       "brand": "Приорбанк",
@@ -7086,7 +7181,7 @@
     }
   },
   "amenity/bank|Промсвязьбанк": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Промсвязьбанк",
@@ -7098,7 +7193,7 @@
     }
   },
   "amenity/bank|РНКБ": {
-    "locationSet": { "include": ["ru", "ua"] },
+    "locationSet": {"include": ["ru", "ua"]},
     "tags": {
       "amenity": "bank",
       "brand": "РНКБ",
@@ -7108,7 +7203,7 @@
     }
   },
   "amenity/bank|Райффайзен": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
       "amenity/bank|Raiffeisenbank~(Albania)",
@@ -7132,7 +7227,7 @@
     }
   },
   "amenity/bank|Райффайзен Банк Аваль": {
-    "locationSet": { "include": ["ua"] },
+    "locationSet": {"include": ["ua"]},
     "matchNames": ["аваль", "банк аваль"],
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
@@ -7159,7 +7254,7 @@
     }
   },
   "amenity/bank|Росбанк": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Росбанк",
@@ -7173,7 +7268,7 @@
     }
   },
   "amenity/bank|Россельхозбанк": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Россельхозбанк",
@@ -7187,7 +7282,7 @@
     }
   },
   "amenity/bank|Русский Стандарт": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Русский Стандарт",
@@ -7201,8 +7296,13 @@
     }
   },
   "amenity/bank|Сбербанк": {
-    "locationSet": { "include": ["kz", "ru"] },
-    "matchNames": ["cбербанк", "cбербанк россии", "сбербанк россии"],
+    "locationSet": {"include": ["kz", "ru"]},
+    "matchNames": [
+      "cбербанк",
+      "cбербанк россии",
+      "сбербанк россии"
+    ],
+    "matchTags": ["amenity/payment_terminal"],
     "tags": {
       "amenity": "bank",
       "brand": "Сбербанк",
@@ -7216,7 +7316,7 @@
     }
   },
   "amenity/bank|Совкомбанк": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Совкомбанк",
@@ -7230,7 +7330,7 @@
     }
   },
   "amenity/bank|УкрСиббанк": {
-    "locationSet": { "include": ["ua"] },
+    "locationSet": {"include": ["ua"]},
     "tags": {
       "amenity": "bank",
       "brand": "УкрСиббанк",
@@ -7244,7 +7344,7 @@
     }
   },
   "amenity/bank|Укргазбанк": {
-    "locationSet": { "include": ["ua"] },
+    "locationSet": {"include": ["ua"]},
     "tags": {
       "amenity": "bank",
       "brand": "Укргазбанк",
@@ -7258,7 +7358,7 @@
     }
   },
   "amenity/bank|Укрсоцбанк": {
-    "locationSet": { "include": ["ua"] },
+    "locationSet": {"include": ["ua"]},
     "tags": {
       "amenity": "bank",
       "brand": "Укрсоцбанк",
@@ -7272,7 +7372,7 @@
     }
   },
   "amenity/bank|УниКредит Булбанк": {
-    "locationSet": { "include": ["bg"] },
+    "locationSet": {"include": ["bg"]},
     "tags": {
       "amenity": "bank",
       "brand": "УниКредит Булбанк",
@@ -7283,7 +7383,7 @@
     }
   },
   "amenity/bank|Уралсиб": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Уралсиб",
@@ -7297,7 +7397,7 @@
     }
   },
   "amenity/bank|Уральский банк реконструкции и развития": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "matchNames": ["убрир", "убрр"],
     "tags": {
       "amenity": "bank",
@@ -7314,7 +7414,7 @@
     }
   },
   "amenity/bank|Хаан банк": {
-    "locationSet": { "include": ["mn"] },
+    "locationSet": {"include": ["mn"]},
     "tags": {
       "amenity": "bank",
       "brand": "Хаан банк",
@@ -7328,7 +7428,7 @@
     }
   },
   "amenity/bank|Хоум Кредит": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "bank",
       "brand": "Хоум Кредит",
@@ -7342,7 +7442,7 @@
     }
   },
   "amenity/bank|בנק אגוד": {
-    "locationSet": { "include": ["il"] },
+    "locationSet": {"include": ["il"]},
     "tags": {
       "alt_name:en": "Bank Igud",
       "amenity": "bank",
@@ -7357,7 +7457,7 @@
     }
   },
   "amenity/bank|בנק אוצר החייל": {
-    "locationSet": { "include": ["il"] },
+    "locationSet": {"include": ["il"]},
     "tags": {
       "amenity": "bank",
       "brand": "בנק אוצר החייל",
@@ -7371,7 +7471,7 @@
     }
   },
   "amenity/bank|בנק דיסקונט": {
-    "locationSet": { "include": ["il"] },
+    "locationSet": {"include": ["il"]},
     "tags": {
       "amenity": "bank",
       "brand": "בנק דיסקונט לישראל",
@@ -7385,7 +7485,7 @@
     }
   },
   "amenity/bank|בנק הפועלים": {
-    "locationSet": { "include": ["il"] },
+    "locationSet": {"include": ["il"]},
     "tags": {
       "amenity": "bank",
       "brand": "בנק הפועלים",
@@ -7399,7 +7499,7 @@
     }
   },
   "amenity/bank|בנק יהד": {
-    "locationSet": { "include": ["il"] },
+    "locationSet": {"include": ["il"]},
     "tags": {
       "amenity": "bank",
       "brand": "בנק יהד",
@@ -7413,7 +7513,7 @@
     }
   },
   "amenity/bank|בנק ירושלים": {
-    "locationSet": { "include": ["il"] },
+    "locationSet": {"include": ["il"]},
     "tags": {
       "amenity": "bank",
       "brand": "בנק ירושלים",
@@ -7427,7 +7527,7 @@
     }
   },
   "amenity/bank|בנק לאומי": {
-    "locationSet": { "include": ["il"] },
+    "locationSet": {"include": ["il"]},
     "tags": {
       "amenity": "bank",
       "brand": "בנק לאומי",
@@ -7441,7 +7541,7 @@
     }
   },
   "amenity/bank|בנק מסד": {
-    "locationSet": { "include": ["il"] },
+    "locationSet": {"include": ["il"]},
     "tags": {
       "amenity": "bank",
       "brand": "בנק מסד",
@@ -7455,7 +7555,7 @@
     }
   },
   "amenity/bank|הבנק הבינלאומי": {
-    "locationSet": { "include": ["il"] },
+    "locationSet": {"include": ["il"]},
     "tags": {
       "amenity": "bank",
       "brand": "הבנק הבינלאומי",
@@ -7469,7 +7569,7 @@
     }
   },
   "amenity/bank|מזרחי טפחות": {
-    "locationSet": { "include": ["il"] },
+    "locationSet": {"include": ["il"]},
     "tags": {
       "amenity": "bank",
       "brand": "מזרחי טפחות",
@@ -7483,7 +7583,7 @@
     }
   },
   "amenity/bank|البنك الوطني الجزائري": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "البنك الوطني الجزائري",
@@ -7491,7 +7591,7 @@
     }
   },
   "amenity/bank|الصندوق الوطني للتوفير والاحتياط": {
-    "locationSet": { "include": ["dz"] },
+    "locationSet": {"include": ["dz"]},
     "tags": {
       "amenity": "bank",
       "brand": "الصندوق الوطني للتوفير والاحتياط",
@@ -7500,7 +7600,7 @@
     }
   },
   "amenity/bank|بانک آینده": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک آینده",
@@ -7512,7 +7612,7 @@
     }
   },
   "amenity/bank|بانک اقتصاد نوین": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک اقتصاد نوین",
@@ -7524,7 +7624,7 @@
     }
   },
   "amenity/bank|بانک انصار": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک انصار",
@@ -7534,7 +7634,7 @@
     }
   },
   "amenity/bank|بانک ایران زمین": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک ایران زمین",
@@ -7544,7 +7644,7 @@
     }
   },
   "amenity/bank|بانک تجارت": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک تجارت",
@@ -7554,7 +7654,7 @@
     }
   },
   "amenity/bank|بانک توسعه تعاون": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک توسعه تعاون",
@@ -7564,7 +7664,7 @@
     }
   },
   "amenity/bank|بانک رفاه": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "matchNames": ["بانک رفاه کارگران"],
     "tags": {
       "amenity": "bank",
@@ -7577,7 +7677,7 @@
     }
   },
   "amenity/bank|بانک سامان": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک سامان",
@@ -7589,7 +7689,7 @@
     }
   },
   "amenity/bank|بانک سرمایه": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک سرمایه",
@@ -7601,7 +7701,7 @@
     }
   },
   "amenity/bank|بانک سپه": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک سپه",
@@ -7613,7 +7713,7 @@
     }
   },
   "amenity/bank|بانک سینا": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک سینا",
@@ -7625,7 +7725,7 @@
     }
   },
   "amenity/bank|بانک شهر": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک شهر",
@@ -7637,7 +7737,7 @@
     }
   },
   "amenity/bank|بانک صادرات": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "matchNames": ["بانک صادرات ایران", "صادرات"],
     "tags": {
       "amenity": "bank",
@@ -7650,7 +7750,7 @@
     }
   },
   "amenity/bank|بانک قوامین": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک قوامین",
@@ -7662,7 +7762,7 @@
     }
   },
   "amenity/bank|بانک مسکن": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک مسکن",
@@ -7674,7 +7774,7 @@
     }
   },
   "amenity/bank|بانک ملت": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک ملت",
@@ -7686,7 +7786,7 @@
     }
   },
   "amenity/bank|بانک ملی": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "matchNames": ["بانک ملی ایران", "ملی"],
     "tags": {
       "amenity": "bank",
@@ -7699,7 +7799,7 @@
     }
   },
   "amenity/bank|بانک مهر اقتصاد": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک مهر اقتصاد",
@@ -7710,7 +7810,7 @@
     }
   },
   "amenity/bank|بانک پارسیان": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک پارسیان",
@@ -7722,7 +7822,7 @@
     }
   },
   "amenity/bank|بانک پاسارگاد": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک پاسارگاد",
@@ -7734,7 +7834,7 @@
     }
   },
   "amenity/bank|بانک کشاورزی": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "بانک کشاورزی",
@@ -7746,7 +7846,7 @@
     }
   },
   "amenity/bank|پست بانک": {
-    "locationSet": { "include": ["ir"] },
+    "locationSet": {"include": ["ir"]},
     "tags": {
       "amenity": "bank",
       "brand": "پست بانک",
@@ -7758,7 +7858,7 @@
     }
   },
   "amenity/bank|অগ্রণী ব্যাংক": {
-    "locationSet": { "include": ["bd"] },
+    "locationSet": {"include": ["bd"]},
     "matchNames": [
       "agrani bank",
       "agrani bank limited",
@@ -7780,7 +7880,7 @@
     }
   },
   "amenity/bank|গ্রামীণ ব্যাংক": {
-    "locationSet": { "include": ["bd"] },
+    "locationSet": {"include": ["bd"]},
     "tags": {
       "amenity": "bank",
       "brand": "গ্রামীণ ব্যাংক",
@@ -7794,7 +7894,7 @@
     }
   },
   "amenity/bank|জনতা ব্যাংক লিমিটেড": {
-    "locationSet": { "include": ["bd"] },
+    "locationSet": {"include": ["bd"]},
     "matchNames": [
       "janata bank",
       "janata bank limited",
@@ -7813,7 +7913,7 @@
     }
   },
   "amenity/bank|বাংলাদেশ কৃষি ব্যাংক": {
-    "locationSet": { "include": ["bd"] },
+    "locationSet": {"include": ["bd"]},
     "tags": {
       "amenity": "bank",
       "brand": "বাংলাদেশ কৃষি ব্যাংক",
@@ -7827,7 +7927,7 @@
     }
   },
   "amenity/bank|সোনালী ব্যাংক লিমিটেড": {
-    "locationSet": { "include": ["bd"] },
+    "locationSet": {"include": ["bd"]},
     "matchNames": [
       "sonali bank",
       "sonali bank limited",
@@ -7846,7 +7946,7 @@
     }
   },
   "amenity/bank|ธนาคารกรุงเทพ": {
-    "locationSet": { "include": ["th"] },
+    "locationSet": {"include": ["th"]},
     "tags": {
       "amenity": "bank",
       "brand": "ธนาคารกรุงเทพ",
@@ -7860,7 +7960,7 @@
     }
   },
   "amenity/bank|ธนาคารกรุงไทย": {
-    "locationSet": { "include": ["th"] },
+    "locationSet": {"include": ["th"]},
     "tags": {
       "amenity": "bank",
       "brand": "ธนาคารกรุงไทย",
@@ -7874,7 +7974,7 @@
     }
   },
   "amenity/bank|ธนาคารกสิกรไทย": {
-    "locationSet": { "include": ["th"] },
+    "locationSet": {"include": ["th"]},
     "tags": {
       "amenity": "bank",
       "brand": "ธนาคารกสิกรไทย",
@@ -7888,7 +7988,7 @@
     }
   },
   "amenity/bank|ธนาคารออมสิน": {
-    "locationSet": { "include": ["th"] },
+    "locationSet": {"include": ["th"]},
     "tags": {
       "amenity": "bank",
       "brand": "ธนาคารออมสิน",
@@ -7902,7 +8002,7 @@
     }
   },
   "amenity/bank|ธนาคารไทยพาณิชย์": {
-    "locationSet": { "include": ["th"] },
+    "locationSet": {"include": ["th"]},
     "tags": {
       "amenity": "bank",
       "brand": "ธนาคารไทยพาณิชย์",
@@ -7916,7 +8016,7 @@
     }
   },
   "amenity/bank|きらぼし銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "きらぼし銀行",
@@ -7930,7 +8030,7 @@
     }
   },
   "amenity/bank|みずほ銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "みずほ銀行",
@@ -7944,7 +8044,7 @@
     }
   },
   "amenity/bank|ゆうちょ銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "ゆうちょ銀行",
@@ -7958,7 +8058,7 @@
     }
   },
   "amenity/bank|りそな銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "りそな銀行",
@@ -7972,7 +8072,7 @@
     }
   },
   "amenity/bank|イオン銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "イオン銀行",
@@ -7986,7 +8086,7 @@
     }
   },
   "amenity/bank|スルガ銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "スルガ銀行",
@@ -8000,7 +8100,7 @@
     }
   },
   "amenity/bank|セブン銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "matchNames": ["7銀行"],
     "tags": {
       "amenity": "bank",
@@ -8015,7 +8115,7 @@
     }
   },
   "amenity/bank|三井住友信託銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "三井住友信託銀行",
@@ -8027,7 +8127,7 @@
     }
   },
   "amenity/bank|三井住友銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "三井住友銀行",
@@ -8042,7 +8142,7 @@
     }
   },
   "amenity/bank|三菱UFJ信託銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "三菱UFJ信託銀行",
@@ -8056,7 +8156,7 @@
     }
   },
   "amenity/bank|三菱UFJ銀行": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "matchNames": ["三菱東京ufj銀行"],
     "tags": {
       "amenity": "bank",
@@ -8071,7 +8171,7 @@
     }
   },
   "amenity/bank|上海商業儲蓄銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "上海商業儲蓄銀行",
@@ -8083,7 +8183,7 @@
     }
   },
   "amenity/bank|上海浦东发展银行": {
-    "locationSet": { "include": ["cn"] },
+    "locationSet": {"include": ["cn"]},
     "tags": {
       "amenity": "bank",
       "brand": "上海浦东发展银行",
@@ -8095,7 +8195,7 @@
     }
   },
   "amenity/bank|东亚银行": {
-    "locationSet": { "include": ["cn"] },
+    "locationSet": {"include": ["cn"]},
     "tags": {
       "amenity": "bank",
       "brand": "东亚银行",
@@ -8106,7 +8206,7 @@
     }
   },
   "amenity/bank|中信银行": {
-    "locationSet": { "include": ["cn"] },
+    "locationSet": {"include": ["cn"]},
     "tags": {
       "amenity": "bank",
       "brand": "中信银行",
@@ -8118,7 +8218,7 @@
     }
   },
   "amenity/bank|中国光大银行": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "中国光大银行",
@@ -8130,7 +8230,7 @@
     }
   },
   "amenity/bank|中国农业银行": {
-    "locationSet": { "include": ["cn"] },
+    "locationSet": {"include": ["cn"]},
     "tags": {
       "amenity": "bank",
       "brand": "中国农业银行",
@@ -8142,7 +8242,7 @@
     }
   },
   "amenity/bank|中国工商银行": {
-    "locationSet": { "include": ["cn"] },
+    "locationSet": {"include": ["cn"]},
     "tags": {
       "amenity": "bank",
       "brand": "中国工商银行",
@@ -8154,7 +8254,7 @@
     }
   },
   "amenity/bank|中国建设银行": {
-    "locationSet": { "include": ["cn"] },
+    "locationSet": {"include": ["cn"]},
     "matchNames": ["建设银行"],
     "tags": {
       "amenity": "bank",
@@ -8167,7 +8267,7 @@
     }
   },
   "amenity/bank|中国民生银行": {
-    "locationSet": { "include": ["cn"] },
+    "locationSet": {"include": ["cn"]},
     "tags": {
       "amenity": "bank",
       "brand": "中国民生银行",
@@ -8179,7 +8279,7 @@
     }
   },
   "amenity/bank|中国邮政储蓄银行": {
-    "locationSet": { "include": ["cn"] },
+    "locationSet": {"include": ["cn"]},
     "tags": {
       "amenity": "bank",
       "brand": "中国邮政储蓄银行",
@@ -8191,7 +8291,7 @@
     }
   },
   "amenity/bank|中国银行": {
-    "locationSet": { "include": ["cn"] },
+    "locationSet": {"include": ["cn"]},
     "tags": {
       "amenity": "bank",
       "brand": "中国银行",
@@ -8203,7 +8303,7 @@
     }
   },
   "amenity/bank|中國信託商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "中國信託商業銀行",
@@ -8215,7 +8315,7 @@
     }
   },
   "amenity/bank|交通银行": {
-    "locationSet": { "include": ["cn"] },
+    "locationSet": {"include": ["cn"]},
     "tags": {
       "amenity": "bank",
       "brand": "交通银行",
@@ -8227,7 +8327,7 @@
     }
   },
   "amenity/bank|京城商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "京城商業銀行",
@@ -8237,7 +8337,7 @@
     }
   },
   "amenity/bank|京葉銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "alt_name:en": "αBANK",
       "amenity": "bank",
@@ -8252,7 +8352,7 @@
     }
   },
   "amenity/bank|京都中央信用金庫": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "京都中央信用金庫",
@@ -8264,7 +8364,7 @@
     }
   },
   "amenity/bank|京都銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "京都銀行",
@@ -8276,7 +8376,7 @@
     }
   },
   "amenity/bank|伊予銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "matchNames": ["いよぎん"],
     "tags": {
       "amenity": "bank",
@@ -8291,7 +8391,7 @@
     }
   },
   "amenity/bank|元大商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "元大商業銀行",
@@ -8303,7 +8403,7 @@
     }
   },
   "amenity/bank|兆豐國際商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "兆豐國際商業銀行",
@@ -8315,7 +8415,7 @@
     }
   },
   "amenity/bank|八十二銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "matchNames": ["82銀行"],
     "tags": {
       "amenity": "bank",
@@ -8330,7 +8430,7 @@
     }
   },
   "amenity/bank|兴业银行": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "兴业银行",
@@ -8340,7 +8440,7 @@
     }
   },
   "amenity/bank|农业银行": {
-    "locationSet": { "include": ["cn"] },
+    "locationSet": {"include": ["cn"]},
     "tags": {
       "amenity": "bank",
       "brand": "农业银行",
@@ -8350,7 +8450,7 @@
     }
   },
   "amenity/bank|北京银行": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "北京银行",
@@ -8360,7 +8460,7 @@
     }
   },
   "amenity/bank|北洋銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "北洋銀行",
@@ -8372,7 +8472,7 @@
     }
   },
   "amenity/bank|北海道銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "北海道銀行",
@@ -8384,7 +8484,7 @@
     }
   },
   "amenity/bank|千葉興業銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "千葉興業銀行",
@@ -8398,7 +8498,7 @@
     }
   },
   "amenity/bank|千葉銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "千葉銀行",
@@ -8412,7 +8512,7 @@
     }
   },
   "amenity/bank|台中商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "台中商業銀行",
@@ -8424,7 +8524,7 @@
     }
   },
   "amenity/bank|台北富邦商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "台北富邦商業銀行",
@@ -8436,7 +8536,7 @@
     }
   },
   "amenity/bank|台新國際商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "台新國際商業銀行",
@@ -8448,7 +8548,7 @@
     }
   },
   "amenity/bank|合作金庫商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "合作金庫商業銀行",
@@ -8460,7 +8560,7 @@
     }
   },
   "amenity/bank|商工中金": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "商工中金",
@@ -8474,7 +8574,7 @@
     }
   },
   "amenity/bank|國泰世華商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "國泰世華商業銀行",
@@ -8486,7 +8586,7 @@
     }
   },
   "amenity/bank|埼玉りそな銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "埼玉りそな銀行",
@@ -8500,7 +8600,7 @@
     }
   },
   "amenity/bank|多摩信用金庫": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "alt_name": "たましん",
       "alt_name:en": "Tamashin",
@@ -8516,7 +8616,7 @@
     }
   },
   "amenity/bank|大眾商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "大眾商業銀行",
@@ -8528,7 +8628,7 @@
     }
   },
   "amenity/bank|宁波银行": {
-    "locationSet": { "include": ["cn"] },
+    "locationSet": {"include": ["cn"]},
     "tags": {
       "amenity": "bank",
       "brand": "宁波银行",
@@ -8542,7 +8642,7 @@
     }
   },
   "amenity/bank|安泰商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "安泰商業銀行",
@@ -8554,7 +8654,7 @@
     }
   },
   "amenity/bank|工商银行": {
-    "locationSet": { "include": ["cn"] },
+    "locationSet": {"include": ["cn"]},
     "tags": {
       "amenity": "bank",
       "brand": "工商银行",
@@ -8566,7 +8666,7 @@
     }
   },
   "amenity/bank|常陽銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "常陽銀行",
@@ -8578,7 +8678,7 @@
     }
   },
   "amenity/bank|彰化商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "彰化商業銀行",
@@ -8590,7 +8690,7 @@
     }
   },
   "amenity/bank|愛知銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "愛知銀行",
@@ -8604,7 +8704,7 @@
     }
   },
   "amenity/bank|招商银行": {
-    "locationSet": { "include": ["cn"] },
+    "locationSet": {"include": ["cn"]},
     "tags": {
       "amenity": "bank",
       "brand": "招商银行",
@@ -8616,7 +8716,7 @@
     }
   },
   "amenity/bank|新生銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "新生銀行",
@@ -8630,7 +8730,7 @@
     }
   },
   "amenity/bank|日本銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "日本銀行",
@@ -8642,7 +8742,7 @@
     }
   },
   "amenity/bank|東亞銀行": {
-    "locationSet": { "include": ["hk"] },
+    "locationSet": {"include": ["hk"]},
     "tags": {
       "amenity": "bank",
       "brand": "東亞銀行",
@@ -8658,7 +8758,7 @@
     }
   },
   "amenity/bank|東京ベイ信金": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "東京ベイ信金",
@@ -8672,7 +8772,7 @@
     }
   },
   "amenity/bank|東日本銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "東日本銀行",
@@ -8686,7 +8786,7 @@
     }
   },
   "amenity/bank|板信商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "板信商業銀行",
@@ -8698,7 +8798,7 @@
     }
   },
   "amenity/bank|横浜銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "横浜銀行",
@@ -8710,7 +8810,7 @@
     }
   },
   "amenity/bank|武蔵野銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "武蔵野銀行",
@@ -8724,7 +8824,7 @@
     }
   },
   "amenity/bank|永豐商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "永豐商業銀行",
@@ -8736,7 +8836,7 @@
     }
   },
   "amenity/bank|沖縄海邦銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "沖縄海邦銀行",
@@ -8750,7 +8850,7 @@
     }
   },
   "amenity/bank|渣打國際商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "渣打國際商業銀行",
@@ -8759,7 +8859,7 @@
     }
   },
   "amenity/bank|玉山商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "玉山商業銀行",
@@ -8771,7 +8871,7 @@
     }
   },
   "amenity/bank|第一商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "第一商業銀行",
@@ -8783,7 +8883,7 @@
     }
   },
   "amenity/bank|聯邦商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "聯邦商業銀行",
@@ -8795,7 +8895,7 @@
     }
   },
   "amenity/bank|臺灣中小企業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "臺灣中小企業銀行",
@@ -8807,7 +8907,7 @@
     }
   },
   "amenity/bank|臺灣土地銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "臺灣土地銀行",
@@ -8819,7 +8919,7 @@
     }
   },
   "amenity/bank|臺灣新光商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "臺灣新光商業銀行",
@@ -8831,7 +8931,7 @@
     }
   },
   "amenity/bank|臺灣銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "臺灣銀行",
@@ -8843,7 +8943,7 @@
     }
   },
   "amenity/bank|芝信用金庫": {
-    "locationSet": { "include": ["001"] },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "amenity": "bank",
       "brand": "芝信用金庫",
@@ -8857,7 +8957,7 @@
     }
   },
   "amenity/bank|華南商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "華南商業銀行",
@@ -8869,7 +8969,7 @@
     }
   },
   "amenity/bank|近畿大阪銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "近畿大阪銀行",
@@ -8883,7 +8983,7 @@
     }
   },
   "amenity/bank|遠東國際商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "遠東國際商業銀行",
@@ -8895,7 +8995,7 @@
     }
   },
   "amenity/bank|陽信商業銀行": {
-    "locationSet": { "include": ["tw"] },
+    "locationSet": {"include": ["tw"]},
     "tags": {
       "amenity": "bank",
       "brand": "陽信商業銀行",
@@ -8907,7 +9007,7 @@
     }
   },
   "amenity/bank|静岡銀行": {
-    "locationSet": { "include": ["jp"] },
+    "locationSet": {"include": ["jp"]},
     "tags": {
       "amenity": "bank",
       "brand": "静岡銀行",
@@ -8921,7 +9021,7 @@
     }
   },
   "amenity/bank|국민은행": {
-    "locationSet": { "include": ["kr"] },
+    "locationSet": {"include": ["kr"]},
     "matchNames": ["국민은행 (gungmin bank)"],
     "tags": {
       "amenity": "bank",
@@ -8936,7 +9036,7 @@
     }
   },
   "amenity/bank|기업은행": {
-    "locationSet": { "include": ["kr"] },
+    "locationSet": {"include": ["kr"]},
     "tags": {
       "amenity": "bank",
       "brand": "기업은행",
@@ -8950,7 +9050,7 @@
     }
   },
   "amenity/bank|농협": {
-    "locationSet": { "include": ["kr"] },
+    "locationSet": {"include": ["kr"]},
     "matchNames": ["nh농협은행"],
     "tags": {
       "amenity": "bank",
@@ -8965,7 +9065,7 @@
     }
   },
   "amenity/bank|새마을금고": {
-    "locationSet": { "include": ["kr"] },
+    "locationSet": {"include": ["kr"]},
     "tags": {
       "amenity": "bank",
       "brand": "새마을금고",
@@ -8977,7 +9077,7 @@
     }
   },
   "amenity/bank|신한은행": {
-    "locationSet": { "include": ["kr"] },
+    "locationSet": {"include": ["kr"]},
     "matchNames": ["신한은행 (sinhan bank)"],
     "tags": {
       "amenity": "bank",
@@ -8992,7 +9092,7 @@
     }
   },
   "amenity/bank|우리은행": {
-    "locationSet": { "include": ["kr"] },
+    "locationSet": {"include": ["kr"]},
     "matchNames": ["우리은행 (uri bank)"],
     "tags": {
       "amenity": "bank",
@@ -9007,7 +9107,7 @@
     }
   },
   "amenity/bank|하나은행": {
-    "locationSet": { "include": ["kr"] },
+    "locationSet": {"include": ["kr"]},
     "tags": {
       "amenity": "bank",
       "brand": "하나은행",

--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -3999,6 +3999,8 @@
     "tags": {
       "amenity": "bank",
       "brand": "Groupama",
+      "brand:wikidata": "Q3083531",
+      "brand:wikipedia": "fr:Groupama",
       "name": "Groupama"
     }
   },

--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -4290,6 +4290,9 @@
   },
   "amenity/bank|J&T Banka": {
     "locationSet": {"include": ["cz", "sk"]},
+    "nomatch": [
+      "amenity/post_office|J&T Express"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "J&T Banka",

--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -1,6 +1,6 @@
 {
   "amenity/bank|ABANCA": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "ABANCA",
@@ -11,7 +11,7 @@
     }
   },
   "amenity/bank|ABN AMRO": {
-    "locationSet": {"include": ["nl"]},
+    "locationSet": { "include": ["nl"] },
     "tags": {
       "amenity": "bank",
       "brand": "ABN AMRO",
@@ -22,7 +22,7 @@
     }
   },
   "amenity/bank|ABSA": {
-    "locationSet": {"include": ["za"]},
+    "locationSet": { "include": ["za"] },
     "tags": {
       "amenity": "bank",
       "brand": "ABSA",
@@ -32,7 +32,7 @@
     }
   },
   "amenity/bank|ACBA": {
-    "locationSet": {"include": ["am"]},
+    "locationSet": { "include": ["am"] },
     "tags": {
       "amenity": "bank",
       "brand": "ACBA",
@@ -42,11 +42,8 @@
     }
   },
   "amenity/bank|AIB": {
-    "locationSet": {"include": ["gb", "ie"]},
-    "matchNames": [
-      "aib bank",
-      "allied irish bank"
-    ],
+    "locationSet": { "include": ["gb", "ie"] },
+    "matchNames": ["aib bank", "allied irish bank"],
     "tags": {
       "amenity": "bank",
       "brand": "AIB",
@@ -57,7 +54,7 @@
     }
   },
   "amenity/bank|AMP": {
-    "locationSet": {"include": ["au", "nz"]},
+    "locationSet": { "include": ["au", "nz"] },
     "matchNames": ["amp bank"],
     "tags": {
       "amenity": "bank",
@@ -69,7 +66,7 @@
     }
   },
   "amenity/bank|ANZ": {
-    "locationSet": {"include": ["au", "nz"]},
+    "locationSet": { "include": ["au", "nz"] },
     "matchNames": ["anz bank"],
     "tags": {
       "amenity": "bank",
@@ -81,7 +78,7 @@
     }
   },
   "amenity/bank|ASB Bank": {
-    "locationSet": {"include": ["nz"]},
+    "locationSet": { "include": ["nz"] },
     "tags": {
       "amenity": "bank",
       "brand": "ASB Bank",
@@ -91,7 +88,7 @@
     }
   },
   "amenity/bank|ATB Financial": {
-    "locationSet": {"include": ["ca"]},
+    "locationSet": { "include": ["ca"] },
     "tags": {
       "amenity": "bank",
       "brand": "ATB Financial",
@@ -102,7 +99,7 @@
     }
   },
   "amenity/bank|AXA": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "nomatch": ["office/insurance|AXA"],
     "tags": {
       "amenity": "bank",
@@ -113,7 +110,7 @@
     }
   },
   "amenity/bank|Access Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Access Bank",
@@ -123,7 +120,7 @@
     }
   },
   "amenity/bank|ActivoBank": {
-    "locationSet": {"include": ["pt"]},
+    "locationSet": { "include": ["pt"] },
     "tags": {
       "amenity": "bank",
       "brand": "ActivoBank",
@@ -145,7 +142,7 @@
     }
   },
   "amenity/bank|Affin Bank": {
-    "locationSet": {"include": ["my"]},
+    "locationSet": { "include": ["my"] },
     "tags": {
       "amenity": "bank",
       "brand": "Affin Bank",
@@ -155,7 +152,7 @@
     }
   },
   "amenity/bank|Affinity Credit Union": {
-    "locationSet": {"include": ["ca"]},
+    "locationSet": { "include": ["ca"] },
     "matchNames": ["affinity"],
     "tags": {
       "amenity": "bank",
@@ -166,7 +163,7 @@
     }
   },
   "amenity/bank|Agribank~(USA)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Agribank",
@@ -176,7 +173,7 @@
     }
   },
   "amenity/bank|Agribank~(Vietnam)": {
-    "locationSet": {"include": ["vn"]},
+    "locationSet": { "include": ["vn"] },
     "tags": {
       "amenity": "bank",
       "brand": "Agribank",
@@ -188,7 +185,7 @@
     }
   },
   "amenity/bank|Agribank~(Zimbabwe)": {
-    "locationSet": {"include": ["zw"]},
+    "locationSet": { "include": ["zw"] },
     "tags": {
       "amenity": "bank",
       "brand": "Agribank",
@@ -198,7 +195,7 @@
     }
   },
   "amenity/bank|Agrobank": {
-    "locationSet": {"include": ["my"]},
+    "locationSet": { "include": ["my"] },
     "tags": {
       "amenity": "bank",
       "brand": "Agrobank",
@@ -208,7 +205,7 @@
     }
   },
   "amenity/bank|Akbank": {
-    "locationSet": {"include": ["tr"]},
+    "locationSet": { "include": ["tr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Akbank",
@@ -218,7 +215,7 @@
     }
   },
   "amenity/bank|Aktia": {
-    "locationSet": {"include": ["fi"]},
+    "locationSet": { "include": ["fi"] },
     "tags": {
       "amenity": "bank",
       "brand": "Aktia",
@@ -228,7 +225,7 @@
     }
   },
   "amenity/bank|Alior Bank": {
-    "locationSet": {"include": ["pl"]},
+    "locationSet": { "include": ["pl"] },
     "tags": {
       "amenity": "bank",
       "brand": "Alior Bank",
@@ -238,7 +235,7 @@
     }
   },
   "amenity/bank|Allahabad Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Allahabad Bank",
@@ -248,7 +245,7 @@
     }
   },
   "amenity/bank|Alliance Bank": {
-    "locationSet": {"include": ["my"]},
+    "locationSet": { "include": ["my"] },
     "tags": {
       "amenity": "bank",
       "brand": "Alliance Bank",
@@ -258,7 +255,7 @@
     }
   },
   "amenity/bank|Allied Bank~(Pakistan)": {
-    "locationSet": {"include": ["pk"]},
+    "locationSet": { "include": ["pk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Allied Bank",
@@ -268,7 +265,7 @@
     }
   },
   "amenity/bank|Allied Bank~(defunct bank in Philipiness)": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "tags": {
       "amenity": "bank",
       "brand": "Allied Bank",
@@ -278,7 +275,7 @@
     }
   },
   "amenity/bank|Alpha Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Alpha Bank",
@@ -288,7 +285,7 @@
     }
   },
   "amenity/bank|Alterna Savings": {
-    "locationSet": {"include": ["ca"]},
+    "locationSet": { "include": ["ca"] },
     "tags": {
       "amenity": "bank",
       "brand": "Alterna Savings",
@@ -298,7 +295,7 @@
     }
   },
   "amenity/bank|AmBank": {
-    "locationSet": {"include": ["my"]},
+    "locationSet": { "include": ["my"] },
     "tags": {
       "amenity": "bank",
       "brand": "AmBank",
@@ -308,7 +305,7 @@
     }
   },
   "amenity/bank|America First Credit Union": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "America First Credit Union",
@@ -319,7 +316,7 @@
     }
   },
   "amenity/bank|Andhra Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Andhra Bank",
@@ -329,7 +326,7 @@
     }
   },
   "amenity/bank|Antonveneta": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Antonveneta",
@@ -339,7 +336,7 @@
     }
   },
   "amenity/bank|Apple Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "nomatch": ["shop/electronics|Apple Store"],
     "tags": {
       "amenity": "bank",
@@ -362,7 +359,7 @@
     }
   },
   "amenity/bank|Arvest Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Arvest Bank",
@@ -372,7 +369,7 @@
     }
   },
   "amenity/bank|Asia United Bank": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "tags": {
       "amenity": "bank",
       "brand": "Asia United Bank",
@@ -382,7 +379,7 @@
     }
   },
   "amenity/bank|Askari Bank": {
-    "locationSet": {"include": ["pk"]},
+    "locationSet": { "include": ["pk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Askari Bank",
@@ -392,7 +389,7 @@
     }
   },
   "amenity/bank|Associated Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Associated Bank",
@@ -402,7 +399,7 @@
     }
   },
   "amenity/bank|Attijariwafa Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Attijariwafa Bank",
@@ -412,7 +409,7 @@
     }
   },
   "amenity/bank|Axis Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Axis Bank",
@@ -422,7 +419,7 @@
     }
   },
   "amenity/bank|BAC Credomatic": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "matchNames": ["bac"],
     "tags": {
       "amenity": "bank",
@@ -433,10 +430,8 @@
     }
   },
   "amenity/bank|BAI": {
-    "locationSet": {"include": ["ao"]},
-    "matchNames": [
-      "banco africano de investimentos"
-    ],
+    "locationSet": { "include": ["ao"] },
+    "matchNames": ["banco africano de investimentos"],
     "tags": {
       "amenity": "bank",
       "brand": "BAI",
@@ -447,7 +442,7 @@
     }
   },
   "amenity/bank|BAWAG PSK": {
-    "locationSet": {"include": ["at"]},
+    "locationSet": { "include": ["at"] },
     "tags": {
       "amenity": "bank",
       "brand": "BAWAG PSK",
@@ -457,7 +452,7 @@
     }
   },
   "amenity/bank|BB&T": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "BB&T",
@@ -467,7 +462,7 @@
     }
   },
   "amenity/bank|BBBank": {
-    "locationSet": {"include": ["de"]},
+    "locationSet": { "include": ["de"] },
     "tags": {
       "amenity": "bank",
       "brand": "BBBank",
@@ -477,7 +472,7 @@
     }
   },
   "amenity/bank|BBVA": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "BBVA",
@@ -488,7 +483,7 @@
     }
   },
   "amenity/bank|BBVA Bancomer": {
-    "locationSet": {"include": ["mx"]},
+    "locationSet": { "include": ["mx"] },
     "tags": {
       "amenity": "bank",
       "brand": "BBVA Bancomer",
@@ -498,7 +493,7 @@
     }
   },
   "amenity/bank|BBVA Compass": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "BBVA Compass",
@@ -509,7 +504,7 @@
     }
   },
   "amenity/bank|BBVA Continental": {
-    "locationSet": {"include": ["pe"]},
+    "locationSet": { "include": ["pe"] },
     "tags": {
       "amenity": "bank",
       "brand": "BBVA Continental",
@@ -519,7 +514,7 @@
     }
   },
   "amenity/bank|BBVA Francés": {
-    "locationSet": {"include": ["ar"]},
+    "locationSet": { "include": ["ar"] },
     "tags": {
       "amenity": "bank",
       "brand": "BBVA Francés",
@@ -533,7 +528,7 @@
     }
   },
   "amenity/bank|BCA": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "matchNames": ["bank bca"],
     "tags": {
       "amenity": "bank",
@@ -545,7 +540,7 @@
     }
   },
   "amenity/bank|BCEE": {
-    "locationSet": {"include": ["lu"]},
+    "locationSet": { "include": ["lu"] },
     "tags": {
       "amenity": "bank",
       "brand": "BCEE",
@@ -556,7 +551,7 @@
     }
   },
   "amenity/bank|BCI": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "matchNames": ["banco bci"],
     "tags": {
       "amenity": "bank",
@@ -570,7 +565,7 @@
     }
   },
   "amenity/bank|BCP~(Bolivia)": {
-    "locationSet": {"include": ["bo"]},
+    "locationSet": { "include": ["bo"] },
     "matchNames": ["banco de crédito", "bcp"],
     "nomatch": [
       "amenity/bank|BCP~(France)",
@@ -587,7 +582,7 @@
     }
   },
   "amenity/bank|BCP~(France)": {
-    "locationSet": {"include": ["fr"]},
+    "locationSet": { "include": ["fr"] },
     "matchNames": ["banque bcp", "bcp"],
     "nomatch": [
       "amenity/bank|BCP~(Bolivia)",
@@ -603,7 +598,7 @@
     }
   },
   "amenity/bank|BCP~(Luxembourg)": {
-    "locationSet": {"include": ["lu"]},
+    "locationSet": { "include": ["lu"] },
     "matchNames": ["banque bcp", "bcp"],
     "nomatch": [
       "amenity/bank|BCP~(Bolivia)",
@@ -619,7 +614,7 @@
     }
   },
   "amenity/bank|BCP~(Peru)": {
-    "locationSet": {"include": ["pe"]},
+    "locationSet": { "include": ["pe"] },
     "matchNames": ["banco de crédito del perú"],
     "nomatch": [
       "amenity/bank|BCP~(Bolivia)",
@@ -638,7 +633,7 @@
     }
   },
   "amenity/bank|BCR~(Banca Comercială Română)": {
-    "locationSet": {"include": ["ro"]},
+    "locationSet": { "include": ["ro"] },
     "matchNames": ["banca comercială română"],
     "tags": {
       "amenity": "bank",
@@ -652,7 +647,7 @@
     }
   },
   "amenity/bank|BCR~(Costa Rica)": {
-    "locationSet": {"include": ["cr"]},
+    "locationSet": { "include": ["cr"] },
     "matchNames": ["banco de costa rica"],
     "tags": {
       "amenity": "bank",
@@ -666,7 +661,7 @@
     }
   },
   "amenity/bank|BDM": {
-    "locationSet": {"include": ["ml"]},
+    "locationSet": { "include": ["ml"] },
     "tags": {
       "amenity": "bank",
       "brand": "BDM",
@@ -679,7 +674,7 @@
     }
   },
   "amenity/bank|BDO": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "tags": {
       "alt_name": "Banco de Oro",
       "amenity": "bank",
@@ -690,7 +685,7 @@
     }
   },
   "amenity/bank|BECU": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "BECU",
@@ -700,7 +695,7 @@
     }
   },
   "amenity/bank|BGL BNP Paribas": {
-    "locationSet": {"include": ["lu"]},
+    "locationSet": { "include": ["lu"] },
     "nomatch": ["amenity/bank|BGŻ BNP Paribas"],
     "tags": {
       "amenity": "bank",
@@ -711,7 +706,7 @@
     }
   },
   "amenity/bank|BGŻ BNP Paribas": {
-    "locationSet": {"include": ["pl"]},
+    "locationSet": { "include": ["pl"] },
     "tags": {
       "amenity": "bank",
       "brand": "BGŻ BNP Paribas",
@@ -721,7 +716,7 @@
     }
   },
   "amenity/bank|BIAT": {
-    "locationSet": {"include": ["tn"]},
+    "locationSet": { "include": ["tn"] },
     "tags": {
       "amenity": "bank",
       "brand": "BIAT",
@@ -734,7 +729,7 @@
     }
   },
   "amenity/bank|BIDV": {
-    "locationSet": {"include": ["vn"]},
+    "locationSet": { "include": ["vn"] },
     "tags": {
       "amenity": "bank",
       "brand": "BIDV",
@@ -747,7 +742,7 @@
     }
   },
   "amenity/bank|BIL": {
-    "locationSet": {"include": ["lu"]},
+    "locationSet": { "include": ["lu"] },
     "tags": {
       "amenity": "bank",
       "brand": "BIL",
@@ -760,7 +755,7 @@
     }
   },
   "amenity/bank|BMCE Bank": {
-    "locationSet": {"include": ["ma"]},
+    "locationSet": { "include": ["ma"] },
     "matchNames": ["bmce"],
     "tags": {
       "amenity": "bank",
@@ -774,7 +769,7 @@
     }
   },
   "amenity/bank|BMCI": {
-    "locationSet": {"include": ["ma"]},
+    "locationSet": { "include": ["ma"] },
     "matchNames": ["bmci bank"],
     "tags": {
       "amenity": "bank",
@@ -785,7 +780,7 @@
     }
   },
   "amenity/bank|BMN": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "BMN",
@@ -796,7 +791,7 @@
     }
   },
   "amenity/bank|BMO Harris Bank~(USA)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "matchNames": [
       "bank of montreal",
       "bmo",
@@ -813,7 +808,7 @@
     }
   },
   "amenity/bank|BMO~(Canada)": {
-    "locationSet": {"include": ["ca"]},
+    "locationSet": { "include": ["ca"] },
     "matchNames": [
       "bank of montreal",
       "banque de montréal",
@@ -831,7 +826,7 @@
     }
   },
   "amenity/bank|BNA~(Algeria)": {
-    "locationSet": {"include": ["dz"]},
+    "locationSet": { "include": ["dz"] },
     "tags": {
       "amenity": "bank",
       "brand": "BNA",
@@ -844,7 +839,7 @@
     }
   },
   "amenity/bank|BNA~(Tunisia)": {
-    "locationSet": {"include": ["tn"]},
+    "locationSet": { "include": ["tn"] },
     "tags": {
       "amenity": "bank",
       "brand": "BNA",
@@ -854,7 +849,7 @@
     }
   },
   "amenity/bank|BNDA": {
-    "locationSet": {"include": ["ml"]},
+    "locationSet": { "include": ["ml"] },
     "tags": {
       "amenity": "bank",
       "brand": "BNDA",
@@ -865,7 +860,7 @@
     }
   },
   "amenity/bank|BNI": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "matchNames": ["bank bni"],
     "tags": {
       "amenity": "bank",
@@ -879,7 +874,7 @@
     }
   },
   "amenity/bank|BNL": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "BNL",
@@ -892,7 +887,7 @@
     }
   },
   "amenity/bank|BNP Paribas": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "BNP Paribas",
@@ -902,7 +897,7 @@
     }
   },
   "amenity/bank|BNP Paribas Fortis": {
-    "locationSet": {"include": ["be"]},
+    "locationSet": { "include": ["be"] },
     "tags": {
       "amenity": "bank",
       "brand": "BNP Paribas Fortis",
@@ -912,7 +907,7 @@
     }
   },
   "amenity/bank|BOC": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "BOC",
@@ -923,7 +918,7 @@
     }
   },
   "amenity/bank|BOM": {
-    "locationSet": {"include": ["au"]},
+    "locationSet": { "include": ["au"] },
     "tags": {
       "amenity": "bank",
       "brand": "BOM",
@@ -934,7 +929,7 @@
     }
   },
   "amenity/bank|BOQ": {
-    "locationSet": {"include": ["au"]},
+    "locationSet": { "include": ["au"] },
     "tags": {
       "amenity": "bank",
       "brand": "BOQ",
@@ -945,7 +940,7 @@
     }
   },
   "amenity/bank|BPC": {
-    "locationSet": {"include": ["ao"]},
+    "locationSet": { "include": ["ao"] },
     "tags": {
       "amenity": "bank",
       "brand": "BPC",
@@ -956,7 +951,7 @@
     }
   },
   "amenity/bank|BPER Banca": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "BPER Banca",
@@ -967,7 +962,7 @@
     }
   },
   "amenity/bank|BPI Family Savings Bank": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "tags": {
       "amenity": "bank",
       "brand": "BPI Family Savings Bank",
@@ -976,10 +971,8 @@
     }
   },
   "amenity/bank|BPI~(Global)": {
-    "locationSet": {"include": ["001"]},
-    "nomatch": [
-      "amenity/bank|Banco BPI~(Portugal)"
-    ],
+    "locationSet": { "include": ["001"] },
+    "nomatch": ["amenity/bank|Banco BPI~(Portugal)"],
     "tags": {
       "amenity": "bank",
       "brand": "BPI",
@@ -990,7 +983,7 @@
     }
   },
   "amenity/bank|BRD": {
-    "locationSet": {"include": ["ro"]},
+    "locationSet": { "include": ["ro"] },
     "tags": {
       "amenity": "bank",
       "brand": "BRD",
@@ -1000,7 +993,7 @@
     }
   },
   "amenity/bank|BRED": {
-    "locationSet": {"include": ["fr"]},
+    "locationSet": { "include": ["fr"] },
     "tags": {
       "amenity": "bank",
       "brand": "BRED",
@@ -1013,7 +1006,7 @@
     }
   },
   "amenity/bank|BRI": {
-    "locationSet": {"include": ["id"]},
+    "locationSet": { "include": ["id"] },
     "matchNames": ["bank bri"],
     "tags": {
       "amenity": "bank",
@@ -1027,7 +1020,7 @@
     }
   },
   "amenity/bank|BTN": {
-    "locationSet": {"include": ["id"]},
+    "locationSet": { "include": ["id"] },
     "tags": {
       "amenity": "bank",
       "brand": "BTN",
@@ -1044,7 +1037,7 @@
     }
   },
   "amenity/bank|BW-Bank": {
-    "locationSet": {"include": ["de"]},
+    "locationSet": { "include": ["de"] },
     "matchNames": ["baden-württembergische bank"],
     "tags": {
       "amenity": "bank",
@@ -1059,7 +1052,7 @@
     }
   },
   "amenity/bank|Banamex": {
-    "locationSet": {"include": ["mx"]},
+    "locationSet": { "include": ["mx"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banamex",
@@ -1072,7 +1065,7 @@
     }
   },
   "amenity/bank|Banca Intesa": {
-    "locationSet": {"include": ["it", "rs"]},
+    "locationSet": { "include": ["it", "rs"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banca Intesa",
@@ -1084,7 +1077,7 @@
     }
   },
   "amenity/bank|Banca March": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banca March",
@@ -1094,7 +1087,7 @@
     }
   },
   "amenity/bank|Banca Mediolanum": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banca Mediolanum",
@@ -1104,7 +1097,7 @@
     }
   },
   "amenity/bank|Banca Popolare di Bari": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banca Popolare di Bari",
@@ -1114,7 +1107,7 @@
     }
   },
   "amenity/bank|Banca Popolare di Milano": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "matchNames": ["bpm"],
     "tags": {
       "amenity": "bank",
@@ -1129,7 +1122,7 @@
     }
   },
   "amenity/bank|Banca Popolare di Novara": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banca Popolare di Novara",
@@ -1143,7 +1136,7 @@
     }
   },
   "amenity/bank|Banca Popolare di Sondrio": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banca Popolare di Sondrio",
@@ -1157,7 +1150,7 @@
     }
   },
   "amenity/bank|Banca Popolare di Verona": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banca Popolare di Verona",
@@ -1171,7 +1164,7 @@
     }
   },
   "amenity/bank|Banca Popolare di Vicenza": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banca Popolare di Vicenza",
@@ -1185,7 +1178,7 @@
     }
   },
   "amenity/bank|Banca Românească": {
-    "locationSet": {"include": ["ro"]},
+    "locationSet": { "include": ["ro"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banca Românească",
@@ -1199,7 +1192,7 @@
     }
   },
   "amenity/bank|Banca Sella": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banca Sella",
@@ -1213,7 +1206,7 @@
     }
   },
   "amenity/bank|Banca Transilvania": {
-    "locationSet": {"include": ["ro"]},
+    "locationSet": { "include": ["ro"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banca Transilvania",
@@ -1227,7 +1220,7 @@
     }
   },
   "amenity/bank|Bancaribe": {
-    "locationSet": {"include": ["ve"]},
+    "locationSet": { "include": ["ve"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bancaribe",
@@ -1237,7 +1230,7 @@
     }
   },
   "amenity/bank|Banco AV Villas": {
-    "locationSet": {"include": ["co"]},
+    "locationSet": { "include": ["co"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco AV Villas",
@@ -1251,7 +1244,7 @@
     }
   },
   "amenity/bank|Banco Agrario": {
-    "locationSet": {"include": ["co"]},
+    "locationSet": { "include": ["co"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Agrario",
@@ -1267,7 +1260,7 @@
     }
   },
   "amenity/bank|Banco Azteca": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Azteca",
@@ -1281,7 +1274,7 @@
     }
   },
   "amenity/bank|Banco BISA": {
-    "locationSet": {"include": ["bo"]},
+    "locationSet": { "include": ["bo"] },
     "matchNames": ["bisa"],
     "tags": {
       "amenity": "bank",
@@ -1292,7 +1285,7 @@
     }
   },
   "amenity/bank|Banco BPI~(Portugal)": {
-    "locationSet": {"include": ["pt"]},
+    "locationSet": { "include": ["pt"] },
     "nomatch": ["amenity/bank|BPI~(Global)"],
     "tags": {
       "amenity": "bank",
@@ -1305,7 +1298,7 @@
     }
   },
   "amenity/bank|Banco BPM": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco BPM",
@@ -1319,7 +1312,7 @@
     }
   },
   "amenity/bank|Banco CTT": {
-    "locationSet": {"include": ["pt"]},
+    "locationSet": { "include": ["pt"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco CTT",
@@ -1329,7 +1322,7 @@
     }
   },
   "amenity/bank|Banco Caja Social": {
-    "locationSet": {"include": ["co"]},
+    "locationSet": { "include": ["co"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Caja Social",
@@ -1343,7 +1336,7 @@
     }
   },
   "amenity/bank|Banco Ciudad": {
-    "locationSet": {"include": ["ar"]},
+    "locationSet": { "include": ["ar"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Ciudad",
@@ -1360,7 +1353,7 @@
     }
   },
   "amenity/bank|Banco Continental~(Paraguay)": {
-    "locationSet": {"include": ["py"]},
+    "locationSet": { "include": ["py"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Continental",
@@ -1373,7 +1366,7 @@
     }
   },
   "amenity/bank|Banco Continental~(Peru)": {
-    "locationSet": {"include": ["pe"]},
+    "locationSet": { "include": ["pe"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Continental",
@@ -1387,7 +1380,7 @@
     }
   },
   "amenity/bank|Banco Económico": {
-    "locationSet": {"include": ["bo"]},
+    "locationSet": { "include": ["bo"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Económico",
@@ -1397,7 +1390,7 @@
     }
   },
   "amenity/bank|Banco Estado": {
-    "locationSet": {"include": ["cl"]},
+    "locationSet": { "include": ["cl"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Estado",
@@ -1417,9 +1410,7 @@
     "locationSet": {
       "include": ["cl", "co", "pe"]
     },
-    "nomatch": [
-      "shop/department_store|Falabella"
-    ],
+    "nomatch": ["shop/department_store|Falabella"],
     "tags": {
       "amenity": "bank",
       "brand": "Banco Falabella",
@@ -1433,7 +1424,7 @@
     }
   },
   "amenity/bank|Banco Fassil": {
-    "locationSet": {"include": ["bo"]},
+    "locationSet": { "include": ["bo"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Fassil",
@@ -1442,7 +1433,7 @@
     }
   },
   "amenity/bank|Banco Fie": {
-    "locationSet": {"include": ["bo"]},
+    "locationSet": { "include": ["bo"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Fie",
@@ -1452,7 +1443,7 @@
     }
   },
   "amenity/bank|Banco Fortaleza": {
-    "locationSet": {"include": ["bo"]},
+    "locationSet": { "include": ["bo"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Fortaleza",
@@ -1461,7 +1452,7 @@
     }
   },
   "amenity/bank|Banco G&T Continental": {
-    "locationSet": {"include": ["gt", "sv"]},
+    "locationSet": { "include": ["gt", "sv"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco G&T Continental",
@@ -1475,7 +1466,7 @@
     }
   },
   "amenity/bank|Banco Ganadero": {
-    "locationSet": {"include": ["bo"]},
+    "locationSet": { "include": ["bo"] },
     "matchNames": ["bg"],
     "tags": {
       "amenity": "bank",
@@ -1486,7 +1477,7 @@
     }
   },
   "amenity/bank|Banco General": {
-    "locationSet": {"include": ["cr", "pa"]},
+    "locationSet": { "include": ["cr", "pa"] },
     "tags": {
       "amenity": "bank",
       "brand": "BW-Bank",
@@ -1500,7 +1491,7 @@
     }
   },
   "amenity/bank|Banco Industrial": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Industrial",
@@ -1514,7 +1505,7 @@
     }
   },
   "amenity/bank|Banco Internacional~(Chile)": {
-    "locationSet": {"include": ["cl"]},
+    "locationSet": { "include": ["cl"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Internacional",
@@ -1528,7 +1519,7 @@
     }
   },
   "amenity/bank|Banco Internacional~(Ecuador)": {
-    "locationSet": {"include": ["ec"]},
+    "locationSet": { "include": ["ec"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Internacional",
@@ -1542,7 +1533,7 @@
     }
   },
   "amenity/bank|Banco Mercantil": {
-    "locationSet": {"include": ["bo"]},
+    "locationSet": { "include": ["bo"] },
     "matchNames": ["bmsc"],
     "nomatch": ["amenity/bank|Mercantil"],
     "tags": {
@@ -1555,7 +1546,7 @@
     }
   },
   "amenity/bank|Banco Metropolitano": {
-    "locationSet": {"include": ["cu"]},
+    "locationSet": { "include": ["cu"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Metropolitano",
@@ -1568,7 +1559,7 @@
     }
   },
   "amenity/bank|Banco Nacional": {
-    "locationSet": {"include": ["cr", "pa"]},
+    "locationSet": { "include": ["cr", "pa"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Nacional de Costa Rica",
@@ -1586,7 +1577,7 @@
     }
   },
   "amenity/bank|Banco Nacional de Bolivia": {
-    "locationSet": {"include": ["bo"]},
+    "locationSet": { "include": ["bo"] },
     "matchNames": ["bnb"],
     "tags": {
       "amenity": "bank",
@@ -1598,7 +1589,7 @@
     }
   },
   "amenity/bank|Banco Nación": {
-    "locationSet": {"include": ["ar"]},
+    "locationSet": { "include": ["ar"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Nación",
@@ -1615,7 +1606,7 @@
     }
   },
   "amenity/bank|Banco Pastor": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Pastor",
@@ -1648,7 +1639,7 @@
     }
   },
   "amenity/bank|Banco Popular de Ahorro": {
-    "locationSet": {"include": ["cu"]},
+    "locationSet": { "include": ["cu"] },
     "matchNames": ["bpa"],
     "tags": {
       "amenity": "bank",
@@ -1662,7 +1653,7 @@
     }
   },
   "amenity/bank|Banco Provincia": {
-    "locationSet": {"include": ["ar"]},
+    "locationSet": { "include": ["ar"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Provincia",
@@ -1679,7 +1670,7 @@
     }
   },
   "amenity/bank|Banco Sabadell": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "matchNames": ["banc sabadell", "sabadell"],
     "tags": {
       "amenity": "bank",
@@ -1695,7 +1686,7 @@
     }
   },
   "amenity/bank|Banco Santa Fe": {
-    "locationSet": {"include": ["ar"]},
+    "locationSet": { "include": ["ar"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Santa Fe",
@@ -1712,7 +1703,7 @@
     }
   },
   "amenity/bank|Banco Santander": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "nomatch": ["amenity/bank|Santander"],
     "tags": {
       "amenity": "bank",
@@ -1728,7 +1719,7 @@
     }
   },
   "amenity/bank|Banco Sol~(Angola)": {
-    "locationSet": {"include": ["ao"]},
+    "locationSet": { "include": ["ao"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Sol",
@@ -1741,7 +1732,7 @@
     }
   },
   "amenity/bank|Banco Sol~(Bolivia)": {
-    "locationSet": {"include": ["bo"]},
+    "locationSet": { "include": ["bo"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco Sol",
@@ -1751,7 +1742,7 @@
     }
   },
   "amenity/bank|Banco Unión": {
-    "locationSet": {"include": ["bo"]},
+    "locationSet": { "include": ["bo"] },
     "nomatch": [
       "amenity/bank|UnionBank",
       "amenity/money_transfer|Express Union"
@@ -1765,7 +1756,7 @@
     }
   },
   "amenity/bank|Banco de Bogotá": {
-    "locationSet": {"include": ["co"]},
+    "locationSet": { "include": ["co"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco de Bogotá",
@@ -1779,7 +1770,7 @@
     }
   },
   "amenity/bank|Banco de Chile": {
-    "locationSet": {"include": ["cl"]},
+    "locationSet": { "include": ["cl"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco de Chile",
@@ -1793,7 +1784,7 @@
     }
   },
   "amenity/bank|Banco de Desarrollo Banrural": {
-    "locationSet": {"include": ["gt"]},
+    "locationSet": { "include": ["gt"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco de Desarrollo Banrural",
@@ -1807,7 +1798,7 @@
     }
   },
   "amenity/bank|Banco de Fomento Angola (BFA)": {
-    "locationSet": {"include": ["ao"]},
+    "locationSet": { "include": ["ao"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco de Fomento Angola (BFA)",
@@ -1821,7 +1812,7 @@
     }
   },
   "amenity/bank|Banco de Occidente": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco de Occidente",
@@ -1831,7 +1822,7 @@
     }
   },
   "amenity/bank|Banco de Venezuela": {
-    "locationSet": {"include": ["ve"]},
+    "locationSet": { "include": ["ve"] },
     "matchNames": ["de venezuela", "venezuela"],
     "tags": {
       "amenity": "bank",
@@ -1842,7 +1833,7 @@
     }
   },
   "amenity/bank|Banco de la Nación~(Argentina)": {
-    "locationSet": {"include": ["ar"]},
+    "locationSet": { "include": ["ar"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco de la Nación",
@@ -1852,7 +1843,7 @@
     }
   },
   "amenity/bank|Banco de la Nación~(Peru)": {
-    "locationSet": {"include": ["pe"]},
+    "locationSet": { "include": ["pe"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco de la Nación",
@@ -1862,7 +1853,7 @@
     }
   },
   "amenity/bank|Banco del Austro": {
-    "locationSet": {"include": ["ec"]},
+    "locationSet": { "include": ["ec"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco del Austro",
@@ -1871,7 +1862,7 @@
     }
   },
   "amenity/bank|Banco di Napoli": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco di Napoli",
@@ -1881,7 +1872,7 @@
     }
   },
   "amenity/bank|Banco di Sardegna": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco di Sardegna",
@@ -1891,7 +1882,7 @@
     }
   },
   "amenity/bank|Banco di Sicilia": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco di Sicilia",
@@ -1901,7 +1892,7 @@
     }
   },
   "amenity/bank|Banco do Brasil": {
-    "locationSet": {"include": ["br"]},
+    "locationSet": { "include": ["br"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco do Brasil",
@@ -1911,7 +1902,7 @@
     }
   },
   "amenity/bank|Banco do Nordeste": {
-    "locationSet": {"include": ["br"]},
+    "locationSet": { "include": ["br"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banco do Nordeste",
@@ -1921,7 +1912,7 @@
     }
   },
   "amenity/bank|Bancolombia": {
-    "locationSet": {"include": ["co"]},
+    "locationSet": { "include": ["co"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bancolombia",
@@ -1931,7 +1922,7 @@
     }
   },
   "amenity/bank|Bancomer": {
-    "locationSet": {"include": ["mx"]},
+    "locationSet": { "include": ["mx"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bancomer",
@@ -1941,7 +1932,7 @@
     }
   },
   "amenity/bank|Bancpost": {
-    "locationSet": {"include": ["ro"]},
+    "locationSet": { "include": ["ro"] },
     "nomatch": ["amenity/bank|Postbank"],
     "tags": {
       "amenity": "bank",
@@ -1952,7 +1943,7 @@
     }
   },
   "amenity/bank|Banesco": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banesco",
@@ -1962,7 +1953,7 @@
     }
   },
   "amenity/bank|Bangkok Bank": {
-    "locationSet": {"include": ["th"]},
+    "locationSet": { "include": ["th"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bangkok Bank",
@@ -1972,7 +1963,7 @@
     }
   },
   "amenity/bank|Bank Al Habib": {
-    "locationSet": {"include": ["pk"]},
+    "locationSet": { "include": ["pk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Al Habib",
@@ -1982,7 +1973,7 @@
     }
   },
   "amenity/bank|Bank Alfalah": {
-    "locationSet": {"include": ["pk"]},
+    "locationSet": { "include": ["pk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Alfalah",
@@ -1992,7 +1983,7 @@
     }
   },
   "amenity/bank|Bank Austria": {
-    "locationSet": {"include": ["at"]},
+    "locationSet": { "include": ["at"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Austria",
@@ -2002,7 +1993,7 @@
     }
   },
   "amenity/bank|Bank Danamon": {
-    "locationSet": {"include": ["id"]},
+    "locationSet": { "include": ["id"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Danamon",
@@ -2012,7 +2003,7 @@
     }
   },
   "amenity/bank|Bank Islam": {
-    "locationSet": {"include": ["my"]},
+    "locationSet": { "include": ["my"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Islam",
@@ -2022,7 +2013,7 @@
     }
   },
   "amenity/bank|Bank Mandiri": {
-    "locationSet": {"include": ["id"]},
+    "locationSet": { "include": ["id"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Mandiri",
@@ -2032,7 +2023,7 @@
     }
   },
   "amenity/bank|Bank Mandiri Syariah": {
-    "locationSet": {"include": ["id"]},
+    "locationSet": { "include": ["id"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Mandiri Syariah",
@@ -2042,7 +2033,7 @@
     }
   },
   "amenity/bank|Bank Mega": {
-    "locationSet": {"include": ["id"]},
+    "locationSet": { "include": ["id"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Mega",
@@ -2052,7 +2043,7 @@
     }
   },
   "amenity/bank|Bank Muamalat": {
-    "locationSet": {"include": ["id", "my"]},
+    "locationSet": { "include": ["id", "my"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Muamalat",
@@ -2062,7 +2053,7 @@
     }
   },
   "amenity/bank|Bank Pekao": {
-    "locationSet": {"include": ["pl"]},
+    "locationSet": { "include": ["pl"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Pekao",
@@ -2072,7 +2063,7 @@
     }
   },
   "amenity/bank|Bank Rakyat": {
-    "locationSet": {"include": ["my"]},
+    "locationSet": { "include": ["my"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Rakyat",
@@ -2082,7 +2073,7 @@
     }
   },
   "amenity/bank|Bank Simpanan Nasional": {
-    "locationSet": {"include": ["my"]},
+    "locationSet": { "include": ["my"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank Simpanan Nasional",
@@ -2093,7 +2084,7 @@
     }
   },
   "amenity/bank|Bank of Africa": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Africa",
@@ -2104,7 +2095,7 @@
     }
   },
   "amenity/bank|Bank of America": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of America",
@@ -2114,7 +2105,7 @@
     }
   },
   "amenity/bank|Bank of Baroda": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Baroda",
@@ -2124,7 +2115,7 @@
     }
   },
   "amenity/bank|Bank of Ceylon": {
-    "locationSet": {"include": ["lk"]},
+    "locationSet": { "include": ["lk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Ceylon",
@@ -2134,7 +2125,7 @@
     }
   },
   "amenity/bank|Bank of Commerce": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Commerce",
@@ -2144,7 +2135,7 @@
     }
   },
   "amenity/bank|Bank of Cyprus": {
-    "locationSet": {"include": ["cy", "gr"]},
+    "locationSet": { "include": ["cy", "gr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Cyprus",
@@ -2154,7 +2145,7 @@
     }
   },
   "amenity/bank|Bank of India": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of India",
@@ -2164,7 +2155,7 @@
     }
   },
   "amenity/bank|Bank of Ireland": {
-    "locationSet": {"include": ["gb", "ie"]},
+    "locationSet": { "include": ["gb", "ie"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Ireland",
@@ -2174,7 +2165,7 @@
     }
   },
   "amenity/bank|Bank of Maharashtra": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Maharashtra",
@@ -2184,7 +2175,7 @@
     }
   },
   "amenity/bank|Bank of New Zealand": {
-    "locationSet": {"include": ["nz"]},
+    "locationSet": { "include": ["nz"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of New Zealand",
@@ -2194,7 +2185,7 @@
     }
   },
   "amenity/bank|Bank of Scotland": {
-    "locationSet": {"include": ["gb"]},
+    "locationSet": { "include": ["gb"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of Scotland",
@@ -2204,7 +2195,7 @@
     }
   },
   "amenity/bank|Bank of the West": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bank of the West",
@@ -2214,10 +2205,8 @@
     }
   },
   "amenity/bank|BankWest~(USA)": {
-    "locationSet": {"include": ["us"]},
-    "nomatch": [
-      "amenity/bank|Bankwest~(Australia)"
-    ],
+    "locationSet": { "include": ["us"] },
+    "nomatch": ["amenity/bank|Bankwest~(Australia)"],
     "tags": {
       "amenity": "bank",
       "brand": "BankWest",
@@ -2226,7 +2215,7 @@
     }
   },
   "amenity/bank|Bankia": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bankia",
@@ -2236,7 +2225,7 @@
     }
   },
   "amenity/bank|Bankinter": {
-    "locationSet": {"include": ["es", "pt"]},
+    "locationSet": { "include": ["es", "pt"] },
     "nomatch": ["amenity/bank|Interbank"],
     "tags": {
       "amenity": "bank",
@@ -2247,7 +2236,7 @@
     }
   },
   "amenity/bank|Bankwest~(Australia)": {
-    "locationSet": {"include": ["au"]},
+    "locationSet": { "include": ["au"] },
     "nomatch": ["amenity/bank|Bankwest~(USA)"],
     "tags": {
       "amenity": "bank",
@@ -2258,7 +2247,7 @@
     }
   },
   "amenity/bank|Banner Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banner Bank",
@@ -2268,7 +2257,7 @@
     }
   },
   "amenity/bank|Banorte": {
-    "locationSet": {"include": ["mx"]},
+    "locationSet": { "include": ["mx"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banorte",
@@ -2278,7 +2267,7 @@
     }
   },
   "amenity/bank|Banpais": {
-    "locationSet": {"include": ["hn"]},
+    "locationSet": { "include": ["hn"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banpais",
@@ -2286,7 +2275,7 @@
     }
   },
   "amenity/bank|Banque Atlantique": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banque Atlantique",
@@ -2296,7 +2285,7 @@
     }
   },
   "amenity/bank|Banque Dupuy de Parseval": {
-    "locationSet": {"include": ["fr"]},
+    "locationSet": { "include": ["fr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banque Dupuy de Parseval",
@@ -2306,7 +2295,7 @@
     }
   },
   "amenity/bank|Banque Laurentienne": {
-    "locationSet": {"include": ["ca"]},
+    "locationSet": { "include": ["ca"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banque Laurentienne",
@@ -2316,7 +2305,7 @@
     }
   },
   "amenity/bank|Banque Populaire~(France)": {
-    "locationSet": {"include": ["fr"]},
+    "locationSet": { "include": ["fr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banque Populaire",
@@ -2338,7 +2327,7 @@
     }
   },
   "amenity/bank|Banque de France": {
-    "locationSet": {"include": ["fr"]},
+    "locationSet": { "include": ["fr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banque de France",
@@ -2348,7 +2337,7 @@
     }
   },
   "amenity/bank|Banque de l'Habitat du Mali": {
-    "locationSet": {"include": ["ml"]},
+    "locationSet": { "include": ["ml"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banque de l'Habitat du Mali",
@@ -2358,7 +2347,7 @@
     }
   },
   "amenity/bank|Banrisul": {
-    "locationSet": {"include": ["br"]},
+    "locationSet": { "include": ["br"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banrisul",
@@ -2368,7 +2357,7 @@
     }
   },
   "amenity/bank|Banrural": {
-    "locationSet": {"include": ["gt", "hn"]},
+    "locationSet": { "include": ["gt", "hn"] },
     "tags": {
       "amenity": "bank",
       "brand": "Banrural",
@@ -2378,7 +2367,7 @@
     }
   },
   "amenity/bank|Bantierra": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bantierra",
@@ -2388,7 +2377,7 @@
     }
   },
   "amenity/bank|Barclays": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "matchNames": ["barclays bank"],
     "tags": {
       "amenity": "bank",
@@ -2399,7 +2388,7 @@
     }
   },
   "amenity/bank|Bcc": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bcc",
@@ -2409,7 +2398,7 @@
     }
   },
   "amenity/bank|Belfius": {
-    "locationSet": {"include": ["be"]},
+    "locationSet": { "include": ["be"] },
     "tags": {
       "amenity": "bank",
       "brand": "Belfius",
@@ -2419,7 +2408,7 @@
     }
   },
   "amenity/bank|Bendigo Bank": {
-    "locationSet": {"include": ["au"]},
+    "locationSet": { "include": ["au"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bendigo Bank",
@@ -2429,7 +2418,7 @@
     }
   },
   "amenity/bank|Beobank": {
-    "locationSet": {"include": ["be"]},
+    "locationSet": { "include": ["be"] },
     "tags": {
       "amenity": "bank",
       "brand": "Beobank",
@@ -2439,7 +2428,7 @@
     }
   },
   "amenity/bank|Berliner Volksbank": {
-    "locationSet": {"include": ["de"]},
+    "locationSet": { "include": ["de"] },
     "tags": {
       "amenity": "bank",
       "brand": "Berliner Volksbank",
@@ -2449,7 +2438,7 @@
     }
   },
   "amenity/bank|Bicentenario": {
-    "locationSet": {"include": ["ve"]},
+    "locationSet": { "include": ["ve"] },
     "tags": {
       "amenity": "bank",
       "brand": "Bicentenario",
@@ -2459,7 +2448,7 @@
     }
   },
   "amenity/bank|Bicici": {
-    "locationSet": {"include": ["ci"]},
+    "locationSet": { "include": ["ci"] },
     "matchNames": ["agence bicici"],
     "tags": {
       "amenity": "bank",
@@ -2470,7 +2459,7 @@
     }
   },
   "amenity/bank|Bradesco": {
-    "locationSet": {"include": ["br"]},
+    "locationSet": { "include": ["br"] },
     "matchNames": ["banco bradesco"],
     "tags": {
       "amenity": "bank",
@@ -2481,7 +2470,7 @@
     }
   },
   "amenity/bank|Budapest Bank": {
-    "locationSet": {"include": ["hu"]},
+    "locationSet": { "include": ["hu"] },
     "tags": {
       "amenity": "bank",
       "brand": "Budapest Bank",
@@ -2491,7 +2480,7 @@
     }
   },
   "amenity/bank|CBAO": {
-    "locationSet": {"include": ["sn"]},
+    "locationSet": { "include": ["sn"] },
     "tags": {
       "amenity": "bank",
       "brand": "CBAO",
@@ -2501,7 +2490,7 @@
     }
   },
   "amenity/bank|CEC Bank": {
-    "locationSet": {"include": ["ro"]},
+    "locationSet": { "include": ["ro"] },
     "tags": {
       "amenity": "bank",
       "brand": "CEC Bank",
@@ -2511,7 +2500,7 @@
     }
   },
   "amenity/bank|CIB Bank": {
-    "locationSet": {"include": ["hu"]},
+    "locationSet": { "include": ["hu"] },
     "tags": {
       "amenity": "bank",
       "brand": "CIB Bank",
@@ -2521,7 +2510,7 @@
     }
   },
   "amenity/bank|CIBC": {
-    "locationSet": {"include": ["ca"]},
+    "locationSet": { "include": ["ca"] },
     "matchNames": ["cibc banking centre"],
     "tags": {
       "amenity": "bank",
@@ -2532,7 +2521,7 @@
     }
   },
   "amenity/bank|CIC": {
-    "locationSet": {"include": ["fr"]},
+    "locationSet": { "include": ["fr"] },
     "tags": {
       "amenity": "bank",
       "brand": "CIC",
@@ -2542,7 +2531,7 @@
     }
   },
   "amenity/bank|CIH Bank": {
-    "locationSet": {"include": ["ma"]},
+    "locationSet": { "include": ["ma"] },
     "tags": {
       "amenity": "bank",
       "brand": "CIH Bank",
@@ -2552,7 +2541,7 @@
     }
   },
   "amenity/bank|CIMB Bank": {
-    "locationSet": {"include": ["my"]},
+    "locationSet": { "include": ["my"] },
     "tags": {
       "amenity": "bank",
       "brand": "CIMB Bank",
@@ -2562,7 +2551,7 @@
     }
   },
   "amenity/bank|CIMB Niaga": {
-    "locationSet": {"include": ["id"]},
+    "locationSet": { "include": ["id"] },
     "tags": {
       "amenity": "bank",
       "brand": "CIMB Niaga",
@@ -2572,7 +2561,7 @@
     }
   },
   "amenity/bank|CNEP": {
-    "locationSet": {"include": ["dz"]},
+    "locationSet": { "include": ["dz"] },
     "tags": {
       "amenity": "bank",
       "brand": "CNEP",
@@ -2582,7 +2571,7 @@
     }
   },
   "amenity/bank|CRDB Bank": {
-    "locationSet": {"include": ["tz"]},
+    "locationSet": { "include": ["tz"] },
     "tags": {
       "amenity": "bank",
       "brand": "CRDB Bank",
@@ -2592,7 +2581,7 @@
     }
   },
   "amenity/bank|Caisse d'Épargne": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Caisse d'Épargne",
@@ -2602,7 +2591,7 @@
     }
   },
   "amenity/bank|Caixa Econômica Federal~(Brazil)": {
-    "locationSet": {"include": ["br"]},
+    "locationSet": { "include": ["br"] },
     "matchNames": ["caixa", "caixabank"],
     "nomatch": ["amenity/bank|Caixabank~(Spain)"],
     "tags": {
@@ -2626,10 +2615,8 @@
     }
   },
   "amenity/bank|Caixabank~(Spain)": {
-    "locationSet": {"include": ["es"]},
-    "nomatch": [
-      "amenity/bank|Caixa Econômica Federal~(Brazil)"
-    ],
+    "locationSet": { "include": ["es"] },
+    "nomatch": ["amenity/bank|Caixa Econômica Federal~(Brazil)"],
     "tags": {
       "amenity": "bank",
       "brand": "Caixabank",
@@ -2639,7 +2626,7 @@
     }
   },
   "amenity/bank|Caja Duero": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "Caja Duero",
@@ -2649,7 +2636,7 @@
     }
   },
   "amenity/bank|Caja España": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "Caja España",
@@ -2659,7 +2646,7 @@
     }
   },
   "amenity/bank|Caja Rural": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "Caja Rural",
@@ -2669,7 +2656,7 @@
     }
   },
   "amenity/bank|Caja Rural de Jaén": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "Caja Rural de Jaén",
@@ -2679,7 +2666,7 @@
     }
   },
   "amenity/bank|CajaSur": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "CajaSur",
@@ -2689,7 +2676,7 @@
     }
   },
   "amenity/bank|Cajamar": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "Cajamar",
@@ -2699,7 +2686,7 @@
     }
   },
   "amenity/bank|California Coast Credit Union": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "California Coast Credit Union",
@@ -2709,7 +2696,7 @@
     }
   },
   "amenity/bank|Canara Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Canara Bank",
@@ -2719,7 +2706,7 @@
     }
   },
   "amenity/bank|Capital Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Capital Bank",
@@ -2729,7 +2716,7 @@
     }
   },
   "amenity/bank|Capital One": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "matchNames": ["capital one bank"],
     "tags": {
       "amenity": "bank",
@@ -2740,7 +2727,7 @@
     }
   },
   "amenity/bank|Carige": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Carige",
@@ -2750,7 +2737,7 @@
     }
   },
   "amenity/bank|Cariparma": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Cariparma",
@@ -2760,7 +2747,7 @@
     }
   },
   "amenity/bank|Carisbo": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Carisbo",
@@ -2770,7 +2757,7 @@
     }
   },
   "amenity/bank|Casden": {
-    "locationSet": {"include": ["fr"]},
+    "locationSet": { "include": ["fr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Casden",
@@ -2780,7 +2767,7 @@
     }
   },
   "amenity/bank|Cassa di Risparmio del Veneto": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Cassa di Risparmio del Veneto",
@@ -2790,7 +2777,7 @@
     }
   },
   "amenity/bank|CatalunyaCaixa": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "CatalunyaCaixa",
@@ -2812,7 +2799,7 @@
     }
   },
   "amenity/bank|Catholic Syrian Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Catholic Syrian Bank",
@@ -2820,7 +2807,7 @@
     }
   },
   "amenity/bank|Centennial Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Centennial Bank",
@@ -2829,7 +2816,7 @@
     }
   },
   "amenity/bank|Central Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Central Bank",
@@ -2837,7 +2824,7 @@
     }
   },
   "amenity/bank|Central Bank of India": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Central Bank of India",
@@ -2847,7 +2834,7 @@
     }
   },
   "amenity/bank|Chase": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "matchNames": ["chase bank"],
     "tags": {
       "amenity": "bank",
@@ -2858,7 +2845,7 @@
     }
   },
   "amenity/bank|Chemical Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Chemical Bank",
@@ -2867,7 +2854,7 @@
     }
   },
   "amenity/bank|China Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "China Bank",
@@ -2877,7 +2864,7 @@
     }
   },
   "amenity/bank|China Bank Savings": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "tags": {
       "amenity": "bank",
       "brand": "China Bank Savings",
@@ -2887,7 +2874,7 @@
     }
   },
   "amenity/bank|China Construction Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "China Construction Bank",
@@ -2898,7 +2885,7 @@
     }
   },
   "amenity/bank|Citibank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Citibank",
@@ -2909,7 +2896,7 @@
     }
   },
   "amenity/bank|Citizens Bank~(Eastern USA)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Citizens Bank",
@@ -2920,7 +2907,7 @@
     }
   },
   "amenity/bank|Citizens Bank~(Kentucky)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "alt_name": "Citizens Bank of Kentucky",
       "amenity": "bank",
@@ -2933,7 +2920,7 @@
     }
   },
   "amenity/bank|Citizens Bank~(Nepal)": {
-    "locationSet": {"include": ["np"]},
+    "locationSet": { "include": ["np"] },
     "tags": {
       "amenity": "bank",
       "brand": "Citizens Bank International",
@@ -2945,7 +2932,7 @@
     }
   },
   "amenity/bank|City National Bank~(California)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "City National Bank",
@@ -2955,7 +2942,7 @@
     }
   },
   "amenity/bank|City National Bank~(Florida)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "City National Bank",
@@ -2966,7 +2953,7 @@
     }
   },
   "amenity/bank|City National Bank~(West Virginia)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "City National Bank",
@@ -2975,7 +2962,7 @@
     }
   },
   "amenity/bank|Clydesdale Bank": {
-    "locationSet": {"include": ["gb"]},
+    "locationSet": { "include": ["gb"] },
     "tags": {
       "amenity": "bank",
       "brand": "Clydesdale Bank",
@@ -2985,11 +2972,8 @@
     }
   },
   "amenity/bank|Coast Capital Savings": {
-    "locationSet": {"include": ["ca"]},
-    "matchNames": [
-      "coast capital",
-      "coast capital savings credit union"
-    ],
+    "locationSet": { "include": ["ca"] },
+    "matchNames": ["coast capital", "coast capital savings credit union"],
     "tags": {
       "amenity": "bank",
       "brand": "Coast Capital Savings",
@@ -3000,7 +2984,7 @@
     }
   },
   "amenity/bank|Columbia Bank~(New Jersey)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "nomatch": [
       "amenity/bank|Columbia Bank~(Washington)",
       "shop/clothes|Columbia"
@@ -3013,7 +2997,7 @@
     }
   },
   "amenity/bank|Columbia Bank~(Washington)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "nomatch": [
       "amenity/bank|Columbia Bank~(New Jersey)",
       "shop/clothes|Columbia"
@@ -3026,7 +3010,7 @@
     }
   },
   "amenity/bank|Comerica Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Comerica Bank",
@@ -3036,7 +3020,7 @@
     }
   },
   "amenity/bank|Commerce Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Commerce Bank",
@@ -3046,7 +3030,7 @@
     }
   },
   "amenity/bank|Commercial Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Commercial Bank",
@@ -3054,7 +3038,7 @@
     }
   },
   "amenity/bank|Commercial Bank of Ceylon PLC": {
-    "locationSet": {"include": ["lk"]},
+    "locationSet": { "include": ["lk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Commercial Bank of Ceylon PLC",
@@ -3064,7 +3048,7 @@
     }
   },
   "amenity/bank|Commerzbank": {
-    "locationSet": {"include": ["de"]},
+    "locationSet": { "include": ["de"] },
     "tags": {
       "amenity": "bank",
       "brand": "Commerzbank",
@@ -3074,7 +3058,7 @@
     }
   },
   "amenity/bank|Commonwealth Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Commonwealth Bank",
@@ -3084,7 +3068,7 @@
     }
   },
   "amenity/bank|Community Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Community Bank",
@@ -3094,7 +3078,7 @@
     }
   },
   "amenity/bank|Corporation Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Corporation Bank",
@@ -3104,7 +3088,7 @@
     }
   },
   "amenity/bank|Credem": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Credem",
@@ -3114,7 +3098,7 @@
     }
   },
   "amenity/bank|Credicoop": {
-    "locationSet": {"include": ["ar"]},
+    "locationSet": { "include": ["ar"] },
     "tags": {
       "amenity": "bank",
       "brand": "Credicoop",
@@ -3124,7 +3108,7 @@
     }
   },
   "amenity/bank|Credit Suisse": {
-    "locationSet": {"include": ["ch"]},
+    "locationSet": { "include": ["ch"] },
     "tags": {
       "amenity": "bank",
       "brand": "Credit Suisse",
@@ -3134,7 +3118,7 @@
     }
   },
   "amenity/bank|Credito Valtellinese": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Credito Valtellinese",
@@ -3144,7 +3128,7 @@
     }
   },
   "amenity/bank|Crelan": {
-    "locationSet": {"include": ["be"]},
+    "locationSet": { "include": ["be"] },
     "tags": {
       "amenity": "bank",
       "brand": "Crelan",
@@ -3154,7 +3138,7 @@
     }
   },
   "amenity/bank|Crédit Agricole": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Crédit Agricole",
@@ -3164,7 +3148,7 @@
     }
   },
   "amenity/bank|Crédit Maritime": {
-    "locationSet": {"include": ["fr"]},
+    "locationSet": { "include": ["fr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Crédit Maritime",
@@ -3174,7 +3158,7 @@
     }
   },
   "amenity/bank|Crédit Mutuel": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Crédit Mutuel",
@@ -3184,7 +3168,7 @@
     }
   },
   "amenity/bank|Crédit Mutuel de Bretagne": {
-    "locationSet": {"include": ["fr"]},
+    "locationSet": { "include": ["fr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Crédit Mutuel de Bretagne",
@@ -3194,7 +3178,7 @@
     }
   },
   "amenity/bank|Crédit du Nord": {
-    "locationSet": {"include": ["fr"]},
+    "locationSet": { "include": ["fr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Crédit du Nord",
@@ -3204,7 +3188,7 @@
     }
   },
   "amenity/bank|Crédito Agrícola": {
-    "locationSet": {"include": ["pt"]},
+    "locationSet": { "include": ["pt"] },
     "tags": {
       "amenity": "bank",
       "brand": "Crédito Agrícola",
@@ -3215,14 +3199,7 @@
   },
   "amenity/bank|Danske Bank": {
     "locationSet": {
-      "include": [
-        "dk",
-        "fi",
-        "gb",
-        "lt",
-        "no",
-        "se"
-      ]
+      "include": ["dk", "fi", "gb", "lt", "no", "se"]
     },
     "tags": {
       "amenity": "bank",
@@ -3246,7 +3223,7 @@
     }
   },
   "amenity/bank|Degussa": {
-    "locationSet": {"include": ["de"]},
+    "locationSet": { "include": ["de"] },
     "tags": {
       "amenity": "bank",
       "brand": "Degussa",
@@ -3256,7 +3233,7 @@
     }
   },
   "amenity/bank|Denizbank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Denizbank",
@@ -3266,7 +3243,7 @@
     }
   },
   "amenity/bank|Desjardins": {
-    "locationSet": {"include": ["ca"]},
+    "locationSet": { "include": ["ca"] },
     "matchNames": ["caisse desjardins"],
     "tags": {
       "amenity": "bank",
@@ -3277,7 +3254,7 @@
     }
   },
   "amenity/bank|Deutsche Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Deutsche Bank",
@@ -3287,7 +3264,7 @@
     }
   },
   "amenity/bank|Dollar Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "nomatch": [
       "amenity/car_rental|Dollar",
       "shop/variety_store|Dollar General",
@@ -3304,7 +3281,7 @@
     }
   },
   "amenity/bank|Dubai Islamic Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Dubai Islamic Bank",
@@ -3314,7 +3291,7 @@
     }
   },
   "amenity/bank|EastWest Unibank": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "matchNames": ["eastwest bank"],
     "tags": {
       "amenity": "bank",
@@ -3325,7 +3302,7 @@
     }
   },
   "amenity/bank|Ecobank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "matchNames": ["agence ecobank"],
     "tags": {
       "amenity": "bank",
@@ -3336,7 +3313,7 @@
     }
   },
   "amenity/bank|Emirates NBD": {
-    "locationSet": {"include": ["ae"]},
+    "locationSet": { "include": ["ae"] },
     "tags": {
       "amenity": "bank",
       "brand": "Emirates NBD",
@@ -3346,7 +3323,7 @@
     }
   },
   "amenity/bank|Equity Bank~(Congo)": {
-    "locationSet": {"include": ["cd"]},
+    "locationSet": { "include": ["cd"] },
     "tags": {
       "amenity": "bank",
       "brand": "Equity Bank",
@@ -3356,7 +3333,7 @@
     }
   },
   "amenity/bank|Equity Bank~(Kenya)": {
-    "locationSet": {"include": ["ke"]},
+    "locationSet": { "include": ["ke"] },
     "tags": {
       "amenity": "bank",
       "brand": "Equity Bank",
@@ -3366,7 +3343,7 @@
     }
   },
   "amenity/bank|Equity Bank~(Rwanda)": {
-    "locationSet": {"include": ["rw"]},
+    "locationSet": { "include": ["rw"] },
     "tags": {
       "amenity": "bank",
       "brand": "Equity Bank",
@@ -3376,7 +3353,7 @@
     }
   },
   "amenity/bank|Equity Bank~(South Sudan)": {
-    "locationSet": {"include": ["ss"]},
+    "locationSet": { "include": ["ss"] },
     "tags": {
       "amenity": "bank",
       "brand": "Equity Bank",
@@ -3386,7 +3363,7 @@
     }
   },
   "amenity/bank|Equity Bank~(Tanzania)": {
-    "locationSet": {"include": ["tz"]},
+    "locationSet": { "include": ["tz"] },
     "tags": {
       "amenity": "bank",
       "brand": "Equity Bank",
@@ -3396,7 +3373,7 @@
     }
   },
   "amenity/bank|Equity Bank~(USA)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Equity Bank",
@@ -3406,7 +3383,7 @@
     }
   },
   "amenity/bank|Equity Bank~(Uganda)": {
-    "locationSet": {"include": ["ug"]},
+    "locationSet": { "include": ["ug"] },
     "tags": {
       "amenity": "bank",
       "brand": "Equity Bank",
@@ -3428,7 +3405,7 @@
     }
   },
   "amenity/bank|EuroBic": {
-    "locationSet": {"include": ["pt"]},
+    "locationSet": { "include": ["pt"] },
     "matchNames": ["banco bic"],
     "tags": {
       "amenity": "bank",
@@ -3440,7 +3417,7 @@
     }
   },
   "amenity/bank|Eurobank~(Greece)": {
-    "locationSet": {"include": ["gr"]},
+    "locationSet": { "include": ["gr"] },
     "matchNames": ["eurobank ergasias"],
     "tags": {
       "amenity": "bank",
@@ -3451,7 +3428,7 @@
     }
   },
   "amenity/bank|Eurobank~(Poland)": {
-    "locationSet": {"include": ["pl"]},
+    "locationSet": { "include": ["pl"] },
     "tags": {
       "amenity": "bank",
       "brand": "Eurobank",
@@ -3461,7 +3438,7 @@
     }
   },
   "amenity/bank|Eurobank~(Serbia)": {
-    "locationSet": {"include": ["rs"]},
+    "locationSet": { "include": ["rs"] },
     "tags": {
       "amenity": "bank",
       "brand": "Eurobank",
@@ -3472,14 +3449,7 @@
   },
   "amenity/bank|FNB~(South Africa)": {
     "locationSet": {
-      "include": [
-        "bw",
-        "mz",
-        "na",
-        "us",
-        "za",
-        "zm"
-      ]
+      "include": ["bw", "mz", "na", "us", "za", "zm"]
     },
     "tags": {
       "amenity": "bank",
@@ -3491,7 +3461,7 @@
     }
   },
   "amenity/bank|Faysal Bank": {
-    "locationSet": {"include": ["pk"]},
+    "locationSet": { "include": ["pk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Faysal Bank",
@@ -3501,7 +3471,7 @@
     }
   },
   "amenity/bank|Federal Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Federal Bank",
@@ -3512,14 +3482,7 @@
   },
   "amenity/bank|Ficohsa": {
     "locationSet": {
-      "include": [
-        "es",
-        "gt",
-        "hn",
-        "ni",
-        "pa",
-        "us"
-      ]
+      "include": ["es", "gt", "hn", "ni", "pa", "us"]
     },
     "matchNames": ["banco ficohsa"],
     "tags": {
@@ -3531,7 +3494,7 @@
     }
   },
   "amenity/bank|Fidelity Bank~(Ghana)": {
-    "locationSet": {"include": ["gh"]},
+    "locationSet": { "include": ["gh"] },
     "tags": {
       "amenity": "bank",
       "brand": "Fidelity Bank",
@@ -3541,7 +3504,7 @@
     }
   },
   "amenity/bank|Fidelity Bank~(Nigeria)": {
-    "locationSet": {"include": ["ng"]},
+    "locationSet": { "include": ["ng"] },
     "tags": {
       "amenity": "bank",
       "brand": "Fidelity Bank",
@@ -3551,7 +3514,7 @@
     }
   },
   "amenity/bank|Fidelity Bank~(USA)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Fidelity Bank",
@@ -3561,7 +3524,7 @@
     }
   },
   "amenity/bank|Fifth Third Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "matchNames": ["5/3"],
     "tags": {
       "amenity": "bank",
@@ -3573,7 +3536,7 @@
     }
   },
   "amenity/bank|Finansbank": {
-    "locationSet": {"include": ["tr"]},
+    "locationSet": { "include": ["tr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Finansbank",
@@ -3583,7 +3546,7 @@
     }
   },
   "amenity/bank|Fio banka": {
-    "locationSet": {"include": ["cz", "sk"]},
+    "locationSet": { "include": ["cz", "sk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Fio banka",
@@ -3593,12 +3556,8 @@
     }
   },
   "amenity/bank|First Bank~(North and South Carolina)": {
-    "locationSet": {"include": ["us"]},
-    "matchNames": [
-      "1st bancorp",
-      "1st bank",
-      "first bancorp"
-    ],
+    "locationSet": { "include": ["us"] },
+    "matchNames": ["1st bancorp", "1st bank", "first bancorp"],
     "tags": {
       "amenity": "bank",
       "brand": "First Bank",
@@ -3608,12 +3567,8 @@
     }
   },
   "amenity/bank|First Bank~(Puerto Rico)": {
-    "locationSet": {"include": ["us"]},
-    "matchNames": [
-      "1st bancorp",
-      "1st bank",
-      "first bancorp"
-    ],
+    "locationSet": { "include": ["us"] },
+    "matchNames": ["1st bancorp", "1st bank", "first bancorp"],
     "tags": {
       "amenity": "bank",
       "brand": "First Bank",
@@ -3623,7 +3578,7 @@
     }
   },
   "amenity/bank|First Bank~(Western USA)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "matchNames": ["1st bank"],
     "tags": {
       "amenity": "bank",
@@ -3635,7 +3590,7 @@
     }
   },
   "amenity/bank|First Citizens Bank~(Trinidad and Tobago)": {
-    "locationSet": {"include": ["bb", "tt"]},
+    "locationSet": { "include": ["bb", "tt"] },
     "matchNames": ["1st citizens bank"],
     "tags": {
       "amenity": "bank",
@@ -3646,7 +3601,7 @@
     }
   },
   "amenity/bank|First Citizens Bank~(USA)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "matchNames": ["1st citizens bank"],
     "tags": {
       "amenity": "bank",
@@ -3657,7 +3612,7 @@
     }
   },
   "amenity/bank|First Financial Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "matchNames": ["1st financial bank"],
     "tags": {
       "amenity": "bank",
@@ -3668,7 +3623,7 @@
     }
   },
   "amenity/bank|First Interstate Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "matchNames": [
       "1st interstate",
       "1st interstate bancsystem",
@@ -3685,7 +3640,7 @@
     }
   },
   "amenity/bank|First Midwest Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "First Midwest Bank",
@@ -3695,7 +3650,7 @@
     }
   },
   "amenity/bank|First National Bank~(USA)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "First National Bank",
@@ -3705,7 +3660,7 @@
     }
   },
   "amenity/bank|First State Bank Nebraska": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "nomatch": [
       "amenity/bank|First State Bank~(Florida)",
       "amenity/bank|First State Bank~(Illinois)",
@@ -3723,7 +3678,7 @@
     }
   },
   "amenity/bank|First State Bank~(Florida)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "nomatch": [
       "amenity/bank|First State Bank Nebraska",
       "amenity/bank|First State Bank~(Illinois)",
@@ -3741,7 +3696,7 @@
     }
   },
   "amenity/bank|First State Bank~(Illinois)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "nomatch": [
       "amenity/bank|First State Bank Nebraska",
       "amenity/bank|First State Bank~(Florida)",
@@ -3759,7 +3714,7 @@
     }
   },
   "amenity/bank|First State Bank~(Michigan)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "nomatch": [
       "amenity/bank|First State Bank Nebraska",
       "amenity/bank|First State Bank~(Florida)",
@@ -3777,7 +3732,7 @@
     }
   },
   "amenity/bank|First State Bank~(Mississippi)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "nomatch": [
       "amenity/bank|First State Bank Nebraska",
       "amenity/bank|First State Bank~(Florida)",
@@ -3795,7 +3750,7 @@
     }
   },
   "amenity/bank|First State Bank~(Nebraska)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "nomatch": [
       "amenity/bank|First State Bank Nebraska",
       "amenity/bank|First State Bank~(Florida)",
@@ -3813,7 +3768,7 @@
     }
   },
   "amenity/bank|First State Bank~(Ohio)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "nomatch": [
       "amenity/bank|First State Bank Nebraska",
       "amenity/bank|First State Bank~(Florida)",
@@ -3831,7 +3786,7 @@
     }
   },
   "amenity/bank|First State Bank~(Texas)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "nomatch": [
       "amenity/bank|First State Bank Nebraska",
       "amenity/bank|First State Bank~(Florida)",
@@ -3849,12 +3804,8 @@
     }
   },
   "amenity/bank|First Tech Credit Union": {
-    "locationSet": {"include": ["us"]},
-    "matchNames": [
-      "1st tech",
-      "1st tech credit union",
-      "first tech"
-    ],
+    "locationSet": { "include": ["us"] },
+    "matchNames": ["1st tech", "1st tech credit union", "first tech"],
     "tags": {
       "amenity": "bank",
       "brand": "First Tech Credit Union",
@@ -3864,7 +3815,7 @@
     }
   },
   "amenity/bank|First West Credit Union": {
-    "locationSet": {"include": ["ca"]},
+    "locationSet": { "include": ["ca"] },
     "tags": {
       "alt_name": "First West",
       "amenity": "bank",
@@ -3875,7 +3826,7 @@
     }
   },
   "amenity/bank|Frost Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Frost Bank",
@@ -3885,7 +3836,7 @@
     }
   },
   "amenity/bank|Fulton Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Fulton Bank",
@@ -3894,7 +3845,7 @@
     }
   },
   "amenity/bank|GCB Bank": {
-    "locationSet": {"include": ["gh"]},
+    "locationSet": { "include": ["gh"] },
     "tags": {
       "amenity": "bank",
       "brand": "GCB Bank",
@@ -3905,18 +3856,7 @@
   },
   "amenity/bank|GT Bank": {
     "locationSet": {
-      "include": [
-        "ci",
-        "gb",
-        "gh",
-        "gm",
-        "ke",
-        "lr",
-        "ng",
-        "rw",
-        "tz",
-        "ug"
-      ]
+      "include": ["ci", "gb", "gh", "gm", "ke", "lr", "ng", "rw", "tz", "ug"]
     },
     "tags": {
       "amenity": "bank",
@@ -3928,7 +3868,7 @@
     }
   },
   "amenity/bank|Galicia": {
-    "locationSet": {"include": ["ar"]},
+    "locationSet": { "include": ["ar"] },
     "tags": {
       "amenity": "bank",
       "brand": "Galicia",
@@ -3938,7 +3878,7 @@
     }
   },
   "amenity/bank|Garanti": {
-    "locationSet": {"include": ["tr"]},
+    "locationSet": { "include": ["tr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Garanti",
@@ -3948,7 +3888,7 @@
     }
   },
   "amenity/bank|Garanti Bankası": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Garanti Bankası",
@@ -3958,7 +3898,7 @@
     }
   },
   "amenity/bank|Getin Bank": {
-    "locationSet": {"include": ["pl"]},
+    "locationSet": { "include": ["pl"] },
     "tags": {
       "amenity": "bank",
       "brand": "Getin Bank",
@@ -3968,7 +3908,7 @@
     }
   },
   "amenity/bank|Golden 1 Credit Union": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "matchNames": [
       "golden 1",
       "golden one",
@@ -3985,7 +3925,7 @@
     }
   },
   "amenity/bank|Great Western Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Great Western Bank",
@@ -3995,7 +3935,7 @@
     }
   },
   "amenity/bank|Groupama": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Groupama",
@@ -4005,7 +3945,7 @@
     }
   },
   "amenity/bank|HBL Bank": {
-    "locationSet": {"include": ["pk"]},
+    "locationSet": { "include": ["pk"] },
     "matchNames": ["hbl"],
     "tags": {
       "amenity": "bank",
@@ -4016,7 +3956,7 @@
     }
   },
   "amenity/bank|HDFC Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "HDFC Bank",
@@ -4026,7 +3966,7 @@
     }
   },
   "amenity/bank|HNB": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "HNB",
@@ -4036,7 +3976,7 @@
     }
   },
   "amenity/bank|HSBC UK~(UK)": {
-    "locationSet": {"include": ["gb"]},
+    "locationSet": { "include": ["gb"] },
     "matchNames": ["hsbc"],
     "tags": {
       "amenity": "bank",
@@ -4046,7 +3986,7 @@
     }
   },
   "amenity/bank|HSBC~(Global)": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "HSBC",
@@ -4056,7 +3996,7 @@
     }
   },
   "amenity/bank|Halifax": {
-    "locationSet": {"include": ["gb"]},
+    "locationSet": { "include": ["gb"] },
     "tags": {
       "amenity": "bank",
       "brand": "Halifax",
@@ -4066,7 +4006,7 @@
     }
   },
   "amenity/bank|Halkbank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Halkbank",
@@ -4076,7 +4016,7 @@
     }
   },
   "amenity/bank|Hamburger Sparkasse": {
-    "locationSet": {"include": ["de"]},
+    "locationSet": { "include": ["de"] },
     "tags": {
       "amenity": "bank",
       "brand": "Hamburger Sparkasse",
@@ -4099,7 +4039,7 @@
     }
   },
   "amenity/bank|Heritage Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Heritage Bank",
@@ -4109,7 +4049,7 @@
     }
   },
   "amenity/bank|Hong Leong Bank": {
-    "locationSet": {"include": ["my"]},
+    "locationSet": { "include": ["my"] },
     "tags": {
       "amenity": "bank",
       "brand": "Hong Leong Bank",
@@ -4121,7 +4061,7 @@
     }
   },
   "amenity/bank|Hrvatska poštanska banka": {
-    "locationSet": {"include": ["hr"]},
+    "locationSet": { "include": ["hr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Hrvatska poštanska banka",
@@ -4131,7 +4071,7 @@
     }
   },
   "amenity/bank|Huntington Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Huntington Bank",
@@ -4141,7 +4081,7 @@
     }
   },
   "amenity/bank|HypoVereinsbank": {
-    "locationSet": {"include": ["de"]},
+    "locationSet": { "include": ["de"] },
     "tags": {
       "amenity": "bank",
       "brand": "HypoVereinsbank",
@@ -4151,7 +4091,7 @@
     }
   },
   "amenity/bank|ICBC": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "ICBC",
@@ -4173,7 +4113,7 @@
     }
   },
   "amenity/bank|IDBI Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "IDBI Bank",
@@ -4183,7 +4123,7 @@
     }
   },
   "amenity/bank|ING": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "matchNames": ["ing bank"],
     "tags": {
       "amenity": "bank",
@@ -4194,7 +4134,7 @@
     }
   },
   "amenity/bank|ING Bank Śląski": {
-    "locationSet": {"include": ["pl"]},
+    "locationSet": { "include": ["pl"] },
     "tags": {
       "amenity": "bank",
       "brand": "ING Bank Śląski",
@@ -4204,7 +4144,7 @@
     }
   },
   "amenity/bank|Ibercaja": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "Ibercaja",
@@ -4214,7 +4154,7 @@
     }
   },
   "amenity/bank|Indian Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Indian Bank",
@@ -4224,7 +4164,7 @@
     }
   },
   "amenity/bank|Indian Overseas Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Indian Overseas Bank",
@@ -4234,7 +4174,7 @@
     }
   },
   "amenity/bank|Interbank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "nomatch": ["amenity/bank|Bankinter"],
     "tags": {
       "amenity": "bank",
@@ -4245,7 +4185,7 @@
     }
   },
   "amenity/bank|Intesa Sanpaolo": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Intesa Sanpaolo",
@@ -4255,7 +4195,7 @@
     }
   },
   "amenity/bank|Investors Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Investors Bank",
@@ -4265,7 +4205,7 @@
     }
   },
   "amenity/bank|Itaú~(Brazil)": {
-    "locationSet": {"include": ["br"]},
+    "locationSet": { "include": ["br"] },
     "matchNames": ["banco itau"],
     "nomatch": ["amenity/bank|Itaú~(Chile)"],
     "tags": {
@@ -4277,7 +4217,7 @@
     }
   },
   "amenity/bank|Itaú~(Chile)": {
-    "locationSet": {"include": ["cl"]},
+    "locationSet": { "include": ["cl"] },
     "matchNames": ["banco itau"],
     "nomatch": ["amenity/bank|Itaú~(Brazil)"],
     "tags": {
@@ -4289,7 +4229,7 @@
     }
   },
   "amenity/bank|J&T Banka": {
-    "locationSet": {"include": ["cz", "sk"]},
+    "locationSet": { "include": ["cz", "sk"] },
     "tags": {
       "amenity": "bank",
       "brand": "J&T Banka",
@@ -4299,7 +4239,7 @@
     }
   },
   "amenity/bank|JAバンク": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "matchNames": ["ja", "ジェイエイバンク"],
     "nomatch": ["amenity/fuel|JA-SS"],
     "tags": {
@@ -4316,7 +4256,7 @@
     }
   },
   "amenity/bank|JS Bank": {
-    "locationSet": {"include": ["pk"]},
+    "locationSet": { "include": ["pk"] },
     "tags": {
       "amenity": "bank",
       "brand": "JS Bank",
@@ -4326,7 +4266,7 @@
     }
   },
   "amenity/bank|Jyske Bank": {
-    "locationSet": {"include": ["dk"]},
+    "locationSet": { "include": ["dk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Jyske Bank",
@@ -4336,7 +4276,7 @@
     }
   },
   "amenity/bank|K&H Bank": {
-    "locationSet": {"include": ["hu"]},
+    "locationSet": { "include": ["hu"] },
     "tags": {
       "amenity": "bank",
       "brand": "K&H Bank",
@@ -4346,7 +4286,7 @@
     }
   },
   "amenity/bank|KBC": {
-    "locationSet": {"include": ["be", "ie"]},
+    "locationSet": { "include": ["be", "ie"] },
     "tags": {
       "amenity": "bank",
       "brand": "KBC",
@@ -4356,7 +4296,7 @@
     }
   },
   "amenity/bank|KBZ Bank": {
-    "locationSet": {"include": ["mm"]},
+    "locationSet": { "include": ["mm"] },
     "tags": {
       "amenity": "bank",
       "brand": "KBZ Bank",
@@ -4366,7 +4306,7 @@
     }
   },
   "amenity/bank|Karnataka Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Karnataka Bank",
@@ -4376,7 +4316,7 @@
     }
   },
   "amenity/bank|Karur Vysya Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Karur Vysya Bank",
@@ -4386,7 +4326,7 @@
     }
   },
   "amenity/bank|Kasa Stefczyka": {
-    "locationSet": {"include": ["pl"]},
+    "locationSet": { "include": ["pl"] },
     "tags": {
       "amenity": "bank",
       "brand": "Kasa Stefczyka",
@@ -4395,7 +4335,7 @@
     }
   },
   "amenity/bank|Kerala Gramin Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Kerala Gramin Bank",
@@ -4405,7 +4345,7 @@
     }
   },
   "amenity/bank|KeyBank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "KeyBank",
@@ -4415,7 +4355,7 @@
     }
   },
   "amenity/bank|Komerční banka": {
-    "locationSet": {"include": ["cz"]},
+    "locationSet": { "include": ["cz"] },
     "tags": {
       "amenity": "bank",
       "brand": "Komerční banka",
@@ -4425,7 +4365,7 @@
     }
   },
   "amenity/bank|Kotak Mahindra Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Kotak Mahindra Bank",
@@ -4435,7 +4375,7 @@
     }
   },
   "amenity/bank|Kutxabank": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "Kutxabank",
@@ -4445,7 +4385,7 @@
     }
   },
   "amenity/bank|Kuveyt Türk": {
-    "locationSet": {"include": ["tr"]},
+    "locationSet": { "include": ["tr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Kuveyt Türk",
@@ -4455,7 +4395,7 @@
     }
   },
   "amenity/bank|LCL": {
-    "locationSet": {"include": ["fr"]},
+    "locationSet": { "include": ["fr"] },
     "tags": {
       "amenity": "bank",
       "brand": "LCL",
@@ -4465,7 +4405,7 @@
     }
   },
   "amenity/bank|LCNB": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "alt_name": "Lebanon Citizens National Bank",
       "amenity": "bank",
@@ -4476,7 +4416,7 @@
     }
   },
   "amenity/bank|La Banque Postale": {
-    "locationSet": {"include": ["fr"]},
+    "locationSet": { "include": ["fr"] },
     "tags": {
       "amenity": "bank",
       "brand": "La Banque Postale",
@@ -4486,7 +4426,7 @@
     }
   },
   "amenity/bank|La Caixa": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "La Caixa",
@@ -4496,7 +4436,7 @@
     }
   },
   "amenity/bank|Laboral Kutxa": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "Laboral Kutxa",
@@ -4506,7 +4446,7 @@
     }
   },
   "amenity/bank|Lake Michigan Credit Union": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Lake Michigan Credit Union",
@@ -4517,7 +4457,7 @@
     }
   },
   "amenity/bank|Landbank": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "matchNames": [
       "bangko sa lupa ng pilipinas",
       "land bank of the philippines",
@@ -4532,7 +4472,7 @@
     }
   },
   "amenity/bank|Leeds Building Society": {
-    "locationSet": {"include": ["gb"]},
+    "locationSet": { "include": ["gb"] },
     "tags": {
       "amenity": "bank",
       "brand": "Leeds Building Society",
@@ -4542,7 +4482,7 @@
     }
   },
   "amenity/bank|Liberbank": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "Liberbank",
@@ -4552,7 +4492,7 @@
     }
   },
   "amenity/bank|Liberty Bank~(Connecticut)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "nomatch": ["amenity/fuel|Liberty"],
     "tags": {
       "amenity": "bank",
@@ -4563,7 +4503,7 @@
     }
   },
   "amenity/bank|Lloyds Bank": {
-    "locationSet": {"include": ["gb", "im"]},
+    "locationSet": { "include": ["gb", "im"] },
     "matchNames": ["lloyds", "lloyds tsb"],
     "tags": {
       "amenity": "bank",
@@ -4574,7 +4514,7 @@
     }
   },
   "amenity/bank|M&T Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "M&T Bank",
@@ -4584,7 +4524,7 @@
     }
   },
   "amenity/bank|MCB": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "matchNames": ["mcb bank"],
     "tags": {
       "amenity": "bank",
@@ -4595,7 +4535,7 @@
     }
   },
   "amenity/bank|MONETA Money Bank": {
-    "locationSet": {"include": ["cz"]},
+    "locationSet": { "include": ["cz"] },
     "tags": {
       "amenity": "bank",
       "brand": "MONETA Money Bank",
@@ -4605,7 +4545,7 @@
     }
   },
   "amenity/bank|Macro": {
-    "locationSet": {"include": ["ar"]},
+    "locationSet": { "include": ["ar"] },
     "tags": {
       "amenity": "bank",
       "brand": "Macro",
@@ -4615,7 +4555,7 @@
     }
   },
   "amenity/bank|Maybank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Maybank",
@@ -4625,7 +4565,7 @@
     }
   },
   "amenity/bank|Meezan Bank": {
-    "locationSet": {"include": ["pk"]},
+    "locationSet": { "include": ["pk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Meezan Bank",
@@ -4635,7 +4575,7 @@
     }
   },
   "amenity/bank|Mercantil": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Mercantil",
@@ -4645,7 +4585,7 @@
     }
   },
   "amenity/bank|Meridian Credit Union": {
-    "locationSet": {"include": ["ca"]},
+    "locationSet": { "include": ["ca"] },
     "tags": {
       "alt_name": "Meridian",
       "amenity": "bank",
@@ -4656,7 +4596,7 @@
     }
   },
   "amenity/bank|Metro Bank~(UK)": {
-    "locationSet": {"include": ["gb"]},
+    "locationSet": { "include": ["gb"] },
     "nomatch": [
       "amenity/bank|Metrobank~(Philippines)",
       "shop/mobile_phone|MetroPCS",
@@ -4674,7 +4614,7 @@
     }
   },
   "amenity/bank|Metrobank~(Philippines)": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "nomatch": [
       "amenity/bank|Metro Bank~(UK)",
       "shop/mobile_phone|MetroPCS",
@@ -4692,7 +4632,7 @@
     }
   },
   "amenity/bank|Mibanco": {
-    "locationSet": {"include": ["pe"]},
+    "locationSet": { "include": ["pe"] },
     "tags": {
       "amenity": "bank",
       "brand": "Mibanco",
@@ -4701,7 +4641,7 @@
     }
   },
   "amenity/bank|MidFirst Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "MidFirst Bank",
@@ -4711,7 +4651,7 @@
     }
   },
   "amenity/bank|Millennium Bank": {
-    "locationSet": {"include": ["pl"]},
+    "locationSet": { "include": ["pl"] },
     "matchNames": ["bank millennium"],
     "tags": {
       "amenity": "bank",
@@ -4722,7 +4662,7 @@
     }
   },
   "amenity/bank|Millennium bcp": {
-    "locationSet": {"include": ["pt"]},
+    "locationSet": { "include": ["pt"] },
     "tags": {
       "amenity": "bank",
       "brand": "Millennium bcp",
@@ -4735,7 +4675,7 @@
     }
   },
   "amenity/bank|Mission Federal Credit Union": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Mission Federal Credit Union",
@@ -4745,7 +4685,7 @@
     }
   },
   "amenity/bank|Mittelbrandenburgische Sparkasse": {
-    "locationSet": {"include": ["de"]},
+    "locationSet": { "include": ["de"] },
     "tags": {
       "amenity": "bank",
       "brand": "Mittelbrandenburgische Sparkasse",
@@ -4755,7 +4695,7 @@
     }
   },
   "amenity/bank|Monte dei Paschi di Siena": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Monte dei Paschi di Siena",
@@ -4765,7 +4705,7 @@
     }
   },
   "amenity/bank|Montepio": {
-    "locationSet": {"include": ["pt"]},
+    "locationSet": { "include": ["pt"] },
     "tags": {
       "amenity": "bank",
       "brand": "Montepio",
@@ -4775,7 +4715,7 @@
     }
   },
   "amenity/bank|Mountain America Credit Union": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Mountain America Credit Union",
@@ -4785,7 +4725,7 @@
     }
   },
   "amenity/bank|NAB": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "NAB",
@@ -4795,7 +4735,7 @@
     }
   },
   "amenity/bank|NASA Federal Credit Union": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "NASA Federal Credit Union",
@@ -4805,7 +4745,7 @@
     }
   },
   "amenity/bank|NLB": {
-    "locationSet": {"include": ["si"]},
+    "locationSet": { "include": ["si"] },
     "tags": {
       "amenity": "bank",
       "brand": "NLB",
@@ -4815,7 +4755,7 @@
     }
   },
   "amenity/bank|NSB": {
-    "locationSet": {"include": ["lk"]},
+    "locationSet": { "include": ["lk"] },
     "matchNames": ["national savings bank"],
     "tags": {
       "amenity": "bank",
@@ -4826,7 +4766,7 @@
     }
   },
   "amenity/bank|NatWest": {
-    "locationSet": {"include": ["gb", "gg"]},
+    "locationSet": { "include": ["gb", "gg"] },
     "tags": {
       "amenity": "bank",
       "brand": "NatWest",
@@ -4836,11 +4776,8 @@
     }
   },
   "amenity/bank|National Bank": {
-    "locationSet": {"include": ["ca"]},
-    "matchNames": [
-      "banque nationale",
-      "banque nationale du canada"
-    ],
+    "locationSet": { "include": ["ca"] },
+    "matchNames": ["banque nationale", "banque nationale du canada"],
     "tags": {
       "amenity": "bank",
       "brand": "National Bank",
@@ -4857,7 +4794,7 @@
     }
   },
   "amenity/bank|Nationwide": {
-    "locationSet": {"include": ["gb"]},
+    "locationSet": { "include": ["gb"] },
     "nomatch": ["office/insurance|Nationwide"],
     "tags": {
       "amenity": "bank",
@@ -4868,7 +4805,7 @@
     }
   },
   "amenity/bank|Navy Federal Credit Union": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Navy Federal Credit Union",
@@ -4878,7 +4815,7 @@
     }
   },
   "amenity/bank|Nedbank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Nedbank",
@@ -4888,7 +4825,7 @@
     }
   },
   "amenity/bank|Nest Bank": {
-    "locationSet": {"include": ["pl"]},
+    "locationSet": { "include": ["pl"] },
     "tags": {
       "amenity": "bank",
       "brand": "Nest Bank",
@@ -4898,7 +4835,7 @@
     }
   },
   "amenity/bank|Nordea": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Nordea",
@@ -4908,7 +4845,7 @@
     }
   },
   "amenity/bank|Novo Banco": {
-    "locationSet": {"include": ["es", "pt"]},
+    "locationSet": { "include": ["es", "pt"] },
     "tags": {
       "amenity": "bank",
       "brand": "Novo Banco",
@@ -4918,7 +4855,7 @@
     }
   },
   "amenity/bank|OCBC Bank": {
-    "locationSet": {"include": ["my", "sg"]},
+    "locationSet": { "include": ["my", "sg"] },
     "tags": {
       "amenity": "bank",
       "brand": "OCBC Bank",
@@ -4930,7 +4867,7 @@
     }
   },
   "amenity/bank|OLB": {
-    "locationSet": {"include": ["de"]},
+    "locationSet": { "include": ["de"] },
     "tags": {
       "amenity": "bank",
       "brand": "OLB",
@@ -4940,7 +4877,7 @@
     }
   },
   "amenity/bank|OTP": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "matchNames": ["otp bank"],
     "tags": {
       "amenity": "bank",
@@ -4963,7 +4900,7 @@
     }
   },
   "amenity/bank|Occidental de Descuento": {
-    "locationSet": {"include": ["ve"]},
+    "locationSet": { "include": ["ve"] },
     "tags": {
       "amenity": "bank",
       "brand": "Occidental de Descuento",
@@ -4973,7 +4910,7 @@
     }
   },
   "amenity/bank|Old National Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Old National Bank",
@@ -4981,7 +4918,7 @@
     }
   },
   "amenity/bank|Oldenburgische Landesbank": {
-    "locationSet": {"include": ["de"]},
+    "locationSet": { "include": ["de"] },
     "tags": {
       "amenity": "bank",
       "brand": "Oldenburgische Landesbank",
@@ -4991,7 +4928,7 @@
     }
   },
   "amenity/bank|One Network Bank": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "tags": {
       "amenity": "bank",
       "brand": "One Network Bank",
@@ -5001,7 +4938,7 @@
     }
   },
   "amenity/bank|Oriental": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "alt_name": "Oriental Bank",
       "amenity": "bank",
@@ -5011,7 +4948,7 @@
     }
   },
   "amenity/bank|Oriental Bank of Commerce": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Oriental Bank of Commerce",
@@ -5021,7 +4958,7 @@
     }
   },
   "amenity/bank|Osuuspankki": {
-    "locationSet": {"include": ["fi"]},
+    "locationSet": { "include": ["fi"] },
     "tags": {
       "amenity": "bank",
       "brand": "Osuuspankki",
@@ -5031,7 +4968,7 @@
     }
   },
   "amenity/bank|PBZ": {
-    "locationSet": {"include": ["hr"]},
+    "locationSet": { "include": ["hr"] },
     "tags": {
       "amenity": "bank",
       "brand": "PBZ",
@@ -5041,7 +4978,7 @@
     }
   },
   "amenity/bank|PKO BP": {
-    "locationSet": {"include": ["pl"]},
+    "locationSet": { "include": ["pl"] },
     "matchNames": ["pko bank polski"],
     "tags": {
       "amenity": "bank",
@@ -5052,7 +4989,7 @@
     }
   },
   "amenity/bank|PNB": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "tags": {
       "amenity": "bank",
       "brand": "PNB",
@@ -5063,7 +5000,7 @@
     }
   },
   "amenity/bank|PNC Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "matchNames": ["pnc"],
     "tags": {
       "amenity": "bank",
@@ -5074,7 +5011,7 @@
     }
   },
   "amenity/bank|PSBank": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "tags": {
       "amenity": "bank",
       "brand": "PSBank",
@@ -5084,7 +5021,7 @@
     }
   },
   "amenity/bank|Panin Bank": {
-    "locationSet": {"include": ["id"]},
+    "locationSet": { "include": ["id"] },
     "tags": {
       "amenity": "bank",
       "brand": "Panin Bank",
@@ -5094,7 +5031,7 @@
     }
   },
   "amenity/bank|Patagonia": {
-    "locationSet": {"include": ["ar"]},
+    "locationSet": { "include": ["ar"] },
     "tags": {
       "amenity": "bank",
       "brand": "Patagonia",
@@ -5104,7 +5041,7 @@
     }
   },
   "amenity/bank|Pekao SA": {
-    "locationSet": {"include": ["pl"]},
+    "locationSet": { "include": ["pl"] },
     "tags": {
       "amenity": "bank",
       "brand": "Pekao SA",
@@ -5114,7 +5051,7 @@
     }
   },
   "amenity/bank|PenFed Credit Union": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "alt_name": "Pentagon Federal Credit Union",
       "amenity": "bank",
@@ -5126,7 +5063,7 @@
     }
   },
   "amenity/bank|People's United Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "People's United Bank",
@@ -5136,7 +5073,7 @@
     }
   },
   "amenity/bank|Peoples Bank~(Flemingsburg, Kentucky)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Peoples Bank",
@@ -5145,7 +5082,7 @@
     }
   },
   "amenity/bank|Peoples Bank~(Ohio)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Peoples Bank",
@@ -5154,7 +5091,7 @@
     }
   },
   "amenity/bank|Peoples Bank~(Washington)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Peoples Bank",
@@ -5164,7 +5101,7 @@
     }
   },
   "amenity/bank|Permanent TSB": {
-    "locationSet": {"include": ["ie"]},
+    "locationSet": { "include": ["ie"] },
     "tags": {
       "amenity": "bank",
       "brand": "Permanent TSB",
@@ -5186,7 +5123,7 @@
     }
   },
   "amenity/bank|Popular": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "matchNames": ["popular bank"],
     "nomatch": ["shop/books|Popular"],
     "tags": {
@@ -5208,7 +5145,7 @@
     }
   },
   "amenity/bank|Postbank~(Bulgaria)": {
-    "locationSet": {"include": ["bg"]},
+    "locationSet": { "include": ["bg"] },
     "nomatch": ["amenity/bank|Bancpost"],
     "tags": {
       "amenity": "bank",
@@ -5219,7 +5156,7 @@
     }
   },
   "amenity/bank|Postbank~(Germany)": {
-    "locationSet": {"include": ["de"]},
+    "locationSet": { "include": ["de"] },
     "matchNames": ["postbank finanzcenter"],
     "nomatch": ["amenity/bank|Bancpost"],
     "tags": {
@@ -5231,7 +5168,7 @@
     }
   },
   "amenity/bank|Poštová banka": {
-    "locationSet": {"include": ["sk"]},
+    "locationSet": { "include": ["sk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Poštová banka",
@@ -5241,7 +5178,7 @@
     }
   },
   "amenity/bank|Prima banka": {
-    "locationSet": {"include": ["sk"]},
+    "locationSet": { "include": ["sk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Prima banka",
@@ -5251,7 +5188,7 @@
     }
   },
   "amenity/bank|Privatbanka": {
-    "locationSet": {"include": ["sk"]},
+    "locationSet": { "include": ["sk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Privatbanka",
@@ -5261,7 +5198,7 @@
     }
   },
   "amenity/bank|Promerica": {
-    "locationSet": {"include": ["cr", "hn"]},
+    "locationSet": { "include": ["cr", "hn"] },
     "matchNames": ["banco promerica"],
     "tags": {
       "amenity": "bank",
@@ -5270,7 +5207,7 @@
     }
   },
   "amenity/bank|Prosperity Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Prosperity Bank",
@@ -5278,7 +5215,7 @@
     }
   },
   "amenity/bank|Provincial": {
-    "locationSet": {"include": ["ve"]},
+    "locationSet": { "include": ["ve"] },
     "matchNames": ["bbva provincial"],
     "tags": {
       "amenity": "bank",
@@ -5289,7 +5226,7 @@
     }
   },
   "amenity/bank|Prvá stavebná sporiteľňa": {
-    "locationSet": {"include": ["sk"]},
+    "locationSet": { "include": ["sk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Prvá stavebná sporiteľňa",
@@ -5299,7 +5236,7 @@
     }
   },
   "amenity/bank|Public Bank~(Malaysia)": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "matchNames": ["public bank berhad"],
     "tags": {
       "amenity": "bank",
@@ -5312,7 +5249,7 @@
     }
   },
   "amenity/bank|Punjab National Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Punjab National Bank",
@@ -5322,12 +5259,8 @@
     }
   },
   "amenity/bank|RBC": {
-    "locationSet": {"include": ["001"]},
-    "matchNames": [
-      "rbc financial group",
-      "rbc royal bank",
-      "royal bank"
-    ],
+    "locationSet": { "include": ["001"] },
+    "matchNames": ["rbc financial group", "rbc royal bank", "royal bank"],
     "tags": {
       "amenity": "bank",
       "brand": "RBC",
@@ -5351,7 +5284,7 @@
     }
   },
   "amenity/bank|RCBC": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "matchNames": ["rcbc savings bank"],
     "tags": {
       "amenity": "bank",
@@ -5387,7 +5320,7 @@
     }
   },
   "amenity/bank|Raiffeisen Polbank": {
-    "locationSet": {"include": ["de", "pl"]},
+    "locationSet": { "include": ["de", "pl"] },
     "nomatch": [
       "amenity/bank|Raiffeisenbank~(Albania)",
       "amenity/bank|Raiffeisenbank~(Bulgaria)",
@@ -5407,7 +5340,7 @@
     }
   },
   "amenity/bank|Raiffeisenbank~(Albania)": {
-    "locationSet": {"include": ["al"]},
+    "locationSet": { "include": ["al"] },
     "matchNames": ["raiffeisen"],
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
@@ -5428,7 +5361,7 @@
     }
   },
   "amenity/bank|Raiffeisenbank~(Bulgaria)": {
-    "locationSet": {"include": ["bg"]},
+    "locationSet": { "include": ["bg"] },
     "matchNames": ["raiffeisen"],
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
@@ -5449,11 +5382,8 @@
     }
   },
   "amenity/bank|Raiffeisenbank~(Czech Republic)": {
-    "locationSet": {"include": ["cz"]},
-    "matchNames": [
-      "raiffeisen",
-      "raiffeisenkasse"
-    ],
+    "locationSet": { "include": ["cz"] },
+    "matchNames": ["raiffeisen", "raiffeisenkasse"],
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
       "amenity/bank|Raiffeisenbank~(Albania)",
@@ -5473,7 +5403,7 @@
     }
   },
   "amenity/bank|Raiffeisenbank~(Romania)": {
-    "locationSet": {"include": ["ro"]},
+    "locationSet": { "include": ["ro"] },
     "matchNames": ["raiffeisen"],
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
@@ -5494,7 +5424,7 @@
     }
   },
   "amenity/bank|Raiffeisenbank~(Serbia)": {
-    "locationSet": {"include": ["rs"]},
+    "locationSet": { "include": ["rs"] },
     "matchNames": ["raiffeisen"],
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
@@ -5515,7 +5445,7 @@
     }
   },
   "amenity/bank|Raiffeisen~(Luxembourg)": {
-    "locationSet": {"include": ["lu"]},
+    "locationSet": { "include": ["lu"] },
     "matchNames": ["raiffeisen"],
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
@@ -5537,7 +5467,7 @@
     }
   },
   "amenity/bank|Regions Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Regions Bank",
@@ -5559,7 +5489,7 @@
     }
   },
   "amenity/bank|Republic Bank~(USA)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Republic Bank",
@@ -5570,7 +5500,7 @@
     }
   },
   "amenity/bank|República": {
-    "locationSet": {"include": ["uy"]},
+    "locationSet": { "include": ["uy"] },
     "tags": {
       "amenity": "bank",
       "brand": "República",
@@ -5580,7 +5510,7 @@
     }
   },
   "amenity/bank|S-Pankki": {
-    "locationSet": {"include": ["fi"]},
+    "locationSet": { "include": ["fi"] },
     "tags": {
       "amenity": "bank",
       "brand": "S-Pankki",
@@ -5590,7 +5520,7 @@
     }
   },
   "amenity/bank|SC제일은행": {
-    "locationSet": {"include": ["kr"]},
+    "locationSet": { "include": ["kr"] },
     "tags": {
       "amenity": "bank",
       "brand": "SC제일은행",
@@ -5614,7 +5544,7 @@
     }
   },
   "amenity/bank|SMBC信託銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "SMBC信託銀行",
@@ -5626,7 +5556,7 @@
     }
   },
   "amenity/bank|SNS Bank": {
-    "locationSet": {"include": ["nl"]},
+    "locationSet": { "include": ["nl"] },
     "tags": {
       "amenity": "bank",
       "brand": "SNS Bank",
@@ -5636,7 +5566,7 @@
     }
   },
   "amenity/bank|Sacombank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Sacombank",
@@ -5646,7 +5576,7 @@
     }
   },
   "amenity/bank|Sampath Bank": {
-    "locationSet": {"include": ["lk"]},
+    "locationSet": { "include": ["lk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Sampath Bank",
@@ -5656,7 +5586,7 @@
     }
   },
   "amenity/bank|San Diego County Credit Union": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "San Diego County Credit Union",
@@ -5667,7 +5597,7 @@
     }
   },
   "amenity/bank|Santander": {
-    "locationSet": {"include": ["gb"]},
+    "locationSet": { "include": ["gb"] },
     "tags": {
       "amenity": "bank",
       "brand": "Santander",
@@ -5677,7 +5607,7 @@
     }
   },
   "amenity/bank|Santander Río": {
-    "locationSet": {"include": ["ar"]},
+    "locationSet": { "include": ["ar"] },
     "tags": {
       "amenity": "bank",
       "brand": "Santander Río",
@@ -5687,7 +5617,7 @@
     }
   },
   "amenity/bank|Santander Totta": {
-    "locationSet": {"include": ["pt"]},
+    "locationSet": { "include": ["pt"] },
     "tags": {
       "amenity": "bank",
       "brand": "Santander Totta",
@@ -5697,7 +5627,7 @@
     }
   },
   "amenity/bank|Sberbank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Sberbank",
@@ -5707,7 +5637,7 @@
     }
   },
   "amenity/bank|Scotiabank~(Québec)": {
-    "locationSet": {"include": ["ca"]},
+    "locationSet": { "include": ["ca"] },
     "matchNames": ["scotia"],
     "nomatch": ["amenity/bank|Scotiabank"],
     "tags": {
@@ -5719,11 +5649,9 @@
     }
   },
   "amenity/bank|Scotiabank~(non-Québec)": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "matchNames": ["scotia"],
-    "nomatch": [
-      "amenity/bank|Scotiabank~(Québec)"
-    ],
+    "nomatch": ["amenity/bank|Scotiabank~(Québec)"],
     "tags": {
       "amenity": "bank",
       "brand": "Scotiabank",
@@ -5733,7 +5661,7 @@
     }
   },
   "amenity/bank|Security Bank": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "tags": {
       "amenity": "bank",
       "brand": "Security Bank",
@@ -5743,7 +5671,7 @@
     }
   },
   "amenity/bank|Security Service Federal Credit Union": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "matchNames": ["security service fcu"],
     "tags": {
       "amenity": "bank",
@@ -5755,7 +5683,7 @@
     }
   },
   "amenity/bank|Service Credit Union": {
-    "locationSet": {"include": ["de", "us"]},
+    "locationSet": { "include": ["de", "us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Service Credit Union",
@@ -5765,7 +5693,7 @@
     }
   },
   "amenity/bank|Servus Credit Union": {
-    "locationSet": {"include": ["ca"]},
+    "locationSet": { "include": ["ca"] },
     "tags": {
       "alt_name": "Servus",
       "amenity": "bank",
@@ -5776,7 +5704,7 @@
     }
   },
   "amenity/bank|Seylan Bank": {
-    "locationSet": {"include": ["lk"]},
+    "locationSet": { "include": ["lk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Seylan Bank",
@@ -5786,7 +5714,7 @@
     }
   },
   "amenity/bank|Siam Commercial Bank": {
-    "locationSet": {"include": ["th"]},
+    "locationSet": { "include": ["th"] },
     "tags": {
       "amenity": "bank",
       "brand": "Siam Commercial Bank",
@@ -5796,7 +5724,7 @@
     }
   },
   "amenity/bank|Sicoob": {
-    "locationSet": {"include": ["br"]},
+    "locationSet": { "include": ["br"] },
     "tags": {
       "amenity": "bank",
       "brand": "Sicoob",
@@ -5806,7 +5734,7 @@
     }
   },
   "amenity/bank|Sicredi": {
-    "locationSet": {"include": ["br"]},
+    "locationSet": { "include": ["br"] },
     "tags": {
       "amenity": "bank",
       "brand": "Sicredi",
@@ -5816,7 +5744,7 @@
     }
   },
   "amenity/bank|Simmons Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Simmons Bank",
@@ -5826,7 +5754,7 @@
     }
   },
   "amenity/bank|Skipton Building Society": {
-    "locationSet": {"include": ["gb"]},
+    "locationSet": { "include": ["gb"] },
     "tags": {
       "amenity": "bank",
       "brand": "Skipton Building Society",
@@ -5836,7 +5764,7 @@
     }
   },
   "amenity/bank|Slovenská sporiteľňa": {
-    "locationSet": {"include": ["sk"]},
+    "locationSet": { "include": ["sk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Slovenská sporiteľňa",
@@ -5846,7 +5774,7 @@
     }
   },
   "amenity/bank|Société Générale": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Société Générale",
@@ -5856,7 +5784,7 @@
     }
   },
   "amenity/bank|Société Marseillaise de Crédit": {
-    "locationSet": {"include": ["fr"]},
+    "locationSet": { "include": ["fr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Société Marseillaise de Crédit",
@@ -5866,7 +5794,7 @@
     }
   },
   "amenity/bank|Société générale Côte d’Ivoire": {
-    "locationSet": {"include": ["ci"]},
+    "locationSet": { "include": ["ci"] },
     "matchNames": ["agence sgbci", "sgbci"],
     "tags": {
       "amenity": "bank",
@@ -5879,7 +5807,7 @@
     }
   },
   "amenity/bank|South Indian Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "South Indian Bank",
@@ -5889,7 +5817,7 @@
     }
   },
   "amenity/bank|South State Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "South State Bank",
@@ -5899,7 +5827,7 @@
     }
   },
   "amenity/bank|Southern Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Southern Bank",
@@ -5909,7 +5837,7 @@
     }
   },
   "amenity/bank|Sparda-Bank": {
-    "locationSet": {"include": ["at", "de"]},
+    "locationSet": { "include": ["at", "de"] },
     "tags": {
       "amenity": "bank",
       "brand": "Sparda-Bank",
@@ -5919,7 +5847,7 @@
     }
   },
   "amenity/bank|Stanbic Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Stanbic Bank",
@@ -5929,7 +5857,7 @@
     }
   },
   "amenity/bank|Standard Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Standard Bank",
@@ -5939,7 +5867,7 @@
     }
   },
   "amenity/bank|Standard Chartered": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "matchNames": ["standard chartered bank"],
     "tags": {
       "amenity": "bank",
@@ -5950,7 +5878,7 @@
     }
   },
   "amenity/bank|State Bank of India": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "State Bank of India",
@@ -5960,7 +5888,7 @@
     }
   },
   "amenity/bank|State Employees Credit Union": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "State Employees Credit Union",
@@ -5971,7 +5899,7 @@
     }
   },
   "amenity/bank|Summit Bank": {
-    "locationSet": {"include": ["pk"]},
+    "locationSet": { "include": ["pk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Summit Bank",
@@ -5981,7 +5909,7 @@
     }
   },
   "amenity/bank|SunTrust": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "matchNames": ["suntrust bank"],
     "tags": {
       "amenity": "bank",
@@ -5992,7 +5920,7 @@
     }
   },
   "amenity/bank|Suncorp": {
-    "locationSet": {"include": ["au"]},
+    "locationSet": { "include": ["au"] },
     "tags": {
       "amenity": "bank",
       "brand": "Suncorp",
@@ -6002,7 +5930,7 @@
     }
   },
   "amenity/bank|Supervielle": {
-    "locationSet": {"include": ["ar"]},
+    "locationSet": { "include": ["ar"] },
     "tags": {
       "amenity": "bank",
       "brand": "Supervielle",
@@ -6024,7 +5952,7 @@
     }
   },
   "amenity/bank|Syndicate Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Syndicate Bank",
@@ -6034,7 +5962,7 @@
     }
   },
   "amenity/bank|Synovus": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Synovus",
@@ -6044,7 +5972,7 @@
     }
   },
   "amenity/bank|TCF Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "TCF Bank",
@@ -6054,7 +5982,7 @@
     }
   },
   "amenity/bank|TD Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "TD Bank",
@@ -6064,7 +5992,7 @@
     }
   },
   "amenity/bank|TD Canada Trust": {
-    "locationSet": {"include": ["ca"]},
+    "locationSet": { "include": ["ca"] },
     "tags": {
       "amenity": "bank",
       "brand": "TD Canada Trust",
@@ -6074,7 +6002,7 @@
     }
   },
   "amenity/bank|TEB": {
-    "locationSet": {"include": ["tr"]},
+    "locationSet": { "include": ["tr"] },
     "tags": {
       "amenity": "bank",
       "brand": "TEB",
@@ -6084,7 +6012,7 @@
     }
   },
   "amenity/bank|TSB": {
-    "locationSet": {"include": ["gb"]},
+    "locationSet": { "include": ["gb"] },
     "tags": {
       "amenity": "bank",
       "brand": "TSB",
@@ -6094,7 +6022,7 @@
     }
   },
   "amenity/bank|Takarékszövetkezet": {
-    "locationSet": {"include": ["hu"]},
+    "locationSet": { "include": ["hu"] },
     "tags": {
       "amenity": "bank",
       "brand": "Takarékszövetkezet",
@@ -6104,7 +6032,7 @@
     }
   },
   "amenity/bank|Tangerine": {
-    "locationSet": {"include": ["ca"]},
+    "locationSet": { "include": ["ca"] },
     "tags": {
       "amenity": "bank",
       "brand": "Tangerine",
@@ -6114,7 +6042,7 @@
     }
   },
   "amenity/bank|Targobank": {
-    "locationSet": {"include": ["de", "es"]},
+    "locationSet": { "include": ["de", "es"] },
     "tags": {
       "amenity": "bank",
       "brand": "Targobank",
@@ -6124,7 +6052,7 @@
     }
   },
   "amenity/bank|Tatra banka": {
-    "locationSet": {"include": ["sk"]},
+    "locationSet": { "include": ["sk"] },
     "tags": {
       "amenity": "bank",
       "brand": "Tatra banka",
@@ -6134,7 +6062,7 @@
     }
   },
   "amenity/bank|Taytay sa Kauswagan": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "tags": {
       "amenity": "bank",
       "brand": "Taytay sa Kauswagan",
@@ -6143,7 +6071,7 @@
     }
   },
   "amenity/bank|Tesoro": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "nomatch": ["amenity/fuel|Tesoro"],
     "tags": {
       "amenity": "bank",
@@ -6152,7 +6080,7 @@
     }
   },
   "amenity/bank|The Co-operative Bank": {
-    "locationSet": {"include": ["gb"]},
+    "locationSet": { "include": ["gb"] },
     "matchNames": ["co-op bank"],
     "tags": {
       "amenity": "bank",
@@ -6163,11 +6091,8 @@
     }
   },
   "amenity/bank|Truist": {
-    "locationSet": {"include": ["us"]},
-    "matchNames": [
-      "truist bank",
-      "truist financial"
-    ],
+    "locationSet": { "include": ["us"] },
+    "matchNames": ["truist bank", "truist financial"],
     "tags": {
       "amenity": "bank",
       "brand": "Truist",
@@ -6177,7 +6102,7 @@
     }
   },
   "amenity/bank|Türkiye İş Bankası": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Türkiye İş Bankası",
@@ -6187,7 +6112,7 @@
     }
   },
   "amenity/bank|U.S. Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "U.S. Bank",
@@ -6197,7 +6122,7 @@
     }
   },
   "amenity/bank|UBA": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "UBA",
@@ -6208,7 +6133,7 @@
     }
   },
   "amenity/bank|UBI Banca": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "UBI Banca",
@@ -6218,7 +6143,7 @@
     }
   },
   "amenity/bank|UBL": {
-    "locationSet": {"include": ["pk"]},
+    "locationSet": { "include": ["pk"] },
     "matchNames": ["ubl bank"],
     "tags": {
       "amenity": "bank",
@@ -6231,7 +6156,7 @@
     }
   },
   "amenity/bank|UBS": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "UBS",
@@ -6241,7 +6166,7 @@
     }
   },
   "amenity/bank|UCO Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "UCO Bank",
@@ -6251,7 +6176,7 @@
     }
   },
   "amenity/bank|UCPB": {
-    "locationSet": {"include": ["ph"]},
+    "locationSet": { "include": ["ph"] },
     "tags": {
       "amenity": "bank",
       "brand": "UCPB",
@@ -6261,7 +6186,7 @@
     }
   },
   "amenity/bank|UIB": {
-    "locationSet": {"include": ["tn"]},
+    "locationSet": { "include": ["tn"] },
     "tags": {
       "amenity": "bank",
       "brand": "UIB",
@@ -6272,7 +6197,7 @@
     }
   },
   "amenity/bank|UMB Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "UMB Bank",
@@ -6282,11 +6207,8 @@
     }
   },
   "amenity/bank|UNI": {
-    "locationSet": {"include": ["ca"]},
-    "matchNames": [
-      "caisse populaire",
-      "caisse populaire acadienne"
-    ],
+    "locationSet": { "include": ["ca"] },
+    "matchNames": ["caisse populaire", "caisse populaire acadienne"],
     "tags": {
       "amenity": "bank",
       "brand": "UNI",
@@ -6297,7 +6219,7 @@
     }
   },
   "amenity/bank|UOB": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "UOB",
@@ -6309,7 +6231,7 @@
     }
   },
   "amenity/bank|USAA": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "USAA",
@@ -6320,7 +6242,7 @@
     }
   },
   "amenity/bank|Ulster Bank": {
-    "locationSet": {"include": ["gb", "ie"]},
+    "locationSet": { "include": ["gb", "ie"] },
     "tags": {
       "amenity": "bank",
       "brand": "Ulster Bank",
@@ -6330,7 +6252,7 @@
     }
   },
   "amenity/bank|Umpqua Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Umpqua Bank",
@@ -6340,11 +6262,8 @@
     }
   },
   "amenity/bank|UniCredit Bank": {
-    "locationSet": {"include": ["001"]},
-    "matchNames": [
-      "unicredit",
-      "unicredit banca"
-    ],
+    "locationSet": { "include": ["001"] },
+    "matchNames": ["unicredit", "unicredit banca"],
     "tags": {
       "amenity": "bank",
       "brand": "UniCredit Bank",
@@ -6354,7 +6273,7 @@
     }
   },
   "amenity/bank|Unicaja Banco": {
-    "locationSet": {"include": ["es"]},
+    "locationSet": { "include": ["es"] },
     "tags": {
       "amenity": "bank",
       "brand": "Unicaja Banco",
@@ -6365,7 +6284,7 @@
     }
   },
   "amenity/bank|Union Bank of India": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Union Bank of India",
@@ -6375,11 +6294,8 @@
     }
   },
   "amenity/bank|Union Bank~(USA)": {
-    "locationSet": {"include": ["us"]},
-    "matchNames": [
-      "mufg union bank",
-      "union bank of california"
-    ],
+    "locationSet": { "include": ["us"] },
+    "matchNames": ["mufg union bank", "union bank of california"],
     "nomatch": [
       "amenity/bank|Banco Unión",
       "amenity/money_transfer|Express Union"
@@ -6394,10 +6310,8 @@
     }
   },
   "amenity/bank|UnionBank~(Philippines)": {
-    "locationSet": {"include": ["ph"]},
-    "matchNames": [
-      "union bank of the philippines"
-    ],
+    "locationSet": { "include": ["ph"] },
+    "matchNames": ["union bank of the philippines"],
     "nomatch": [
       "amenity/bank|Banco Unión",
       "amenity/money_transfer|Express Union"
@@ -6411,7 +6325,7 @@
     }
   },
   "amenity/bank|United Bank~(Connecticut)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "nomatch": [
       "amenity/bank|United Bank~(West Virginia)",
       "amenity/fuel|United",
@@ -6425,7 +6339,7 @@
     }
   },
   "amenity/bank|United Bank~(West Virginia)": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "nomatch": [
       "amenity/bank|United Bank~(Connecticut)",
       "amenity/fuel|United",
@@ -6440,7 +6354,7 @@
     }
   },
   "amenity/bank|United Community Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "United Community Bank",
@@ -6450,7 +6364,7 @@
     }
   },
   "amenity/bank|VTB": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "VTB",
@@ -6458,7 +6372,7 @@
     }
   },
   "amenity/bank|Vakıfbank": {
-    "locationSet": {"include": ["tr"]},
+    "locationSet": { "include": ["tr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Vakıfbank",
@@ -6468,7 +6382,7 @@
     }
   },
   "amenity/bank|Vancity": {
-    "locationSet": {"include": ["ca"]},
+    "locationSet": { "include": ["ca"] },
     "matchNames": ["vancouver city savings"],
     "tags": {
       "amenity": "bank",
@@ -6480,7 +6394,7 @@
     }
   },
   "amenity/bank|Veneto Banca": {
-    "locationSet": {"include": ["it"]},
+    "locationSet": { "include": ["it"] },
     "tags": {
       "amenity": "bank",
       "brand": "Veneto Banca",
@@ -6490,7 +6404,7 @@
     }
   },
   "amenity/bank|Vietcombank": {
-    "locationSet": {"include": ["vn"]},
+    "locationSet": { "include": ["vn"] },
     "tags": {
       "amenity": "bank",
       "brand": "Vietcombank",
@@ -6500,7 +6414,7 @@
     }
   },
   "amenity/bank|VietinBank": {
-    "locationSet": {"include": ["vn"]},
+    "locationSet": { "include": ["vn"] },
     "tags": {
       "amenity": "bank",
       "brand": "VietinBank",
@@ -6510,7 +6424,7 @@
     }
   },
   "amenity/bank|Vijaya Bank": {
-    "locationSet": {"include": ["in"]},
+    "locationSet": { "include": ["in"] },
     "tags": {
       "amenity": "bank",
       "brand": "Vijaya Bank",
@@ -6520,7 +6434,7 @@
     }
   },
   "amenity/bank|Virgin Money": {
-    "locationSet": {"include": ["gb"]},
+    "locationSet": { "include": ["gb"] },
     "tags": {
       "amenity": "bank",
       "brand": "Virgin Money",
@@ -6530,7 +6444,7 @@
     }
   },
   "amenity/bank|Volksbank Köln Bonn eG": {
-    "locationSet": {"include": ["de"]},
+    "locationSet": { "include": ["de"] },
     "tags": {
       "amenity": "bank",
       "brand": "Volksbank Köln Bonn eG",
@@ -6540,7 +6454,7 @@
     }
   },
   "amenity/bank|VÚB": {
-    "locationSet": {"include": ["sk"]},
+    "locationSet": { "include": ["sk"] },
     "tags": {
       "amenity": "bank",
       "brand": "VÚB",
@@ -6550,7 +6464,7 @@
     }
   },
   "amenity/bank|Washington Federal": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Washington Federal",
@@ -6560,7 +6474,7 @@
     }
   },
   "amenity/bank|Webster Bank": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Webster Bank",
@@ -6570,7 +6484,7 @@
     }
   },
   "amenity/bank|Wells Fargo": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "matchNames": ["wells fargo bank"],
     "tags": {
       "amenity": "bank",
@@ -6581,7 +6495,7 @@
     }
   },
   "amenity/bank|WesBanco": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "WesBanco",
@@ -6591,10 +6505,8 @@
     }
   },
   "amenity/bank|Western Union": {
-    "locationSet": {"include": ["001"]},
-    "nomatch": [
-      "amenity/money_transfer|Western Union"
-    ],
+    "locationSet": { "include": ["001"] },
+    "nomatch": ["amenity/money_transfer|Western Union"],
     "tags": {
       "amenity": "bank",
       "brand": "Western Union",
@@ -6604,7 +6516,7 @@
     }
   },
   "amenity/bank|Westpac": {
-    "locationSet": {"include": ["au", "nz"]},
+    "locationSet": { "include": ["au", "nz"] },
     "tags": {
       "amenity": "bank",
       "brand": "Westpac",
@@ -6614,7 +6526,7 @@
     }
   },
   "amenity/bank|Wings Financial Credit Union": {
-    "locationSet": {"include": ["us"]},
+    "locationSet": { "include": ["us"] },
     "tags": {
       "amenity": "bank",
       "brand": "Wings Financial Credit Union",
@@ -6624,7 +6536,7 @@
     }
   },
   "amenity/bank|Yapı Kredi": {
-    "locationSet": {"include": ["tr"]},
+    "locationSet": { "include": ["tr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Yapı Kredi",
@@ -6634,7 +6546,7 @@
     }
   },
   "amenity/bank|Yorkshire Bank": {
-    "locationSet": {"include": ["gb"]},
+    "locationSet": { "include": ["gb"] },
     "tags": {
       "amenity": "bank",
       "brand": "Yorkshire Bank",
@@ -6644,7 +6556,7 @@
     }
   },
   "amenity/bank|Yorkshire Building Society": {
-    "locationSet": {"include": ["gb"]},
+    "locationSet": { "include": ["gb"] },
     "tags": {
       "amenity": "bank",
       "brand": "Yorkshire Building Society",
@@ -6654,7 +6566,7 @@
     }
   },
   "amenity/bank|Zagrebačka banka": {
-    "locationSet": {"include": ["hr"]},
+    "locationSet": { "include": ["hr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Zagrebačka banka",
@@ -6665,14 +6577,7 @@
   },
   "amenity/bank|Zenith Bank": {
     "locationSet": {
-      "include": [
-        "gb",
-        "gh",
-        "gm",
-        "ng",
-        "sl",
-        "za"
-      ]
+      "include": ["gb", "gh", "gm", "ng", "sl", "za"]
     },
     "tags": {
       "amenity": "bank",
@@ -6683,7 +6588,7 @@
     }
   },
   "amenity/bank|Zions Bank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Zions Bank",
@@ -6692,7 +6597,7 @@
     }
   },
   "amenity/bank|Ziraat Bankası": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Ziraat Bankası",
@@ -6702,7 +6607,7 @@
     }
   },
   "amenity/bank|bank99": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "bank99",
@@ -6710,7 +6615,7 @@
     }
   },
   "amenity/bank|mBank": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "mBank",
@@ -6720,7 +6625,7 @@
     }
   },
   "amenity/bank|st.george": {
-    "locationSet": {"include": ["au"]},
+    "locationSet": { "include": ["au"] },
     "matchNames": ["st.george bank"],
     "tags": {
       "amenity": "bank",
@@ -6731,7 +6636,7 @@
     }
   },
   "amenity/bank|Ålandsbanken": {
-    "locationSet": {"include": ["fi"]},
+    "locationSet": { "include": ["fi"] },
     "tags": {
       "amenity": "bank",
       "brand": "Ålandsbanken",
@@ -6741,7 +6646,7 @@
     }
   },
   "amenity/bank|ČSOB": {
-    "locationSet": {"include": ["cz", "sk"]},
+    "locationSet": { "include": ["cz", "sk"] },
     "tags": {
       "amenity": "bank",
       "brand": "ČSOB",
@@ -6751,7 +6656,7 @@
     }
   },
   "amenity/bank|Česká spořitelna": {
-    "locationSet": {"include": ["cz"]},
+    "locationSet": { "include": ["cz"] },
     "tags": {
       "amenity": "bank",
       "brand": "Česká spořitelna",
@@ -6761,7 +6666,7 @@
     }
   },
   "amenity/bank|İş Bankası": {
-    "locationSet": {"include": ["tr"]},
+    "locationSet": { "include": ["tr"] },
     "tags": {
       "amenity": "bank",
       "brand": "İş Bankası",
@@ -6771,7 +6676,7 @@
     }
   },
   "amenity/bank|Εθνική Τράπεζα": {
-    "locationSet": {"include": ["gr"]},
+    "locationSet": { "include": ["gr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Εθνική Τράπεζα",
@@ -6785,7 +6690,7 @@
     }
   },
   "amenity/bank|Τράπεζα Πειραιώς": {
-    "locationSet": {"include": ["gr"]},
+    "locationSet": { "include": ["gr"] },
     "tags": {
       "amenity": "bank",
       "brand": "Τράπεζα Πειραιώς",
@@ -6802,7 +6707,7 @@
     }
   },
   "amenity/bank|А-Банк": {
-    "locationSet": {"include": ["ua"]},
+    "locationSet": { "include": ["ua"] },
     "tags": {
       "amenity": "bank",
       "brand": "А-Банк",
@@ -6812,7 +6717,7 @@
     }
   },
   "amenity/bank|Авангард": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Авангард",
@@ -6821,7 +6726,7 @@
     }
   },
   "amenity/bank|Ак Барс Банк": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "Ак Барс Банк",
@@ -6845,7 +6750,7 @@
     }
   },
   "amenity/bank|Альфа-Банк~(Украина)": {
-    "locationSet": {"include": ["ua"]},
+    "locationSet": { "include": ["ua"] },
     "tags": {
       "amenity": "bank",
       "brand": "Альфа-Банк",
@@ -6860,7 +6765,7 @@
     }
   },
   "amenity/bank|БПС-Сбербанк": {
-    "locationSet": {"include": ["by"]},
+    "locationSet": { "include": ["by"] },
     "tags": {
       "amenity": "bank",
       "brand": "БПС-Сбербанк",
@@ -6870,7 +6775,7 @@
     }
   },
   "amenity/bank|Банк Дабрабыт": {
-    "locationSet": {"include": ["by"]},
+    "locationSet": { "include": ["by"] },
     "tags": {
       "amenity": "bank",
       "brand": "Банк Дабрабыт",
@@ -6879,7 +6784,7 @@
     }
   },
   "amenity/bank|Банка ДСК": {
-    "locationSet": {"include": ["bg"]},
+    "locationSet": { "include": ["bg"] },
     "tags": {
       "amenity": "bank",
       "brand": "Банка ДСК",
@@ -6893,7 +6798,7 @@
     }
   },
   "amenity/bank|Белагропромбанк": {
-    "locationSet": {"include": ["by"]},
+    "locationSet": { "include": ["by"] },
     "tags": {
       "amenity": "bank",
       "brand": "Белагропромбанк",
@@ -6905,7 +6810,7 @@
     }
   },
   "amenity/bank|Беларусбанк": {
-    "locationSet": {"include": ["by"]},
+    "locationSet": { "include": ["by"] },
     "matchTags": ["amenity/bureau_de_change"],
     "tags": {
       "amenity": "bank",
@@ -6918,7 +6823,7 @@
     }
   },
   "amenity/bank|Белинвестбанк": {
-    "locationSet": {"include": ["by"]},
+    "locationSet": { "include": ["by"] },
     "tags": {
       "amenity": "bank",
       "brand": "Белинвестбанк",
@@ -6928,7 +6833,7 @@
     }
   },
   "amenity/bank|Бинбанк": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Бинбанк",
@@ -6940,7 +6845,7 @@
     }
   },
   "amenity/bank|ВТБ~(Россия)": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "matchNames": ["втб банк москвы"],
     "tags": {
       "amenity": "bank",
@@ -6953,7 +6858,7 @@
     }
   },
   "amenity/bank|ВТБ~(Украина)": {
-    "locationSet": {"include": ["ua"]},
+    "locationSet": { "include": ["ua"] },
     "matchNames": ["втб банк"],
     "tags": {
       "amenity": "bank",
@@ -6966,7 +6871,7 @@
     }
   },
   "amenity/bank|Возрождение": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Возрождение",
@@ -6976,7 +6881,7 @@
     }
   },
   "amenity/bank|Газпромбанк": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Газпромбанк",
@@ -6988,7 +6893,7 @@
     }
   },
   "amenity/bank|Генбанк": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Генбанк",
@@ -6997,7 +6902,7 @@
     }
   },
   "amenity/bank|Зенит": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Зенит",
@@ -7011,7 +6916,7 @@
     }
   },
   "amenity/bank|Казкоммерцбанк": {
-    "locationSet": {"include": ["kz"]},
+    "locationSet": { "include": ["kz"] },
     "tags": {
       "amenity": "bank",
       "brand": "Казкоммерцбанк",
@@ -7023,7 +6928,7 @@
     }
   },
   "amenity/bank|Московский индустриальный банк": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Московский индустриальный банк",
@@ -7035,7 +6940,7 @@
     }
   },
   "amenity/bank|Мособлбанк": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Мособлбанк",
@@ -7059,7 +6964,7 @@
     }
   },
   "amenity/bank|ОТП Банк": {
-    "locationSet": {"include": ["ru", "ua"]},
+    "locationSet": { "include": ["ru", "ua"] },
     "tags": {
       "amenity": "bank",
       "brand": "ОТП Банк",
@@ -7071,7 +6976,7 @@
     }
   },
   "amenity/bank|Обединена Българска Банка": {
-    "locationSet": {"include": ["bg"]},
+    "locationSet": { "include": ["bg"] },
     "tags": {
       "amenity": "bank",
       "brand": "Обединена Българска Банка",
@@ -7083,7 +6988,7 @@
     }
   },
   "amenity/bank|Открытие": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "matchNames": ["банк открытие"],
     "tags": {
       "amenity": "bank",
@@ -7094,7 +6999,7 @@
     }
   },
   "amenity/bank|Ощадбанк": {
-    "locationSet": {"include": ["ua"]},
+    "locationSet": { "include": ["ua"] },
     "tags": {
       "amenity": "bank",
       "brand": "Ощадбанк",
@@ -7106,7 +7011,7 @@
     }
   },
   "amenity/bank|ПУМБ": {
-    "locationSet": {"include": ["ua"]},
+    "locationSet": { "include": ["ua"] },
     "tags": {
       "amenity": "bank",
       "brand": "ПУМБ",
@@ -7118,7 +7023,7 @@
     }
   },
   "amenity/bank|Почта Банк": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Почта Банк",
@@ -7130,7 +7035,7 @@
     }
   },
   "amenity/bank|Пощенска банка": {
-    "locationSet": {"include": ["bg"]},
+    "locationSet": { "include": ["bg"] },
     "tags": {
       "amenity": "bank",
       "brand": "Пощенска банка",
@@ -7141,7 +7046,8 @@
     }
   },
   "amenity/bank|ПриватБанк": {
-    "locationSet": {"include": ["ua"]},
+    "locationSet": { "include": ["ua"] },
+    "matchTags": ["amenity/payment_terminal"],
     "tags": {
       "amenity": "bank",
       "brand": "ПриватБанк",
@@ -7153,7 +7059,7 @@
     }
   },
   "amenity/bank|Приднестровский Сбербанк": {
-    "locationSet": {"include": ["md"]},
+    "locationSet": { "include": ["md"] },
     "matchNames": ["приднестровский cбербанк"],
     "tags": {
       "amenity": "bank",
@@ -7168,7 +7074,7 @@
     }
   },
   "amenity/bank|Приорбанк": {
-    "locationSet": {"include": ["by"]},
+    "locationSet": { "include": ["by"] },
     "tags": {
       "amenity": "bank",
       "brand": "Приорбанк",
@@ -7180,7 +7086,7 @@
     }
   },
   "amenity/bank|Промсвязьбанк": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Промсвязьбанк",
@@ -7192,7 +7098,7 @@
     }
   },
   "amenity/bank|РНКБ": {
-    "locationSet": {"include": ["ru", "ua"]},
+    "locationSet": { "include": ["ru", "ua"] },
     "tags": {
       "amenity": "bank",
       "brand": "РНКБ",
@@ -7202,7 +7108,7 @@
     }
   },
   "amenity/bank|Райффайзен": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
       "amenity/bank|Raiffeisenbank~(Albania)",
@@ -7226,7 +7132,7 @@
     }
   },
   "amenity/bank|Райффайзен Банк Аваль": {
-    "locationSet": {"include": ["ua"]},
+    "locationSet": { "include": ["ua"] },
     "matchNames": ["аваль", "банк аваль"],
     "nomatch": [
       "amenity/bank|Raiffeisen Polbank",
@@ -7253,7 +7159,7 @@
     }
   },
   "amenity/bank|Росбанк": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Росбанк",
@@ -7267,7 +7173,7 @@
     }
   },
   "amenity/bank|Россельхозбанк": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Россельхозбанк",
@@ -7281,7 +7187,7 @@
     }
   },
   "amenity/bank|Русский Стандарт": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Русский Стандарт",
@@ -7295,12 +7201,8 @@
     }
   },
   "amenity/bank|Сбербанк": {
-    "locationSet": {"include": ["kz", "ru"]},
-    "matchNames": [
-      "cбербанк",
-      "cбербанк россии",
-      "сбербанк россии"
-    ],
+    "locationSet": { "include": ["kz", "ru"] },
+    "matchNames": ["cбербанк", "cбербанк россии", "сбербанк россии"],
     "tags": {
       "amenity": "bank",
       "brand": "Сбербанк",
@@ -7314,7 +7216,7 @@
     }
   },
   "amenity/bank|Совкомбанк": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Совкомбанк",
@@ -7328,7 +7230,7 @@
     }
   },
   "amenity/bank|УкрСиббанк": {
-    "locationSet": {"include": ["ua"]},
+    "locationSet": { "include": ["ua"] },
     "tags": {
       "amenity": "bank",
       "brand": "УкрСиббанк",
@@ -7342,7 +7244,7 @@
     }
   },
   "amenity/bank|Укргазбанк": {
-    "locationSet": {"include": ["ua"]},
+    "locationSet": { "include": ["ua"] },
     "tags": {
       "amenity": "bank",
       "brand": "Укргазбанк",
@@ -7356,7 +7258,7 @@
     }
   },
   "amenity/bank|Укрсоцбанк": {
-    "locationSet": {"include": ["ua"]},
+    "locationSet": { "include": ["ua"] },
     "tags": {
       "amenity": "bank",
       "brand": "Укрсоцбанк",
@@ -7370,7 +7272,7 @@
     }
   },
   "amenity/bank|УниКредит Булбанк": {
-    "locationSet": {"include": ["bg"]},
+    "locationSet": { "include": ["bg"] },
     "tags": {
       "amenity": "bank",
       "brand": "УниКредит Булбанк",
@@ -7381,7 +7283,7 @@
     }
   },
   "amenity/bank|Уралсиб": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Уралсиб",
@@ -7395,7 +7297,7 @@
     }
   },
   "amenity/bank|Уральский банк реконструкции и развития": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "matchNames": ["убрир", "убрр"],
     "tags": {
       "amenity": "bank",
@@ -7412,7 +7314,7 @@
     }
   },
   "amenity/bank|Хаан банк": {
-    "locationSet": {"include": ["mn"]},
+    "locationSet": { "include": ["mn"] },
     "tags": {
       "amenity": "bank",
       "brand": "Хаан банк",
@@ -7426,7 +7328,7 @@
     }
   },
   "amenity/bank|Хоум Кредит": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "bank",
       "brand": "Хоум Кредит",
@@ -7440,7 +7342,7 @@
     }
   },
   "amenity/bank|בנק אגוד": {
-    "locationSet": {"include": ["il"]},
+    "locationSet": { "include": ["il"] },
     "tags": {
       "alt_name:en": "Bank Igud",
       "amenity": "bank",
@@ -7455,7 +7357,7 @@
     }
   },
   "amenity/bank|בנק אוצר החייל": {
-    "locationSet": {"include": ["il"]},
+    "locationSet": { "include": ["il"] },
     "tags": {
       "amenity": "bank",
       "brand": "בנק אוצר החייל",
@@ -7469,7 +7371,7 @@
     }
   },
   "amenity/bank|בנק דיסקונט": {
-    "locationSet": {"include": ["il"]},
+    "locationSet": { "include": ["il"] },
     "tags": {
       "amenity": "bank",
       "brand": "בנק דיסקונט לישראל",
@@ -7483,7 +7385,7 @@
     }
   },
   "amenity/bank|בנק הפועלים": {
-    "locationSet": {"include": ["il"]},
+    "locationSet": { "include": ["il"] },
     "tags": {
       "amenity": "bank",
       "brand": "בנק הפועלים",
@@ -7497,7 +7399,7 @@
     }
   },
   "amenity/bank|בנק יהד": {
-    "locationSet": {"include": ["il"]},
+    "locationSet": { "include": ["il"] },
     "tags": {
       "amenity": "bank",
       "brand": "בנק יהד",
@@ -7511,7 +7413,7 @@
     }
   },
   "amenity/bank|בנק ירושלים": {
-    "locationSet": {"include": ["il"]},
+    "locationSet": { "include": ["il"] },
     "tags": {
       "amenity": "bank",
       "brand": "בנק ירושלים",
@@ -7525,7 +7427,7 @@
     }
   },
   "amenity/bank|בנק לאומי": {
-    "locationSet": {"include": ["il"]},
+    "locationSet": { "include": ["il"] },
     "tags": {
       "amenity": "bank",
       "brand": "בנק לאומי",
@@ -7539,7 +7441,7 @@
     }
   },
   "amenity/bank|בנק מסד": {
-    "locationSet": {"include": ["il"]},
+    "locationSet": { "include": ["il"] },
     "tags": {
       "amenity": "bank",
       "brand": "בנק מסד",
@@ -7553,7 +7455,7 @@
     }
   },
   "amenity/bank|הבנק הבינלאומי": {
-    "locationSet": {"include": ["il"]},
+    "locationSet": { "include": ["il"] },
     "tags": {
       "amenity": "bank",
       "brand": "הבנק הבינלאומי",
@@ -7567,7 +7469,7 @@
     }
   },
   "amenity/bank|מזרחי טפחות": {
-    "locationSet": {"include": ["il"]},
+    "locationSet": { "include": ["il"] },
     "tags": {
       "amenity": "bank",
       "brand": "מזרחי טפחות",
@@ -7581,7 +7483,7 @@
     }
   },
   "amenity/bank|البنك الوطني الجزائري": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "البنك الوطني الجزائري",
@@ -7589,7 +7491,7 @@
     }
   },
   "amenity/bank|الصندوق الوطني للتوفير والاحتياط": {
-    "locationSet": {"include": ["dz"]},
+    "locationSet": { "include": ["dz"] },
     "tags": {
       "amenity": "bank",
       "brand": "الصندوق الوطني للتوفير والاحتياط",
@@ -7598,7 +7500,7 @@
     }
   },
   "amenity/bank|بانک آینده": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک آینده",
@@ -7610,7 +7512,7 @@
     }
   },
   "amenity/bank|بانک اقتصاد نوین": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک اقتصاد نوین",
@@ -7622,7 +7524,7 @@
     }
   },
   "amenity/bank|بانک انصار": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک انصار",
@@ -7632,7 +7534,7 @@
     }
   },
   "amenity/bank|بانک ایران زمین": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک ایران زمین",
@@ -7642,7 +7544,7 @@
     }
   },
   "amenity/bank|بانک تجارت": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک تجارت",
@@ -7652,7 +7554,7 @@
     }
   },
   "amenity/bank|بانک توسعه تعاون": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک توسعه تعاون",
@@ -7662,7 +7564,7 @@
     }
   },
   "amenity/bank|بانک رفاه": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "matchNames": ["بانک رفاه کارگران"],
     "tags": {
       "amenity": "bank",
@@ -7675,7 +7577,7 @@
     }
   },
   "amenity/bank|بانک سامان": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک سامان",
@@ -7687,7 +7589,7 @@
     }
   },
   "amenity/bank|بانک سرمایه": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک سرمایه",
@@ -7699,7 +7601,7 @@
     }
   },
   "amenity/bank|بانک سپه": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک سپه",
@@ -7711,7 +7613,7 @@
     }
   },
   "amenity/bank|بانک سینا": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک سینا",
@@ -7723,7 +7625,7 @@
     }
   },
   "amenity/bank|بانک شهر": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک شهر",
@@ -7735,7 +7637,7 @@
     }
   },
   "amenity/bank|بانک صادرات": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "matchNames": ["بانک صادرات ایران", "صادرات"],
     "tags": {
       "amenity": "bank",
@@ -7748,7 +7650,7 @@
     }
   },
   "amenity/bank|بانک قوامین": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک قوامین",
@@ -7760,7 +7662,7 @@
     }
   },
   "amenity/bank|بانک مسکن": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک مسکن",
@@ -7772,7 +7674,7 @@
     }
   },
   "amenity/bank|بانک ملت": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک ملت",
@@ -7784,7 +7686,7 @@
     }
   },
   "amenity/bank|بانک ملی": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "matchNames": ["بانک ملی ایران", "ملی"],
     "tags": {
       "amenity": "bank",
@@ -7797,7 +7699,7 @@
     }
   },
   "amenity/bank|بانک مهر اقتصاد": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک مهر اقتصاد",
@@ -7808,7 +7710,7 @@
     }
   },
   "amenity/bank|بانک پارسیان": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک پارسیان",
@@ -7820,7 +7722,7 @@
     }
   },
   "amenity/bank|بانک پاسارگاد": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک پاسارگاد",
@@ -7832,7 +7734,7 @@
     }
   },
   "amenity/bank|بانک کشاورزی": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "بانک کشاورزی",
@@ -7844,7 +7746,7 @@
     }
   },
   "amenity/bank|پست بانک": {
-    "locationSet": {"include": ["ir"]},
+    "locationSet": { "include": ["ir"] },
     "tags": {
       "amenity": "bank",
       "brand": "پست بانک",
@@ -7856,7 +7758,7 @@
     }
   },
   "amenity/bank|অগ্রণী ব্যাংক": {
-    "locationSet": {"include": ["bd"]},
+    "locationSet": { "include": ["bd"] },
     "matchNames": [
       "agrani bank",
       "agrani bank limited",
@@ -7878,7 +7780,7 @@
     }
   },
   "amenity/bank|গ্রামীণ ব্যাংক": {
-    "locationSet": {"include": ["bd"]},
+    "locationSet": { "include": ["bd"] },
     "tags": {
       "amenity": "bank",
       "brand": "গ্রামীণ ব্যাংক",
@@ -7892,7 +7794,7 @@
     }
   },
   "amenity/bank|জনতা ব্যাংক লিমিটেড": {
-    "locationSet": {"include": ["bd"]},
+    "locationSet": { "include": ["bd"] },
     "matchNames": [
       "janata bank",
       "janata bank limited",
@@ -7911,7 +7813,7 @@
     }
   },
   "amenity/bank|বাংলাদেশ কৃষি ব্যাংক": {
-    "locationSet": {"include": ["bd"]},
+    "locationSet": { "include": ["bd"] },
     "tags": {
       "amenity": "bank",
       "brand": "বাংলাদেশ কৃষি ব্যাংক",
@@ -7925,7 +7827,7 @@
     }
   },
   "amenity/bank|সোনালী ব্যাংক লিমিটেড": {
-    "locationSet": {"include": ["bd"]},
+    "locationSet": { "include": ["bd"] },
     "matchNames": [
       "sonali bank",
       "sonali bank limited",
@@ -7944,7 +7846,7 @@
     }
   },
   "amenity/bank|ธนาคารกรุงเทพ": {
-    "locationSet": {"include": ["th"]},
+    "locationSet": { "include": ["th"] },
     "tags": {
       "amenity": "bank",
       "brand": "ธนาคารกรุงเทพ",
@@ -7958,7 +7860,7 @@
     }
   },
   "amenity/bank|ธนาคารกรุงไทย": {
-    "locationSet": {"include": ["th"]},
+    "locationSet": { "include": ["th"] },
     "tags": {
       "amenity": "bank",
       "brand": "ธนาคารกรุงไทย",
@@ -7972,7 +7874,7 @@
     }
   },
   "amenity/bank|ธนาคารกสิกรไทย": {
-    "locationSet": {"include": ["th"]},
+    "locationSet": { "include": ["th"] },
     "tags": {
       "amenity": "bank",
       "brand": "ธนาคารกสิกรไทย",
@@ -7986,7 +7888,7 @@
     }
   },
   "amenity/bank|ธนาคารออมสิน": {
-    "locationSet": {"include": ["th"]},
+    "locationSet": { "include": ["th"] },
     "tags": {
       "amenity": "bank",
       "brand": "ธนาคารออมสิน",
@@ -8000,7 +7902,7 @@
     }
   },
   "amenity/bank|ธนาคารไทยพาณิชย์": {
-    "locationSet": {"include": ["th"]},
+    "locationSet": { "include": ["th"] },
     "tags": {
       "amenity": "bank",
       "brand": "ธนาคารไทยพาณิชย์",
@@ -8014,7 +7916,7 @@
     }
   },
   "amenity/bank|きらぼし銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "きらぼし銀行",
@@ -8028,7 +7930,7 @@
     }
   },
   "amenity/bank|みずほ銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "みずほ銀行",
@@ -8042,7 +7944,7 @@
     }
   },
   "amenity/bank|ゆうちょ銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "ゆうちょ銀行",
@@ -8056,7 +7958,7 @@
     }
   },
   "amenity/bank|りそな銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "りそな銀行",
@@ -8070,7 +7972,7 @@
     }
   },
   "amenity/bank|イオン銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "イオン銀行",
@@ -8084,7 +7986,7 @@
     }
   },
   "amenity/bank|スルガ銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "スルガ銀行",
@@ -8098,7 +8000,7 @@
     }
   },
   "amenity/bank|セブン銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "matchNames": ["7銀行"],
     "tags": {
       "amenity": "bank",
@@ -8113,7 +8015,7 @@
     }
   },
   "amenity/bank|三井住友信託銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "三井住友信託銀行",
@@ -8125,7 +8027,7 @@
     }
   },
   "amenity/bank|三井住友銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "三井住友銀行",
@@ -8140,7 +8042,7 @@
     }
   },
   "amenity/bank|三菱UFJ信託銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "三菱UFJ信託銀行",
@@ -8154,7 +8056,7 @@
     }
   },
   "amenity/bank|三菱UFJ銀行": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "matchNames": ["三菱東京ufj銀行"],
     "tags": {
       "amenity": "bank",
@@ -8169,7 +8071,7 @@
     }
   },
   "amenity/bank|上海商業儲蓄銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "上海商業儲蓄銀行",
@@ -8181,7 +8083,7 @@
     }
   },
   "amenity/bank|上海浦东发展银行": {
-    "locationSet": {"include": ["cn"]},
+    "locationSet": { "include": ["cn"] },
     "tags": {
       "amenity": "bank",
       "brand": "上海浦东发展银行",
@@ -8193,7 +8095,7 @@
     }
   },
   "amenity/bank|东亚银行": {
-    "locationSet": {"include": ["cn"]},
+    "locationSet": { "include": ["cn"] },
     "tags": {
       "amenity": "bank",
       "brand": "东亚银行",
@@ -8204,7 +8106,7 @@
     }
   },
   "amenity/bank|中信银行": {
-    "locationSet": {"include": ["cn"]},
+    "locationSet": { "include": ["cn"] },
     "tags": {
       "amenity": "bank",
       "brand": "中信银行",
@@ -8216,7 +8118,7 @@
     }
   },
   "amenity/bank|中国光大银行": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "中国光大银行",
@@ -8228,7 +8130,7 @@
     }
   },
   "amenity/bank|中国农业银行": {
-    "locationSet": {"include": ["cn"]},
+    "locationSet": { "include": ["cn"] },
     "tags": {
       "amenity": "bank",
       "brand": "中国农业银行",
@@ -8240,7 +8142,7 @@
     }
   },
   "amenity/bank|中国工商银行": {
-    "locationSet": {"include": ["cn"]},
+    "locationSet": { "include": ["cn"] },
     "tags": {
       "amenity": "bank",
       "brand": "中国工商银行",
@@ -8252,7 +8154,7 @@
     }
   },
   "amenity/bank|中国建设银行": {
-    "locationSet": {"include": ["cn"]},
+    "locationSet": { "include": ["cn"] },
     "matchNames": ["建设银行"],
     "tags": {
       "amenity": "bank",
@@ -8265,7 +8167,7 @@
     }
   },
   "amenity/bank|中国民生银行": {
-    "locationSet": {"include": ["cn"]},
+    "locationSet": { "include": ["cn"] },
     "tags": {
       "amenity": "bank",
       "brand": "中国民生银行",
@@ -8277,7 +8179,7 @@
     }
   },
   "amenity/bank|中国邮政储蓄银行": {
-    "locationSet": {"include": ["cn"]},
+    "locationSet": { "include": ["cn"] },
     "tags": {
       "amenity": "bank",
       "brand": "中国邮政储蓄银行",
@@ -8289,7 +8191,7 @@
     }
   },
   "amenity/bank|中国银行": {
-    "locationSet": {"include": ["cn"]},
+    "locationSet": { "include": ["cn"] },
     "tags": {
       "amenity": "bank",
       "brand": "中国银行",
@@ -8301,7 +8203,7 @@
     }
   },
   "amenity/bank|中國信託商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "中國信託商業銀行",
@@ -8313,7 +8215,7 @@
     }
   },
   "amenity/bank|交通银行": {
-    "locationSet": {"include": ["cn"]},
+    "locationSet": { "include": ["cn"] },
     "tags": {
       "amenity": "bank",
       "brand": "交通银行",
@@ -8325,7 +8227,7 @@
     }
   },
   "amenity/bank|京城商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "京城商業銀行",
@@ -8335,7 +8237,7 @@
     }
   },
   "amenity/bank|京葉銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "alt_name:en": "αBANK",
       "amenity": "bank",
@@ -8350,7 +8252,7 @@
     }
   },
   "amenity/bank|京都中央信用金庫": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "京都中央信用金庫",
@@ -8362,7 +8264,7 @@
     }
   },
   "amenity/bank|京都銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "京都銀行",
@@ -8374,7 +8276,7 @@
     }
   },
   "amenity/bank|伊予銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "matchNames": ["いよぎん"],
     "tags": {
       "amenity": "bank",
@@ -8389,7 +8291,7 @@
     }
   },
   "amenity/bank|元大商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "元大商業銀行",
@@ -8401,7 +8303,7 @@
     }
   },
   "amenity/bank|兆豐國際商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "兆豐國際商業銀行",
@@ -8413,7 +8315,7 @@
     }
   },
   "amenity/bank|八十二銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "matchNames": ["82銀行"],
     "tags": {
       "amenity": "bank",
@@ -8428,7 +8330,7 @@
     }
   },
   "amenity/bank|兴业银行": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "兴业银行",
@@ -8438,7 +8340,7 @@
     }
   },
   "amenity/bank|农业银行": {
-    "locationSet": {"include": ["cn"]},
+    "locationSet": { "include": ["cn"] },
     "tags": {
       "amenity": "bank",
       "brand": "农业银行",
@@ -8448,7 +8350,7 @@
     }
   },
   "amenity/bank|北京银行": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "北京银行",
@@ -8458,7 +8360,7 @@
     }
   },
   "amenity/bank|北洋銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "北洋銀行",
@@ -8470,7 +8372,7 @@
     }
   },
   "amenity/bank|北海道銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "北海道銀行",
@@ -8482,7 +8384,7 @@
     }
   },
   "amenity/bank|千葉興業銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "千葉興業銀行",
@@ -8496,7 +8398,7 @@
     }
   },
   "amenity/bank|千葉銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "千葉銀行",
@@ -8510,7 +8412,7 @@
     }
   },
   "amenity/bank|台中商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "台中商業銀行",
@@ -8522,7 +8424,7 @@
     }
   },
   "amenity/bank|台北富邦商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "台北富邦商業銀行",
@@ -8534,7 +8436,7 @@
     }
   },
   "amenity/bank|台新國際商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "台新國際商業銀行",
@@ -8546,7 +8448,7 @@
     }
   },
   "amenity/bank|合作金庫商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "合作金庫商業銀行",
@@ -8558,7 +8460,7 @@
     }
   },
   "amenity/bank|商工中金": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "商工中金",
@@ -8572,7 +8474,7 @@
     }
   },
   "amenity/bank|國泰世華商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "國泰世華商業銀行",
@@ -8584,7 +8486,7 @@
     }
   },
   "amenity/bank|埼玉りそな銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "埼玉りそな銀行",
@@ -8598,7 +8500,7 @@
     }
   },
   "amenity/bank|多摩信用金庫": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "alt_name": "たましん",
       "alt_name:en": "Tamashin",
@@ -8614,7 +8516,7 @@
     }
   },
   "amenity/bank|大眾商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "大眾商業銀行",
@@ -8626,7 +8528,7 @@
     }
   },
   "amenity/bank|宁波银行": {
-    "locationSet": {"include": ["cn"]},
+    "locationSet": { "include": ["cn"] },
     "tags": {
       "amenity": "bank",
       "brand": "宁波银行",
@@ -8640,7 +8542,7 @@
     }
   },
   "amenity/bank|安泰商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "安泰商業銀行",
@@ -8652,7 +8554,7 @@
     }
   },
   "amenity/bank|工商银行": {
-    "locationSet": {"include": ["cn"]},
+    "locationSet": { "include": ["cn"] },
     "tags": {
       "amenity": "bank",
       "brand": "工商银行",
@@ -8664,7 +8566,7 @@
     }
   },
   "amenity/bank|常陽銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "常陽銀行",
@@ -8676,7 +8578,7 @@
     }
   },
   "amenity/bank|彰化商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "彰化商業銀行",
@@ -8688,7 +8590,7 @@
     }
   },
   "amenity/bank|愛知銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "愛知銀行",
@@ -8702,7 +8604,7 @@
     }
   },
   "amenity/bank|招商银行": {
-    "locationSet": {"include": ["cn"]},
+    "locationSet": { "include": ["cn"] },
     "tags": {
       "amenity": "bank",
       "brand": "招商银行",
@@ -8714,7 +8616,7 @@
     }
   },
   "amenity/bank|新生銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "新生銀行",
@@ -8728,7 +8630,7 @@
     }
   },
   "amenity/bank|日本銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "日本銀行",
@@ -8740,7 +8642,7 @@
     }
   },
   "amenity/bank|東亞銀行": {
-    "locationSet": {"include": ["hk"]},
+    "locationSet": { "include": ["hk"] },
     "tags": {
       "amenity": "bank",
       "brand": "東亞銀行",
@@ -8756,7 +8658,7 @@
     }
   },
   "amenity/bank|東京ベイ信金": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "東京ベイ信金",
@@ -8770,7 +8672,7 @@
     }
   },
   "amenity/bank|東日本銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "東日本銀行",
@@ -8784,7 +8686,7 @@
     }
   },
   "amenity/bank|板信商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "板信商業銀行",
@@ -8796,7 +8698,7 @@
     }
   },
   "amenity/bank|横浜銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "横浜銀行",
@@ -8808,7 +8710,7 @@
     }
   },
   "amenity/bank|武蔵野銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "武蔵野銀行",
@@ -8822,7 +8724,7 @@
     }
   },
   "amenity/bank|永豐商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "永豐商業銀行",
@@ -8834,7 +8736,7 @@
     }
   },
   "amenity/bank|沖縄海邦銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "沖縄海邦銀行",
@@ -8848,7 +8750,7 @@
     }
   },
   "amenity/bank|渣打國際商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "渣打國際商業銀行",
@@ -8857,7 +8759,7 @@
     }
   },
   "amenity/bank|玉山商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "玉山商業銀行",
@@ -8869,7 +8771,7 @@
     }
   },
   "amenity/bank|第一商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "第一商業銀行",
@@ -8881,7 +8783,7 @@
     }
   },
   "amenity/bank|聯邦商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "聯邦商業銀行",
@@ -8893,7 +8795,7 @@
     }
   },
   "amenity/bank|臺灣中小企業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "臺灣中小企業銀行",
@@ -8905,7 +8807,7 @@
     }
   },
   "amenity/bank|臺灣土地銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "臺灣土地銀行",
@@ -8917,7 +8819,7 @@
     }
   },
   "amenity/bank|臺灣新光商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "臺灣新光商業銀行",
@@ -8929,7 +8831,7 @@
     }
   },
   "amenity/bank|臺灣銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "臺灣銀行",
@@ -8941,7 +8843,7 @@
     }
   },
   "amenity/bank|芝信用金庫": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "bank",
       "brand": "芝信用金庫",
@@ -8955,7 +8857,7 @@
     }
   },
   "amenity/bank|華南商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "華南商業銀行",
@@ -8967,7 +8869,7 @@
     }
   },
   "amenity/bank|近畿大阪銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "近畿大阪銀行",
@@ -8981,7 +8883,7 @@
     }
   },
   "amenity/bank|遠東國際商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "遠東國際商業銀行",
@@ -8993,7 +8895,7 @@
     }
   },
   "amenity/bank|陽信商業銀行": {
-    "locationSet": {"include": ["tw"]},
+    "locationSet": { "include": ["tw"] },
     "tags": {
       "amenity": "bank",
       "brand": "陽信商業銀行",
@@ -9005,7 +8907,7 @@
     }
   },
   "amenity/bank|静岡銀行": {
-    "locationSet": {"include": ["jp"]},
+    "locationSet": { "include": ["jp"] },
     "tags": {
       "amenity": "bank",
       "brand": "静岡銀行",
@@ -9019,7 +8921,7 @@
     }
   },
   "amenity/bank|국민은행": {
-    "locationSet": {"include": ["kr"]},
+    "locationSet": { "include": ["kr"] },
     "matchNames": ["국민은행 (gungmin bank)"],
     "tags": {
       "amenity": "bank",
@@ -9034,7 +8936,7 @@
     }
   },
   "amenity/bank|기업은행": {
-    "locationSet": {"include": ["kr"]},
+    "locationSet": { "include": ["kr"] },
     "tags": {
       "amenity": "bank",
       "brand": "기업은행",
@@ -9048,7 +8950,7 @@
     }
   },
   "amenity/bank|농협": {
-    "locationSet": {"include": ["kr"]},
+    "locationSet": { "include": ["kr"] },
     "matchNames": ["nh농협은행"],
     "tags": {
       "amenity": "bank",
@@ -9063,7 +8965,7 @@
     }
   },
   "amenity/bank|새마을금고": {
-    "locationSet": {"include": ["kr"]},
+    "locationSet": { "include": ["kr"] },
     "tags": {
       "amenity": "bank",
       "brand": "새마을금고",
@@ -9075,7 +8977,7 @@
     }
   },
   "amenity/bank|신한은행": {
-    "locationSet": {"include": ["kr"]},
+    "locationSet": { "include": ["kr"] },
     "matchNames": ["신한은행 (sinhan bank)"],
     "tags": {
       "amenity": "bank",
@@ -9090,7 +8992,7 @@
     }
   },
   "amenity/bank|우리은행": {
-    "locationSet": {"include": ["kr"]},
+    "locationSet": { "include": ["kr"] },
     "matchNames": ["우리은행 (uri bank)"],
     "tags": {
       "amenity": "bank",
@@ -9105,7 +9007,7 @@
     }
   },
   "amenity/bank|하나은행": {
-    "locationSet": {"include": ["kr"]},
+    "locationSet": { "include": ["kr"] },
     "tags": {
       "amenity": "bank",
       "brand": "하나은행",

--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -6144,6 +6144,7 @@
   },
   "amenity/bank|Tesoro": {
     "locationSet": {"include": ["001"]},
+    "nomatch": ["amenity/fuel|Tesoro"],
     "tags": {
       "amenity": "bank",
       "brand": "Tesoro",
@@ -6905,6 +6906,7 @@
   },
   "amenity/bank|Беларусбанк": {
     "locationSet": {"include": ["by"]},
+    "matchTags": ["amenity/bureau_de_change"],
     "tags": {
       "amenity": "bank",
       "brand": "Беларусбанк",

--- a/brands/amenity/bureau_de_change.json
+++ b/brands/amenity/bureau_de_change.json
@@ -48,14 +48,6 @@
       "name": "Travelex"
     }
   },
-  "amenity/bureau_de_change|Беларусбанк": {
-    "locationSet": {"include": ["001"]},
-    "tags": {
-      "amenity": "bureau_de_change",
-      "brand": "Беларусбанк",
-      "name": "Беларусбанк"
-    }
-  },
   "amenity/bureau_de_change|Обмен валют Кит Group": {
     "locationSet": {"include": ["001"]},
     "tags": {

--- a/brands/amenity/cafe.json
+++ b/brands/amenity/cafe.json
@@ -1281,6 +1281,7 @@
   },
   "amenity/cafe|Лакомка": {
     "locationSet": {"include": ["001"]},
+    "matchTags": ["shop/confectionery"],
     "tags": {
       "amenity": "cafe",
       "brand": "Лакомка",

--- a/brands/amenity/fuel.json
+++ b/brands/amenity/fuel.json
@@ -2985,6 +2985,7 @@
   },
   "amenity/fuel|Tesoro": {
     "locationSet": {"include": ["us"]},
+    "nomatch": ["amenity/bank|Tesoro"],
     "tags": {
       "amenity": "fuel",
       "brand": "Tesoro",

--- a/brands/amenity/payment_terminal.json
+++ b/brands/amenity/payment_terminal.json
@@ -1,6 +1,6 @@
 {
   "amenity/payment_terminal|Qiwi": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "payment_terminal",
       "brand": "Qiwi",
@@ -9,16 +9,8 @@
       "name": "Qiwi"
     }
   },
-  "amenity/payment_terminal|Сбербанк": {
-    "locationSet": { "include": ["001"] },
-    "tags": {
-      "amenity": "payment_terminal",
-      "brand": "Сбербанк",
-      "name": "Сбербанк"
-    }
-  },
   "amenity/payment_terminal|Элекснет": {
-    "locationSet": { "include": ["ru"] },
+    "locationSet": {"include": ["ru"]},
     "tags": {
       "amenity": "payment_terminal",
       "brand": "Элекснет",

--- a/brands/amenity/payment_terminal.json
+++ b/brands/amenity/payment_terminal.json
@@ -1,6 +1,6 @@
 {
   "amenity/payment_terminal|Qiwi": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "payment_terminal",
       "brand": "Qiwi",
@@ -9,18 +9,8 @@
       "name": "Qiwi"
     }
   },
-  "amenity/payment_terminal|ПриватБанк": {
-    "locationSet": {"include": ["ua"]},
-    "tags": {
-      "amenity": "payment_terminal",
-      "brand": "ПриватБанк",
-      "brand:wikidata": "Q1515015",
-      "brand:wikipedia": "en:PrivatBank",
-      "name": "ПриватБанк"
-    }
-  },
   "amenity/payment_terminal|Сбербанк": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": { "include": ["001"] },
     "tags": {
       "amenity": "payment_terminal",
       "brand": "Сбербанк",
@@ -28,7 +18,7 @@
     }
   },
   "amenity/payment_terminal|Элекснет": {
-    "locationSet": {"include": ["ru"]},
+    "locationSet": { "include": ["ru"] },
     "tags": {
       "amenity": "payment_terminal",
       "brand": "Элекснет",

--- a/brands/amenity/post_office.json
+++ b/brands/amenity/post_office.json
@@ -203,6 +203,7 @@
     "locationSet": {
       "include": ["id", "my", "ph"]
     },
+    "nomatch": ["amenity/bank|J&T Banka"],
     "tags": {
       "amenity": "post_office",
       "brand": "J&T Express",

--- a/brands/amenity/restaurant.json
+++ b/brands/amenity/restaurant.json
@@ -1833,6 +1833,7 @@
     "tags": {
       "amenity": "restaurant",
       "brand": "Osmow's",
+      "cuisine": "mediterranean",
       "name": "Osmow's"
     }
   },

--- a/brands/shop/confectionery.json
+++ b/brands/shop/confectionery.json
@@ -122,14 +122,6 @@
       "shop": "confectionery"
     }
   },
-  "shop/confectionery|Лакомка": {
-    "locationSet": {"include": ["001"]},
-    "tags": {
-      "brand": "Лакомка",
-      "name": "Лакомка",
-      "shop": "confectionery"
-    }
-  },
   "shop/confectionery|シャトレーゼ": {
     "locationSet": {"include": ["jp"]},
     "tags": {

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -1879,6 +1879,7 @@
   },
   "shop/convenience|Studenac": {
     "locationSet": {"include": ["hr"]},
+    "matchTags": ["shop/supermarket"],
     "tags": {
       "brand": "Studenac",
       "brand:wikidata": "Q65156084",

--- a/brands/shop/department_store.json
+++ b/brands/shop/department_store.json
@@ -210,6 +210,8 @@
     "locationSet": {"include": ["001"]},
     "tags": {
       "brand": "Elektra",
+      "brand:wikidata": "Q1142753",
+      "brand:wikipedia": "es:Grupo Elektra",
       "name": "Elektra",
       "shop": "department_store"
     }

--- a/brands/shop/electronics.json
+++ b/brands/shop/electronics.json
@@ -162,13 +162,9 @@
     }
   },
   "shop/electronics|Elektra": {
-    "locationSet": {
-      "include": ["gt", "hn", "pa", "pe", "sv"]
-    },
+    "locationSet": {"include": ["001"]},
     "tags": {
       "brand": "Elektra",
-      "brand:wikidata": "Q1142753",
-      "brand:wikipedia": "es:Grupo Elektra",
       "name": "Elektra",
       "shop": "electronics"
     }

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -4124,7 +4124,7 @@
     "locationSet": {"include": ["us"]},
     "tags": {
       "brand": "Stop & Shop",
-      "brand:wikidata": "Q3658429",
+      "brand:wikidata": "Qn3658429",
       "brand:wikipedia": "en:Stop & Shop",
       "name": "Stop & Shop",
       "shop": "supermarket"

--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -4130,14 +4130,6 @@
       "shop": "supermarket"
     }
   },
-  "shop/supermarket|Studenac": {
-    "locationSet": {"include": ["001"]},
-    "tags": {
-      "brand": "Studenac",
-      "name": "Studenac",
-      "shop": "supermarket"
-    }
-  },
   "shop/supermarket|Suma": {
     "locationSet": {"include": ["es"]},
     "tags": {


### PR DESCRIPTION
Hi, 

I've recently forked the name suggestion index to my profile and run all the relevant installs. I've fixed a number of duplicate brand errors which occur when you run npm run build. 

There was a slight issue with one error, there's an error for Groupama which is a banking and insurance company in France. The match tags for ["amenity/bank'] are already in the office/insurance entry for Groupama but when I try to remove the Groupama entry from bank.json the project keeps crashing upon save. I couldn't fix this error, but I added the wikidata (which I previously removed from bank to insurance files) back to the bank file. 

All other errors have been fixed and removed after running npm build and no errors are occurring when executing npm run build from local machine.