### PR TITLE
Canadian Tire Gas+ is (unsurprisingly) in Canada

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -777,7 +777,7 @@
     {
       "displayName": "Canadian Tire Gas+",
       "id": "canadiantire-b3d110",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["ca"]},
       "matchNames": ["canadian tire gas bar"],
       "tags": {
         "amenity": "fuel",


### PR DESCRIPTION
<img width="1228" alt="Screenshot 2021-03-06 at 11 06 43 am" src="https://user-images.githubusercontent.com/83251/110204789-e6e0ec00-7e6c-11eb-8ca7-e410ad2f2fb8.png">
https://overpass-turbo.eu/s/14IN