### PR TITLE
Add Yonghe Dawang

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -4627,6 +4627,18 @@
       "takeaway": "yes"
     }
   },
+  "amenity/fast_food|永和大王": {
+    "locationSet": {"include": ["cn"]},
+    "tags": {
+      "amenity": "fast_food",
+      "brand": "永和大王",
+      "brand:wikidata": "Q8055004",
+      "brand:wikipedia": "zh:永和大王",
+      "cuisine": "chinese",
+      "name": "永和大王",
+      "takeaway": "yes"
+    }
+  },
   "amenity/fast_food|汉堡王": {
     "locationSet": {"include": ["cn"]},
     "tags": {


### PR DESCRIPTION
Yonghe Dawang opened its first restaurant in Shanghai on December 12, 1995. Today Yonghe has branches throughout China, with over 70 restaurants in major Chinese cities. 

![img](https://upload.wikimedia.org/wikipedia/commons/thumb/7/7a/YongheKingShanghai.jpg/440px-YongheKingShanghai.jpg)
https://zh.wikipedia.org/wiki/%E6%B0%B8%E5%92%8C%E5%A4%A7%E7%8E%8B
https://www.wikidata.org/wiki/Q8055004