### PR TITLE
Add matchNames to provinzial to prevent error

### DIFF
--- a/data/brands/office/insurance.json
+++ b/data/brands/office/insurance.json
@@ -750,19 +750,10 @@
       }
     },
     {
-      "displayName": "Provinzial",
-      "id": "provinzial-422e71",
-      "locationSet": {"include": ["de"]},
-      "tags": {
-        "brand": "Provinzial",
-        "name": "Provinzial",
-        "office": "insurance"
-      }
-    },
-    {
       "displayName": "Provinzial NordWest",
       "id": "provinzialnordwest-422e71",
       "locationSet": {"include": ["de"]},
+      "matchNames": ["provinzial"],
       "tags": {
         "brand": "Provinzial NordWest",
         "brand:wikidata": "Q1778922",
@@ -775,6 +766,7 @@
       "displayName": "Provinzial Rheinland",
       "id": "provinzialrheinland-422e71",
       "locationSet": {"include": ["de"]},
+      "matchNames": ["provinzial"],
       "tags": {
         "brand": "Provinzial Rheinland",
         "brand:wikidata": "Q2114066",


### PR DESCRIPTION
Re https://github.com/osmlab/name-suggestion-index/issues/4544#issuecomment-714524865, adding the matchNames prevents the script to re-add the previous "Provinzial" data.

@bhousel I just added the `matchNames` and the previous "Provinzial" data did not come back (which it did before https://github.com/osmlab/name-suggestion-index/pull/4548#issuecomment-713498993).

To this might be enough and no need to add separate `locationSet`, right?

Update to https://github.com/osmlab/name-suggestion-index/pull/4548.
Fixes https://github.com/osmlab/name-suggestion-index/issues/4544.