### PR TITLE
Add wiki tags for NJ Transit

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -6404,16 +6404,6 @@
       }
     },
     {
-      "displayName": "New Jersey Transit",
-      "id": "newjerseytransit-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "New Jersey Transit",
-        "operator": "New Jersey Transit",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "NFTA Metro",
       "id": "nftametro-a45453",
       "locationSet": {"include": ["001"]},
@@ -6475,11 +6465,16 @@
     },
     {
       "displayName": "NJ Transit",
-      "id": "njtransit-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "njtransit-a21cc9",
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["new jersey transit"],
       "tags": {
         "network": "NJ Transit",
+        "network:wikidata": "Q498553",
+        "network:wikipedia": "en:NJ Transit",
         "operator": "NJ Transit",
+        "operator:wikidata": "Q498553",
+        "operator:wikipedia": "en:NJ Transit",
         "route": "bus"
       }
     },

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -655,11 +655,16 @@
     },
     {
       "displayName": "NJ Transit",
-      "id": "njtransit-44bbb3",
-      "locationSet": {"include": ["001"]},
+      "id": "njtransit-012d27",
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["new jersey transit"],
       "tags": {
         "network": "NJ Transit",
+        "network:wikidata": "Q498553",
+        "network:wikipedia": "en:NJ Transit",
         "operator": "NJ Transit",
+        "operator:wikidata": "Q498553",
+        "operator:wikipedia": "en:NJ Transit",
         "route": "train"
       }
     },

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -282,6 +282,21 @@
       }
     },
     {
+      "displayName": "NJ Transit",
+      "id": "njtransit-a89e98",
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["new jersey transit"],
+      "tags": {
+        "network": "NJ Transit",
+        "network:wikidata": "Q498553",
+        "network:wikipedia": "en:NJ Transit",
+        "operator": "NJ Transit",
+        "operator:wikidata": "Q498553",
+        "operator:wikipedia": "en:NJ Transit",
+        "route": "tram"
+      }
+    },
+    {
       "displayName": "NVV",
       "id": "nvv-2e09b9",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
These are inconsistent, but I'm choosing "NJ Transit" as the more common tag that I see used on the stop locations, stations, and other infrastructure, and keeping "New Jersey Transit" as a matchName.