### PR TITLE
Add Wikidata tags to MTS transit entry

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -6942,17 +6942,20 @@
       "displayName": "MTS",
       "id": "mts-a21cc9",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["San Diego Metropolitan Transit System", "Metropolitan Transit System"],
+      "matchNames": [
+        "metropolitan transit system",
+        "san diego metropolitan transit system"
+      ],
       "tags": {
-      "network": "MTS",
-      "network:wikidata": "Q3471406",
-      "network:wikipedia": "en:San Diego Metropolitan Transit System",
-      "operator": "MTS",
-      "operator:wikidata": "Q3471406",
-      "operator:wikipedia": "en:San Diego Metropolitan Transit System",
-      "route": "bus"
-           }
-         },
+        "network": "MTS",
+        "network:wikidata": "Q3471406",
+        "network:wikipedia": "en:San Diego Metropolitan Transit System",
+        "operator": "MTS",
+        "operator:wikidata": "Q3471406",
+        "operator:wikipedia": "en:San Diego Metropolitan Transit System",
+        "route": "bus"
+      }
+    },
     {
       "displayName": "MUK Zgierz",
       "id": "mukzgierz-9340cc",

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -6941,13 +6941,18 @@
     {
       "displayName": "MTS",
       "id": "mts-a21cc9",
-      "locationSet": {"include": ["us"]},
-      "tags": {
-        "network": "MTS",
-        "operator": "MTS",
-        "route": "bus"
-      }
-    },
+     "locationSet": {"include": ["us"]},
+     "matchNames": ["San Diego Metropolitan Transit System", "Metropolitan Transit System"],
+     "tags": {
+     "network": "MTS",
+     "network:wikidata": "Q3471406",
+     "network:wikipedia": "en:San Diego Metropolitan Transit System",
+     "operator": "MTS",
+     "operator:wikidata": "Q3471406",
+     "operator:wikipedia": "en:San Diego Metropolitan Transit System",
+     "route": "bus"
+           }
+         },
     {
       "displayName": "MUK Zgierz",
       "id": "mukzgierz-9340cc",

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -6941,16 +6941,16 @@
     {
       "displayName": "MTS",
       "id": "mts-a21cc9",
-     "locationSet": {"include": ["us"]},
-     "matchNames": ["San Diego Metropolitan Transit System", "Metropolitan Transit System"],
-     "tags": {
-     "network": "MTS",
-     "network:wikidata": "Q3471406",
-     "network:wikipedia": "en:San Diego Metropolitan Transit System",
-     "operator": "MTS",
-     "operator:wikidata": "Q3471406",
-     "operator:wikipedia": "en:San Diego Metropolitan Transit System",
-     "route": "bus"
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["San Diego Metropolitan Transit System", "Metropolitan Transit System"],
+      "tags": {
+      "network": "MTS",
+      "network:wikidata": "Q3471406",
+      "network:wikipedia": "en:San Diego Metropolitan Transit System",
+      "operator": "MTS",
+      "operator:wikidata": "Q3471406",
+      "operator:wikipedia": "en:San Diego Metropolitan Transit System",
+      "route": "bus"
            }
          },
     {


### PR DESCRIPTION
Adds operator and network Wikidata information to the MTS entry.  Please scrutinize this PR as it's my first use of the new transit category.