### PR TITLE
Added Metro Trains Melbourne to transit

### DIFF
--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -804,6 +804,18 @@
       }
     },
     {
+      "displayName": "Metro Trains Melbourne",
+      "locationSet": {"include": ["au"]},
+      "matchNames": ["Metro", "MTM", "Metro Melbourne"],
+      "tags": {
+        "network": "Metro Trains Melbourne",
+        "operator": "Metro Trains Melbourne",
+        "network:wikidata": "Q10931299",
+        "network:wikipedia": "en:Metro Trains Melbourne",
+        "route": "train"
+      }
+    },
+    {
       "displayName": "Mitre",
       "id": "mitre-44bbb3",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Added Metro Trains Melbourne to transit data, including wikidata and wikipedia