### PR TITLE
Remove Liberty fuel from Australia

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -2389,7 +2389,7 @@
     {
       "displayName": "Liberty",
       "id": "liberty-734d12",
-      "locationSet": {"include": ["au", "us"]},
+      "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "fuel",
         "brand": "Liberty",


### PR DESCRIPTION
We have a petrol station called Liberty Oil in Australia, but it's not the one described by this entry.  
The Australian one doesn't have a serious online presence to be able to tag them correctly at the moment.  This will avoid confusing editors with the wrong wikidata.