### PR TITLE
Australian EV network wikidata

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -389,7 +389,8 @@
       "locationSet": {"include": ["au"]},
       "tags": {
         "amenity": "charging_station",
-        "operator": "Chargefox"
+        "operator": "Chargefox",
+        "operator:wikidata": "Q105775824"
       }
     },
     {
@@ -1013,7 +1014,8 @@
       "locationSet": {"include": ["au"]},
       "tags": {
         "amenity": "charging_station",
-        "operator": "Evie Networks"
+        "operator": "Evie Networks",
+        "operator:wikidata": "Q105795220"
       }
     },
     {


### PR DESCRIPTION
Add operator:wikidata tags for Chargefox and Evie Networks.