### PR TITLE
Add smaller Brazilian pharmacy chains

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -451,6 +451,18 @@
       }
     },
     {
+      "displayName": "Droga Quinze",
+      "id": "drogaquinze-295f06",
+      "locationSet": {"include": ["br"]},
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "Droga Quinze",
+        "brand:wikidata": "Q100491051",
+        "healthcare": "pharmacy",
+        "name": "Droga Quinze"
+      }
+    },
+    {
       "displayName": "Droga Raia",
       "id": "drogaraia-295f06",
       "locationSet": {"include": ["br"]},

--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -566,6 +566,18 @@
       }
     },
     {
+      "displayName": "Farma Conde",
+      "id": "farmaconde-295f06",
+      "locationSet": {"include": ["br"]},
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "Farma Conde",
+        "brand:wikidata": "Q100492677",
+        "healthcare": "pharmacy",
+        "name": "Farma Conde"
+      }
+    },
+    {
       "displayName": "Farmacenter (Colombia)",
       "id": "farmacenter-e95dde",
       "locationSet": {"include": ["co"]},


### PR DESCRIPTION
Hey there,

This PR adds a couple of smallish Brazilian pharmacy chains operating mainly in the São Paulo state area.

I created a wikidata page for each of them as well:
* [Droga Quinze](https://www.wikidata.org/wiki/Q100491051)
* [Farma Conde](https://www.wikidata.org/wiki/Q100492677)

I have mapped quite a few of these pharmacies in the city I live and have always missed their brand preset.

Please let me know if there is anything I should change to make this acceptable :smiley: