### PR TITLE
Updates on bank brands in Poland

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -4317,18 +4317,6 @@
       }
     },
     {
-      "displayName": "Eurobank (Poland)",
-      "id": "eurobank-68054b",
-      "locationSet": {"include": ["pl"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Eurobank",
-        "brand:wikidata": "Q9256201",
-        "brand:wikipedia": "pl:Euro Bank",
-        "name": "Eurobank"
-      }
-    },
-    {
       "displayName": "Eurobank (Ελλάδα)",
       "id": "eurobank-f14c4e",
       "locationSet": {"include": ["gr"]},
@@ -6511,18 +6499,6 @@
       }
     },
     {
-      "displayName": "Pekao SA",
-      "id": "pekaosa-68054b",
-      "locationSet": {"include": ["pl"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Pekao SA",
-        "brand:wikidata": "Q806642",
-        "brand:wikipedia": "pl:Bank Polska Kasa Opieki",
-        "name": "Pekao SA"
-      }
-    },
-    {
       "displayName": "PenFed Credit Union",
       "id": "penfedcreditunion-ea2e2d",
       "locationSet": {"include": ["us"]},
@@ -6879,18 +6855,6 @@
         "brand:wikidata": "Q11220162",
         "brand:wikipedia": "en:Banque Raiffeisen",
         "name": "Raiffeisen"
-      }
-    },
-    {
-      "displayName": "Raiffeisen Polbank",
-      "id": "raiffeisenpolbank-3aae9e",
-      "locationSet": {"include": ["de", "pl"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Raiffeisen Polbank",
-        "brand:wikidata": "Q9303218",
-        "brand:wikipedia": "pl:Raiffeisen Bank Polska",
-        "name": "Raiffeisen Polbank"
       }
     },
     {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -2601,15 +2601,15 @@
       }
     },
     {
-      "displayName": "BGŻ BNP Paribas",
+      "displayName": "BNP Paribas Bank Polska",
       "id": "bgzbnpparibas-68054b",
       "locationSet": {"include": ["pl"]},
       "tags": {
         "amenity": "bank",
-        "brand": "BGŻ BNP Paribas",
+        "brand": "BNP Paribas Bank Polska",
         "brand:wikidata": "Q20744004",
         "brand:wikipedia": "pl:BNP Paribas Bank Polska",
-        "name": "BGŻ BNP Paribas"
+        "name": "BNP Paribas Polska"
       }
     },
     {
@@ -2849,7 +2849,10 @@
     {
       "displayName": "BNP Paribas",
       "id": "bnpparibas-b7a026",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": ["001"],
+        "exclude": ["pl"]
+      },
       "tags": {
         "amenity": "bank",
         "brand": "BNP Paribas",


### PR DESCRIPTION
Hello,
I reviewed some banks avaible in presets for Poland. I made following changes:
1. Since 30 Mar 2019 BGŻ BNP Paribas Bank in Poland changed brand name. Apart of that I'm excluding global BNP Paribas bank from Poland.
2. Raiffeisen is gone from Poland. They were present under name od Raiffeisen Polbank.
3. PEKAO SA is duplicate of Bank Pekao which is better suited name.
4. Eurobank is gone.

Those changes are part of my [automated edit proposal](https://wiki.openstreetmap.org/wiki/Automated_edits/kubahahaha_-_bot_account/Banks_in_Poland#Edit_NSI_templates) and [has been discussed](https://forum.openstreetmap.org/viewtopic.php?pid=824085) on polish OSM forum.