### PR TITLE
merge Softbank

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -1118,7 +1118,7 @@
       "displayName": "ソフトバンクショップ",
       "id": "softbankshop-0a8be9",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["softbank","ソフトバンク"],
+      "matchNames": ["softbank","ソフトバンク","ソフトバンクショップ"],
       "tags": {
         "brand": "ソフトバンクショップ",
         "brand:en": "SoftBankShop",


### PR DESCRIPTION
#4868 has been closed because SoftBank Telecom (Q7553832) and SoftBank Shop (Q11315281) are not integrated, so I edited it.

> I understand there are two brands in wikidata for mobile_phone shops:
> SoftBank Telecom (Q7553832)
> SoftBank Shop (Q11315281)
> Are both legitimate and distinct retail chains ?
> 
> The Japanese version of Wikipedia clearly states that "SoftBank Telecom has merged with SoftBank Mobile.".
