### PR TITLE
Update charging_station.json

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -225,7 +225,6 @@
         "amenity": "charging_station",
         "brand": "bike-energy",
         "brand:wikidata": "Q67770877",
-        "name": "bike-energy",
         "operator": "bike-energy",
         "operator:wikidata": "Q67770877"
       }
@@ -253,7 +252,6 @@
         "brand": "BKK",
         "brand:wikidata": "Q4891601",
         "brand:wikipedia": "no:BKK (selskap)",
-        "name": "BKK",
         "operator": "BKK",
         "operator:wikidata": "Q4891601",
         "operator:wikipedia": "no:BKK (selskap)"
@@ -276,7 +274,6 @@
         "amenity": "charging_station",
         "brand": "Blink",
         "brand:wikidata": "Q62065645",
-        "name": "Blink",
         "operator": "Blink",
         "operator:wikidata": "Q62065645"
       }
@@ -329,7 +326,6 @@
       "tags": {
         "amenity": "charging_station",
         "brand": "Bosch eBike Systems",
-        "name": "Bosch eBike Systems",
         "operator": "Bosch eBike Systems",
         "operator:wikidata": "Q234021",
         "operator:wikipedia": "en:Robert Bosch GmbH"
@@ -443,7 +439,6 @@
         "brand": "ChargePoint",
         "brand:wikidata": "Q5176149",
         "brand:wikipedia": "en:ChargePoint",
-        "name": "ChargePoint",
         "operator": "ChargePoint",
         "operator:wikidata": "Q5176149",
         "operator:wikipedia": "en:ChargePoint"
@@ -458,7 +453,6 @@
         "brand": "Chargy",
         "brand:wikidata": "Q62702950",
         "brand:wikipedia": "lb:Chargy",
-        "name": "Chargy",
         "operator": "Chargy",
         "operator:wikidata": "Q62702950",
         "operator:wikipedia": "lb:Chargy"
@@ -475,9 +469,6 @@
         "brand:fr": "Circuit électrique",
         "brand:wikidata": "Q24934590",
         "brand:wikipedia": "fr:Le Circuit électrique",
-        "name": "Circuit électrique",
-        "name:en": "Electric Circuit",
-        "name:fr": "Circuit électrique",
         "operator": "Circuit électrique",
         "operator:en": "Electric Circuit",
         "operator:fr": "Circuit électrique",
@@ -616,7 +607,6 @@
         "amenity": "charging_station",
         "brand": "E-WALD",
         "brand:wikidata": "Q61804335",
-        "name": "E-WALD",
         "operator": "E-WALD",
         "operator:wikidata": "Q61804335"
       }
@@ -856,7 +846,6 @@
         "brand": "Enel",
         "brand:wikidata": "Q651222",
         "brand:wikipedia": "en:Enel",
-        "name": "Enel",
         "operator": "Enel",
         "operator:wikidata": "Q651222",
         "operator:wikipedia": "en:Enel"
@@ -872,7 +861,6 @@
         "brand": "Enel X",
         "brand:wikidata": "Q5376815",
         "brand:wikipedia": "en:Enel X",
-        "name": "Enel X",
         "operator": "Enel X",
         "operator:wikidata": "Q5376815",
         "operator:wikipedia": "en:Enel X"
@@ -1050,7 +1038,6 @@
         "amenity": "charging_station",
         "brand": "eVgo",
         "brand:wikidata": "Q61803820",
-        "name": "eVgo",
         "operator": "eVgo",
         "operator:wikidata": "Q61803820"
       }
@@ -1195,7 +1182,6 @@
         "amenity": "charging_station",
         "brand": "FLO",
         "brand:wikidata": "Q64971203",
-        "name": "FLO",
         "operator": "FLO",
         "operator:wikidata": "Q64971203"
       }
@@ -1212,7 +1198,6 @@
         "brand": "Fortum",
         "brand:wikidata": "Q1439075",
         "brand:wikipedia": "en:Fortum",
-        "name": "Fortum",
         "operator": "Fortum",
         "operator:wikidata": "Q1439075",
         "operator:wikipedia": "en:Fortum"
@@ -1281,7 +1266,6 @@
         "brand": "Gogoro 電池交換站",
         "brand:wikidata": "Q19880591",
         "brand:wikipedia": "zh:Gogoro",
-        "name": "Gogoro 電池交換站",
         "operator": "Gogoro 電池交換站",
         "operator:wikidata": "Q19880591",
         "operator:wikipedia": "zh:Gogoro"
@@ -1313,7 +1297,6 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
-        "name": "Gridserve",
         "operator": "Gridserve",
         "operator:wikidata": "Q89575318",
         "operator:wikipedia": "en:Gridserve"
@@ -1327,7 +1310,6 @@
         "amenity": "charging_station",
         "brand": "Grønn kontakt",
         "brand:wikidata": "Q100821564",
-        "name": "Grønn kontakt",
         "operator": "Grønn kontakt",
         "operator:wikidata": "Q100821564"
       }
@@ -1372,7 +1354,6 @@
         "amenity": "charging_station",
         "brand": "InCharge",
         "brand:wikidata": "Q71041027",
-        "name": "InCharge",
         "operator": "InCharge",
         "operator:wikidata": "Q71041027"
       }
@@ -1400,7 +1381,6 @@
         "brand": "Innogy",
         "brand:wikidata": "Q2124721",
         "brand:wikipedia": "de:Innogy",
-        "name": "Innogy",
         "operator": "Innogy",
         "operator:wikidata": "Q2124721",
         "operator:wikipedia": "de:Innogy"
@@ -1711,7 +1691,6 @@
       "tags": {
         "amenity": "charging_station",
         "brand": "Mobiliti",
-        "name": "Mobiliti",
         "operator": "Mobiliti"
       }
     },
@@ -2356,7 +2335,6 @@
         "brand": "Source London",
         "brand:wikidata": "Q7565133",
         "brand:wikipedia": "en:Source London",
-        "name": "Source London",
         "operator": "Source London",
         "operator:wikidata": "Q7565133",
         "operator:wikipedia": "en:Source London"
@@ -2758,7 +2736,6 @@
         "brand": "Tesla Supercharger",
         "brand:wikidata": "Q17089620",
         "brand:wikipedia": "en:Tesla Supercharger",
-        "name": "Tesla Supercharger",
         "operator": "Tesla, Inc.",
         "operator:wikidata": "Q478214",
         "operator:wikipedia": "en:Tesla, Inc.",
@@ -2781,7 +2758,6 @@
       "tags": {
         "amenity": "charging_station",
         "brand": "Toka",
-        "name": "Toka",
         "operator": "Toka"
       }
     },
@@ -2848,7 +2824,6 @@
       "tags": {
         "amenity": "charging_station",
         "brand": "VIRTA",
-        "name": "VIRTA",
         "operator": "VIRTA"
       }
     },
@@ -2983,7 +2958,6 @@
         "brand": "Белоруснефть",
         "brand:wikidata": "Q4082693",
         "brand:wikipedia": "ru:Белоруснефть",
-        "name": "Белоруснефть",
         "operator": "Белоруснефть",
         "operator:wikidata": "Q4082693",
         "operator:wikipedia": "ru:Белоруснефть"
@@ -3054,9 +3028,6 @@
         "brand:wikidata": "Q209078",
         "brand:wikipedia": "zh:国家电网",
         "brand:zh": "国家电网",
-        "name": "国家电网",
-        "name:en": "State Grid Corporation of China",
-        "name:zh": "国家电网",
         "operator": "国家电网",
         "operator:en": "State Grid Corporation of China",
         "operator:wikidata": "Q209078",
@@ -3075,9 +3046,6 @@
         "brand:ja": "東光高岳",
         "brand:wikidata": "Q17220263",
         "brand:wikipedia": "ja:東光高岳",
-        "name": "東光高岳",
-        "name:en": "Takaoka Toko",
-        "name:ja": "東光高岳",
         "operator": "東光高岳",
         "operator:en": "Takaoka Toko",
         "operator:ja": "東光高岳",


### PR DESCRIPTION
Delete `name` tag for charging stations.
According to OSM [wiki](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dcharging_station) it should not be used in that context.
There seems no information gain as `name` just duplicates the `operator` value.