### PR TITLE
Changed the Max Computation time in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
   "editor.formatOnSave": false
+  "diffEditor.maxComputationTime": 10000
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-  "editor.formatOnSave": false
+  "editor.formatOnSave": false,
   "diffEditor.maxComputationTime": 10000
 }


### PR DESCRIPTION
Changed the Timeout in milliseconds after which diff computation is cancelled. the default Vs Code Setting was 5000