### PR TITLE
Add wiki tags for in Philadelphia, including SEPTA/PATCO

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -8817,11 +8817,18 @@
     },
     {
       "displayName": "SEPTA",
-      "id": "septa-a45453",
-      "locationSet": {"include": ["001"]},
+      "id": "septa-a21cc9",
+      "locationSet": {"include": ["us"]},
+      "matchNames": [
+        "southeastern pennsylvania transportation authority"
+      ],
       "tags": {
         "network": "SEPTA",
+        "network:wikidata": "Q2037863",
+        "network:wikipedia": "en:SEPTA",
         "operator": "SEPTA",
+        "operator:wikidata": "Q2037863",
+        "operator:wikipedia": "en:SEPTA",
         "route": "bus"
       }
     },

--- a/data/transit/route/light_rail.json
+++ b/data/transit/route/light_rail.json
@@ -113,6 +113,24 @@
       }
     },
     {
+      "displayName": "SEPTA",
+      "id": "septa-2d6c3f",
+      "locationSet": {"include": ["us"]},
+      "matchNames": [
+        "southeastern pennsylvania transportation authority"
+      ],
+      "note": "For some reason, subway/light_rail in Philadelphia are tagged with network=SEPTA but network:wikidata=Q11158637, 'Philadelphia subway'",
+      "tags": {
+        "network": "SEPTA",
+        "network:wikidata": "Q11158637",
+        "network:wikipedia": "en:SEPTA",
+        "operator": "SEPTA",
+        "operator:wikidata": "Q2037863",
+        "operator:wikipedia": "en:SEPTA",
+        "route": "light_rail"
+      }
+    },
+    {
       "displayName": "SL",
       "id": "sl-55ac4f",
       "locationSet": {"include": ["001"]},

--- a/data/transit/route/subway.json
+++ b/data/transit/route/subway.json
@@ -197,6 +197,22 @@
       }
     },
     {
+      "displayName": "PATCO",
+      "id": "patco-c94044",
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["patco speedline"],
+      "note": "See also the note on SEPTA. PATCO is 'part of' Q11158637 on Wikidata, but not tagged network:wikidata=Q11158637 in OSM",
+      "tags": {
+        "network": "PATCO",
+        "network:wikidata": "Q2043730",
+        "network:wikipedia": "en:PATCO Speedline",
+        "operator": "Delaware River Port Authority",
+        "operator:wikidata": "Q948591",
+        "operator:wikipedia": "en:Delaware River Port Authority",
+        "route": "subway"
+      }
+    },
+    {
       "displayName": "PATH",
       "id": "path-c94044",
       "locationSet": {"include": ["us"]},
@@ -247,6 +263,24 @@
       "tags": {
         "network": "Ruter",
         "operator": "Ruter",
+        "route": "subway"
+      }
+    },
+    {
+      "displayName": "SEPTA",
+      "id": "septa-c94044",
+      "locationSet": {"include": ["us"]},
+      "matchNames": [
+        "southeastern pennsylvania transportation authority"
+      ],
+      "note": "For some reason, subway/light_rail in Philadelphia are tagged with network=SEPTA but network:wikidata=Q11158637, 'Philadelphia subway'",
+      "tags": {
+        "network": "SEPTA",
+        "network:wikidata": "Q11158637",
+        "network:wikipedia": "en:SEPTA",
+        "operator": "SEPTA",
+        "operator:wikidata": "Q2037863",
+        "operator:wikipedia": "en:SEPTA",
         "route": "subway"
       }
     },

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -1166,11 +1166,18 @@
     },
     {
       "displayName": "SEPTA",
-      "id": "septa-44bbb3",
-      "locationSet": {"include": ["001"]},
+      "id": "septa-012d27",
+      "locationSet": {"include": ["us"]},
+      "matchNames": [
+        "southeastern pennsylvania transportation authority"
+      ],
       "tags": {
         "network": "SEPTA",
+        "network:wikidata": "Q2037863",
+        "network:wikipedia": "en:SEPTA",
         "operator": "SEPTA",
+        "operator:wikidata": "Q2037863",
+        "operator:wikipedia": "en:SEPTA",
         "route": "train"
       }
     },

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -436,11 +436,18 @@
     },
     {
       "displayName": "SEPTA",
-      "id": "septa-2e09b9",
-      "locationSet": {"include": ["001"]},
+      "id": "septa-a89e98",
+      "locationSet": {"include": ["us"]},
+      "matchNames": [
+        "southeastern pennsylvania transportation authority"
+      ],
       "tags": {
         "network": "SEPTA",
+        "network:wikidata": "Q2037863",
+        "network:wikipedia": "en:SEPTA",
         "operator": "SEPTA",
+        "operator:wikidata": "Q2037863",
+        "operator:wikipedia": "en:SEPTA",
         "route": "tram"
       }
     },

--- a/data/transit/route/trolleybus.json
+++ b/data/transit/route/trolleybus.json
@@ -206,6 +206,23 @@
       }
     },
     {
+      "displayName": "SEPTA",
+      "id": "septa-62d74d",
+      "locationSet": {"include": ["us"]},
+      "matchNames": [
+        "southeastern pennsylvania transportation authority"
+      ],
+      "tags": {
+        "network": "SEPTA",
+        "network:wikidata": "Q2037863",
+        "network:wikipedia": "en:SEPTA",
+        "operator": "SEPTA",
+        "operator:wikidata": "Q2037863",
+        "operator:wikipedia": "en:SEPTA",
+        "route": "trolleybus"
+      }
+    },
+    {
       "displayName": "Szeged",
       "id": "szeged-c2505f",
       "locationSet": {"include": ["hu"]},


### PR DESCRIPTION
This Pull Request adds the network and operator tags for Philadelphia transit networks.  
- SEPTA (bus, tram, trolleybus) - Q2037863
- SEPTA (light_rail, subway) - Q11158637
- PATCO Speedline (subway) - Q2043730

The tagging of SEPTA's light_rail and subway is unusual in OpenStreetMap in that it already has `network=SEPTA` but `network:wikidata=Q11158637`  'Philadelphia subway'.  This QID does not have an English language wiki, and is only used to group the light_rail and subway networks.  I don't really agree with this, but I'm going to keep it that way in NSI for now.
