### PR TITLE
Add Hall & Woodhouse brand

### DIFF
--- a/data/brands/amenity/pub.json
+++ b/data/brands/amenity/pub.json
@@ -101,6 +101,16 @@
       }
     },
     {
+      "displayName": "Hall & Woodhouse",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "amenity": "pub",
+        "brand": "Hall & Woodhouse",
+        "brand:wikidata": "Q5642555",
+        "brand:wikipedia": "en:Hall & Woodhouse"
+      }
+    },
+    {
       "displayName": "つぼ八",
       "id": "tsubohachi-0435b9",
       "locationSet": {"include": ["jp"]},


### PR DESCRIPTION
H&W is a chain of pubs in the south of England. Each pub has it's [own name](https://www.hall-woodhouse.co.uk/our-pubs/).