### PR TITLE
Update subway.json

### DIFF
--- a/data/transit/route/subway.json
+++ b/data/transit/route/subway.json
@@ -57,12 +57,15 @@
       }
     },
     {
-      "displayName": "HVV",
+      "displayName": "Hamburger Verkehrsverbund",
       "id": "hvv-447f34",
       "locationSet": {"include": ["de"]},
+      "matchNames": ["hvv"],
       "tags": {
-        "network": "HVV",
-        "operator": "HVV",
+        "network": "Hamburger Verkehrsverbund",
+        "network:short": "HVV",
+        "network:wikidata": "Q896916",
+        "network:wikipedia": "de:Hamburger Verkehrsverbund",
         "route": "subway"
       }
     },
@@ -182,6 +185,7 @@
       "displayName": "Münchner Verkehrs- und Tarifverbund",
       "id": "munchnerverkehrsundtarifverbund-447f34",
       "locationSet": {"include": ["de"]},
+      "matchNames": ["mvv"],
       "tags": {
         "network": "Münchner Verkehrs- und Tarifverbund",
         "network:guid": "DE-BY-MVV",
@@ -256,12 +260,15 @@
       }
     },
     {
-      "displayName": "RMV",
+      "displayName": "Rhein-Main-Verkehrsverbund",
       "id": "rmv-447f34",
       "locationSet": {"include": ["de"]},
+      "matchNames": ["rmv"],
       "tags": {
-        "network": "RMV",
-        "operator": "RMV",
+        "network": "Rhein-Main-Verkehrsverbund",
+        "network:short": "RMV",
+        "network:wikidata": "Q314042",
+        "network:wikipedia": "de:Rhein-Main-Verkehrsverbund",
         "route": "subway"
       }
     },
@@ -346,6 +353,7 @@
       "displayName": "Verkehrsverbund Berlin-Brandenburg",
       "id": "verkehrsverbundberlinbrandenburg-447f34",
       "locationSet": {"include": ["de"]},
+      "matchNames": ["vbb"],
       "tags": {
         "network": "Verkehrsverbund Berlin-Brandenburg",
         "network:short": "VBB",
@@ -355,19 +363,15 @@
       }
     },
     {
-      "displayName": "VRR",
+      "displayName": "Verkehrsverbund Rhein-Ruhr",
       "id": "vrr-447f34",
       "locationSet": {"include": ["de"]},
-      "matchNames": [
-        "verkehrsverbund rhein-ruhr"
-      ],
+      "matchNames": ["vrr"],
       "tags": {
-        "network": "VRR",
+        "network": "Verkehrsverbund Rhein-Ruhr",
+        "network:short": "VRR",
         "network:wikidata": "Q448199",
         "network:wikipedia": "de:Verkehrsverbund Rhein-Ruhr",
-        "operator": "VRR",
-        "operator:wikidata": "Q448199",
-        "operator:wikipedia": "de:Verkehrsverbund Rhein-Ruhr",
         "route": "subway"
       }
     },


### PR DESCRIPTION
update German subway networks:

- delete wrong operator tags
- make network names and short names consistent
- add wikidata
- add match names