### PR TITLE
Central clean up

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -345,7 +345,7 @@
     }
   },
   "shop/convenience|Central": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": {"include": ["gb"]},
     "tags": {
       "brand": "Central Convenience Store",
       "brand:wikidata": "Q97104475",

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -344,12 +344,13 @@
       "shop": "convenience"
     }
   },
-  "shop/convenience|Central Convenience Store": {
+  "shop/convenience|Central": {
     "locationSet": {"include": ["001"]},
     "tags": {
       "brand": "Central Convenience Store",
       "brand:wikidata": "Q97104475",
-      "name": "Central Convenience Store",
+      "name": "Central",
+      "official_name": "Central Convenience Store",
       "shop": "convenience"
     }
   },

--- a/brands/shop/newsagent.json
+++ b/brands/shop/newsagent.json
@@ -1,6 +1,6 @@
 {
   "shop/convenience|Central": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": {"include": ["gb"]},
     "tags": {
       "brand": "Central Convenience Store",
       "brand:wikidata": "Q97104475",

--- a/brands/shop/newsagent.json
+++ b/brands/shop/newsagent.json
@@ -1,5 +1,5 @@
 {
-  "shop/convenience|Central": {
+  "shop/newsagent|Central": {
     "locationSet": {"include": ["gb"]},
     "tags": {
       "brand": "Central Convenience Store",

--- a/brands/shop/newsagent.json
+++ b/brands/shop/newsagent.json
@@ -1,4 +1,13 @@
 {
+  "shop/convenience|Central": {
+    "locationSet": {"include": ["001"]},
+    "tags": {
+      "brand": "Central Convenience Store",
+      "brand:wikidata": "Q97104475",
+      "name": "Central",
+      "shop": "newsagent"
+    }
+  },
   "shop/newsagent|Cigo": {
     "locationSet": {"include": ["de", "nl"]},
     "tags": {


### PR DESCRIPTION
I've done a few things, changed it to GB only, I think it's mainly the south of England, but I doubt you get that specific.

Split it into a newsagent and a convenience store, they also have a 3rd store format, but for tagging purposes it's the same as the convenience preset.

And I've changed the name to "Central", this matches the shop fascia.