### PR TITLE
Flyers

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -1440,6 +1440,22 @@
       }
     },
     {
+      "displayName": "Flyers",
+      "id": "flyers-c5cf43",
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["flyers energy"],
+      "tags": {
+        "amenity": "fuel",
+        "brand": "Flyers",
+        "brand:wikidata": "Q103882231",
+        "name": "Flyers",
+        "payment:cash": "no",
+        "payment:cfn": "yes",
+        "payment:credit_cards": "no",
+        "payment:debit_cards": "no"
+      }
+    },
+    {
       "displayName": "Flying J",
       "id": "flyingj-337af2",
       "locationSet": {"include": ["ca", "us"]},


### PR DESCRIPTION
Added the Flyers chain of cardlock gas stations owned by [Flyers Energy](https://www.wikidata.org/wiki/Q103882231).

These gas stations are intended for commercial fleets. [The wiki](https://wiki.openstreetmap.org/wiki/Special:PermanentLink/2062278#List_of_possible_values) recommends `access=private` for members-only facilities, but I think it’s important to distinguish these publicly accessible facilities from a private gas station operated by a city or power company for their private fleet. As far as I can tell, you don’t need to have a Flyers CFN card; any CFN card will do. Therefore, I’ve eschewed the `access` key in favor of `payment` keys.