### PR TITLE
Check VBB transit

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -11307,11 +11307,12 @@
     },
     {
       "displayName": "Verkehrsverbund Berlin-Brandenburg",
-      "id": "verkehrsverbundberlinbrandenburg-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "verkehrsverbundberlinbrandenburg-3b9544",
+      "locationSet": {"include": ["de"]},
       "tags": {
         "network": "Verkehrsverbund Berlin-Brandenburg",
-        "operator": "Verkehrsverbund Berlin-Brandenburg",
+        "network:short": "VBB",
+        "network:wikidata": "Q315451",
         "route": "bus"
       }
     },

--- a/data/transit/route/subway.json
+++ b/data/transit/route/subway.json
@@ -271,11 +271,12 @@
     },
     {
       "displayName": "Verkehrsverbund Berlin-Brandenburg",
-      "id": "verkehrsverbundberlinbrandenburg-907487",
-      "locationSet": {"include": ["001"]},
+      "id": "verkehrsverbundberlinbrandenburg-447f34",
+      "locationSet": {"include": ["de"]},
       "tags": {
         "network": "Verkehrsverbund Berlin-Brandenburg",
-        "operator": "Verkehrsverbund Berlin-Brandenburg",
+        "network:short": "VBB",
+        "network:wikidata": "Q315451",
         "route": "subway"
       }
     },

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -1280,11 +1280,12 @@
     },
     {
       "displayName": "Verkehrsverbund Berlin-Brandenburg",
-      "id": "verkehrsverbundberlinbrandenburg-44bbb3",
-      "locationSet": {"include": ["001"]},
+      "id": "verkehrsverbundberlinbrandenburg-da20e0",
+      "locationSet": {"include": ["de"]},
       "tags": {
         "network": "Verkehrsverbund Berlin-Brandenburg",
-        "operator": "Verkehrsverbund Berlin-Brandenburg",
+        "network:short": "VBB",
+        "network:wikidata": "Q315451",
         "route": "train"
       }
     },

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -503,11 +503,12 @@
     },
     {
       "displayName": "Verkehrsverbund Berlin-Brandenburg",
-      "id": "verkehrsverbundberlinbrandenburg-2e09b9",
-      "locationSet": {"include": ["001"]},
+      "id": "verkehrsverbundberlinbrandenburg-37759c",
+      "locationSet": {"include": ["de"]},
       "tags": {
         "network": "Verkehrsverbund Berlin-Brandenburg",
-        "operator": "Verkehrsverbund Berlin-Brandenburg",
+        "network:short": "VBB",
+        "network:wikidata": "Q315451",
         "route": "tram"
       }
     },


### PR DESCRIPTION
The Verkehrsverbund Berlin-Brandenburg is a network only. There are different operators which can be added later.