### PR TITLE
Smaller geofence for DC transit

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -5397,8 +5397,8 @@
     {
       "displayName": "Lothian Buses",
       "id": "lothianbuses-8e0970",
-      "matchNames": ["lothian city buses"],
       "locationSet": {"include": ["gb"]},
+      "matchNames": ["lothian city buses"],
       "tags": {
         "network": "Lothian Buses",
         "network:wikidata": "Q6684760",
@@ -8575,8 +8575,10 @@
     },
     {
       "displayName": "Ride On",
-      "id": "rideon-a21cc9",
-      "locationSet": {"include": ["us"]},
+      "id": "rideon-614208",
+      "locationSet": {
+        "include": ["giant_de_md_va.geojson"]
+      },
       "tags": {
         "network": "Ride On",
         "network:wikidata": "Q7332502",
@@ -12942,8 +12944,10 @@
     },
     {
       "displayName": "WMATA Metrobus",
-      "id": "wmatametrobus-a21cc9",
-      "locationSet": {"include": ["us"]},
+      "id": "wmatametrobus-614208",
+      "locationSet": {
+        "include": ["giant_de_md_va.geojson"]
+      },
       "tags": {
         "network": "WMATA Metrobus",
         "network:wikidata": "Q6824810",

--- a/data/transit/route/subway.json
+++ b/data/transit/route/subway.json
@@ -443,8 +443,10 @@
     },
     {
       "displayName": "WMATA Metrorail",
-      "id": "washingtonmetro-c94044",
-      "locationSet": {"include": ["us"]},
+      "id": "washingtonmetro-9cf36c",
+      "locationSet": {
+        "include": ["giant_de_md_va.geojson"]
+      },
       "tags": {
         "network": "Washington Metro",
         "network:wikidata": "Q171221",

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -733,11 +733,14 @@
     },
     {
       "displayName": "MARC",
-      "id": "marc-012d27",
-      "locationSet": {"include": ["us"]},
+      "id": "marc-e3244a",
+      "locationSet": {
+        "include": ["giant_de_md_va.geojson"]
+      },
       "matchNames": [
         "maryland area regional commuter"
       ],
+      "note": "Also has stops in DC and eastern WV",
       "tags": {
         "network": "MARC",
         "network:wikidata": "Q6714458",
@@ -1929,11 +1932,13 @@
     },
     {
       "displayName": "Virginia Railway Express",
-      "id": "virginiarailwayexpress-012d27",
-      "locationSet": {"include": ["us"]},
-      "matchNames": ["vre"],
+      "id": "virginiarailwayexpress-e3244a",
+      "locationSet": {
+        "include": ["giant_de_md_va.geojson"]
+      },
       "tags": {
         "network": "Virginia Railway Express",
+        "network:short": "VRE",
         "network:wikidata": "Q170781",
         "network:wikipedia": "en:Virginia Railway Express",
         "operator": "Keolis",


### PR DESCRIPTION
Also tag VRE as `network:short`