### PR TITLE
Add Tong Ren Tang

### DIFF
--- a/brands/amenity/pharmacy.json
+++ b/brands/amenity/pharmacy.json
@@ -2376,6 +2376,17 @@
       "name": "丁丁藥局"
     }
   },
+  "amenity/pharmacy|同仁堂": {
+    "locationSet": {"include": ["cn"]},
+    "tags": {
+      "amenity": "pharmacy",
+      "brand": "同仁堂",
+      "brand:wikidata": "Q842099",
+      "brand:wikipedia": "en:Tong Ren Tang",
+      "healthcare": "pharmacy",
+      "name": "同仁堂"
+    }
+  },
   "amenity/pharmacy|屈臣氏": {
     "locationSet": {"include": ["001"]},
     "nomatch": ["shop/chemist|屈臣氏"],


### PR DESCRIPTION
Tong Ren Tang (TRT; Chinese: 同仁堂) is a Chinese pharmaceutical company founded in 1669, which is now the largest producer of traditional Chinese medicine (TCM). 
![image](https://user-images.githubusercontent.com/1942091/88502449-05425780-d001-11ea-8ca1-e7b8bec9d552.png)

https://en.wikipedia.org/wiki/Tong_Ren_Tang
https://www.wikidata.org/wiki/Q842099