### PR TITLE
Tweaks to QESH network

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -2036,9 +2036,8 @@
       "locationSet": {"include": ["au"]},
       "tags": {
         "amenity": "charging_station",
-        "operator": "Queensland Government",
-        "operator:wikidata": "Q3112627",
-        "operator:wikipedia": "en:Queensland Government"
+        "operator": "Yurika",
+        "operator:wikidata": "Q106234391"
       }
     },
     {


### PR DESCRIPTION
There's a lack of clarity around this network so I've tried to fix it up.
The network is called the "Queensland Electric Super Highway"
It was funded by The Queensland state government via the Department of Transport and Main Roads.
It is now branded as "Yurika", which is a subsidiary of Energy Queensland, which itself is a Queensland state government owned corporation.
The previous Qld Govt logo wasn't representative of the branding of the network itself so I've switched things up a bit.
Hopefully it's clear!