### PR TITLE
Add Chow Sang Sang

### DIFF
--- a/brands/shop/jewelry.json
+++ b/brands/shop/jewelry.json
@@ -418,5 +418,19 @@
       "name:zh": "周大福",
       "shop": "jewelry"
     }
+  },
+  "shop/jewelry|周生生": {
+    "locationSet": {"include": ["cn", "tw"]},
+    "tags": {
+      "brand": "周生生",
+      "brand:en": "Chow Sang Sang",
+      "brand:wikidata": "Q10920877",
+      "brand:wikipedia": "en:Chow Sang Sang",
+      "brand:zh": "周生生",
+      "name": "周生生",
+      "name:en": "Chow Sang Sang",
+      "name:zh": "周生生",
+      "shop": "jewelry"
+    }
   }
 }


### PR DESCRIPTION
Chow Sang Sang (Chinese: 周生生; pinyin: Zhōu Shēngshēng), is a jewelry company. Over 50 stores combined are in Hong Kong, Macau, and Taiwan. Another 155 stores are located in 60 cities in Mainland China.

![img](https://upload.wikimedia.org/wikipedia/commons/thumb/6/6b/Chow_Sang_Sang_store_in_Central.jpg/440px-Chow_Sang_Sang_store_in_Central.jpg)

https://en.wikipedia.org/wiki/Chow_Sang_Sang
https://www.wikidata.org/wiki/Q10920877