### PR TITLE
amenity restaurant add 'La Pataterie'

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -1702,6 +1702,20 @@
       }
     },
     {
+      "displayName": "La Pataterie",
+      "id": "lapataterie-dee615",
+      "locationSet": {"include": ["fr"]},
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "La Pataterie",
+        "brand:wikidata": "Q20899937",
+        "brand:wikipedia": "fr:La Pataterie",
+        "cuisine": "potato",
+        "name": "La Pataterie",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "La Sureña",
       "id": "lasurena-acf031",
       "locationSet": {"include": ["es"]},


### PR DESCRIPTION
Add french restaurant chain: 'La Pataterie'

Top 7 french chain by number of restaurants in France (given OSM data).

Note, I completed the wikidata element: https://www.wikidata.org/wiki/Q20899937