### PR TITLE
Add Alsa wikidata and wikipedia 

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -219,10 +219,14 @@
     {
       "displayName": "Alsa",
       "id": "alsa-a45453",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["es"]},
       "tags": {
         "network": "Alsa",
+        "network:wikidata": "Q294510",
+        "network:wikipedia": "en:ALSA (bus company)",
         "operator": "Alsa",
+        "operator:wikidata": "Q294510",
+        "operator:wikipedia": "en:ALSA (bus company)",
         "route": "bus"
       }
     },


### PR DESCRIPTION
I've created a wikidata and wikipedia entity for Alsa at transit/route/bus