### PR TITLE
Update Dirk supermarket

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1565,23 +1565,14 @@
     },
     {
       "displayName": "Dirk",
-      "id": "dirk-986a24",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "brand": "Dirk",
-        "name": "Dirk",
-        "shop": "supermarket"
-      }
-    },
-    {
-      "displayName": "Dirk van den Broek",
-      "id": "dirkvandenbroek-ebf2d9",
+      "id": "dirk-ebf2d9",
       "locationSet": {"include": ["nl"]},
       "tags": {
-        "brand": "Dirk van den Broek",
+        "brand": "Dirk",
         "brand:wikidata": "Q17502722",
         "brand:wikipedia": "en:Dirk (supermarket)",
-        "name": "Dirk van den Broek",
+        "name": "Dirk",
+        "old_name": "Dirk van den Broek",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
Wikipedia says that "Dirk van den Broek" is now only "Dirk": https://en.wikipedia.org/wiki/Dirk_(supermarket)
Location is only Netherlands