### PR TITLE
Australian IGA stores

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -2744,14 +2744,24 @@
     },
     {
       "displayName": "IGA",
-      "id": "iga-5e6eb2",
-      "locationSet": {
-        "include": ["au", "ca", "us"]
-      },
+      "id": "iga-166dbe",
+      "locationSet": {"include": ["ca", "us"]},
       "tags": {
         "brand": "IGA",
         "brand:wikidata": "Q3146662",
         "brand:wikipedia": "en:IGA (supermarkets)",
+        "name": "IGA",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "IGA (Australia)",
+      "id": "iga-c254c9",
+      "locationSet": {"include": ["au"]},
+      "tags": {
+        "brand": "IGA",
+        "brand:wikidata": "Q5970945",
+        "brand:wikipedia": "en:IGA (Australian supermarket group)",
         "name": "IGA",
         "shop": "supermarket"
       }
@@ -4881,6 +4891,18 @@
         "brand:wikidata": "Q3741108",
         "brand:wikipedia": "en:Rimi Baltic",
         "name": "Rimi",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "Ritchies",
+      "id": "ritchies-c254c9",
+      "locationSet": {"include": ["au"]},
+      "tags": {
+        "brand": "Ritchies",
+        "brand:wikidata": "Q7336696",
+        "brand:wikipedia": "en:Ritchies Stores",
+        "name": "Ritchies",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
Separate the Australian IGA from the USA definition.   Add Ritchies which while an IGA franchisee is large enough to have its own branding.