### PR TITLE
Added some bus networks

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -3891,6 +3891,18 @@
         "route": "bus"
       }
     },
+     {
+      "displayName": "Hamburger Verkehrsverbund",
+      "id": " ",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "network": "Hamburger Verkehrsverbund",
+        "network:short": "HVV",
+        "network:wikidata": "Q896916",
+        "network:wikipedia": "de:Hamburger Verkehrsverbund",
+        "route": "bus"
+      }
+    },
     {
       "displayName": "Hamilton Street Railway",
       "id": "hamiltonstreetrailway-a45453",
@@ -6436,6 +6448,18 @@
         "route": "bus"
       }
     },
+    { 
+      "displayName": "Nahverkehrsverbund Schleswig-Holstein",
+      "id": " ",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "network": "Nahverkehrsverbund Schleswig-Holstein",
+        "network:short": "NAH.SH",
+        "network:wikidata": "Q896916",
+        "network:wikipedia": "de:Nahverkehrsverbund Schleswig-Holstein",
+        "route": "bus"
+      }
+    },
     {
       "displayName": "National Express",
       "id": "nationalexpress-a45453",
@@ -6601,6 +6625,17 @@
         "route": "bus"
       }
     },
+    { "displayName": "Nordhessischer Verkehrsverbund",
+      "id": " ",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "network": "Nordhessischer Verkehrsverbund",
+        "network:short": "NVV",
+        "network:wikidata": "Q1998056",
+        "network:wikipedia": "de:Nordhessischer Verkehrsverbund",
+        "route": "bus
+      }
+    }, 
     {
       "displayName": "Noord-Holland Noord",
       "id": "noordhollandnoord-a45453",
@@ -8150,6 +8185,30 @@
       }
     },
     {
+      "displayName": "Rhein-Main-Verkehrsverbund",
+      "id": " ",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "network": "Rhein-Main-Verkehrsverbund",
+        "network:short": "RMV",
+        "network:wikidata": "Q314042",
+        "network:wikipedia": "de:Rhein-Main-Verkehrsverbund",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Rhein-Nahe-Nahverkehrsverbund",
+      "id": " ",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "network": "Rhein-Nahe-Nahverkehrsverbund",
+        "network:short": "RNN",
+        "network:wikidata": "Q1245949",
+        "network:wikipedia": "de:Rhein-Nahe-Nahverkehrsverbund",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "Ride KC",
       "id": "ridekc-a45453",
       "locationSet": {"include": ["001"]},
@@ -8436,6 +8495,18 @@
       "tags": {
         "network": "saarVV",
         "operator": "saarVV",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Saarländischer Verkehrsverbund",
+      "id": " ",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "network": "Saarländischer Verkehrsverbund",
+        "network:short": "SaarVV",
+        "network:wikidata": "Q2209244",
+        "network:wikipedia": "de:Saarländischer Verkehrsverbund",
         "route": "bus"
       }
     },
@@ -11311,6 +11382,18 @@
       }
     },
     {
+      "displayName": "Verkehrsverbund Warnow",
+      "id": " ",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+       "network": "Verkehrsverbund Warnow",
+       "network:short": "VVW",
+       "network:wikidata": "Q2516492",
+       "network:wikipedia": "de:Verkehrsverbund Warnow",
+       "route": "bus"
+      }
+    },
+    {
       "displayName": "Verkehrsgemeinschaft am Bayerischen Untermain",
       "id": "verkehrsgemeinschaftambayerischenuntermain-a45453",
       "locationSet": {"include": ["001"]},
@@ -11412,6 +11495,18 @@
         "network:short": "VBB",
         "network:wikidata": "Q315451",
         "network:wikipedia": "de:Verkehrsverbund Berlin-Brandenburg",
+        "route": "bus"
+      }
+    },
+    { 
+      "displayName": "Verkehrsverbund Bremen/Niedersachsen",
+      "id": " ",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "network": "Verkehrsverbund Bremen/Niedersachsen",
+        "network:short": "VBN",
+        "network:wikidata": "Q1306245",
+        "network:wikipedia": "de:Verkehrsverbund Bremen/Niedersachsen",
         "route": "bus"
       }
     },
@@ -11538,6 +11633,18 @@
         "network:short": "VRN",
         "network:wikidata": "Q1553051",
         "network:wikipedia": "de:Verkehrsverbund Rhein-Neckar",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Verkehrsverbund Region-Trier",
+      "id": " ",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "network": "Verkehrsverbund Region-Trier",
+        "network:short": "VRT",
+        "network:wikidata": "Q2516480",
+        "network:wikipedia": "de:Verkehrsverbund Region Trier",
         "route": "bus"
       }
     },


### PR DESCRIPTION
Fixes : #4475
I left " " in front of id.
Also didnt do for 
"network": "Verkehrsverbund Rhein-Mosel" , wasnt sure what to do !! coz of this 
"network:wikipedia": "de:Verkehrsverbund Rhein-Mosel". This has a "de" and "Verkehrsverbund Rhein-Mosel" display name exists with location set 001. 

Also if I did something wrong do tell , I am still learning all this. Thanks.