### PR TITLE
Add Thai department store chain

### DIFF
--- a/data/brands/shop/department_store.json
+++ b/data/brands/shop/department_store.json
@@ -206,6 +206,18 @@
       }
     },
     {
+      "displayName": "Central Department Store",
+      "locationSet": {"include": ["id", "th"]},
+      "tags": {
+        "brand": "Central Department Store",
+        "brand:th": "สรรพสินค้าเซ็นทรัล",
+        "brand:cn": "尚泰",
+        "brand:wikidata": "Q5060703",
+        "brand:wikipedia": "en:Central Department Store",
+        "shop": "department_store"
+      }
+    },
+    {
       "displayName": "Century 21",
       "id": "century21-592fe0",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
`name` tag intentionally missing. The stores themselves are named like "Central Rama II," "Central Rama IX," "Central Chitlom," etc.