### PR TITLE
Keep table headers on top when scrolling

### DIFF
--- a/app/style.css
+++ b/app/style.css
@@ -237,6 +237,7 @@ table.summary th {
   font-size: 15px;
   font-weight: bold;
   color: #000;
+  z-index: 1; /* stay on top when scrolling */
 }
 .dark table.summary th {
   background: #1a1a1a;


### PR DESCRIPTION
Prevents brand icons from weirdly overlapping when the page is scrolled and the table headings stick to the top of the screen

Would usually just push this, but here's a PR just in case it could cause any unintended side effects