### PR TITLE
amenity restaurant: add brand:wikidata to 'Au Bureau'

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -94,6 +94,7 @@
       "tags": {
         "amenity": "restaurant",
         "brand": "Au Bureau",
+        "brand:wikidata": "Q100701566",
         "cuisine": "french;american;european",
         "name": "Au Bureau"
       }


### PR DESCRIPTION
Hi, just adding the corresponding tag brand:wikidata to french restaurant chain 'Au Bureau'