### PR TITLE
Alsco

### DIFF
--- a/data/operators/industrial/laundry.json
+++ b/data/operators/industrial/laundry.json
@@ -1,0 +1,31 @@
+{
+  "operators/industrial/laundry": [
+    {
+      "displayName": "Alsco",
+      "id": "alsco-75a496",
+      "locationSet": {
+        "include": [
+          "au",
+          "br",
+          "ca",
+          "cn",
+          "de",
+          "gb",
+          "it",
+          "my",
+          "nz",
+          "sg",
+          "th",
+          "us"
+        ]
+      },
+      "tags": {
+        "industrial": "laundry",
+        "name": "Alsco",
+        "operator": "Alsco",
+        "operator:wikidata": "Q60752605",
+        "operator:wikipedia": "en:Alsco"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Added [Alsco](https://en.wikipedia.org/wiki/Alsco), a uniform rental service, as an operator. I’ve been tagging uniform rental services’ industrial laundry facilities as [`industrial=laundry`](https://taginfo.openstreetmap.org/tags/industrial=laundry) in the absence of an established tag. This tag isn’t common, but then again, neither have these facilities been mapped all that much, and `industrial=laundry` seems like a good analogue to the well-established `shop=laundry` (which this definitely isn’t). The [`industrial`](https://wiki.openstreetmap.org/wiki/Key:industrial) key itself is a bit of a free-for-all.