### PR TITLE
German transit districts

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -11,6 +11,20 @@
       }
     },
     {
+      "displayName": "Aachener Verkehrsverbund",
+      "id": "aavv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "AVV"
+      ],
+      "tags": {
+        "network": "AVV",
+        "network:wikidata": "Q300763",
+        "network:wikipedia": "de:Aachener Verkehrsverbund",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "ABQ RIDE",
       "id": "abqride-a45453",
       "locationSet": {"include": ["001"]},
@@ -27,20 +41,6 @@
       "tags": {
         "network": "AC Transit",
         "operator": "AC Transit",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "Aachener Verkehrsverbund",
-      "id": "aavv-a45453",
-      "locationSet": {"include": ["de"]},
-      "matchNames": [
-        "AVV"
-      ],
-      "tags": {
-        "network": "AVV",
-        "network:wikidata": "Q300763",
-        "network:wikipedia": "de:Aachener Verkehrsverbund",
         "route": "bus"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -11504,7 +11504,7 @@
       "tags": {
         "network": "VGC",
         "network:wikidata": "Q2516220",
-        "network:wikipedia": "de:Verkehrsgemeinschaft Landkreis Cloppenburg,
+        "network:wikipedia": "de:Verkehrsgemeinschaft Landkreis Cloppenburg",
         "route": "bus"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -1727,6 +1727,17 @@
       }
     },
     {
+      "displayName": "CeBus",
+      "id": "cebus-a45453",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "network": "CeBus",
+        "network:wikidata": "Q1052172",
+        "network:wikipedia": "de:CeBus",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "Central Fraser Valley Transit System",
       "id": "centralfraservalleytransitsystem-a45453",
       "locationSet": {"include": ["001"]},
@@ -2463,6 +2474,20 @@
       "tags": {
         "network": "DETRO",
         "operator": "DETRO",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "die Öffis",
+      "id": "dieoffis-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "Öffentlicher Nahverkehr in Hameln-Pyrmont"
+      ],
+      "tags": {
+        "network": "die Öffis",
+        "network:wikidata": "Q46285860",
+        "network:wikipedia": "de:Öffentlicher Nahverkehr in Hameln-Pyrmont",
         "route": "bus"
       }
     },
@@ -3464,6 +3489,18 @@
       }
     },
     {
+      "displayName": "Gemeinschaftstarif Vorpommern",
+      "id": "gtv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "GTV"
+      ],
+      "tags": {
+        "network": "GTV",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "Génovébus",
       "id": "genovebus-a45453",
       "locationSet": {"include": ["001"]},
@@ -4214,12 +4251,16 @@
       }
     },
     {
-      "displayName": "Ingolstädter Verkehrsgesellschaft mbH",
-      "id": "ingolstadterverkehrsgesellschaftmbh-a45453",
-      "locationSet": {"include": ["001"]},
+      "displayName": "Ingolstädter Verkehrsgesellschaft",
+      "id": "invg-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "INVG"
+      ],
       "tags": {
-        "network": "Ingolstädter Verkehrsgesellschaft mbH",
-        "operator": "Ingolstädter Verkehrsgesellschaft mbH",
+        "network": "INVG",
+        "network:wikidata": "Q1663262",
+        "network:wikipedia": "de:Ingolstädter Verkehrsgesellschaft",
         "route": "bus"
       }
     },
@@ -4280,16 +4321,6 @@
       "tags": {
         "network": "Interurbanos de Madrid",
         "operator": "Interurbanos de Madrid",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "INVG",
-      "id": "invg-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "INVG",
-        "operator": "INVG",
         "route": "bus"
       }
     },
@@ -6011,6 +6042,21 @@
       }
     },
     {
+      "displayName": "Mona",
+      "id": "mona-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "Mona Allgäu",
+        "Mobilitätsgesellschaft für den Nahverkehr im Allgäu"
+      ],
+      "tags": {
+        "network": "Mona",
+        "network:wikidata": "Q29043552",
+        "network:wikipedia": "de:Mona Allgäu",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "monbus",
       "id": "monbus-a45453",
       "locationSet": {"include": ["001"]},
@@ -6427,10 +6473,14 @@
     {
       "displayName": "NAH.SH",
       "id": "nahsh-a45453",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "Nahverkehrsverbund Schleswig-Holstein"
+      ],
       "tags": {
         "network": "NAH.SH",
-        "operator": "NAH.SH",
+        "network:wikidata": "Q15825147",
+        "network:wikipedia": "de:Nahverkehrsverbund Schleswig-Holstein",
         "route": "bus"
       }
     },
@@ -6451,10 +6501,14 @@
     {
       "displayName": "naldo",
       "id": "naldo-a45453",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "Verkehrsverbund Neckar-Alb-Donau"
+      ],
       "tags": {
         "network": "naldo",
-        "operator": "naldo",
+        "network:wikidata": "Q1467217",
+        "network:wikipedia": "de:Verkehrsverbund Neckar-Alb-Donau",
         "route": "bus"
       }
     },
@@ -6963,20 +7017,6 @@
         "network": "OstalbMobil",
         "network:wikidata": "Q2034809",
         "network:wikipedia": "de:OstalbMobil",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "Ostallgäuer Verkehrsgemeinschaft",
-      "id": "ovg-a45453",
-      "locationSet": {"include": ["de"]},
-      "matchNames": [
-        "OVG"
-      ],
-      "tags": {
-        "network": "OVG",
-        "network:wikidata": "Q1479507",
-        "network:wikipedia": "de:Ostallgäuer Verkehrsgemeinschaft",
         "route": "bus"
       }
     },
@@ -7872,11 +7912,15 @@
     },
     {
       "displayName": "Regensburger Verkehrsverbund",
-      "id": "regensburgerverkehrsverbund-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "rvv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "RVV"
+      ],
       "tags": {
-        "network": "Regensburger Verkehrsverbund",
-        "operator": "Regensburger Verkehrsverbund",
+        "network": "RVV",
+        "network:wikidata": "Q2137458",
+        "network:wikipedia": "de:Regensburger Verkehrsverbund",
         "route": "bus"
       }
     },
@@ -7892,11 +7936,29 @@
     },
     {
       "displayName": "Regio-Verkehrsverbund Freiburg",
-      "id": "regioverkehrsverbundfreiburg-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "rvf-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "RVF"
+      ],
       "tags": {
-        "network": "Regio-Verkehrsverbund Freiburg",
-        "operator": "Regio-Verkehrsverbund Freiburg",
+        "network": "RVF",
+        "network:wikidata": "Q972037",
+        "network:wikipedia": "de:Regio-Verkehrsverbund Freiburg",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Regio Verkehrsverbund Lörrach",
+      "id": "rvl-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "RVL"
+      ],
+      "tags": {
+        "network": "RVL",
+        "network:wikidata": "Q2138145",
+        "network:wikipedia": "de:Regio Verkehrsverbund Lörrach",
         "route": "bus"
       }
     },
@@ -7911,42 +7973,16 @@
       }
     },
     {
-      "displayName": "Regionalbus Augsburg",
-      "id": "regionalbusaugsburg-a45453",
-      "locationSet": {"include": ["001"]},
+      "displayName": "Regionalbus-Gesellschaft Unstrut-Hainich- und Kyffhäuserkreis",
+      "id": "rs-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "RS"
+      ],
       "tags": {
-        "network": "Regionalbus Augsburg",
-        "operator": "Regionalbus Augsburg",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "Regionalbus Augsburg GmbH",
-      "id": "regionalbusaugsburggmbh-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "Regionalbus Augsburg GmbH",
-        "operator": "Regionalbus Augsburg GmbH",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "Regionalbus Ostbayern",
-      "id": "regionalbusostbayern-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "Regionalbus Ostbayern",
-        "operator": "Regionalbus Ostbayern",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "Regionalverkehr Oberbayern",
-      "id": "regionalverkehroberbayern-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "Regionalverkehr Oberbayern",
-        "operator": "Regionalverkehr Oberbayern",
+        "network": "RS",
+        "network:wikidata": "Q1358980",
+        "network:wikipedia": "de:Regionalbus-Gesellschaft Unstrut-Hainich- und Kyffhäuserkreis",
         "route": "bus"
       }
     },
@@ -8181,6 +8217,34 @@
       }
     },
     {
+      "displayName": "Rhein-Main-Verkehrsverbund",
+      "id": "rmv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "RMV"
+      ],
+      "tags": {
+        "network": "RMV",
+        "network:wikidata": "Q314042",
+        "network:wikipedia": "de:Rhein-Main-Verkehrsverbund",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Rhein-Nahe-Nahverkehrsverbund",
+      "id": "rnn-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "RNN"
+      ],
+      "tags": {
+        "network": "RNN",
+        "network:wikidata": "Q1245949",
+        "network:wikipedia": "de:Rhein-Nahe-Nahverkehrsverbund",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "Ride KC",
       "id": "ridekc-a45453",
       "locationSet": {"include": ["001"]},
@@ -8221,26 +8285,6 @@
       }
     },
     {
-      "displayName": "RMV",
-      "id": "rmv-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "RMV",
-        "operator": "RMV",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "RNN",
-      "id": "rnn-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "RNN",
-        "operator": "RNN",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "Rock Region Metro",
       "id": "rockregionmetro-a45453",
       "locationSet": {"include": ["001"]},
@@ -8261,22 +8305,27 @@
       }
     },
     {
-      "displayName": "Rosenheimer Verkehrsgesellschaft",
-      "id": "rosenheimerverkehrsgesellschaft-a45453",
-      "locationSet": {"include": ["001"]},
+      "displayName": "ROSA Tarifverbund",
+      "id": "rosa-a45453",
+      "locationSet": {"include": ["de"]},
       "tags": {
-        "network": "Rosenheimer Verkehrsgesellschaft",
-        "operator": "Rosenheimer Verkehrsgesellschaft",
+        "network": "ROSA",
+        "network:wikidata": "Q77041777",
+        "network:wikipedia": "de:ROSA Tarifverbund",
         "route": "bus"
       }
     },
     {
-      "displayName": "RS",
-      "id": "rs-a45453",
-      "locationSet": {"include": ["001"]},
+      "displayName": "Rosenheimer Verkehrsgesellschaft",
+      "id": "rovg-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "RoVG"
+      ],
       "tags": {
-        "network": "RS",
-        "operator": "RS",
+        "network": "RoVG",
+        "network:wikidata": "Q2167149",
+        "network:wikipedia": "de:Rosenheimer Verkehrsgesellschaft",
         "route": "bus"
       }
     },
@@ -8411,42 +8460,12 @@
       }
     },
     {
-      "displayName": "RVF",
-      "id": "rvf-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "RVF",
-        "operator": "RVF",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "RVL",
-      "id": "rvl-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "RVL",
-        "operator": "RVL",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "RVS",
       "id": "rvs-a45453",
       "locationSet": {"include": ["001"]},
       "tags": {
         "network": "RVS",
         "operator": "RVS",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "RVV",
-      "id": "rvv-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "RVV",
-        "operator": "RVV",
         "route": "bus"
       }
     },
@@ -8471,12 +8490,16 @@
       }
     },
     {
-      "displayName": "saarVV",
+      "displayName": "SaarVV",
       "id": "saarvv-a45453",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "Saarländischer Verkehrsverbund"
+      ],
       "tags": {
-        "network": "saarVV",
-        "operator": "saarVV",
+        "network": "SaarVV",
+        "network:wikidata": "Q2209244",
+        "network:wikipedia": "de:Saarländischer Verkehrsverbund",
         "route": "bus"
       }
     },
@@ -8532,11 +8555,15 @@
     },
     {
       "displayName": "Salzburger Verkehrsverbund",
-      "id": "salzburgerverkehrsverbund-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "svv-a45453",
+      "locationSet": {"include": ["at", "de"]},
+      "matchNames": [
+        "SVV"
+      ],
       "tags": {
-        "network": "Salzburger Verkehrsverbund",
-        "operator": "Salzburger Verkehrsverbund",
+        "network": "SVV",
+        "network:wikidata": "Q1254319",
+        "network:wikipedia": "de:Salzburger Verkehrsverbund",
         "route": "bus"
       }
     },
@@ -9941,6 +9968,20 @@
       }
     },
     {
+      "displayName": "Tarif Oberpfalz Nord",
+      "id": "ton-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "TON"
+      ],
+      "tags": {
+        "network": "TON",
+        "network:wikidata": "Q2394153",
+        "network:wikipedia": "de:Tarif Oberpfalz Nord",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "Tarifverbund Ortenau",
       "id": "tgo-a45453",
       "locationSet": {"include": ["de"]},
@@ -10957,10 +10998,14 @@
     {
       "displayName": "TUTicket",
       "id": "tuticket-a45453",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "Verkehrsverbund Tuttlingen"
+      ],
       "tags": {
         "network": "TUTicket",
-        "operator": "TUTicket",
+        "network:wikidata": "Q2385570",
+        "network:wikipedia": "de:TUTicket",
         "route": "bus"
       }
     },
@@ -11245,26 +11290,6 @@
       }
     },
     {
-      "displayName": "VBN",
-      "id": "vbn-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VBN",
-        "operator": "VBN",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VEJ",
-      "id": "vej-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VEJ",
-        "operator": "VEJ",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "Veluwe",
       "id": "veluwe-a45453",
       "locationSet": {"include": ["001"]},
@@ -11275,72 +11300,351 @@
       }
     },
     {
-      "displayName": "Verkehrs- und Tarifverbund Stuttgart",
-      "id": "verkehrsundtarifverbundstuttgart-a45453",
-      "locationSet": {"include": ["001"]},
+      "displayName": "Verkehrs- und Tarifgemeinschaft Ostharz",
+      "id": "vto-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VTO"
+      ],
       "tags": {
-        "network": "Verkehrs- und Tarifverbund Stuttgart",
-        "operator": "Verkehrs- und Tarifverbund Stuttgart",
+        "network": "VTO",
+        "network:wikidata": "Q2516092",
+        "network:wikipedia": "de:Verkehrs- und Tarifgemeinschaft Ostharz",
         "route": "bus"
       }
     },
     {
-      "displayName": "Verkehrsbetriebsgesellschaft Passau",
-      "id": "verkehrsbetriebsgesellschaftpassau-a45453",
-      "locationSet": {"include": ["001"]},
+      "displayName": "Verkehrs- und Tarifverbund Stuttgart",
+      "id": "vvs-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VVS"
+      ],
       "tags": {
-        "network": "Verkehrsbetriebsgesellschaft Passau",
-        "operator": "Verkehrsbetriebsgesellschaft Passau",
+        "network": "VVS",
+        "network:wikidata": "Q2516108",
+        "network:wikipedia": "de:Verkehrs- und Tarifverbund Stuttgart",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Altmühltal",
+      "id": "vga-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGA"
+      ],
+      "tags": {
+        "network": "VGA",
+        "network:wikidata": "Q2516204",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Altmühltal",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Altötting",
+      "id": "vgao-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGAÖ"
+      ],
+      "tags": {
+        "network": "VGAÖ",
+        "network:wikidata": "Q1269865",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Altötting",
         "route": "bus"
       }
     },
     {
       "displayName": "Verkehrsgemeinschaft am Bayerischen Untermain",
-      "id": "verkehrsgemeinschaftambayerischenuntermain-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "vab-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VAB"
+      ],
       "tags": {
-        "network": "Verkehrsgemeinschaft am Bayerischen Untermain",
-        "operator": "Verkehrsgemeinschaft am Bayerischen Untermain",
+        "network": "VAB",
+        "network:wikidata": "Q2516264",
+        "network:wikipedia": "de:Verkehrsgemeinschaft am Bayerischen Untermain",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Coburg",
+      "id": "vgco-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGC"
+      ],
+      "tags": {
+        "network": "VGC",
+        "network:wikidata": "Q1434428",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Coburg",
         "route": "bus"
       }
     },
     {
       "displayName": "Verkehrsgemeinschaft des Landkreises Greiz",
-      "id": "verkehrsgemeinschaftdeslandkreisesgreiz-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "vglg-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGLG"
+      ],
       "tags": {
-        "network": "Verkehrsgemeinschaft des Landkreises Greiz",
-        "operator": "Verkehrsgemeinschaft des Landkreises Greiz",
+        "network": "VGLG",
+        "network:wikidata": "Q81440717",
+        "network:wikipedia": "de:Verkehrsgemeinschaft des Landkreises Greiz",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Donau-Ries",
+      "id": "vdr-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VDR"
+      ],
+      "tags": {
+        "network": "VDR",
+        "network:wikidata": "Q1478096",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Donau-Ries",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Emsland-Süd",
+      "id": "vge-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGE"
+      ],
+      "tags": {
+        "network": "VGE",
+        "network:wikidata": "Q2516209",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Emsland-Süd",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Fichtelgebirge",
+      "id": "vgfi-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGF"
+      ],
+      "tags": {
+        "network": "VGF",
+        "network:wikidata": "Q2516210",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Fichtelgebirge",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Grafschaft Bentheim",
+      "id": "vgb-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGB"
+      ],
+      "tags": {
+        "network": "VGB",
+        "network:wikidata": "Q2516212",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Grafschaft Bentheim",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Garmisch-Partenkirchen",
+      "id": "vggap-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VG-GAP",
+        "VGGAP"
+      ],
+      "tags": {
+        "network": "VG-GAP",
+        "network:wikidata": "Q1671508",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Garmisch-Partenkirchen",
         "route": "bus"
       }
     },
     {
       "displayName": "Verkehrsgemeinschaft Heidekreis",
-      "id": "verkehrsgemeinschaftheidekreis-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "vh-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VH"
+      ],
       "tags": {
-        "network": "Verkehrsgemeinschaft Heidekreis",
-        "operator": "Verkehrsgemeinschaft Heidekreis",
+        "network": "VH",
         "route": "bus"
       }
     },
     {
-      "displayName": "Verkehrsgemeinschaft Hof",
-      "id": "verkehrsgemeinschafthof-a45453",
-      "locationSet": {"include": ["001"]},
+      "displayName": "Verkehrsgemeinschaft Landkreis Cham",
+      "id": "vlc-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VLC"
+      ],
       "tags": {
-        "network": "Verkehrsgemeinschaft Hof",
-        "operator": "Verkehrsgemeinschaft Hof",
+        "network": "VLC",
+        "network:wikidata": "Q1795575",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Landkreis Cham",
         "route": "bus"
       }
     },
     {
-      "displayName": "Verkehrsgemeinschaft Oberallgäu",
-      "id": "verkehrsgemeinschaftoberallgau-a45453",
-      "locationSet": {"include": ["001"]},
+      "displayName": "Verkehrsgemeinschaft Landkreis Cloppenburg",
+      "id": "vgcl-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGC"
+      ],
       "tags": {
-        "network": "Verkehrsgemeinschaft Oberallgäu",
-        "operator": "Verkehrsgemeinschaft Oberallgäu",
+        "network": "VGC",
+        "network:wikidata": "Q2516220",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Landkreis Cloppenburg,
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Landkreis Deggendorf",
+      "id": "vld-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VLD"
+      ],
+      "tags": {
+        "network": "VLD",
+        "network:wikidata": "Q2516222",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Landkreis Deggendorf",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Landkreis Freudenstadt",
+      "id": "vgfr-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGF"
+      ],
+      "tags": {
+        "network": "VGF",
+        "network:wikidata": "Q1689141",
+        "network:wikipedia": "de:Verkehrs-Gemeinschaft Landkreis Freudenstadt",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Landkreis Mühldorf",
+      "id": "vlmu-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VLMÜ"
+      ],
+      "tags": {
+        "network": "VLMÜ",
+        "network:wikidata": "Q2516227",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Landkreis Mühldorf",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Landkreis Kelheim",
+      "id": "vlk-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VLK"
+      ],
+      "tags": {
+        "network": "VLK",
+        "network:wikidata": "Q2516224",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Landkreis Kelheim",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Landkreis Passau",
+      "id": "vlp-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VLP"
+      ],
+      "tags": {
+        "network": "VLP",
+        "network:wikidata": "Q2516229",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Landkreis Passau",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Landkreis Schaumburg",
+      "id": "vls-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VLS"
+      ],
+      "tags": {
+        "network": "VLS",
+        "network:wikidata": "Q2516231",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Landkreis Schaumburg",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Landkreis Vechta",
+      "id": "vgv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGV"
+      ],
+      "tags": {
+        "network": "VGV",
+        "network:wikidata": "Q2516235",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Landkreis Vechta",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Neuburg-Schrobenhausen",
+      "id": "vgnd-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGND"
+      ],
+      "tags": {
+        "network": "VGND",
+        "network:wikidata": "Q2516243",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Neuburg-Schrobenhausen",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Nordost-Niedersachsen",
+      "id": "vnn-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VNN"
+      ],
+      "tags": {
+        "network": "VNN",
+        "network:wikidata": "Q2516245",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Nordost-Niedersachsen",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Osnabrück",
+      "id": "vos-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VOS"
+      ],
+      "tags": {
+        "network": "VOS",
+        "network:wikidata": "Q2516249",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Osnabrück",
         "route": "bus"
       }
     },
@@ -11355,132 +11659,421 @@
       }
     },
     {
-      "displayName": "Verkehrsgemeinschaft Straubinger Land",
-      "id": "verkehrsgemeinschaftstraubingerland-a45453",
-      "locationSet": {"include": ["001"]},
+      "displayName": "Verkehrsgemeinschaft Rhön-Grabfeld",
+      "id": "vrg-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VRG"
+      ],
       "tags": {
-        "network": "Verkehrsgemeinschaft Straubinger Land",
-        "operator": "Verkehrsgemeinschaft Straubinger Land",
+        "network": "VRG",
+        "network:wikidata": "Q1424574",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Rhön-Grabfeld",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Rottal-Inn",
+      "id": "vgri-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGRI"
+      ],
+      "tags": {
+        "network": "VGRI",
+        "network:wikidata": "Q2516251",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Rottal-Inn",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Schleswig-Flensburg",
+      "id": "vgsf-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGSF"
+      ],
+      "tags": {
+        "network": "VGSF",
+        "network:wikidata": "Q1265093",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Schleswig-Flensburg",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Schweinfurt",
+      "id": "vsw-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VSW"
+      ],
+      "tags": {
+        "network": "VSW",
+        "network:wikidata": "Q2516253",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Schweinfurt",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Straubinger Land",
+      "id": "vsl-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VSL"
+      ],
+      "tags": {
+        "network": "VSL",
+        "network:wikidata": "Q2516255",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Straubinger Land",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsgemeinschaft Wartburgregion",
+      "id": "vgw-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGW"
+      ],
+      "tags": {
+        "network": "VGW",
+        "network:wikidata": "Q64431601",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Wartburgregion",
         "route": "bus"
       }
     },
     {
       "displayName": "Verkehrsgemeinschaft Westmecklenburg",
-      "id": "verkehrsgemeinschaftwestmecklenburg-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "vwm-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VWM"
+      ],
       "tags": {
-        "network": "Verkehrsgemeinschaft Westmecklenburg",
-        "operator": "Verkehrsgemeinschaft Westmecklenburg",
+        "network": "VWM",
+        "network:wikidata": "Q2516262",
+        "network:wikipedia": "de:Verkehrsgemeinschaft Westmecklenburg",
         "route": "bus"
       }
     },
     {
       "displayName": "Verkehrsgesellschaft Bäderkreis Calw",
-      "id": "verkehrsgesellschaftbaderkreiscalw-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "vgca-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGC"
+      ],
       "tags": {
-        "network": "Verkehrsgesellschaft Bäderkreis Calw",
-        "operator": "Verkehrsgesellschaft Bäderkreis Calw",
+        "network": "VGC",
+        "network:wikidata": "Q1493646",
+        "network:wikipedia": "de:Verkehrsgesellschaft Bäderkreis Calw",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrskooperation Kulmbach",
+      "id": "vkk-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VKK"
+      ],
+      "tags": {
+        "network": "VKK",
+        "network:wikidata": "Q2516322",
+        "network:wikipedia": "de:Verkehrskooperation Kulmbach",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsservice Landkreis Nienburg/Weser",
+      "id": "vln-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VLN"
+      ],
+      "tags": {
+        "network": "VLN",
+        "network:wikidata": "Q2516286",
+        "network:wikipedia": "de:Verkehrsservice Landkreis Nienburg/Weser",
         "route": "bus"
       }
     },
     {
       "displayName": "Verkehrsverbund Berlin-Brandenburg",
-      "id": "verkehrsverbundberlinbrandenburg-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "vbb-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VBB"
+      ],
       "tags": {
-        "network": "Verkehrsverbund Berlin-Brandenburg",
-        "operator": "Verkehrsverbund Berlin-Brandenburg",
+        "network": "VBB",
+        "network:wikidata": "Q315451",
+        "network:wikipedia": "de:Verkehrsverbund Berlin-Brandenburg",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsverbund Bremen/Niedersachsen",
+      "id": "vbn-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VBN"
+      ],
+      "tags": {
+        "network": "VBN",
+        "network:wikidata": "Q1306245",
+        "network:wikipedia": "de:Verkehrsverbund Bremen/Niedersachsen",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsverbund Ems-Jade",
+      "id": "vej-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VEJ"
+      ],
+      "tags": {
+        "network": "VEJ",
+        "network:wikidata": "Q1324337",
+        "network:wikipedia": "de:Verkehrsverbund Ems-Jade",
         "route": "bus"
       }
     },
     {
       "displayName": "Verkehrsverbund Großraum Nürnberg",
-      "id": "verkehrsverbundgrossraumnurnberg-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "vgn-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VGN"
+      ],
       "tags": {
-        "network": "Verkehrsverbund Großraum Nürnberg",
-        "operator": "Verkehrsverbund Großraum Nürnberg",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "Verkehrsverbund Großraum Nürnberg GmbH",
-      "id": "verkehrsverbundgrossraumnurnberggmbh-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "Verkehrsverbund Großraum Nürnberg GmbH",
-        "operator": "Verkehrsverbund Großraum Nürnberg GmbH",
+        "network": "VGN",
+        "network:wikidata": "Q2516463",
+        "network:wikipedia": "de:Verkehrsverbund Großraum Nürnberg",
         "route": "bus"
       }
     },
     {
       "displayName": "Verkehrsverbund Hegau-Bodensee",
-      "id": "verkehrsverbundhegaubodensee-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "vhb-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VHB"
+      ],
       "tags": {
-        "network": "Verkehrsverbund Hegau-Bodensee",
-        "operator": "Verkehrsverbund Hegau-Bodensee",
+        "network": "VHB",
+        "network:wikidata": "Q1484666",
+        "network:wikipedia": "de:Verkehrsverbund Hegau-Bodensee",
         "route": "bus"
       }
     },
     {
-      "displayName": "Verkehrsverbund Mittelsachsen",
-      "id": "verkehrsverbundmittelsachsen-a45453",
-      "locationSet": {"include": ["001"]},
+      "displayName": "Verkehrsverbund Mainfranken",
+      "id": "vvma-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VVM"
+      ],
       "tags": {
-        "network": "Verkehrsverbund Mittelsachsen",
-        "operator": "Verkehrsverbund Mittelsachsen",
+        "network": "VVM",
+        "network:wikidata": "Q2516466",
+        "network:wikipedia": "de:Verkehrsverbund Mainfranken",
+      }
+    },
+    {
+      "displayName": "Verkehrsverbund Mittelsachsen",
+      "id": "vms-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VMS"
+      ],
+      "tags": {
+        "network": "VMS",
+        "network:wikidata": "Q1145755",
+        "network:wikipedia": "de:Verkehrsverbund Mittelsachsen",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsverbund Mittelschwaben",
+      "id": "vvmi-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VVM"
+      ],
+      "tags": {
+        "network": "VVM",
+        "network:wikidata": "Q1758268",
+        "network:wikipedia": "de:Verkehrsverbund Mittelschwaben",
+      }
+    },
+    {
+      "displayName": "Verkehrsverbund Mittelthüringen",
+      "id": "vmt-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VMT"
+      ],
+      "tags": {
+        "network": "VMT",
+        "network:wikidata": "Q2516468",
+        "network:wikipedia": "de:Verkehrsverbund Mittelthüringen",
         "route": "bus"
       }
     },
     {
       "displayName": "Verkehrsverbund Oberelbe",
-      "id": "verkehrsverbundoberelbe-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "vvo-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VVO"
+      ],
       "tags": {
-        "network": "Verkehrsverbund Oberelbe",
-        "operator": "Verkehrsverbund Oberelbe",
+        "network": "VVO",
+        "network:wikidata": "Q1426445",
+        "network:wikipedia": "de:Verkehrsverbund Oberelbe",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsverbund Oberlausitz-Niederschlesien",
+      "id": "zvon-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "ZVON",
+        "Zweckverband Verkehrsverbund Oberlausitz-Niederschlesien"
+      ],
+      "tags": {
+        "network": "ZVON",
+        "network:wikidata": "Q2516483",
+        "network:wikipedia": "de:Verkehrsverbund Oberlausitz-Niederschlesien",
         "route": "bus"
       }
     },
     {
       "displayName": "Verkehrsverbund Pforzheim-Enzkreis",
-      "id": "verkehrsverbundpforzheimenzkreis-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "vpe-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VPE"
+      ],
       "tags": {
-        "network": "Verkehrsverbund Pforzheim-Enzkreis",
-        "operator": "Verkehrsverbund Pforzheim-Enzkreis",
+        "network": "VPE",
+        "network:wikidata": "Q2516474",
+        "network:wikipedia": "de:Verkehrsverbund Pforzheim-Enzkreis",
         "route": "bus"
       }
     },
     {
       "displayName": "Verkehrsverbund Region Braunschweig",
-      "id": "verkehrsverbundregionbraunschweig-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "vrb-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VRB"
+      ],
       "tags": {
-        "network": "Verkehrsverbund Region Braunschweig",
-        "operator": "Verkehrsverbund Region Braunschweig",
+        "network": "VRB",
+        "network:wikidata": "Q2514431",
+        "network:wikipedia": "de:Verkehrsverbund Region Braunschweig",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsverbund Region Trier",
+      "id": "vrt-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VRT"
+      ],
+      "tags": {
+        "network": "VRT",
+        "network:wikidata": "Q2516480",
+        "network:wikipedia": "de:Verkehrsverbund Region Trier",
         "route": "bus"
       }
     },
     {
       "displayName": "Verkehrsverbund Rhein-Mosel",
-      "id": "verkehrsverbundrheinmosel-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "vrm-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VRM"
+      ],
       "tags": {
-        "network": "Verkehrsverbund Rhein-Mosel",
-        "operator": "Verkehrsverbund Rhein-Mosel",
+        "network": "VRM",
+        "network:wikidata": "Q2516481",
+        "network:wikipedia": "de:Verkehrsverbund Rhein-Mosel",
         "route": "bus"
       }
     },
     {
       "displayName": "Verkehrsverbund Rhein-Neckar",
-      "id": "verkehrsverbundrheinneckar-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "vrn-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VRN"
+      ],
       "tags": {
-        "network": "Verkehrsverbund Rhein-Neckar",
-        "operator": "Verkehrsverbund Rhein-Neckar",
+        "network": "VRN",
+        "network:wikidata": "Q1553051",
+        "network:wikipedia": "de:Verkehrsverbund Rhein-Neckar",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsverbund Rhein-Ruhr",
+      "id": "vrr-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VRR"
+      ],
+      "tags": {
+        "network": "VRR",
+        "network:wikidata": "Q448199",
+        "network:wikipedia": "de:Verkehrsverbund Rhein-Ruhr",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsverbund Rhein-Sieg",
+      "id": "vrs-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VRS"
+      ],
+      "tags": {
+        "network": "VRS",
+        "network:wikidata": "Q896041",
+        "network:wikipedia": "de:Verkehrsverbund Rhein-Sieg",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsverbund Rottweil",
+      "id": "vvr-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VVR"
+      ],
+      "tags": {
+        "network": "VVR",
+        "network:wikidata": "Q1582791",
+        "network:wikipedia": "de:Verkehrsverbund Rottweil",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsverbund Schwarzwald-Baar",
+      "id": "vsb-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VSB"
+      ],
+      "tags": {
+        "network": "VSB",
+        "network:wikidata": "Q2516487",
+        "network:wikipedia": "de:Verkehrsverbund Schwarzwald-Baar",
         "route": "bus"
       }
     },
@@ -11496,11 +12089,15 @@
     },
     {
       "displayName": "Verkehrsverbund Süd-Niedersachsen",
-      "id": "verkehrsverbundsudniedersachsen-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "vsn-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VSN"
+      ],
       "tags": {
-        "network": "Verkehrsverbund Süd-Niedersachsen",
-        "operator": "Verkehrsverbund Süd-Niedersachsen",
+        "network": "VSN",
+        "network:wikidata": "Q1360635",
+        "network:wikipedia": "de:Verkehrsverbund Süd-Niedersachsen",
         "route": "bus"
       }
     },
@@ -11515,12 +12112,54 @@
       }
     },
     {
+      "displayName": "Verkehrsverbund Vogtland",
+      "id": "vvv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VVV"
+      ],
+      "tags": {
+        "network": "VVV",
+        "network:wikidata": "Q2516490",
+        "network:wikipedia": "de:Verkehrsverbund Vogtland",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "Verkehrsverbund Vorarlberg",
       "id": "verkehrsverbundvorarlberg-a45453",
       "locationSet": {"include": ["001"]},
       "tags": {
         "network": "Verkehrsverbund Vorarlberg",
         "operator": "Verkehrsverbund Vorarlberg",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsverbund Warnow",
+      "id": "vvw-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VVW"
+      ],
+      "tags": {
+        "network": "VVW",
+        "network:wikidata": "Q2516492",
+        "network:wikipedia": "de:Verkehrsverbund Warnow",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verwaltungsgesellschaft des ÖPNV Sömmerda",
+      "id": "vwg-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "VWG"
+      ],
+      "tags": {
+        "network": "VWG",
+        "network:wikidata": "Q1801295",
+        "network:wikipedia": "de:Verwaltungsgesellschaft des ÖPNV Sömmerda",
         "route": "bus"
       }
     },
@@ -11545,42 +12184,12 @@
       }
     },
     {
-      "displayName": "VGB",
-      "id": "vgb-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VGB",
-        "operator": "VGB",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VGE-Süd",
-      "id": "vgesud-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VGE-Süd",
-        "operator": "VGE-Süd",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "VGI",
       "id": "vgi-a45453",
       "locationSet": {"include": ["001"]},
       "tags": {
         "network": "VGI",
         "operator": "VGI",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VGN",
-      "id": "vgn-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VGN",
-        "operator": "VGN",
         "route": "bus"
       }
     },
@@ -11665,56 +12274,6 @@
       }
     },
     {
-      "displayName": "VLN",
-      "id": "vln-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VLN",
-        "operator": "VLN",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VLS",
-      "id": "vls-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VLS",
-        "operator": "VLS",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VMS",
-      "id": "vms-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VMS",
-        "operator": "VMS",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VMT",
-      "id": "vmt-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VMT",
-        "operator": "VMT",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VNN",
-      "id": "vnn-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VNN",
-        "operator": "VNN",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "Voironnais",
       "id": "voironnais-a45453",
       "locationSet": {"include": ["001"]},
@@ -11765,46 +12324,6 @@
       }
     },
     {
-      "displayName": "VOS",
-      "id": "vos-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VOS",
-        "operator": "VOS",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VOS Ost",
-      "id": "vosost-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VOS Ost",
-        "operator": "VOS Ost",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VPE",
-      "id": "vpe-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VPE",
-        "operator": "VPE",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VRB",
-      "id": "vrb-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VRB",
-        "operator": "VRB",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "VRD",
       "id": "vrd-a45453",
       "locationSet": {"include": ["001"]},
@@ -11825,129 +12344,12 @@
       }
     },
     {
-      "displayName": "VRM",
-      "id": "vrm-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VRM",
-        "operator": "VRM",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VRN",
-      "id": "vrn-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VRN",
-        "operator": "VRN",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VRR",
-      "id": "vrr-3b9544",
-      "locationSet": {"include": ["de"]},
-      "matchNames": [
-        "verkehrsverbund rhein-ruhr"
-      ],
-      "tags": {
-        "network": "VRR",
-        "network:wikidata": "Q448199",
-        "network:wikipedia": "de:Verkehrsverbund Rhein-Ruhr",
-        "operator": "VRR",
-        "operator:wikidata": "Q448199",
-        "operator:wikipedia": "de:Verkehrsverbund Rhein-Ruhr",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VRS",
-      "id": "vrs-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VRS",
-        "operator": "VRS",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VRT",
-      "id": "vrt-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VRT",
-        "operator": "VRT",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VSB",
-      "id": "vsb-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VSB",
-        "operator": "VSB",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VSN",
-      "id": "vsn-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VSN",
-        "operator": "VSN",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "VTA",
       "id": "vta-a45453",
       "locationSet": {"include": ["001"]},
       "tags": {
         "network": "VTA",
         "operator": "VTA",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VVM",
-      "id": "vvm-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VVM",
-        "operator": "VVM",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VVO",
-      "id": "vvo-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VVO",
-        "operator": "VVO",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VVR",
-      "id": "vvr-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VVR",
-        "operator": "VVR",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VVS",
-      "id": "vvs-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VVS",
-        "operator": "VVS",
         "route": "bus"
       }
     },
@@ -11972,26 +12374,6 @@
       }
     },
     {
-      "displayName": "VVW",
-      "id": "vvw-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VVW",
-        "operator": "VVW",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "VWM",
-      "id": "vwm-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "VWM",
-        "operator": "VWM",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "VyBus",
       "id": "vybus-a45453",
       "locationSet": {"include": ["001"]},
@@ -12003,11 +12385,15 @@
     },
     {
       "displayName": "Waldshuter Tarifverbund",
-      "id": "waldshutertarifverbund-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "wtv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "WTV"
+      ],
       "tags": {
-        "network": "Waldshuter Tarifverbund",
-        "operator": "Waldshuter Tarifverbund",
+        "network": "WTV",
+        "network:wikidata": "Q2541897",
+        "network:wikipedia": "de:Waldshuter Tarifverbund",
         "route": "bus"
       }
     },
@@ -12102,12 +12488,16 @@
       }
     },
     {
-      "displayName": "WestfalenTarif",
-      "id": "westfalentarif-a45453",
-      "locationSet": {"include": ["001"]},
+      "displayName": "Westfalentarif",
+      "id": "wt-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "WT"
+      ],
       "tags": {
-        "network": "WestfalenTarif",
-        "operator": "WestfalenTarif",
+        "network": "WT",
+        "network:wikidata": "Q27926285",
+        "network:wikipedia": "de:Westfalentarif",
         "route": "bus"
       }
     },
@@ -12618,16 +13008,6 @@
       "tags": {
         "network": "Zuidoost-Fryslân en Wadden",
         "operator": "Zuidoost-Fryslân en Wadden",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "ZVON",
-      "id": "zvon-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "ZVON",
-        "operator": "ZVON",
         "route": "bus"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -31,6 +31,20 @@
       }
     },
     {
+      "displayName": "Aachener Verkehrsverbund",
+      "id": "aavv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "AVV"
+      ],
+      "tags": {
+        "network": "AVV",
+        "network:wikidata": "Q300763",
+        "network:wikipedia": "de:Aachener Verkehrsverbund",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "Achterhoek-Rivierenland",
       "id": "achterhoekrivierenland-a45453",
       "locationSet": {"include": ["001"]},
@@ -662,11 +676,15 @@
     },
     {
       "displayName": "Augsburger Verkehrs- und Tarifverbund",
-      "id": "augsburgerverkehrsundtarifverbund-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "auvv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "AVV"
+      ],
       "tags": {
-        "network": "Augsburger Verkehrs- und Tarifverbund",
-        "operator": "Augsburger Verkehrs- und Tarifverbund",
+        "network": "AVV",
+        "network:wikidata": "Q760574",
+        "network:wikipedia": "de:Augsburger Verkehrs- und Tarifverbund",
         "route": "bus"
       }
     },
@@ -777,34 +795,6 @@
       "tags": {
         "network": "AVTA",
         "operator": "AVTA",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "Aachener Verkehrsverbund",
-      "id": "aavv-a45453",
-      "locationSet": {"include": ["de"]},
-      "matchNames": [
-        "AVV"
-      ],
-      "tags": {
-        "network": "AVV",
-        "network:wikidata": "Q300763",
-        "network:wikipedia": "de:Aachener Verkehrsverbund",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "Augsburger Verkehrs- und Tarifverbund",
-      "id": "auvv-a45453",
-      "locationSet": {"include": ["de"]},
-      "matchNames": [
-        "AVV"
-      ],
-      "tags": {
-        "network": "AVV",
-        "network:wikidata": "Q760574",
-        "network:wikipedia": "de:Augsburger Verkehrs- und Tarifverbund",
         "route": "bus"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -781,12 +781,30 @@
       }
     },
     {
-      "displayName": "AVV",
-      "id": "avv-a45453",
-      "locationSet": {"include": ["001"]},
+      "displayName": "Aachener Verkehrsverbund",
+      "id": "aavv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "AVV"
+      ],
       "tags": {
         "network": "AVV",
-        "operator": "AVV",
+        "network:wikidata": "Q300763",
+        "network:wikipedia": "de:Aachener Verkehrsverbund",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Augsburger Verkehrs- und Tarifverbund",
+      "id": "auvv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "AVV"
+      ],
+      "tags": {
+        "network": "AVV",
+        "network:wikidata": "Q760574",
+        "network:wikipedia": "de:Augsburger Verkehrs- und Tarifverbund",
         "route": "bus"
       }
     },
@@ -1123,10 +1141,14 @@
     {
       "displayName": "bodo",
       "id": "bodo-a45453",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "Bodensee-Oberschwaben Verkehrsverbund"
+      ],
       "tags": {
         "network": "bodo",
-        "operator": "bodo",
+        "network:wikidata": "Q889680",
+        "network:wikipedia": "de:Bodensee-Oberschwaben Verkehrsverbund",
         "route": "bus"
       }
     },
@@ -1437,6 +1459,20 @@
       "tags": {
         "network": "Busval d'Oise",
         "operator": "Busval d'Oise",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "BV-Emsland Mitte/Nord",
+      "id": "bvemsland-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "Busverkehr Emsland-Mitte/Nord"
+      ],
+      "tags": {
+        "network": "BV-Emsland Mitte/Nord",
+        "network:wikidata": "Q1017814",
+        "network:wikipedia": "de:Busverkehr Emsland-Mitte/Nord",
         "route": "bus"
       }
     },
@@ -2433,11 +2469,14 @@
     {
       "displayName": "DING",
       "id": "ding-a45453",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "Donau-Iller-Nahverkehrsverbund"
+      ],
       "tags": {
         "network": "DING",
-        "operator": "DING",
-        "route": "bus"
+        "network:wikidata": "Q315403",
+        "network:wikipedia": "de:Donau-Iller-Nahverkehrsverbund",
       }
     },
     {
@@ -3143,20 +3182,11 @@
     {
       "displayName": "Filsland Mobilitätsverbund",
       "id": "filslandmobilitatsverbund-a45453",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["de"]},
       "tags": {
         "network": "Filsland Mobilitätsverbund",
-        "operator": "Filsland Mobilitätsverbund",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "Filsland Mobilitätsverbund GmbH",
-      "id": "filslandmobilitatsverbundgmbh-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "Filsland Mobilitätsverbund GmbH",
-        "operator": "Filsland Mobilitätsverbund GmbH",
+        "network:wikidata": "Q1415517",
+        "network:wikipedia": "de:Filsland Mobilitätsverbund",
         "route": "bus"
       }
     },
@@ -3174,9 +3204,12 @@
       "displayName": "Flixbus",
       "id": "flixbus-a45453",
       "locationSet": {"include": ["001"]},
+      "matchNames": [
+        "Flixmobility"
+      ],
       "tags": {
         "network": "Flixbus",
-        "operator": "Flixbus",
+        "network:wikidata": "Q15712258",
         "route": "bus"
       }
     },
@@ -3681,16 +3714,6 @@
       }
     },
     {
-      "displayName": "Großraum-Verkehr Hannover",
-      "id": "grossraumverkehrhannover-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "Großraum-Verkehr Hannover",
-        "operator": "Großraum-Verkehr Hannover",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "GRT",
       "id": "grt-a45453",
       "locationSet": {"include": ["001"]},
@@ -3727,16 +3750,6 @@
       "tags": {
         "network": "Guelph Transit",
         "operator": "Guelph Transit",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "GVH",
-      "id": "gvh-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "GVH",
-        "operator": "GVH",
         "route": "bus"
       }
     },
@@ -3821,6 +3834,34 @@
       }
     },
     {
+      "displayName": "Großraum-Verkehr Hannover",
+      "id": "gvh-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "GVH"
+      ],
+      "tags": {
+        "network": "GVH",
+        "network:wikidata": "Q1549516",
+        "network:wikipedia": "de:Großraum-Verkehr Hannover",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Hamburger Verkehrsverbund",
+      "id": "hvv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "HVV"
+      ],
+      "tags": {
+        "network": "HVV",
+        "network:wikidata": "Q896916",
+        "network:wikipedia": "de:Hamburger Verkehrsverbund",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "Hämeenlinna",
       "id": "hameenlinna-a45453",
       "locationSet": {"include": ["001"]},
@@ -3871,12 +3912,30 @@
       }
     },
     {
-      "displayName": "Heilbronn-Hohenlohe-Haller Nahverkehr",
-      "id": "heilbronnhohenlohehallernahverkehr-a45453",
-      "locationSet": {"include": ["001"]},
+      "displayName": "Heidenheimer Tarifverbund",
+      "id": "htv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "HTV"
+      ],
       "tags": {
-        "network": "Heilbronn-Hohenlohe-Haller Nahverkehr",
-        "operator": "Heilbronn-Hohenlohe-Haller Nahverkehr",
+        "network": "HTV",
+        "network:wikidata": "Q1594169",
+        "network:wikipedia": "de:Heidenheimer Tarifverbund",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Heilbronner Hohenloher Haller Nahverkehr",
+      "id": "hnv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "HNV"
+      ],
+      "tags": {
+        "network": "HNV",
+        "network:wikidata": "Q1594788",
+        "network:wikipedia": "de:Heilbronner Hohenloher Haller Nahverkehr",
         "route": "bus"
       }
     },
@@ -3951,16 +4010,6 @@
       }
     },
     {
-      "displayName": "HNV",
-      "id": "hnv-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "HNV",
-        "operator": "HNV",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "Hoeksche Waard - Goeree-Overflakkee",
       "id": "hoekschewaardgoereeoverflakkee-a45453",
       "locationSet": {"include": ["001"]},
@@ -4027,16 +4076,6 @@
       "tags": {
         "network": "Huddersfield",
         "operator": "Huddersfield",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "HVV",
-      "id": "hvv-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "HVV",
-        "operator": "HVV",
         "route": "bus"
       }
     },
@@ -4127,6 +4166,20 @@
       "tags": {
         "network": "Ilévia",
         "operator": "Ilévia",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Ilm-Kreis Personenverkehrsgesellschaft",
+      "id": "ikpv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "IKPV"
+      ],
+      "tags": {
+        "network": "IKPV",
+        "network:wikidata": "Q16319486",
+        "network:wikipedia": "de:Ilm-Kreis Personenverkehrsgesellschaft",
         "route": "bus"
       }
     },
@@ -4341,16 +4394,6 @@
       }
     },
     {
-      "displayName": "IVRPV",
-      "id": "ivrpv-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "IVRPV",
-        "operator": "IVRPV",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "JES",
       "id": "jes-a45453",
       "locationSet": {"include": ["001"]},
@@ -4432,11 +4475,15 @@
     },
     {
       "displayName": "Karlsruher Verkehrsverbund",
-      "id": "karlsruherverkehrsverbund-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "kvv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "KVV"
+      ],
       "tags": {
-        "network": "Karlsruher Verkehrsverbund",
-        "operator": "Karlsruher Verkehrsverbund",
+        "network": "KVV",
+        "network:wikidata": "Q1733986",
+        "network:wikipedia": "de:Karlsruher Verkehrsverbund",
         "route": "bus"
       }
     },
@@ -4551,6 +4598,20 @@
       }
     },
     {
+      "displayName": "Kissingen mobil",
+      "id": "kissingenmobil-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "Kim"
+      ],
+      "tags": {
+        "network": "Kissingen mobil",
+        "network:wikidata": "Q1434241",
+        "network:wikipedia": "de:Kissingen mobil",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "Kitsap Transit",
       "id": "kitsaptransit-a45453",
       "locationSet": {"include": ["001"]},
@@ -4597,6 +4658,17 @@
       "tags": {
         "network": "Kolumbus",
         "operator": "Kolumbus",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "KomBus",
+      "id": "kombus-a45453",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "network": "KomBus",
+        "network:wikidata": "Q1779744",
+        "network:wikipedia": "de:KomBus",
         "route": "bus"
       }
     },
@@ -4681,6 +4753,20 @@
       }
     },
     {
+      "displayName": "KreisVerkehr Schwäbisch Hall",
+      "id": "kvsh-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "KVSH"
+      ],
+      "tags": {
+        "network": "KVSH",
+        "network:wikidata": "Q1504893",
+        "network:wikipedia": "de:KreisVerkehr Schwäbisch Hall",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "KTEL",
       "id": "ktel-a45453",
       "locationSet": {"include": ["001"]},
@@ -4717,16 +4803,6 @@
       "tags": {
         "network": "KVG",
         "operator": "KVG",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "KVV",
-      "id": "kvv-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "KVV",
-        "operator": "KVV",
         "route": "bus"
       }
     },
@@ -4791,12 +4867,30 @@
       }
     },
     {
+      "displayName": "Landsberger Verkehrsgemeinschaft",
+      "id": "lvg-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "LVG"
+      ],
+      "tags": {
+        "network": "LVG",
+        "network:wikidata": "Q1673799",
+        "network:wikipedia": "de:Landsberger Verkehrsgemeinschaft",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "Landshuter Verkehrsverbund",
-      "id": "landshuterverkehrsverbund-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "lavv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "LAVV"
+      ],
       "tags": {
         "network": "Landshuter Verkehrsverbund",
-        "operator": "Landshuter Verkehrsverbund",
+        "network:wikidata": "Q65952782",
+        "network:wikipedia": "de:Landshuter Verkehrsverbund",
         "route": "bus"
       }
     },
@@ -5191,16 +5285,6 @@
       }
     },
     {
-      "displayName": "LVG",
-      "id": "lvg-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "LVG",
-        "operator": "LVG",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "M1",
       "id": "m1-a45453",
       "locationSet": {"include": ["001"]},
@@ -5273,10 +5357,15 @@
     {
       "displayName": "marego",
       "id": "marego-a45453",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "Magdeburger Regionalverkehrsverbund",
+        "Magdeburger Verkehrsverbund"
+      ],
       "tags": {
         "network": "marego",
-        "operator": "marego",
+        "network:wikidata": "Q1883891",
+        "network:wikipedia": "de:Magdeburger Regionalverkehrsverbund",
         "route": "bus"
       }
     },
@@ -5404,16 +5493,6 @@
       "tags": {
         "network": "MDT",
         "operator": "MDT",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "MDV",
-      "id": "mdv-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "MDV",
-        "operator": "MDV",
         "route": "bus"
       }
     },
@@ -5859,11 +5938,15 @@
     },
     {
       "displayName": "Mitteldeutscher Verkehrsverbund",
-      "id": "mitteldeutscherverkehrsverbund-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "mdv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "MDV"
+      ],
       "tags": {
-        "network": "Mitteldeutscher Verkehrsverbund",
-        "operator": "Mitteldeutscher Verkehrsverbund",
+        "network": "MDV",
+        "network:wikidata": "Q1742463",
+        "network:wikipedia": "de:Mitteldeutscher Verkehrsverbund",
         "route": "bus"
       }
     },
@@ -6149,11 +6232,15 @@
     },
     {
       "displayName": "Münchner Verkehrs- und Tarifverbund",
-      "id": "munchnerverkehrsundtarifverbund-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "mvv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "MVV"
+      ],
       "tags": {
-        "network": "Münchner Verkehrs- und Tarifverbund",
-        "operator": "Münchner Verkehrs- und Tarifverbund",
+        "network": "MVV",
+        "network:wikidata": "Q259000",
+        "network:wikipedia": "de:Münchner Verkehrs- und Tarifverbund",
         "route": "bus"
       }
     },
@@ -6344,6 +6431,20 @@
       "tags": {
         "network": "NAH.SH",
         "operator": "NAH.SH",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Nahverkehrsservicegesellschaft Thüringen",
+      "id": "nvs-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "NVS"
+      ],
+      "tags": {
+        "network": "NVS",
+        "network:wikidata": "Q1963809",
+        "network:wikipedia": "de:Nahverkehrsservicegesellschaft Thüringen",
         "route": "bus"
       }
     },
@@ -6539,11 +6640,15 @@
     },
     {
       "displayName": "Nordhessischer VerkehrsVerbund",
-      "id": "nordhessischerverkehrsverbund-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "nvv-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "NVV"
+      ],
       "tags": {
-        "network": "Nordhessischer VerkehrsVerbund",
-        "operator": "Nordhessischer VerkehrsVerbund",
+        "network": "NVV",
+        "network:wikidata": "Q1998056",
+        "network:wikipedia": "de:Nordhessischer Verkehrsverbund",
         "route": "bus"
       }
     },
@@ -6604,16 +6709,6 @@
       "tags": {
         "network": "Nova Brasília",
         "operator": "Nova Brasília",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "NVV",
-      "id": "nvv-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "NVV",
-        "operator": "NVV",
         "route": "bus"
       }
     },
@@ -6860,10 +6955,28 @@
     {
       "displayName": "OstalbMobil",
       "id": "ostalbmobil-a45453",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "OAM"
+      ],
       "tags": {
         "network": "OstalbMobil",
-        "operator": "OstalbMobil",
+        "network:wikidata": "Q2034809",
+        "network:wikipedia": "de:OstalbMobil",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Ostallgäuer Verkehrsgemeinschaft",
+      "id": "ovg-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "OVG"
+      ],
+      "tags": {
+        "network": "OVG",
+        "network:wikidata": "Q1479507",
+        "network:wikipedia": "de:Ostallgäuer Verkehrsgemeinschaft",
         "route": "bus"
       }
     },
@@ -9268,16 +9381,6 @@
       }
     },
     {
-      "displayName": "Stadtbus Weiden",
-      "id": "stadtbusweiden-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "Stadtbus Weiden",
-        "operator": "Stadtbus Weiden",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "Stadtverkehr Rosenheim",
       "id": "stadtverkehrrosenheim-a45453",
       "locationSet": {"include": ["001"]},
@@ -9839,11 +9942,15 @@
     },
     {
       "displayName": "Tarifverbund Ortenau",
-      "id": "tarifverbundortenau-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "tgo-a45453",
+      "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "TGO"
+      ],
       "tags": {
-        "network": "Tarifverbund Ortenau",
-        "operator": "Tarifverbund Ortenau",
+        "network": "TGO",
+        "network:wikidata": "Q1525084",
+        "network:wikipedia": "de:Tarifverbund Ortenau",
         "route": "bus"
       }
     },
@@ -10044,16 +10151,6 @@
       "tags": {
         "network": "TfGM",
         "operator": "TfGM",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "TGO",
-      "id": "tgo-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "TGO",
-        "operator": "TGO",
         "route": "bus"
       }
     },


### PR DESCRIPTION
added network:wikipedia + network:wikidata links, removed operator tags, duplicates and historical networks and added a few missing networks