### PR TITLE
Change Tesco Express wikidata item to a more specific entry

### DIFF
--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -2042,7 +2042,7 @@
     ],
     "tags": {
       "brand": "Tesco Express",
-      "brand:wikidata": "Q487494",
+      "brand:wikidata": "Q98456772",
       "brand:wikipedia": "en:Tesco",
       "name": "Tesco Express",
       "shop": "convenience"

--- a/brands/shop/convenience.json
+++ b/brands/shop/convenience.json
@@ -2043,7 +2043,6 @@
     "tags": {
       "brand": "Tesco Express",
       "brand:wikidata": "Q98456772",
-      "brand:wikipedia": "en:Tesco",
       "name": "Tesco Express",
       "shop": "convenience"
     }


### PR DESCRIPTION
Other Tesco sub-brands (Tesco Extra, Tesco Metro) have their own Wikidata entries but Tesco Express was missing. I've created a Wikidata item for it at https://www.wikidata.org/wiki/Q98456772 , and would now like to update the NSI to use it.