### PR TITLE
Add fitness centres in Taiwan

### DIFF
--- a/brands/leisure/fitness_centre.json
+++ b/brands/leisure/fitness_centre.json
@@ -359,6 +359,30 @@
       "name": "World Class"
     }
   },
+  "leisure/fitness_centre|World Gym": {
+    "locationSet": {"include": ["001"], "exclude": ["tw"]},
+    "tags": {
+      "brand": "World Gym",
+      "brand:wikidata": "Q8035794",
+      "brand:wikipedia": "en:World Gym",
+      "leisure": "fitness_centre",
+      "name": "World Gym"
+    }
+  },
+  "leisure/fitness_centre|World Gym~(Taiwan)": {
+    "locationSet": {"include": ["tw"]},
+    "tags": {
+      "brand": "World Gym健身俱樂部",
+      "brand:en": "World Gym",
+      "brand:zh": "世界健身俱樂部",
+      "brand:wikidata": "Q8035794",
+      "brand:wikipedia": "zh:世界健身俱樂部",
+      "leisure": "fitness_centre",
+      "name": "World Gym健身俱樂部",
+      "name:en": "World Gym",
+      "name:zh": "世界健身俱樂部"
+    }
+  },
   "leisure/fitness_centre|Xercise4Less": {
     "locationSet": {"include": ["gb"]},
     "tags": {
@@ -451,6 +475,18 @@
       "name": "メガロス",
       "name:en": "MEGALOS",
       "name:ja": "メガロス"
+    }
+  },
+  "leisure/fitness_centre|健身工廠": {
+    "locationSet": {"include": ["tw"]},
+    "tags": {
+      "brand": "健身工廠",
+      "brand:en": "Fitness Factory",
+      "brand:zh": "健身工廠",
+      "leisure": "fitness_centre",
+      "name": "健身工廠",
+      "name:en": "Fitness Factory",
+      "name:zh": "健身工廠"
     }
   }
 }


### PR DESCRIPTION
https://en.wikipedia.org/wiki/World_Gym
World Gym is a global fitness center chain and have more than 200 branches around the world.
But it has more than 80 branches in Taiwan, being the largest fitness center brand in Taiwan. So I want to separate them into two tagging methods just like the commit.
Note: 「世界健身俱樂部」 is the Chinese name but not a common used name, so I put it in the alt_name tag just for searching.

健身工廠 Fitness Factory is the 2nd large fitness center chain in Taiwan, will have more than 50 branches before the end of 2020, but still have no Wikipedia and Wikidata item now.