### PR TITLE
add Premio

### DIFF
--- a/data/brands/shop/car_repair.json
+++ b/data/brands/shop/car_repair.json
@@ -630,6 +630,17 @@
       }
     },
     {
+      "displayName": "Premio",
+      "locationSet": {"include": ["de", "ch", "be", "bg", "cz", "hu", "nl", "pl", "ro", "ru", "sk"]},
+      "matchTags": ["shop/tyres"],
+      "tags": {
+        "brand": "Premio",
+        "brand:wikidata": "Q100895958",
+        "name": "Premio",
+        "shop": "car_repair"
+      }
+    },
+    {
       "displayName": "Renault",
       "id": "renault-dc8719",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Add car repair franchise "Premio".
They also sell tyres but brand themselves as full service car repair shops.
According to overpass, capital letter is preferred.