### PR TITLE
Add HERC'S Nutrition to data/brands/shop/nutrition_supplements

### DIFF
--- a/data/brands/shop/nutrition_supplements.json
+++ b/data/brands/shop/nutrition_supplements.json
@@ -3,7 +3,7 @@
     {
       "displayName": "GNC",
       "id": "gnc-699d49",
-      "locationSet": {"include": ["001"]},
+      "locationSet": { "include": ["001"] },
       "matchNames": ["gnc live well"],
       "tags": {
         "brand": "GNC",
@@ -14,9 +14,19 @@
       }
     },
     {
+      "displayName": "HERC'S NUTRITION",
+      "id": "",
+      "locationSet": { "include": ["ca"] },
+      "tags": {
+        "brand": "HERC'S NUTRITION",
+        "name": "HERC'S NUTRITION",
+        "shop": "nutrition_supplements"
+      }
+    },
+    {
       "displayName": "Popeye's Supplements",
       "id": "popeyessupplements-be7a88",
-      "locationSet": {"include": ["ca"]},
+      "locationSet": { "include": ["ca"] },
       "tags": {
         "brand": "Popeye's Supplements",
         "brand:wikidata": "Q71096495",
@@ -27,7 +37,7 @@
     {
       "displayName": "The Vitamin Shoppe",
       "id": "thevitaminshoppe-8feed0",
-      "locationSet": {"include": ["us"]},
+      "locationSet": { "include": ["us"] },
       "matchTags": ["shop/chemist"],
       "tags": {
         "brand": "The Vitamin Shoppe",
@@ -40,7 +50,7 @@
     {
       "displayName": "Vitamin World",
       "id": "vitaminworld-8feed0",
-      "locationSet": {"include": ["us"]},
+      "locationSet": { "include": ["us"] },
       "tags": {
         "brand": "Vitamin World",
         "brand:wikidata": "Q7936979",

--- a/data/brands/shop/nutrition_supplements.json
+++ b/data/brands/shop/nutrition_supplements.json
@@ -14,12 +14,12 @@
       }
     },
     {
-      "displayName": "HERC'S NUTRITION",
+      "displayName": "HERC'S Nutrition",
       "id": "",
       "locationSet": { "include": ["ca"] },
       "tags": {
-        "brand": "HERC'S NUTRITION",
-        "name": "HERC'S NUTRITION",
+        "brand": "HERC'S Nutrition",
+        "name": "HERC'S Nutrition",
         "shop": "nutrition_supplements"
       }
     },


### PR DESCRIPTION
HERC'S Nutrition to data/brands/shop/nutrition_supplements
{
      "displayName": "HERC'S NUTRITION",
      "id": "",
      "locationSet": { "include": ["ca"] },
      "tags": {
        "brand": "HERC'S NUTRITION",
        "name": "HERC'S NUTRITION",
        "shop": "nutrition_supplements"
      }
    },