### PR TITLE
Panda Express is only active in the US

### DIFF
--- a/brands/amenity/fast_food.json
+++ b/brands/amenity/fast_food.json
@@ -2139,7 +2139,7 @@
     }
   },
   "amenity/fast_food|Panda Express": {
-    "locationSet": {"include": ["001"]},
+    "locationSet": {"include": ["us"]},
     "matchNames": ["panda"],
     "tags": {
       "amenity": "fast_food",


### PR DESCRIPTION
There are 'Panda Express' restaurants in Europe (UK, NL, FR,...) but these are all just similary named. Not related to the US brand