### PR TITLE
Add "BMart" toy store and fix name and location of "Ri Happy"

### DIFF
--- a/data/brands/shop/toys.json
+++ b/data/brands/shop/toys.json
@@ -18,6 +18,17 @@
       }
     },
     {
+      "displayName": "BMart",
+      "id": "bmart-9c99b8",
+      "locationSet": {"include": ["br"]},
+      "tags": {
+        "brand": "BMart",
+        "brand:wikidata": "Q106752739",
+        "name": "BMart",
+        "shop": "toys"
+      }
+    },
+    {
       "displayName": "Build-A-Bear Workshop",
       "id": "buildabearworkshop-0e7d81",
       "locationSet": {
@@ -219,14 +230,14 @@
       }
     },
     {
-      "displayName": "Ri Happy Brinquedos",
-      "id": "rihappybrinquedos-27836a",
-      "locationSet": {"include": ["pt"]},
+      "displayName": "Ri Happy",
+      "id": "rihappy-9c99b8",
+      "locationSet": {"include": ["br"]},
       "tags": {
         "brand": "Ri Happy Brinquedos",
         "brand:wikidata": "Q10360441",
         "brand:wikipedia": "pt:Ri Happy Brinquedos",
-        "name": "Ri Happy Brinquedos",
+        "name": "Ri Happy",
         "shop": "toys"
       }
     },


### PR DESCRIPTION
🤖  Ri Happy Brinquedos is the official name of the company, but the name we see on the facade is only "Ri Happy". The correct location is Brazil, not Portugal.