### PR TITLE
Added wiki references to multiple brands

### DIFF
--- a/data/brands/shop/car.json
+++ b/data/brands/shop/car.json
@@ -300,6 +300,7 @@
       "tags": {
         "brand": "Jaguar",
         "brand:wikidata": "Q26742231",
+        "brand:wikipedia": "en:Jaguar Cars",
         "name": "Jaguar",
         "shop": "car"
       }

--- a/data/brands/shop/car.json
+++ b/data/brands/shop/car.json
@@ -664,6 +664,8 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "Vauxhall",
+        "brand:wikidata": "Q59187",
+        "brand:wikipedia": "en:Vauxhall Motors",
         "name": "Vauxhall",
         "shop": "car"
       }

--- a/data/brands/shop/car.json
+++ b/data/brands/shop/car.json
@@ -275,6 +275,8 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "Infiniti",
+        "brand:wikidata": "Q29714",
+        "brand:wikipedia": "en:Infiniti",
         "name": "Infiniti",
         "shop": "car"
       }

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -480,6 +480,8 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "M.Видео",
+        "brand:wikidata": "Q6558800",
+        "brand:wikipedia": "en:M Video",
         "name": "M.Видео",
         "shop": "electronics"
       }


### PR DESCRIPTION
Fixes issue #4526 

Wiki references (brand:wikidata and brand:wikipedia) is missing for few brands

M.Видео in shops/electronics.json
Infiniti in shops/car.json
Jaguar in shops/car.json
Vauxhall in shops/car.json