### PR TITLE
Remove name from Premier

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -2092,7 +2092,6 @@
         "brand": "Premier",
         "brand:wikidata": "Q7240340",
         "brand:wikipedia": "en:Premier Stores",
-        "name": "Premier",
         "shop": "convenience"
       }
     },


### PR DESCRIPTION
Shops will often have a unique name (see the Weatherspoons situation).