### PR TITLE
added Hirebase to tool hire shops

### DIFF
--- a/data/brands/shop/tool_hire.json
+++ b/data/brands/shop/tool_hire.json
@@ -1,6 +1,17 @@
 {
   "brands/shop/tool_hire": [
     {
+      "displayName": "Hirebase",
+      "id": "hirebase-92549b",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "Hirebase",
+        "brand:wikidata": "Q100297859",
+        "name": "Hirebase",
+        "shop": "tool_hire"
+      }
+    },
+    {
       "displayName": "HSS Hire",
       "id": "hsshire-a3cdb3",
       "locationSet": {"include": ["gb", "ie"]},


### PR DESCRIPTION
Added Hirebase to the list of tool hire shops.

Fixes: https://github.com/osmlab/name-suggestion-index/issues/4489