### PR TITLE
Remove wikidata entry from Nelson Alexander.

### DIFF
--- a/data/brands/office/estate_agent.json
+++ b/data/brands/office/estate_agent.json
@@ -459,7 +459,6 @@
       "locationSet": {"include": ["au"]},
       "tags": {
         "brand": "Nelson Alexander",
-        "brand:wikidata": "Q106236053",
         "name": "Nelson Alexander",
         "office": "estate_agent"
       }


### PR DESCRIPTION
Someone on Wikidata decided it was "nonsensical" and not notable enough.  
I didn't see the alert in time to respond so it has been deleted.