### PR TITLE
Excluded "nl" from GB Halfords

### DIFF
--- a/brands/shop/car_parts.json
+++ b/brands/shop/car_parts.json
@@ -83,7 +83,10 @@
     }
   },
   "shop/car_parts|Halfords": {
-    "locationSet": {"include": ["gb", "ie"]},
+    "locationSet": {
+      "include": ["gb", "ie"],
+      "exclude": ["nl"]
+    },
     "matchTags": ["shop/bicycle"],
     "nomatch": [
       "shop/car_repair|Halfords Autocentre"


### PR DESCRIPTION
Via #3889 it details that there is a Halfords brand in the Netherlands that isn't a part of the UK brand, as there is currently no separate Netherlands brand entry for Halfords.

I have added an **exclude** clause to the UK Halfords which excludes the NL variation, but as I've not come across locationSet yet, I wanted to check if doing this would be worthwhile?

As I understand it, iD will currently only offer the UK Halfords brand when adding a node or way in the UK now, as it has location data attached to it. But, for the entries in the Netherlands that are already incorrectly branded with the UK Halfords, would adding an exclude clause do anything meaningful, such as add a warning on iD that says "this brand doesn't appear to be present in this Country"?