### PR TITLE
Add entry for PATH subway

### DIFF
--- a/data/transit/route/subway.json
+++ b/data/transit/route/subway.json
@@ -192,6 +192,20 @@
       }
     },
     {
+      "displayName": "PATH",
+      "id": "path-c94044",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "PATH",
+        "network:wikidata": "Q1055811",
+        "network:wikipedia": "en:PATH (rail system)",
+        "operator": "Port Authority of New York and New Jersey",
+        "operator:wikidata": "Q908666",
+        "operator:wikipedia": "en:Port Authority of New York and New Jersey",
+        "route": "subway"
+      }
+    },
+    {
       "displayName": "Rail Rotterdam",
       "id": "railrotterdam-907487",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Here's another one that didn't make it into the initial collection of `network` tags, as they only operate a few routes.
https://en.wikipedia.org/wiki/PATH_(rail_system)