### PR TITLE
add boost juice

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -262,6 +262,19 @@
       }
     },
     {
+      "displayName": "Boost Juice",
+      "locationSet": {"include": ["au"]},
+      "tags": {
+        "amenity": "cafe",
+        "brand": "Boost Juice",
+        "brand:wikidata": "Q4943789",
+        "brand:wikipedia": "en:Boost Juice",
+        "cuisine": "juice",
+        "name": "Boost Juice",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Boston Tea Party",
       "id": "bostonteaparty-a89223",
       "locationSet": {"include": ["gb"]},


### PR DESCRIPTION
Unfortunately the amenity=drinks proposal at https://wiki.openstreetmap.org/wiki/Proposed_features/Takeaway_drink_shops
was not accepted by the community and so these need to be tagged as cafe.

Currently they are mostly mapped as either amenity=cafe + amenity=fast_food, because the proposal wasn't approved it's even more important that we tag the brand:wikidata so that data consumers can fix the cafe/fast_food tagging to show them as mostly takeaway drink shops.