### PR TITLE
Add Farmhouse Inns and Belhaven Pubs

### DIFF
--- a/data/brands/amenity/pub.json
+++ b/data/brands/amenity/pub.json
@@ -1,6 +1,15 @@
 {
   "brands/amenity/pub": [
     {
+      "displayName": "Belhaven Pubs",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "amenity": "pub",
+        "brand": "Belhaven Pubs",
+        "brand:wikidata": "Q105516156"
+      }
+    },
+    {
       "displayName": "Brewers Fayre",
       "id": "brewersfayre-eaed91",
       "locationSet": {"include": ["gb"]},

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -1080,6 +1080,15 @@
       }
     },
     {
+      "displayName": "Farmhouse Inns",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "Farmhouse Inns",
+        "brand:wikidata": "Q105504972"
+      }
+    },
+    {
       "displayName": "Fatz",
       "id": "fatz-96af40",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
These are different brands that Greene King has bough, but continues to operate separate brands. They both sit on the boundary of pub with food vs restaurant, but doing a spot check on current OSM data Belhaven Pubs gets mainly `amenity=pub`, and Farmhouse Inns gets `amenity=restaurant`. I don't disagree with those definitions.