### PR TITLE
Update tram.json

### DIFF
--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -728,10 +728,10 @@
       "id": "wurzburgerversorgungsundverkehrsgmbh-37759c",
       "locationSet": {"include": ["de"]},
       "tags": {
-        "network": "Würzburger Versorgungs- und Verkehrs-GmbH",
-        "network:short": "WVV",
-        "network:wikidata": "Q1291006",
-        "network:wikipedia": "de:Würzburger Versorgungs- und Verkehrs-GmbH",
+        "operator": "Würzburger Versorgungs- und Verkehrs-GmbH",
+        "operator:short": "WVV",
+        "operator:wikidata": "Q1291006",
+        "operator:wikipedia": "de:Würzburger Versorgungs- und Verkehrs-GmbH",
         "route": "tram"
       }
     },


### PR DESCRIPTION
WVV is no network. They operate tram lines within the "Verkehrsverbund Mainfranken" network.