### PR TITLE
Add Timpson

### DIFF
--- a/data/brands/shop/locksmith.json
+++ b/data/brands/shop/locksmith.json
@@ -1,6 +1,18 @@
 {
   "brands/shop/locksmith": [
     {
+      "displayName": "Timpson",
+      "id": "timpson-5c571a",
+      "locationSet": {"include": ["gb", "ie"]},
+      "tags": {
+        "brand": "Timpson",
+        "brand:wikidata": "Q7807658",
+        "brand:wikipedia": "en:Timpson (retailer)",
+        "name": "Timpson",
+        "shop": "locksmith"
+      }
+    },
+    {
       "displayName": "カギの110番",
       "id": "kagi110-214af9",
       "locationSet": {"include": ["jp"]},


### PR DESCRIPTION
Add UK-based locksmith chain [Timpson](https://www.timpson.co.uk/). 

They have 2100 owned stores across GB and IE