### PR TITLE
Add country codes + wikidata/wikipedia for trolleybus networks

### DIFF
--- a/data/transit/route/trolleybus.json
+++ b/data/transit/route/trolleybus.json
@@ -2,8 +2,8 @@
   "transit/route/trolleybus": [
     {
       "displayName": "Arnhem-Nijmegen",
-      "id": "arnhemnijmegen-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "arnhemnijmegen-de7a49",
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "network": "Arnhem-Nijmegen",
         "operator": "Arnhem-Nijmegen",
@@ -12,21 +12,29 @@
     },
     {
       "displayName": "CTP (Compania de Transport Public Cluj Napoca SA)",
-      "id": "ctpcompaniadetransportpublicclujnapocasa-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "ctpcompaniadetransportpublicclujnapocasa-6b6251",
+      "locationSet": {"include": ["ro"]},
       "tags": {
         "network": "CTP (Compania de Transport Public Cluj Napoca SA)",
+        "network:wikidata": "Q266625",
+        "network:wikipedia": "ro:Compania de Transport Public Cluj-Napoca",
         "operator": "CTP (Compania de Transport Public Cluj Napoca SA)",
+        "operator:wikidata": "Q266625",
+        "operator:wikipedia": "ro:Compania de Transport Public Cluj-Napoca",
         "route": "trolleybus"
       }
     },
     {
       "displayName": "IDS JMK",
-      "id": "idsjmk-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "idsjmk-706c20",
+      "locationSet": {"include": ["cz"]},
       "tags": {
         "network": "IDS JMK",
+        "network:wikidata": "Q12020731",
+        "network:wikipedia": "cs:Integrovaný dopravní systém Jihomoravského kraje",
         "operator": "IDS JMK",
+        "operator:wikidata": "Q12020731",
+        "operator:wikipedia": "cs:Integrovaný dopravní systém Jihomoravského kraje",
         "route": "trolleybus"
       }
     },
@@ -42,8 +50,8 @@
     },
     {
       "displayName": "Lublin",
-      "id": "lublin-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "lublin-ac5bc5",
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "network": "Lublin",
         "operator": "Lublin",
@@ -69,8 +77,8 @@
     },
     {
       "displayName": "MHD Bratislava",
-      "id": "mhdbratislava-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "mhdbratislava-acc88b",
+      "locationSet": {"include": ["sk"]},
       "tags": {
         "network": "MHD Bratislava",
         "operator": "MHD Bratislava",
@@ -79,8 +87,8 @@
     },
     {
       "displayName": "MHD Hradec Králové",
-      "id": "mhdhradeckralove-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "mhdhradeckralove-706c20",
+      "locationSet": {"include": ["cz"]},
       "tags": {
         "network": "MHD Hradec Králové",
         "operator": "MHD Hradec Králové",
@@ -89,8 +97,8 @@
     },
     {
       "displayName": "MHD Opava",
-      "id": "mhdopava-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "mhdopava-706c20",
+      "locationSet": {"include": ["cz"]},
       "tags": {
         "network": "MHD Opava",
         "operator": "MHD Opava",
@@ -99,8 +107,8 @@
     },
     {
       "displayName": "MHD Plzeň",
-      "id": "mhdplzen-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "mhdplzen-706c20",
+      "locationSet": {"include": ["cz"]},
       "tags": {
         "network": "MHD Plzeň",
         "operator": "MHD Plzeň",
@@ -109,8 +117,8 @@
     },
     {
       "displayName": "MHD Prešov",
-      "id": "mhdpresov-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "mhdpresov-acc88b",
+      "locationSet": {"include": ["sk"]},
       "tags": {
         "network": "MHD Prešov",
         "operator": "MHD Prešov",
@@ -119,8 +127,8 @@
     },
     {
       "displayName": "MHD Teplice",
-      "id": "mhdteplice-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "mhdteplice-706c20",
+      "locationSet": {"include": ["cz"]},
       "tags": {
         "network": "MHD Teplice",
         "operator": "MHD Teplice",
@@ -129,8 +137,8 @@
     },
     {
       "displayName": "MHD Ústí nad Labem",
-      "id": "mhdustinadlabem-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "mhdustinadlabem-706c20",
+      "locationSet": {"include": ["cz"]},
       "tags": {
         "network": "MHD Ústí nad Labem",
         "operator": "MHD Ústí nad Labem",
@@ -149,8 +157,8 @@
     },
     {
       "displayName": "R.A.T. Brașov",
-      "id": "ratbrasov-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "ratbrasov-6b6251",
+      "locationSet": {"include": ["ro"]},
       "tags": {
         "network": "R.A.T. Brașov",
         "operator": "R.A.T. Brașov",
@@ -169,8 +177,8 @@
     },
     {
       "displayName": "RATB (Regia Autonomă de Transport București)",
-      "id": "ratbregiaautonomadetransportbucuresti-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "ratbregiaautonomadetransportbucuresti-6b6251",
+      "locationSet": {"include": ["ro"]},
       "tags": {
         "network": "RATB (Regia Autonomă de Transport București)",
         "operator": "RATB (Regia Autonomă de Transport București)",
@@ -189,8 +197,8 @@
     },
     {
       "displayName": "Salzburger Verkehrsverbund",
-      "id": "salzburgerverkehrsverbund-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "salzburgerverkehrsverbund-54cb1f",
+      "locationSet": {"include": ["de"]},
       "tags": {
         "network": "Salzburger Verkehrsverbund",
         "operator": "Salzburger Verkehrsverbund",
@@ -199,8 +207,8 @@
     },
     {
       "displayName": "Szeged",
-      "id": "szeged-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "szeged-c2505f",
+      "locationSet": {"include": ["hu"]},
       "tags": {
         "network": "Szeged",
         "operator": "Szeged",
@@ -209,11 +217,15 @@
     },
     {
       "displayName": "TCL",
-      "id": "tcl-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "tcl-6f0cb3",
+      "locationSet": {"include": ["fr"]},
       "tags": {
         "network": "TCL",
+        "network:wikidata": "Q8700",
+        "network:wikipedia": "fr:Transports en commun lyonnais",
         "operator": "TCL",
+        "operator:wikidata": "Q8700",
+        "operator:wikipedia": "fr:Transports en commun lyonnais",
         "route": "trolleybus"
       }
     },
@@ -249,8 +261,8 @@
     },
     {
       "displayName": "Unireso",
-      "id": "unireso-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "unireso-00a6ee",
+      "locationSet": {"include": ["ch", "fr"]},
       "tags": {
         "network": "Unireso",
         "operator": "Unireso",
@@ -259,8 +271,8 @@
     },
     {
       "displayName": "Vilniaus miesto savivaldybė",
-      "id": "vilniausmiestosavivaldybe-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "vilniausmiestosavivaldybe-b0cd15",
+      "locationSet": {"include": ["lt"]},
       "tags": {
         "network": "Vilniaus miesto savivaldybė",
         "operator": "Vilniaus miesto savivaldybė",
@@ -286,21 +298,29 @@
     },
     {
       "displayName": "Zarząd Transportu Metropolitalnego",
-      "id": "zarzadtransportumetropolitalnego-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "zarzadtransportumetropolitalnego-ac5bc5",
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "network": "Zarząd Transportu Metropolitalnego",
+        "network:wikidata": "Q48862619",
+        "network:wikipedia": "pl:Zarząd Transportu Metropolitalnego",
         "operator": "Zarząd Transportu Metropolitalnego",
+        "operator:wikidata": "Q48862619",
+        "operator:wikipedia": "pl:Zarząd Transportu Metropolitalnego",
         "route": "trolleybus"
       }
     },
     {
       "displayName": "ZKM Gdynia",
-      "id": "zkmgdynia-97f884",
-      "locationSet": {"include": ["001"]},
+      "id": "zkmgdynia-ac5bc5",
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "network": "ZKM Gdynia",
+        "network:wikidata": "Q9387114",
+        "network:wikipedia": "pl:Zarząd Komunikacji Miejskiej w Gdyni",
         "operator": "ZKM Gdynia",
+        "operator:wikidata": "Q9387114",
+        "operator:wikipedia": "pl:Zarząd Komunikacji Miejskiej w Gdyni",
         "route": "trolleybus"
       }
     },


### PR DESCRIPTION
I tried to find the right codes for network names in latin script (avoiding acronyms), added some wikidata/wikipedia while doing so.