### PR TITLE
Remove name from UK Post Office entry

### DIFF
--- a/data/brands/amenity/post_office.json
+++ b/data/brands/amenity/post_office.json
@@ -407,7 +407,6 @@
         "brand": "Post Office",
         "brand:wikidata": "Q1783168",
         "brand:wikipedia": "en:Post Office Ltd",
-        "name": "Post Office"
       }
     },
     {

--- a/data/brands/amenity/post_office.json
+++ b/data/brands/amenity/post_office.json
@@ -402,6 +402,8 @@
       "displayName": "Post Office (UK)",
       "id": "postoffice-a028f7",
       "locationSet": {"include": ["gb"]},
+      "matchNames": ["Post Office"],
+      "matchTags": ["amenity/post_office"],
       "tags": {
         "amenity": "post_office",
         "brand": "Post Office",

--- a/data/brands/amenity/post_office.json
+++ b/data/brands/amenity/post_office.json
@@ -402,8 +402,6 @@
       "displayName": "Post Office (UK)",
       "id": "postoffice-a028f7",
       "locationSet": {"include": ["gb"]},
-      "matchNames": ["Post Office"],
-      "matchTags": ["amenity/post_office"],
       "tags": {
         "amenity": "post_office",
         "brand": "Post Office",


### PR DESCRIPTION
Each UK Post Office has a unique name, the NSI shouldn't try to push people towards a inaccurate alternative.

It may be worth looking at other regions to see if the same should be done there.