### PR TITLE
Add MPREIS miniM

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1649,6 +1649,18 @@
       }
     },
     {
+      "displayName": "miniM",
+      "id": "minim-d41f40",
+      "locationSet": {"include": ["at"]},
+      "tags": {
+        "brand": "miniM",
+        "brand:wikidata": "Q873491",
+        "brand:wikipedia": "de:MPreis",
+        "name": "miniM",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "Ministop",
       "id": "ministop-4d6b4b",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
With this pull request I added the convenience store chain "miniM" which belongs to the MPREIS supermarket chain. I've set the `brand` tag to miniM because that's what it says on the store logos but it is very frequently referred to as MPREIS miniM (on e.g. Google Maps) so maybe MPREIS would be a better value for the brand tag.