### PR TITLE
added rail networks in the Western United States

### DIFF
--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -21,6 +21,18 @@
       }
     },
     {
+      "displayName": "Altamont Corridor Express",
+      "id": "altamontcorridorexpress-44bbb3",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "ACE",
+        "network:wikidata": "Q434302",
+        "network:wikipedia": "en:Altamont Corridor Express",
+        "operator": "San Joaquin Regional Rail Commission",
+        "route": "train"
+      }
+    },
+    {
       "displayName": "Amtrak",
       "id": "amtrak-44bbb3",
       "locationSet": {"include": ["us"]},
@@ -265,6 +277,18 @@
       }
     },
     {
+      "displayName": "FrontRunner",
+      "id": "frontrunner-44bbb3",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "UTA",
+        "network:wikidata": "Q5505779",
+        "network:wikipedia": "en:FrontRunner",
+        "operator": "UTA",
+        "route": "train"
+      }
+    },
+    {
       "displayName": "Großraum-Verkehr Hannover",
       "id": "grossraumverkehrhannover-44bbb3",
       "locationSet": {"include": ["001"]},
@@ -477,6 +501,18 @@
       }
     },
     {
+      "displayName": "Metrolink",
+      "id": "metrolink-44bbb3",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "Metrolink",
+        "network:wikidata": "Q766647",
+        "network:wikipedia": "en:Metrolink (California)",
+        "operator": "Southern California Regional Rail Authority",
+        "route": "train"
+      }
+    },
+    {
       "displayName": "Metrorail Gauteng",
       "id": "metrorailgauteng-44bbb3",
       "locationSet": {"include": ["001"]},
@@ -573,6 +609,30 @@
       "tags": {
         "network": "National Rail",
         "operator": "National Rail",
+        "route": "train"
+      }
+    },
+    {
+      "displayName": "NCTD Coaster",
+      "id": "nctd-44bbb3",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "NCTD",
+        "network:wikidata": "Q5138375",
+        "network:wikipedia": "en:Coaster (commuter rail)",
+        "operator": "NCTD",
+        "route": "train"
+      }
+    },
+    {
+      "displayName": "New Mexico Rail Runner Express",
+      "id": "newmexicorailrunnerexpress-44bbb3",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "Rio Metro",
+        "network:wikidata": "Q11324955",
+        "network:wikipedia": "en:New Mexico Rail Runner Express",
+        "operator": "Rio Metro",
         "route": "train"
       }
     },
@@ -823,6 +883,18 @@
       "tags": {
         "network": "SL",
         "operator": "SL",
+        "route": "train"
+      }
+    },
+    {
+      "displayName": "Sounder",
+      "id": "sounder-44bbb3",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "Sound Transit",
+        "network:wikidata": "Q7564853",
+        "network:wikipedia": "en:Sounder commuter rail",
+        "operator": "Sound Transit",
         "route": "train"
       }
     },


### PR DESCRIPTION
added Wikidata and Wikipedia for:

- Altamont Corridor Express
- UTA FrontRunner
- Metrolink
- NCTD Coaster
- NM Rail Runner Express
- Sounder