### PR TITLE
Add Oppo

### DIFF
--- a/brands/shop/mobile_phone.json
+++ b/brands/shop/mobile_phone.json
@@ -336,6 +336,16 @@
       "shop": "mobile_phone"
     }
   },
+  "shop/mobile_phone|Oppo": {
+    "locationSet": {"include": ["001"]},
+    "tags": {
+      "brand": "Oppo",
+      "brand:wikidata": "Q2084900",
+      "brand:wikipedia": "en:Oppo",
+      "name": "Oppo",
+      "shop": "mobile_phone"
+    }
+  },
   "shop/mobile_phone|Optie1": {
     "locationSet": {"include": ["nl"]},
     "tags": {


### PR DESCRIPTION
Oppo is a Chinese consumer electronics and mobile communications company headquartered in Dongguan, Guangdong. Since then, they have expanded to all parts of the world.
![img](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/OPPO_LOGO_2019.svg/440px-OPPO_LOGO_2019.svg.png)
https://www.wikidata.org/wiki/Q2084900
https://en.wikipedia.org/wiki/Oppo