### PR TITLE
Tiny correction in CategoryInstructions.jsx

### DIFF
--- a/app/src/CategoryInstructions.jsx
+++ b/app/src/CategoryInstructions.jsx
@@ -12,7 +12,7 @@ export default function CategoryInstructions(props) {
     wikidataTag = 'brand:wikidata';
   } else if (t === 'operators') {
     a = 'an';
-    itemType = 'aoperator';
+    itemType = 'operator';
     wikidataTag = 'operator:wikidata';
   } else if (t === 'transit') {
     a = 'a';


### PR DESCRIPTION
Tiny correction in "CategoryInstructions.jsx" where the nsi.guide web site is displaying "aoperator" (with an 'a' at the beginning) instead of "operator" within the "_Some things you can do here:_" instructions!

This minor edit is done as a pull request, just in case another file needs to be edited that I'm not aware of.

If merged, I believe **npm run docbuild** will be required to make this change live on the nsi.guide web site!