### PR TITLE
shop: add tags to 'La Halle'

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -2749,6 +2749,7 @@
       "locationSet": {"include": ["ch", "fr"]},
       "tags": {
         "brand": "La Halle",
+        "brand:wikidata": "Q62390731",
         "name": "La Halle",
         "shop": "clothes"
       }

--- a/data/brands/shop/shoes.json
+++ b/data/brands/shop/shoes.json
@@ -664,7 +664,7 @@
       "id": "lahalleauxchaussures-c57706",
       "locationSet": {"include": ["fr"]},
       "tags": {
-        "brand": "La Halle aux Chaussures",
+        "brand": "La Halle",
         "brand:wikidata": "Q62390731",
         "name": "La Halle aux Chaussures",
         "shop": "shoes"


### PR DESCRIPTION
The shoes brand 'La Halle aux chaussures' have been merged with a clothes brand.
The only brand remaining is "La Halle".