### PR TITLE
Add pizzeria chains in Israel

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -4558,6 +4558,44 @@
       }
     },
     {
+      "displayName": "פיצה פרגו",
+      "id": "pizzaprego-dbdcb8",
+      "locationSet": {"include": ["il"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "פיצה פרגו",
+        "brand:he": "פיצה פרגו",
+        "brand:wikidata": "Q99769214",
+        "cuisine": "pizza",
+        "delivery": "yes",
+        "diet:vegan": "yes",
+        "name": "פיצה פרגו",
+        "name:en": "Pizza Prego",
+        "name:he": "פיצה פרגו",
+        "alt_name:en": "Prego Pizza",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "פיצה שמש",
+      "id": "pizzashemesh-dbdcb8",
+      "locationSet": {"include": ["il"]},
+      "tags": {
+        "alt_name:en": "Shemesh Pizza",
+        "amenity": "fast_food",
+        "brand": "פיצה שמש",
+        "brand:he": "פיצה שמש",
+        "brand:wikidata": "Q99769124",
+        "cuisine": "pizza",
+        "delivery": "yes",
+        "diet:kosher": "yes",
+        "name": "פיצה שמש",
+        "name:en": "Pizza Shemesh",
+        "name:he": "פיצה שמש",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "دجاج كنتاكي",
       "id": "kfc-8cd980",
       "locationSet": {


### PR DESCRIPTION
Sadly both chains are not well mapped yet but Pizza Shemesh have 63 branches and Pizza Prego 21 so hopefully it will help in the future.