### PR TITLE
For Benu, also match "benu aptieka"

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -202,7 +202,7 @@
           "sk"
         ]
       },
-      "matchNames": ["benu vaistinė"],
+      "matchNames": ["benu vaistinė", "benu aptieka"],
       "tags": {
         "amenity": "pharmacy",
         "brand": "Benu",


### PR DESCRIPTION
That's the same in Latvia as "benu vaistinė" in Lithuania.