### PR TITLE
Merge Europris and Eurorpris

### DIFF
--- a/data/brands/shop/general.json
+++ b/data/brands/shop/general.json
@@ -4,20 +4,11 @@
       "displayName": "Europris",
       "id": "europris-fd026c",
       "locationSet": {"include": ["no"]},
+      "matchNames": ["eurorpris"],
       "tags": {
         "brand": "Europris",
         "brand:wikidata": "Q17770215",
         "brand:wikipedia": "no:Europris",
-        "shop": "general"
-      }
-    },
-    {
-      "displayName": "Eurorpris",
-      "id": "eurorpris-f47ae0",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "brand": "Eurorpris",
-        "name": "Eurorpris",
         "shop": "general"
       }
     }


### PR DESCRIPTION
Removed "Eurorpris" (extra 'r') that seems to be a planet grab with a misspelling (as it's currently misspelled en-mass in OSM), and adds it as a match name to "Europris".

This was also done using GitHub Desktop to test my first usage of it!