### PR TITLE
IT-banks: fix BCC Roma, add Credem official_name

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -2261,14 +2261,15 @@
       "name": "Barclays"
     }
   },
-  "amenity/bank|Bcc": {
+  "amenity/bank|Bcc Roma": {
     "locationSet": {"include": ["it"]},
     "tags": {
       "amenity": "bank",
-      "brand": "Bcc",
+      "brand": "BCC Roma",
       "brand:wikidata": "Q25060394",
       "brand:wikipedia": "en:Banca di Credito Cooperativo di Roma",
-      "name": "Bcc"
+      "name": "BCC Roma",
+      "official_name": "Banca di Credito Cooperativo di Roma"
     }
   },
   "amenity/bank|Belfius": {
@@ -2973,7 +2974,8 @@
       "brand": "Credem",
       "brand:wikidata": "Q3696881",
       "brand:wikipedia": "en:Credito Emiliano",
-      "name": "Credem"
+      "name": "Credem",
+      "official_name": "Credito Emiliano"
     }
   },
   "amenity/bank|Credicoop": {


### PR DESCRIPTION
Hello,

BCC is a "generic" bank (BCC Roma, BCC Milano, BCC Fano...) I added "Roma" as per the wikipedia link.
Add Credem's official_name to mimic other items

Cheers
Francesco