### PR TITLE
Add Romney, Hythe & Dymchurch Railway

### DIFF
--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -791,7 +791,7 @@
     },
     {
       "displayName": "Romney, Hythe & Dymchurch Railway",
-      "locationSet": {"include": ["gb-eng"]},
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "network": "Romney, Hythe & Dymchurch Railway",
         "network:wikidata": "Q2090360",

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -1410,6 +1410,18 @@
         "route": "train"
       }
     },
+
+    {
+      "displayName": "Romney, Hythe & Dymchurch Railway",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "network": "Romney, Hythe & Dymchurch Railway",
+        "network:wikidata": Q2090360
+        "network:wikipedia": "en:Romney, Hythe and Dymchurch Railway",
+        "operator": "Romney, Hythe & Dymchurch Railway PLC",
+        "route": "train"
+      }
+    },
     {
       "displayName": "ZVV",
       "id": "zvv-44bbb3",

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -790,6 +790,17 @@
       }
     },
     {
+      "displayName": "Romney, Hythe & Dymchurch Railway",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "network": "Romney, Hythe & Dymchurch Railway",
+        "network:wikidata": "Q2090360",
+        "network:wikipedia": "en:Romney, Hythe and Dymchurch Railway",
+        "operator": "Romney, Hythe & Dymchurch Railway PLC",
+        "route": "train"
+      }
+    },
+    {
       "displayName": "S",
       "id": "s-44bbb3",
       "locationSet": {"include": ["001"]},
@@ -1407,18 +1418,6 @@
         "network:wikipedia": "en:West Somerset Railway",
         "operator": "West Somerset Railway Plc",
         "operator:wikidata": "Q20970722",
-        "route": "train"
-      }
-    },
-
-    {
-      "displayName": "Romney, Hythe & Dymchurch Railway",
-      "locationSet": {"include": ["gb-eng"]},
-      "tags": {
-        "network": "Romney, Hythe & Dymchurch Railway",
-        "network:wikidata": Q2090360
-        "network:wikipedia": "en:Romney, Hythe and Dymchurch Railway",
-        "operator": "Romney, Hythe & Dymchurch Railway PLC",
         "route": "train"
       }
     },


### PR DESCRIPTION
I didn't realise it had stopped, but up until July 2015 it was still running school services, it's more than just a tourist attraction though:
https://en.wikipedia.org/wiki/Romney,_Hythe_and_Dymchurch_Railway#Passenger_services