### PR TITLE
Australian malls

### DIFF
--- a/data/brands/shop/mall.json
+++ b/data/brands/shop/mall.json
@@ -28,6 +28,7 @@
         "brand": "GPT Group",
         "brand:wikidata": "Q3100507",
         "brand:wikipedia": "en:GPT Group",
+        "name": "GPT Group",
         "shop": "mall"
       }
     },
@@ -55,6 +56,7 @@
         "brand": "Vicinity Centres",
         "brand:wikidata": "Q1054327",
         "brand:wikipedia": "en:Vicinity Centres",
+        "name": "Vicinity Centres",
         "shop": "mall"
       }
     },
@@ -79,6 +81,7 @@
       "locationSet": {"include": ["au", "nz"]},
       "tags": {
         "brand": "Westfield",
+        "name": "Westfield",
         "operator": "Scentre Group",
         "operator:wikidata": "Q18378048",
         "operator:wikipedia": "en:Scentre Group",

--- a/data/brands/shop/mall.json
+++ b/data/brands/shop/mall.json
@@ -32,18 +32,6 @@
       }
     },
     {
-      "displayName": "Scentre Group",
-      "id": "westfield-1e4415",
-      "locationSet": {"include": ["au", "nz"]},
-      "tags": {
-        "brand": "Westfield",
-        "operator": "Scentre Group",
-        "operator:wikidata": "Q18378048",
-        "operator:wikipedia": "en:Scentre Group",
-        "shop": "mall"
-      }
-    },
-    {
       "displayName": "The Mall Group",
       "id": "themallgroup-13d253",
       "locationSet": {"include": ["th"]},
@@ -82,6 +70,18 @@
         "brand:wikidata": "Q608518",
         "brand:wikipedia": "en:Unibail-Rodamco-Westfield",
         "name": "Westfield",
+        "shop": "mall"
+      }
+    },
+    {
+      "displayName": "Westfield (Australia)",
+      "id": "westfield-1e4415",
+      "locationSet": {"include": ["au", "nz"]},
+      "tags": {
+        "brand": "Westfield",
+        "operator": "Scentre Group",
+        "operator:wikidata": "Q18378048",
+        "operator:wikipedia": "en:Scentre Group",
         "shop": "mall"
       }
     },

--- a/data/brands/shop/mall.json
+++ b/data/brands/shop/mall.json
@@ -28,19 +28,18 @@
         "brand": "GPT Group",
         "brand:wikidata": "Q3100507",
         "brand:wikipedia": "en:GPT Group",
-        "name": "GPT Group",
         "shop": "mall"
       }
     },
     {
       "displayName": "Scentre Group",
-      "id": "scentregroup-1e4415",
+      "id": "westfield-1e4415",
       "locationSet": {"include": ["au", "nz"]},
       "tags": {
-        "brand": "Scentre Group",
-        "brand:wikidata": "Q18378048",
-        "brand:wikipedia": "en:Scentre Group",
-        "name": "Scentre Group",
+        "brand": "Westfield",
+        "operator": "Scentre Group",
+        "operator:wikidata": "Q18378048",
+        "operator:wikipedia": "en:Scentre Group",
         "shop": "mall"
       }
     },
@@ -65,10 +64,9 @@
       "id": "vicinitycentres-3fb812",
       "locationSet": {"include": ["au"]},
       "tags": {
-        "brand": "Scentre Group",
+        "brand": "Vicinity Centres",
         "brand:wikidata": "Q1054327",
         "brand:wikipedia": "en:Vicinity Centres",
-        "name": "Vicinity Centres",
         "shop": "mall"
       }
     },


### PR DESCRIPTION
Fix copy paste error on Vicinity Centres brand
Remove name from Vicinity and GPT, every mall has an individual name.

Change Scentre Group brand to Westfield (Australia) and make Scentre Group the operator.
Most people on the street will never have heard of Scentre group and Westfield is what appears on the buildings. 
Trouble is there isn't a current Westfield Australia wikidata I can link brand to. The one available is the "old" Westfield before it was split between Australia and International operations.
Open to advice on how to improve this.