### PR TITLE
add Madeira Brewery to beverages shops

### DIFF
--- a/data/brands/shop/beverages.json
+++ b/data/brands/shop/beverages.json
@@ -130,6 +130,17 @@
       }
     },
     {
+      "displayName": "Madeira Brewery",
+      "id": "madeirabrewery-48ec32",
+      "locationSet": {"include": ["pt"]},
+      "tags": {
+        "brand": "Madeira Brewery",
+        "brand:wikidata": "Q10272528",
+        "name": "Madeira Brewery",
+        "shop": "beverages"
+      }
+    },
+    {
       "displayName": "Markgrafen Getränkemarkt",
       "id": "markgrafengetrankemarkt-c4cb62",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
Added Madeira Brewery to beverages shops. The company is the biggest producer and drink distributor in the Autonomous Region of Madeira, Portugal.