### PR TITLE
Added/improved pastry and bakery chains in Luxembourg

### DIFF
--- a/brands/shop/bakery.json
+++ b/brands/shop/bakery.json
@@ -340,6 +340,7 @@
     },
     "tags": {
       "brand": "Fischer",
+      "brand:wikidata": "Q13104464",
       "brand:wikipedia": "lb:Panelux",
       "name": "Fischer",
       "shop": "bakery"

--- a/brands/shop/pastry.json
+++ b/brands/shop/pastry.json
@@ -14,6 +14,20 @@
       "shop": "pastry"
     }
   },
+  "shop/pastry|Hoffmann": {
+    "locationSet": {"include": ["lu"]},
+    "matchNames": ["pâtisserie hoffmann"],
+    "matchTags": [
+      "shop/bakery",
+      "shop/confectionery"
+    ],
+    "tags": {
+      "brand": "Hoffmann",
+      "brand:wikidata": "Q98770209",
+      "name": "Hoffmann",
+      "shop": "pastry"
+    }
+  },
   "shop/pastry|Namur": {
     "locationSet": {"include": ["lu"]},
     "matchTags": [
@@ -22,6 +36,7 @@
     ],
     "tags": {
       "brand": "Namur",
+      "brand:wikidata": "Q98815398",
       "name": "Namur",
       "shop": "pastry"
     }
@@ -34,6 +49,7 @@
     ],
     "tags": {
       "brand": "Oberweis",
+      "brand:wikidata": "Q98815408",
       "name": "Oberweis",
       "shop": "pastry"
     }


### PR DESCRIPTION
This PR adds Wikidata identifiers for pastry/bakery chains in Luxembourg. I also added a chain that was missing.