### PR TITLE
Add Chowtaifook

### DIFF
--- a/brands/shop/jewelry.json
+++ b/brands/shop/jewelry.json
@@ -394,5 +394,17 @@
       "official_name:ja": "ジュエリーツツミ",
       "shop": "jewelry"
     }
+  },
+  "shop/jewelry|周大福": {
+    "locationSet": {"include": ["001"]},
+    "tags": {
+      "brand": "周大福",
+      "brand:en": "Chowtaifook",
+      "brand:wikidata": "Q48880993",
+      "brand:wikipedia": "en:Chow_Tai_Fook",
+      "name": "周大福",
+      "name:en": "Chowtaifook",
+      "shop": "jewelry"
+    }
   }
 }


### PR DESCRIPTION
Chow Tai Fook Jewellery is a jewellery store and gold shop founded by Chow Chi-yuen in 1929 in Guangzhou, China. 
![image](https://user-images.githubusercontent.com/1942091/87650667-97866800-c784-11ea-9f37-2583d029d96b.png)
https://www.wikidata.org/wiki/Q48880993
https://en.wikipedia.org/wiki/Chow_Tai_Fook