### PR TITLE
Add EV charging and hydrogen network

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -4128,6 +4128,16 @@
       }
     },
     {
+      "displayName": "True Zero",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "amenity": "fuel",
+        "brand": "True Zero",
+        "brand:wikidata": "Q106320436",
+        "name": "True Zero"
+      }
+    },
+    {
       "displayName": "Turkey Hill",
       "id": "turkeyhill-c5cf43",
       "locationSet": {"include": ["us"]},

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -4132,6 +4132,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "fuel",
+        "fuel:h70": "yes",
         "brand": "True Zero",
         "brand:wikidata": "Q106320436",
         "name": "True Zero"

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -461,7 +461,7 @@
     },
     {
       "displayName": "Charging the Regions",
-      "locationSet": {"include": ["au-vic"]},
+      "locationSet": {"include": ["au-vic.geojson"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Charging the Regions",

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -460,6 +460,17 @@
       }
     },
     {
+      "displayName": "Charging the Regions",
+      "locationSet": {"include": ["au-vic"]},
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Charging the Regions",
+        "brand:wikidata": "Q106320264",
+        "operator": "Central Victorian Greenhouse Alliance",
+        "operator:wikidata": "Q106320329"
+      }
+    },
+    {
       "displayName": "Chargy",
       "id": "chargy-026cfa",
       "locationSet": {"include": ["lu"]},
@@ -1695,6 +1706,16 @@
         "operator": "Mercadona",
         "operator:wikidata": "Q377705",
         "operator:wikipedia": "es:Mercadona"
+      }
+    },
+    {
+      "displayName": "Meridian Energy",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Meridian Energy",
+        "operator:wikidata": "Q6819305",
+        "operator:wikipedia": "en:Meridian Energy"
       }
     },
     {


### PR DESCRIPTION
Note: True Zero is a Californian hydrogen network operator.  Should "fuel:h70=yes" be added to the tags to ensure this is always included with locations associated with the brand?