### PR TITLE
Add diet:vegetarian to some fast food brands.

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -30,7 +30,7 @@
     },
     {
       "displayName": "A&W (USA)",
-      "id": "aandw-4d2ff4",Tr
+      "id": "aandw-4d2ff4",
       "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "fast_food",

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -4409,7 +4409,7 @@
         "brand:wikidata": "Q752941",
         "brand:wikipedia": "en:Taco Bell",
         "cuisine": "tex-mex",
-        "diet:vegetarian": "yes",
+        "diet:vegan": "yes",
         "name": "Taco Bell",
         "takeaway": "yes"
       }
@@ -4993,7 +4993,7 @@
         "brand:wikidata": "Q1244034",
         "brand:wikipedia": "en:White Castle (restaurant)",
         "cuisine": "burger",
-        "diet:vegetarian": "yes",
+        "diet:vegan": "yes",
         "name": "White Castle",
         "takeaway": "yes"
       }

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -796,7 +796,7 @@
         "brand:wikidata": "Q465751",
         "brand:wikipedia": "en:Chipotle Mexican Grill",
         "cuisine": "mexican",
-        "diet:vegetarian": "yes"
+        "diet:vegetarian": "yes",
         "name": "Chipotle",
         "official_name": "Chipotle Mexican Grill",
         "takeaway": "yes"
@@ -1519,7 +1519,7 @@
         "brand:wikidata": "Q1131810",
         "brand:wikipedia": "en:Five Guys",
         "cuisine": "burger",
-        "diet:vegetarian": "yes"
+        "diet:vegetarian": "yes",
         "name": "Five Guys",
         "official_name": "Five Guys Burgers and Fries",
         "takeaway": "yes"
@@ -4309,7 +4309,7 @@
         "brand:wikidata": "Q244457",
         "brand:wikipedia": "en:Subway (restaurant)",
         "cuisine": "sandwich",
-        "diet:vegetarian": "yes"
+        "diet:vegetarian": "yes",
         "name": "Subway",
         "takeaway": "yes"
       }

--- a/data/brands/shop/furniture.json
+++ b/data/brands/shop/furniture.json
@@ -97,6 +97,15 @@
       }
     },
     {
+      "displayName": "Bedmart",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "brand": "Bedmart",
+        "name": "Bedmart",
+        "shop": "furniture"
+      }
+    },
+    {
       "displayName": "Bellona",
       "id": "bellona-12c613",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
I've been adding the diet:vegetarian tag to some local restaurants but, according to the brand's website, these places universally have vegetarian options.