### PR TITLE
Update Tesla Supercharger operator

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -2619,9 +2619,9 @@
         "brand:wikidata": "Q17089620",
         "brand:wikipedia": "en:Tesla Supercharger",
         "name": "Tesla Supercharger",
-        "operator": "Tesla Supercharger",
-        "operator:wikidata": "Q17089620",
-        "operator:wikipedia": "en:Tesla Supercharger",
+        "operator": "Tesla, Inc.",
+        "operator:wikidata": "Q478214",
+        "operator:wikipedia": "en:Tesla, Inc.",
         "short_name": "Tesla"
       }
     },


### PR DESCRIPTION
Update operator of Tesla Supercharger to Tesla, Inc.