### PR TITLE
Improved bank in Luxembourg. Both names are used interchangeably.

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -546,7 +546,10 @@
   },
   "amenity/bank|BCEE": {
     "locationSet": {"include": ["lu"]},
+    "matchNames": ["Spuerkeess", "S-Bank"],
     "tags": {
+      "alt_name:lb": "Spuerkeess",
+      "alt_name": "S-Bank",
       "amenity": "bank",
       "brand": "BCEE",
       "brand:wikidata": "Q668996",


### PR DESCRIPTION
Hi,
As both brand names are used [interchangeably](https://www.sandweiler.lu/media/cache/413_cropped_1920_1080_100_57c6826ad81b5_bcee-spuerkeess-agence-sandweiler-resize-.jpg), I added the second one as alt_name.

Edit: Squashed commits