### PR TITLE
Change Safeway to Safeway Fuel Station

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -3342,7 +3342,7 @@
       }
     },
     {
-      "displayName": "Safeway",
+      "displayName": "Safeway Fuel Station",
       "id": "safeway-b3d110",
       "locationSet": {"include": ["001"]},
       "tags": {
@@ -3350,7 +3350,7 @@
         "brand": "Safeway",
         "brand:wikidata": "Q1508234",
         "brand:wikipedia": "en:Safeway Inc.",
-        "name": "Safeway"
+        "name": "Safeway Fuel Station"
       }
     },
     {


### PR DESCRIPTION
1. Avoid name confusion with Safeway supermarket
2. Official name used by https://local.fuel.safeway.com/