### PR TITLE
Updated Category Instructions

### DIFF
--- a/app/src/CategoryInstructions.jsx
+++ b/app/src/CategoryInstructions.jsx
@@ -25,7 +25,7 @@ export default function CategoryInstructions(props) {
     <div className='instructions'>Some things you can do here:
     <ul>
     <li>Is {a} {itemType} name missing or something is incorrect? <a target='_blank' href='https://github.com/osmlab/name-suggestion-index/issues'>Open an issue</a> or pull request to add it!</li>
-    <li>Click the "View on Overpass Turbo" link to see where the name is used in OpenStreetMap.</li>
+    <li>Click the "Search Overpass Turbo" link to see where the name is used in OpenStreetMap.</li>
     <li>If a record is missing a <code>'{wikidataTag}'</code> tag, you can do the research to add it to our project, or filter it out if it is not {a} {itemType}.<br/>
       See <a target='_blank' href='https://github.com/osmlab/name-suggestion-index/blob/main/CONTRIBUTING.md'>CONTRIBUTING.md</a> for more info.</li>
     <li>If a record with a <code>'{wikidataTag}'</code> tag has a poor description or is missing logos, click the Wikidata link and edit the Wikidata page.<br/>


### PR DESCRIPTION
Just a minor edit, I've changed the instruction text "_View on Overpass Turbo_" to "_Search Overpass Turbo_" just to match the link text we use now.