### PR TITLE
Further Tas, NZ, UK charging station operators

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -498,7 +498,7 @@
     {
       "displayName": "City of Launceston",
       "locationSet": {
-        "include": [[-41.4, 147.1]]
+        "include": [[147.1, -41.4]]
       },
       "tags": {
         "amenity": "charging_station",

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -419,7 +419,8 @@
       "locationSet": {"include": ["nz"]},
       "tags": {
         "amenity": "charging_station",
-        "operator": "ChargeNet NZ"
+        "operator": "ChargeNet NZ",
+        "operator:wikidata": "Q105872959"
       }
     },
     {

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -306,8 +306,8 @@
       "locationSet": {"include": ["au"]},
       "tags": {
         "amenity": "charging_station",
-        "operator": "Bolt"
-        "operator:wikidata": "Q105846404",
+        "operator": "Bolt",
+        "operator:wikidata": "Q105846404"
       }
     },
     {

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -302,6 +302,15 @@
       }
     },
     {
+      "displayName": "Bolt",
+      "locationSet": {"include": ["au"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Bolt"
+        "operator:wikidata": "Q105846404",
+      }
+    },
+    {
       "displayName": "Booths",
       "id": "booths-0793ce",
       "locationSet": {"include": ["gb"]},
@@ -472,6 +481,30 @@
         "operator:fr": "Circuit électrique",
         "operator:wikidata": "Q24934590",
         "operator:wikipedia": "fr:Le Circuit électrique"
+      }
+    },
+    {
+      "displayName": "City of Hobart",
+      "locationSet": {
+        "include": [[147.3, -42.9]]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "City of Hobart",
+        "operator:wikidata": "Q1621560",
+        "operator:wikipedia": "en:City of Hobart"
+      }
+    },
+    {
+      "displayName": "City of Launceston",
+      "locationSet": {
+        "include": [[-41.4, 147.1]]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "City of Launceston",
+        "operator:wikidata": "Q937765",
+        "operator:wikipedia": "en:City of Launceston"
       }
     },
     {

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -1303,6 +1303,15 @@
       }
     },
     {
+      "displayName": "Gridserve",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "amenity": "charging_station",
+        "name": "Gridserve",
+        "operator": "Gridserve",
+        "operator:wikidata": "Q89575318"
+      }
+    },    {
       "displayName": "Grønn kontakt",
       "id": "gronnkontakt-c454f0",
       "locationSet": {"include": ["no", "se"]},
@@ -1779,7 +1788,8 @@
       },
       "tags": {
         "amenity": "charging_station",
-        "operator": "NewMotion"
+        "operator": "NewMotion",
+        "operator:wikidata": "Q105883058"
       }
     },
     {


### PR DESCRIPTION
Add Bolt, and two city councils which operate chargers