### PR TITLE
Added Trink & Spare (German beverage shops, mainly in NRW)

### DIFF
--- a/brands/shop/beverages.json
+++ b/brands/shop/beverages.json
@@ -141,6 +141,7 @@
     "locationSet": {"include": ["de"]},
     "tags": {
       "brand": "Trink & Spare",
+      "brand:wikidata": "Q99284521",
       "name": "Trink & Spare",
       "shop": "beverages"
     }

--- a/brands/shop/beverages.json
+++ b/brands/shop/beverages.json
@@ -137,6 +137,14 @@
       "shop": "beverages"
     }
   },
+  "shop/beverages|Trink & Spare": {
+    "locationSet": {"include": ["de"]},
+    "tags": {
+      "brand": "Trink & Spare",
+      "name": "Trink & Spare",
+      "shop": "beverages"
+    }
+  },
   "shop/beverages|大苑子": {
     "locationSet": {"include": ["001"]},
     "tags": {


### PR DESCRIPTION
Added German beverage shops Trink & Spare (website http://trink-und-spare.de/unternehmen/)