### PR TITLE
Add Duck duck go as an option for the search functionallity

### DIFF
--- a/app/src/CategoryRow.jsx
+++ b/app/src/CategoryRow.jsx
@@ -98,6 +98,7 @@ relation[${k}=${v}][network=${n}][network:wikidata=${qid}]
       <div className='viewlink'>
         { searchOverpassLink(n, overpassQuery) }<br/>
         { searchGoogleLink(n) }<br/>
+        { searchDuckDuckGoLink(n) }<br/>
         { searchWikipediaLink(n) }
       </div>
     </td>
@@ -143,6 +144,13 @@ relation[${k}=${v}][network=${n}][network:wikidata=${qid}]
     const href = `https://google.com/search?q=${q}`;
     const title = `Search Google for ${name}`;
     return (<a target='_blank' href={href} title={title}>Search Google</a>);
+  }
+  
+  function searchDuckDuckGoLink(name) {
+    const q = encodeURIComponent(name);
+    const href = `https://duckduckgo.com/?q=${q}`;
+    const title = `Search DuckDuckGo for ${name}`;
+    return (<a target='_blank' href={href} title={title}>Search DuckDuckGo</a>);
   }
 
   function searchWikipediaLink(name) {


### PR DESCRIPTION
1. Is this a slippery slope to adding all Search engines ?
I'd like to have ddg cause of privacy 
We could also search wikipedia with DDG instead of Google with the excact same syntax for even more privacy