### PR TITLE
Clarify Habitat split

### DIFF
--- a/data/brands/shop/furniture.json
+++ b/data/brands/shop/furniture.json
@@ -470,7 +470,7 @@
       "tags": {
         "brand": "Habitat",
         "brand:wikidata": "Q28232260",
-        "brand:wikipedia": "fr:Habitat (entreprise)",
+        "brand:wikipedia": "en:Groupe Habitat",
         "name": "Habitat",
         "shop": "furniture"
       }

--- a/data/brands/shop/furniture.json
+++ b/data/brands/shop/furniture.json
@@ -436,7 +436,22 @@
       }
     },
     {
-      "displayName": "Habitat",
+      "displayName": "Habitat (UK)",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
+      "tags": {
+        "brand": "Habitat",
+        "brand:wikidata": "Q689059",
+        "brand:wikipedia": "en:Habitat_(retailer)",
+        "name": "Habitat",
+        "shop": "furniture"
+      }
+    },
+    {
+      "displayName": "Groupe Habitat",
       "id": "habitat-437cef",
       "locationSet": {
         "include": [
@@ -454,7 +469,7 @@
       },
       "tags": {
         "brand": "Habitat",
-        "brand:wikidata": "Q689059",
+        "brand:wikidata": "Q28232260",
         "brand:wikipedia": "fr:Habitat (entreprise)",
         "name": "Habitat",
         "shop": "furniture"


### PR DESCRIPTION
I was going to just add GB to the list, but then I did a bit more looking. I think the UK Wikidata item has the wrong URL (should be https://www.habitat.co.uk/) and French Wikipedia doesn't seem to link to the right Wikidata/fully acknowledge the split.