### PR TITLE
Trying out operators for Police, Fire and Ambulance services

### DIFF
--- a/data/operators/amenity/fire_station.json
+++ b/data/operators/amenity/fire_station.json
@@ -1,0 +1,34 @@
+{
+  "operators/amenity/fire_station": [
+      {
+      "displayName": "Cornwall Fire and Rescue Service",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "amenity": "fire_station",
+        "operator": "Cornwall Fire and Rescue Service",
+        "operator:wikidata": "Q5171976",
+        "operator:wikipedia": "en:Cornwall Fire and Rescue Service"
+      }
+    },
+    {
+      "displayName": "Devon and Somerset Fire and Rescue Service",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "amenity": "fire_station",
+        "operator": "Devon and Somerset Fire and Rescue Service",
+        "operator:wikidata": "Q5267788",
+        "operator:wikipedia": "en:Devon and Somerset Fire and Rescue Service"
+      }
+    },
+    {
+      "displayName": "Dorset & Wiltshire Fire and Rescue Service",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "amenity": "fire_station",
+        "operator": "Dorset & Wiltshire Fire and Rescue Service",
+        "operator:wikidata": "Q28402600",
+        "operator:wikipedia": "en:Dorset & Wiltshire Fire and Rescue Service"
+      }
+    }
+  ]
+}

--- a/data/operators/amenity/fire_station.json
+++ b/data/operators/amenity/fire_station.json
@@ -1,6 +1,6 @@
 {
   "operators/amenity/fire_station": [
-      {
+    {
       "displayName": "Cornwall Fire and Rescue Service",
       "locationSet": {"include": ["gb-eng"]},
       "tags": {

--- a/data/operators/amenity/fire_station.json
+++ b/data/operators/amenity/fire_station.json
@@ -29,6 +29,16 @@
         "operator:wikidata": "Q28402600",
         "operator:wikipedia": "en:Dorset & Wiltshire Fire and Rescue Service"
       }
+    },
+    {
+      "displayName": "Scottish Fire and Rescue Service",
+      "locationSet": {"include": ["gb-sct"]},
+      "tags": {
+        "amenity": "fire_station",
+        "operator": "Scottish Fire and Rescue Service",
+        "operator:wikidata": "Q7437729",
+        "operator:wikipedia": "en:Scottish Fire and Rescue Service"
+      }
     }
   ]
 }

--- a/data/operators/amenity/police.json
+++ b/data/operators/amenity/police.json
@@ -19,6 +19,26 @@
         "operator:wikidata": "Q5267784",
         "operator:wikipedia": "en:Devon and Cornwall Police"
       }
+    },
+    {
+      "displayName": "Police Service of Northern Ireland",
+      "locationSet": {"include": ["gb-nir"]},
+      "tags": {
+        "amenity": "police",
+        "operator": "Police Service of Northern Ireland",
+        "operator:wikidata": "Q1482170",
+        "operator:wikipedia": "en:Police Service of Northern Ireland"
+      }
+    },
+    {
+      "displayName": "Police Scotland",
+      "locationSet": {"include": ["gb-sct"]},
+      "tags": {
+        "amenity": "police",
+        "operator": "Police Scotland",
+        "operator:wikidata": "Q7209499",
+        "operator:wikipedia": "en:Police Scotland"
+      }
     }
   ]
 }

--- a/data/operators/amenity/police.json
+++ b/data/operators/amenity/police.json
@@ -1,0 +1,24 @@
+{
+  "operators/amenity/police": [
+      {
+      "displayName": "Avon and Somerset Police",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "amenity": "police",
+        "operator": "Avon and Somerset Police",
+        "operator:wikidata": "Q4829263",
+        "operator:wikipedia": "en:Avon and Somerset Police"
+      }
+    },
+    {
+      "displayName": "Devon and Cornwall Police",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "amenity": "police",
+        "operator": "Devon and Cornwall Police",
+        "operator:wikidata": "Q5267784",
+        "operator:wikipedia": "en:Devon and Cornwall Police"
+      }
+    }
+  ]
+}

--- a/data/operators/amenity/police.json
+++ b/data/operators/amenity/police.json
@@ -1,6 +1,6 @@
 {
   "operators/amenity/police": [
-      {
+    {
       "displayName": "Avon and Somerset Police",
       "locationSet": {"include": ["gb-eng"]},
       "tags": {

--- a/data/operators/amenity/police.json
+++ b/data/operators/amenity/police.json
@@ -21,6 +21,16 @@
       }
     },
     {
+      "displayName": "Garda Síochána",
+      "locationSet": {"include": ["ie"]},
+      "tags": {
+        "amenity": "police",
+        "operator": "Garda Síochána",
+        "operator:wikidata": "Q1366959",
+        "operator:wikipedia": "en:Garda Síochána"
+      }
+    },
+    {
       "displayName": "Police Service of Northern Ireland",
       "locationSet": {"include": ["gb-nir"]},
       "tags": {

--- a/data/operators/emergency/ambulance_station.json
+++ b/data/operators/emergency/ambulance_station.json
@@ -1,6 +1,16 @@
 {
   "operators/emergency/ambulance_station": [
     {
+      "displayName": "Northern Ireland Ambulance Service",
+      "locationSet": {"include": ["gb-nir"]},
+      "tags": {
+        "emergency": "ambulance_station",
+        "operator": "Northern Ireland Ambulance Service",
+        "operator:wikidata": "Q7058462",
+        "operator:wikipedia": "en:Northern Ireland Ambulance Service"
+      }
+    },
+    {
       "displayName": "Scottish Ambulance Service",
       "locationSet": {"include": ["gb-sct"]},
       "tags": {

--- a/data/operators/emergency/ambulance_station.json
+++ b/data/operators/emergency/ambulance_station.json
@@ -1,6 +1,6 @@
 {
   "operators/emergency/ambulance_station": [
-        {
+    {
       "displayName": "Scottish Ambulance Service",
       "locationSet": {"include": ["gb-sct"]},
       "tags": {

--- a/data/operators/emergency/ambulance_station.json
+++ b/data/operators/emergency/ambulance_station.json
@@ -1,0 +1,14 @@
+{
+  "operators/emergency/ambulance_station": [
+    {
+      "displayName": "South Western Ambulance Service",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "emergency": "ambulance_station",
+        "operator": "South Western Ambulance Service",
+        "operator:wikidata": "Q7568903",
+        "operator:wikipedia": "en:South Western Ambulance Service"
+      }
+    }
+  ]
+}

--- a/data/operators/emergency/ambulance_station.json
+++ b/data/operators/emergency/ambulance_station.json
@@ -1,5 +1,15 @@
 {
   "operators/emergency/ambulance_station": [
+        {
+      "displayName": "Scottish Ambulance Service",
+      "locationSet": {"include": ["gb-sct"]},
+      "tags": {
+        "emergency": "ambulance_station",
+        "operator": "Scottish Ambulance Service",
+        "operator:wikidata": "Q2411102",
+        "operator:wikipedia": "en:Scottish Ambulance Service"
+      }
+    },
     {
       "displayName": "South Western Ambulance Service",
       "locationSet": {"include": ["gb-eng"]},
@@ -8,6 +18,16 @@
         "operator": "South Western Ambulance Service",
         "operator:wikidata": "Q7568903",
         "operator:wikipedia": "en:South Western Ambulance Service"
+      }
+    },
+    {
+      "displayName": "Welsh Ambulance Service",
+      "locationSet": {"include": ["gb-wls"]},
+      "tags": {
+        "emergency": "ambulance_station",
+        "operator": "Welsh Ambulance Service",
+        "operator:wikidata": "Q7981848",
+        "operator:wikipedia": "en:Welsh Ambulance Service"
       }
     }
   ]

--- a/data/operators/emergency/ambulance_station.json
+++ b/data/operators/emergency/ambulance_station.json
@@ -1,6 +1,76 @@
 {
   "operators/emergency/ambulance_station": [
     {
+      "displayName": "East Midlands Ambulance Service",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "emergency": "ambulance_station",
+        "operator": "East Midlands Ambulance Service",
+        "operator:wikidata": "Q5328979",
+        "operator:wikipedia": "en:East Midlands Ambulance Service"
+      }
+    },
+    {
+      "displayName": "East of England Ambulance Service",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "emergency": "ambulance_station",
+        "operator": "East of England Ambulance Service",
+        "operator:wikidata": "Q5329757",
+        "operator:wikipedia": "en:East of England Ambulance Service"
+      }
+    },
+    {
+      "displayName": "HSE National Ambulance Service",
+      "locationSet": {"include": ["ie"]},
+      "tags": {
+        "emergency": "ambulance_station",
+        "operator": "HSE National Ambulance Service",
+        "operator:wikidata": "Q5635955",
+        "operator:wikipedia": "en:HSE National Ambulance Service"
+      }
+    },
+    {
+      "displayName": "Isle of Wight NHS Trust",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "emergency": "ambulance_station",
+        "operator": "Isle of Wight NHS Trust",
+        "operator:wikidata": "Q16995139",
+        "operator:wikipedia": "en:Isle of Wight NHS Trust"
+      }
+    },
+    {
+      "displayName": "London Ambulance Service",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "emergency": "ambulance_station",
+        "operator": "London Ambulance Service",
+        "operator:wikidata": "Q1794466",
+        "operator:wikipedia": "en:London Ambulance Service"
+      }
+    },
+    {
+      "displayName": "North East Ambulance Service",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "emergency": "ambulance_station",
+        "operator": "North East Ambulance Service",
+        "operator:wikidata": "Q16258059",
+        "operator:wikipedia": "en:North East Ambulance Service"
+      }
+    },
+    {
+      "displayName": "North West Ambulance Service",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "emergency": "ambulance_station",
+        "operator": "North West Ambulance Service",
+        "operator:wikidata": "Q7057220",
+        "operator:wikipedia": "en:North West Ambulance Service"
+      }
+    },
+    {
       "displayName": "Northern Ireland Ambulance Service",
       "locationSet": {"include": ["gb-nir"]},
       "tags": {
@@ -21,6 +91,26 @@
       }
     },
     {
+      "displayName": "South Central Ambulance Service",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "emergency": "ambulance_station",
+        "operator": "Q7566742",
+        "operator:wikidata": "South Central Ambulance Service",
+        "operator:wikipedia": "en:South Central Ambulance Service"
+      }
+    },
+    {
+      "displayName": "South East Coast Ambulance Service",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "emergency": "ambulance_station",
+        "operator": "South East Coast Ambulance Service",
+        "operator:wikidata": "Q7567104",
+        "operator:wikipedia": "en:South East Coast Ambulance Service"
+      }
+    },
+    {
       "displayName": "South Western Ambulance Service",
       "locationSet": {"include": ["gb-eng"]},
       "tags": {
@@ -38,6 +128,26 @@
         "operator": "Welsh Ambulance Service",
         "operator:wikidata": "Q7981848",
         "operator:wikipedia": "en:Welsh Ambulance Service"
+      }
+    },
+    {
+      "displayName": "West Midlands Ambulance Service",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "emergency": "ambulance_station",
+        "operator": "West Midlands Ambulance Service",
+        "operator:wikidata": "Q7985932",
+        "operator:wikipedia": "en:West Midlands Ambulance Service"
+      }
+    },
+    {
+      "displayName": "Yorkshire Ambulance Service",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "emergency": "ambulance_station",
+        "operator": "Yorkshire Ambulance Service",
+        "operator:wikidata": "Q8055673",
+        "operator:wikipedia": "en:Yorkshire Ambulance Service"
       }
     }
   ]


### PR DESCRIPTION
As previously attempted (#3337) prior to the "_operator_" tag being added to the index, this PR is aimed at trying out operators for Police, Fire and Ambulance services, part filled with UK based data at the moment.

It is possible these services would be better added under automation, similar to previous additions (#4646, #4638 ).