### PR TITLE
Add HomeCo

### DIFF
--- a/data/brands/shop/mall.json
+++ b/data/brands/shop/mall.json
@@ -33,6 +33,18 @@
       }
     },
     {
+      "displayName": "HomeCo",
+      "id": "homeco-3fb812",
+      "locationSet": {"include": ["au"]},
+      "matchNames": ["home consortium"],
+      "tags": {
+        "brand": "HomeCo",
+        "brand:wikidata": "Q106773031",
+        "name": "HomeCo",
+        "shop": "mall"
+      }
+    },
+    {
       "displayName": "The Mall Group",
       "id": "themallgroup-13d253",
       "locationSet": {"include": ["th"]},


### PR DESCRIPTION
Add Home Consortium (HomeCo).  
They have approximately 30 locations across Australia in former Masters hardware stores.