### PR TITLE
Change subject of Flag of Europe

### DIFF
--- a/data/flags/man_made/flagpole.json
+++ b/data/flags/man_made/flagpole.json
@@ -1419,8 +1419,8 @@
         "flag:type": "governmental",
         "flag:wikidata": "Q122482",
         "man_made": "flagpole",
-        "subject": "European Union",
-        "subject:wikidata": "Q458"
+        "subject": "Europe",
+        "subject:wikidata": "Q46"
       }
     },
     {


### PR DESCRIPTION
European Union -> Europe
The Flag of Europe is not only the symbol of the European Union. There is actually a separate Wikidata item for the flag of the EU (Q98055852)