### PR TITLE
Add Suzuki wiki brands in shop/car_repair list

### DIFF
--- a/data/brands/amenity/clinic.json
+++ b/data/brands/amenity/clinic.json
@@ -134,7 +134,7 @@
     },
     {
       "displayName": "Posyandu",
-      "id": "posyandu-ed675b",
+      "id": "posyandu-87a279",
       "locationSet": {"include": ["id"]},
       "tags": {
         "amenity": "clinic",
@@ -144,7 +144,7 @@
     },
     {
       "displayName": "Puskesmas",
-      "id": "puskesmas-ed675b",
+      "id": "puskesmas-87a279",
       "locationSet": {"include": ["id"]},
       "tags": {
         "amenity": "clinic",
@@ -154,7 +154,7 @@
     },
     {
       "displayName": "Puskesmas Pembantu",
-      "id": "puskesmaspembantu-ed675b",
+      "id": "puskesmaspembantu-87a279",
       "locationSet": {"include": ["id"]},
       "tags": {
         "amenity": "clinic",

--- a/data/brands/amenity/ice_cream.json
+++ b/data/brands/amenity/ice_cream.json
@@ -2,8 +2,10 @@
   "brands/amenity/ice_cream": [
     {
       "displayName": "33 пингвина",
-      "id": "fd1d7e-87d971",
-      "locationSet": {"include": ["ru", "kz", "by"]},
+      "id": "fd1d7e-7c9908",
+      "locationSet": {
+        "include": ["by", "kz", "ru"]
+      },
       "tags": {
         "amenity": "ice_cream",
         "brand": "33 пингвина",
@@ -59,7 +61,7 @@
     },
     {
       "displayName": "Amy's Ice Creams",
-      "id": "amysicecreams-87d971",
+      "id": "amysicecreams-8697a4",
       "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "ice_cream",
@@ -190,8 +192,19 @@
     },
     {
       "displayName": "Freddo",
-      "id": "freddo-87d971",
-      "locationSet": {"include": ["ar", "us", "bo", "uy", "cl", "br", "it", "gb"]},
+      "id": "freddo-3a94a6",
+      "locationSet": {
+        "include": [
+          "ar",
+          "bo",
+          "br",
+          "cl",
+          "gb",
+          "it",
+          "us",
+          "uy"
+        ]
+      },
       "tags": {
         "amenity": "ice_cream",
         "brand": "Freddo",
@@ -521,7 +534,7 @@
     },
     {
       "displayName": "Yogurt Mountain",
-      "id": "yogurtmountain-87d971",
+      "id": "yogurtmountain-8697a4",
       "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "ice_cream",

--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -16,7 +16,7 @@
     },
     {
       "displayName": "ADEL",
-      "id": "adel-f5140f",
+      "id": "adel-c16414",
       "locationSet": {"include": ["by"]},
       "tags": {
         "amenity": "pharmacy",
@@ -151,9 +151,22 @@
     },
     {
       "displayName": "Benu",
-      "id": "benu-f5140f",
-      "locationSet": {"include": ["cz", "ee", "hu", "lv", "lt", "me", "nl", "rs", "sk", "ch"]},
-      "matchNames": ["BENU Vaistinė"],
+      "id": "benu-6d3c46",
+      "locationSet": {
+        "include": [
+          "ch",
+          "cz",
+          "ee",
+          "hu",
+          "lt",
+          "lv",
+          "me",
+          "nl",
+          "rs",
+          "sk"
+        ]
+      },
+      "matchNames": ["benu vaistinė"],
       "tags": {
         "amenity": "pharmacy",
         "brand": "Benu",
@@ -227,7 +240,7 @@
     },
     {
       "displayName": "Brunet",
-      "id": "brunet-f5140f",
+      "id": "brunet-b56451",
       "locationSet": {"include": ["ca"]},
       "tags": {
         "amenity": "pharmacy",
@@ -307,7 +320,7 @@
     },
     {
       "displayName": "Cohens Chemist",
-      "id": "cohenschemist-f5140f",
+      "id": "cohenschemist-b98d4f",
       "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "pharmacy",
@@ -840,7 +853,7 @@
     },
     {
       "displayName": "Farmahorro",
-      "id": "farmahorro-f5140f",
+      "id": "farmahorro-291746",
       "locationSet": {"include": ["ve"]},
       "tags": {
         "amenity": "pharmacy",
@@ -1367,7 +1380,7 @@
     },
     {
       "displayName": "Nissei",
-      "id": "nissei-f5140f",
+      "id": "nissei-295f06",
       "locationSet": {"include": ["br"]},
       "tags": {
         "amenity": "pharmacy",
@@ -1405,7 +1418,7 @@
     },
     {
       "displayName": "Parafarmacia Conad",
-      "id": "parafarmaciaconad-f5140f",
+      "id": "parafarmaciaconad-6aafeb",
       "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "pharmacy",
@@ -1517,7 +1530,7 @@
     },
     {
       "displayName": "Proxim",
-      "id": "proxim-f5140f",
+      "id": "proxim-b56451",
       "locationSet": {"include": ["ca"]},
       "tags": {
         "amenity": "pharmacy",
@@ -1733,7 +1746,7 @@
     },
     {
       "displayName": "Şifa Eczanesi",
-      "id": "sifaeczanesi-f5140f",
+      "id": "sifaeczanesi-ba5564",
       "locationSet": {"include": ["tr"]},
       "tags": {
         "amenity": "pharmacy",
@@ -1768,8 +1781,10 @@
     },
     {
       "displayName": "Super-Pharm",
-      "id": "superpharm-f5140f",
-      "locationSet": {"include": ["pl", "cn", "il"]},
+      "id": "superpharm-8f2066",
+      "locationSet": {
+        "include": ["cn", "il", "pl"]
+      },
       "tags": {
         "amenity": "pharmacy",
         "brand": "Super-Pharm",

--- a/data/brands/shop/car_repair.json
+++ b/data/brands/shop/car_repair.json
@@ -719,6 +719,8 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "Suzuki",
+        "brand:wikidata": "Q181642",
+        "brand:wikipedia": "en:Suzuki",
         "name": "Suzuki",
         "shop": "car_repair"
       }


### PR DESCRIPTION
Given that Suzuki is a brand both for car selling and car repairing, `brand:wikipedia` and `brand:wikidata` were added to Suzuki entry in `shop/car_repair` to fix the duplicates warning.
After running `npm run build` the console output seems ok for Suzuki.