### PR TITLE
Fix Беларусбанк duplicate

### DIFF
--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -6786,6 +6786,7 @@
   },
   "amenity/bank|Беларусбанк": {
     "locationSet": {"include": ["by"]},
+    "matchTags": ["amenity/bureau_de_change"],
     "tags": {
       "amenity": "bank",
       "brand": "Беларусбанк",

--- a/brands/amenity/bank.json
+++ b/brands/amenity/bank.json
@@ -6786,7 +6786,9 @@
   },
   "amenity/bank|Беларусбанк": {
     "locationSet": {"include": ["by"]},
-    "matchTags": ["amenity/bureau_de_change"],
+    "nomatch": [
+      "amenity/bureau_de_change|Беларусбанк"
+    ],
     "tags": {
       "amenity": "bank",
       "brand": "Беларусбанк",

--- a/brands/amenity/bureau_de_change.json
+++ b/brands/amenity/bureau_de_change.json
@@ -60,7 +60,7 @@
     }
   },
   "amenity/bureau_de_change|Беларусбанк": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": {"include": ["by"]},
     "nomatch": ["amenity/bank|Беларусбанк"],
     "tags": {
       "amenity": "bureau_de_change",

--- a/brands/amenity/bureau_de_change.json
+++ b/brands/amenity/bureau_de_change.json
@@ -59,14 +59,6 @@
       "name": "Travelex"
     }
   },
-  "amenity/bureau_de_change|Беларусбанк": {
-    "locationSet": {"include": ["001"]},
-    "tags": {
-      "amenity": "bureau_de_change",
-      "brand": "Беларусбанк",
-      "name": "Беларусбанк"
-    }
-  },
   "amenity/bureau_de_change|Обмен валют Кит Group": {
     "locationSet": {"include": ["001"]},
     "tags": {

--- a/brands/amenity/bureau_de_change.json
+++ b/brands/amenity/bureau_de_change.json
@@ -59,6 +59,15 @@
       "name": "Travelex"
     }
   },
+  "amenity/bureau_de_change|Беларусбанк": {
+    "locationSet": {"include": ["001"]},
+    "nomatch": ["amenity/bank|Беларусбанк"],
+    "tags": {
+      "amenity": "bureau_de_change",
+      "brand": "Беларусбанк",
+      "name": "Беларусбанк"
+    }
+  },
   "amenity/bureau_de_change|Обмен валют Кит Group": {
     "locationSet": {"include": ["001"]},
     "tags": {

--- a/brands/shop/storage_rental.json
+++ b/brands/shop/storage_rental.json
@@ -38,7 +38,6 @@
       "shop": "storage_rental"
     }
   },
-  
   "shop/storage_rental|Lok'nStore": {
     "locationSet": {"include": ["gb"]},
     "tags": {

--- a/dist/brands.json
+++ b/dist/brands.json
@@ -6632,6 +6632,7 @@
     },
     "amenity/bank|Беларусбанк": {
       "locationSet": {"include": ["by"]},
+      "matchTags": ["amenity/bureau_de_change"],
       "tags": {
         "amenity": "bank",
         "brand": "Беларусбанк",
@@ -9100,14 +9101,6 @@
         "brand:wikidata": "Q2337964",
         "brand:wikipedia": "en:Travelex",
         "name": "Travelex"
-      }
-    },
-    "amenity/bureau_de_change|Беларусбанк": {
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "amenity": "bureau_de_change",
-        "brand": "Беларусбанк",
-        "name": "Беларусбанк"
       }
     },
     "amenity/bureau_de_change|Обмен валют Кит Group": {


### PR DESCRIPTION
Some Беларусбанк locations are just a bank and others are just a bureau de change. I added the nomatch tags for each entry. I hope its correct