### PR TITLE
add heytea wikidata

### DIFF
--- a/brands/amenity/cafe.json
+++ b/brands/amenity/cafe.json
@@ -1784,12 +1784,16 @@
     }
   },
   "amenity/cafe|喜茶": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": {"include": ["cn"]},
     "tags": {
       "amenity": "cafe",
       "brand": "喜茶",
-      "cuisine": "coffee_shop",
+      "brand:en": "Heytea",
+      "brand:wikidata": "Q60875376",
+      "brand:wikipedia": "zh:喜茶",
+      "cuisine": "bubble_tea",
       "name": "喜茶",
+      "name:en": "Heytea",
       "takeaway": "yes"
     }
   },


### PR DESCRIPTION
Hey Tea (Chinese: 喜茶) is a Chinese tea drink chain founded in 2012 and headquartered in Nanshan District, Shenzhen.By the end of Aug, 2019, Hey Tea operates 265 stores in 37 Chinese cities.
![img](https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/%E5%87%AF%E5%8D%8E%E5%9B%BD%E9%99%85%E4%B8%AD%E5%BF%83%E5%96%9C%E8%8C%B6_201902.jpg/440px-%E5%87%AF%E5%8D%8E%E5%9B%BD%E9%99%85%E4%B8%AD%E5%BF%83%E5%96%9C%E8%8C%B6_201902.jpg)