### PR TITLE
Fix location of Minipreço and Globus supermarkets

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -2284,7 +2284,7 @@
     {
       "displayName": "Globus",
       "id": "globus-986a24",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["cz", "de", "ru"]},
       "tags": {
         "brand": "Globus",
         "brand:wikidata": "Q457503",
@@ -3718,7 +3718,7 @@
     {
       "displayName": "Minipreço",
       "id": "minipreco-986a24",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "brand": "Minipreço",
         "brand:wikidata": "Q3042224",


### PR DESCRIPTION
They were tagged as global and have very common names