### PR TITLE
Correcting Potential Duplicate Warnings

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -69,15 +69,17 @@
       }
     },
     {
-      "displayName": "Asda",
+      "displayName": "Asda Café",
       "id": "asda-e1ef51",
       "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "cafe",
         "brand": "Asda",
         "cuisine": "coffee_shop",
-        "name": "Asda",
-        "takeaway": "yes"
+        "name": "Asda Café",
+        "takeaway": "yes",
+        "brand:wikidata": "Q297410",
+        "brand:wikipedia":"en:Asda"
       }
     },
     {

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -3473,6 +3473,8 @@
       "tags": {
         "amenity": "fuel",
         "brand": "Sol",
+        "brand:wikidata": "Q465751",
+        "brand:wikipedia": "en:List of automotive fuel retailers#cite note-23",
         "name": "Sol"
       }
     },

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -3474,7 +3474,6 @@
         "amenity": "fuel",
         "brand": "Sol",
         "brand:wikidata": "Q465751",
-        "brand:wikipedia": "en:List of automotive fuel retailers#cite note-23",
         "name": "Sol"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -10818,6 +10818,18 @@
       }
     },
     {
+      "displayName": "Tulsa Transit",
+      "id": "tul-a45453",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "Tulsa Transit",
+        "network:wikidata": "Q6825293",
+        "network:wikipedia":"en:Metropolitan Tulsa Transit Authority",
+        "operator": "Tulsa Transit",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "TUP",
       "id": "tup-a45453",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
I corrected a duplicate warning in brands\amenity\fuel.json for "Sol". I included a brand:widkipedia tag and brand:wikidata however the wikipedia page should be updated. Sol Petroleum does not currently have it's own wikipedia page but the referenced wikipedia page links to the company's website.