### PR TITLE
Add brand:wikidata to 'De Kringwinkel'

### DIFF
--- a/data/brands/shop/second_hand.json
+++ b/data/brands/shop/second_hand.json
@@ -6,6 +6,7 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "De Kringwinkel",
+        "brand:wikidata": "Q55935433",
         "name": "De Kringwinkel",
         "shop": "second_hand"
       }


### PR DESCRIPTION
@hgcvm spent a lot of time mapping all the wikidata links to 'De Kringwinkel': https://overpass-turbo.eu/s/Zjl

It would be cool to have this honoured