### PR TITLE
Increase "Country Code" search box size

### DIFF
--- a/app/src/Filters.jsx
+++ b/app/src/Filters.jsx
@@ -26,7 +26,7 @@ export default function Filters(props) {
 
     <span className='field'>
       <label for='cc'>Country Code:</label>
-      <input type='text' id='cc' name='cc' autocorrect='off' maxlength='2' size='2'
+      <input type='text' id='cc' name='cc' autocorrect='off' maxlength='5' size='3'
         value={cc} onChange={filtersChanged} />
     </span>
 


### PR DESCRIPTION
Increase the "_Country Code_" search box size on the web site to accommodate searches, e.g. "[gb-eng](https://nsi.guide/index.html?t=operators&k=amenity&v=fire_station&cc=gb-eng)".

PR'd in case other edits are needed to make this work.