### PR TITLE
Remove Caju Bike - bicycle_rental

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -902,17 +902,6 @@
       }
     },
     {
-      "displayName": "Caju Bike",
-      "id": "cajubike-c7dd41",
-      "locationSet": {"include": ["br"]},
-      "tags": {
-        "amenity": "bicycle_rental",
-        "brand": "Caju Bike",
-        "network": "Caju Bike",
-        "operator": "Caju Bike"
-      }
-    },
-    {
       "displayName": "Call a Bike",
       "id": "callabike-937152",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
This bicycle_rental is not active any more: https://infonet.com.br/noticias/cidade/operacao-do-caju-bike-e-encerrada-apos-fim-de-contrato/