### PR TITLE
Added Penti

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -4748,6 +4748,19 @@
       }
     },
     {
+      "displayName": "Penti",
+      "id": "penti-86c702",
+      "locationSet": {"include": ["tr"]},
+      "tags": {
+        "brand": "Penti",
+        "brand:wikidata": "Q28729986",
+        "brand:wikipedia": "tr:Penti",
+        "clothes": "underwear;women",
+        "name": "Penti",
+        "shop": "clothes"
+      }
+    },
+    {
       "displayName": "Pep",
       "id": "pep-c712e2",
       "locationSet": {


### PR DESCRIPTION
added Penti, a Turkish brand for women. has stores in most of the malls in the country.