### PR TITLE
Update bicycle_rental.json

### DIFF
--- a/data/operators/amenity/bicycle_rental.json
+++ b/data/operators/amenity/bicycle_rental.json
@@ -18,6 +18,7 @@
       "tags": {
         "amenity": "bicycle_rental",
         "brand": "fLotte",
+        "brand:wikidata": "Q102333872",
         "operator": "ADFC",
         "operator:wikidata": "Q24349",
         "operator:wikipedia": "de:ADFC"

--- a/data/operators/amenity/bicycle_rental.json
+++ b/data/operators/amenity/bicycle_rental.json
@@ -12,14 +12,15 @@
       }
     },
     {
-      "displayName": "ADFC",
+      "displayName": "fLotte",
       "id": "adfc-012211",
       "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "bicycle_rental",
-        "brand": "ADFC",
-        "name": "ADFC",
-        "operator": "ADFC"
+        "brand": "fLotte",
+        "operator": "ADFC",
+        "operator:wikidata": "Q24349",
+        "operator:wikipedia": "de:ADFC"
       }
     },
     {
@@ -747,17 +748,6 @@
         "brand": "fahrradspezialitaeten.com",
         "name": "fahrradspezialitaeten.com",
         "operator": "fahrradspezialitaeten.com"
-      }
-    },
-    {
-      "displayName": "fLotte",
-      "id": "flotte-012211",
-      "locationSet": {"include": ["de"]},
-      "tags": {
-        "amenity": "bicycle_rental",
-        "brand": "fLotte",
-        "name": "fLotte",
-        "operator": "fLotte"
       }
     },
     {


### PR DESCRIPTION
the common German tagging scheme for bike sharing systems seems to be:

`name=*`  -  name of the actual station within the system
`brand=*`  -  branded name of the sharing system itself
`operator=*`  -  name of the company that operates the system