### PR TITLE
Added wiki tags for Qualipet

### DIFF
--- a/data/brands/shop/pet.json
+++ b/data/brands/shop/pet.json
@@ -273,6 +273,8 @@
       "locationSet": {"include": ["ch"]},
       "tags": {
         "brand": "Qualipet",
+        "brand:wikidata": "Q15841340",
+        "brand:wikipedia": "de:Qualipet",
         "name": "Qualipet",
         "shop": "pet"
       }


### PR DESCRIPTION
- added wiki tags
        "brand:wikidata": "Q15841340",
        "brand:wikipedia": "de:Qualipet",
- Ran npm run build with no errors