### PR TITLE
"Clydesdale Bank" becoming "Virgin Money"

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -7769,6 +7769,7 @@
       "id": "virginmoney-e1e9d0",
       "locationSet": {"include": ["gb"]},
       "matchNames": ["Clydesdale", "Clydesdale Bank"],
+      "note": "osmlab#4667 - Clydesdale Bank branches have been rebranded to become Virgin Money.",
       "tags": {
         "amenity": "bank",
         "brand": "Virgin Money",

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -3471,18 +3471,6 @@
       }
     },
     {
-      "displayName": "Clydesdale Bank",
-      "id": "clydesdalebank-e1e9d0",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Clydesdale Bank",
-        "brand:wikidata": "Q971680",
-        "brand:wikipedia": "en:Clydesdale Bank",
-        "name": "Clydesdale Bank"
-      }
-    },
-    {
       "displayName": "CNEP",
       "id": "cnep-47c9bd",
       "locationSet": {"include": ["dz"]},
@@ -7780,6 +7768,7 @@
       "displayName": "Virgin Money",
       "id": "virginmoney-e1e9d0",
       "locationSet": {"include": ["gb"]},
+      "matchNames": ["Clydesdale", "Clydesdale Bank"],
       "tags": {
         "amenity": "bank",
         "brand": "Virgin Money",


### PR DESCRIPTION
As per #4667 "_Clydesdale Bank_" is rebranding branches to become "_Virgin Money_" after Clydesdale acquired Virgin.

I've removed "_Clydesdale Bank_" and added a **matchNames** to "_Virgin Money_".

I've done this as a pull request to make sure I've followed the correct process.