### PR TITLE
Update bus.json

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -1632,7 +1632,11 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "network": "Caltrain",
+        "network:wikidata": "Q166817",
+        "network:wikipedia": "en:Caltrain",
         "operator": "Caltrain",
+        "operator:wikidata": "Q166817",
+        "operator:wikipedia": "en:Caltrain",
         "route": "bus"
       }
     },
@@ -8911,9 +8915,16 @@
       "displayName": "SamTrans",
       "id": "samtrans-a21cc9",
       "locationSet": {"include": ["us"]},
+      "matchNames": [
+        "san mateo county transit district"
+      ],
       "tags": {
         "network": "SamTrans",
+        "network:wikidata": "Q7407040",
+        "network:wikipedia": "en:SamTrans",
         "operator": "SamTrans",
+        "operator:wikidata": "Q7407040",
+        "operator:wikipedia": "en:SamTrans",
         "route": "bus"
       }
     },


### PR DESCRIPTION
Added two more San Francisco Bay Area agencies. I was going to update VTA as well, but it looks like the overpass-turbo query shows that it is used by the Santa Clara VTA, but also some other VTA in Massachusetts. I don't know what to do about that situation, can you provide guidance?