### PR TITLE
Updated Italian police tags

### DIFF
--- a/data/operators/amenity/police.json
+++ b/data/operators/amenity/police.json
@@ -13,12 +13,13 @@
       "displayName": "Arma dei Carabinieri",
       "id": "armadeicarabinieri-f71f16",
       "locationSet": {"include": ["it"]},
+      "matchNames": ["carabinieri"],
+      "matchTags": ["operator/carabinieri"]
       "tags": {
         "amenity": "police",
         "operator": "Arma dei Carabinieri",
         "operator:short": "Carabinieri",
-        "operator:wikidata": "Q54852",
-        "operator:wikipedia": "en:Carabinieri"
+        "operator:wikidata": "Q54852"
       }
     },
     {
@@ -225,17 +226,6 @@
       "tags": {
         "amenity": "police",
         "operator": "Comunidad de Madrid"
-      }
-    },
-    {
-      "displayName": "Corpo Forestale dello Stato",
-      "id": "corpoforestaledellostato-f71f16",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "amenity": "police",
-        "operator": "Corpo Forestale dello Stato",
-        "operator:wikidata": "Q1134650",
-        "operator:wikipedia": "it:Corpo forestale dello Stato"
       }
     },
     {
@@ -513,8 +503,7 @@
       "tags": {
         "amenity": "police",
         "operator": "Guardia Costiera",
-        "operator:wikidata": "Q1552839",
-        "operator:wikipedia": "it:Corpo delle capitanerie di porto - Guardia costiera"
+        "operator:wikidata": "Q1552839"
       }
     },
     {
@@ -524,8 +513,7 @@
       "tags": {
         "amenity": "police",
         "operator": "Guardia di Finanza",
-        "operator:wikidata": "Q1552861",
-        "operator:wikipedia": "it:Guardia di Finanza"
+        "operator:wikidata": "Q1552861"
       }
     },
     {
@@ -2098,23 +2086,14 @@
       }
     },
     {
-      "displayName": "Polizia",
-      "id": "polizia-f71f16",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "amenity": "police",
-        "operator": "Polizia"
-      }
-    },
-    {
       "displayName": "Polizia di Stato",
       "id": "poliziadistato-f71f16",
       "locationSet": {"include": ["it"]},
+      "matchNames": ["polizia"],
       "tags": {
         "amenity": "police",
         "operator": "Polizia di Stato",
-        "operator:wikidata": "Q897817",
-        "operator:wikipedia": "it:Polizia di Stato"
+        "operator:wikidata": "Q897817"
       }
     },
     {
@@ -2123,28 +2102,19 @@
       "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "police",
-        "operator": "Polizia Locale"
+        "operator": "Polizia Locale",
+        "operator:wikidata": "Q61634147"
       }
     },
     {
       "displayName": "Polizia Municipale",
       "id": "poliziamunicipale-f71f16",
       "locationSet": {"include": ["it"]},
+      "matchNames": ["vigili urbani"],
       "tags": {
         "amenity": "police",
-        "operator": "Polizia Municipale"
-      }
-    },
-    {
-      "displayName": "Polizia Stradale",
-      "id": "poliziastradale-f71f16",
-      "locationSet": {"include": ["it"]},
-      "note": "Highway Patrol; Subgroup of Polizia di Stato",
-      "tags": {
-        "amenity": "police",
-        "operator": "Polizia Stradale",
-        "operator:wikidata": "Q3907573",
-        "operator:wikipedia": "it:Polizia stradale"
+        "operator": "Polizia Municipale",
+        "operator:wikidata": "Q1431981"
       }
     },
     {

--- a/data/operators/amenity/police.json
+++ b/data/operators/amenity/police.json
@@ -14,7 +14,7 @@
       "id": "armadeicarabinieri-f71f16",
       "locationSet": {"include": ["it"]},
       "matchNames": ["carabinieri"],
-      "matchTags": ["operator/carabinieri"]
+      "matchTags": ["operator/carabinieri"],
       "tags": {
         "amenity": "police",
         "operator": "Arma dei Carabinieri",

--- a/data/operators/amenity/police.json
+++ b/data/operators/amenity/police.json
@@ -19,7 +19,8 @@
         "amenity": "police",
         "operator": "Arma dei Carabinieri",
         "operator:short": "Carabinieri",
-        "operator:wikidata": "Q54852"
+        "operator:wikidata": "Q54852",
+        "operator:wikipedia": "it:Arma dei Carabinieri"
       }
     },
     {
@@ -503,7 +504,8 @@
       "tags": {
         "amenity": "police",
         "operator": "Guardia Costiera",
-        "operator:wikidata": "Q1552839"
+        "operator:wikidata": "Q1552839",
+        "operator:wikipedia": "it:Guardia costiera"
       }
     },
     {
@@ -513,7 +515,8 @@
       "tags": {
         "amenity": "police",
         "operator": "Guardia di Finanza",
-        "operator:wikidata": "Q1552861"
+        "operator:wikidata": "Q1552861",
+        "operator:wikipedia": "it:Guardia di Finanza"
       }
     },
     {
@@ -2093,7 +2096,8 @@
       "tags": {
         "amenity": "police",
         "operator": "Polizia di Stato",
-        "operator:wikidata": "Q897817"
+        "operator:wikidata": "Q897817",
+        "operator:wikipedia": "it:Polizia di Stato"
       }
     },
     {
@@ -2103,7 +2107,8 @@
       "tags": {
         "amenity": "police",
         "operator": "Polizia Locale",
-        "operator:wikidata": "Q61634147"
+        "operator:wikidata": "Q61634147",
+        "operator:wikipedia": "it:Polizia locale (Italia)"
       }
     },
     {
@@ -2114,7 +2119,8 @@
       "tags": {
         "amenity": "police",
         "operator": "Polizia Municipale",
-        "operator:wikidata": "Q1431981"
+        "operator:wikidata": "Q1431981",
+        "operator:wikiperdia": "it:Polizia municipale"
       }
     },
     {


### PR DESCRIPTION
As [I promised](https://github.com/streetcomplete/StreetComplete/pull/2675#discussion_r617373834) to @michaelblyons, here are the updated tags for the Italian police!
What has changed:
- No Wikipedia links, we decided not to use Wikipedia tags, just Wikidata
- Removed Corpo Forestale dello Stato, it doesn't exist anymore
- Removed Polizia Stradale, we're still deciding how to tag these branches operated by Polizia di Stato
- Removed Polizia, too generic
- Added some matches, so when people write common names for these forces, the suggestion appears
- Added Wikidata elements to Polizia Locale and Polizia Municipale