### PR TITLE
Tesco Lotus to Lotus's

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -5615,14 +5615,14 @@
       }
     },
     {
-      "displayName": "Tesco Lotus",
+      "displayName": "Lotus's",
       "id": "tescolotus-fd4d8d",
-      "locationSet": {"include": ["th"]},
+      "locationSet": {"include": ["my", "th"]},
       "tags": {
-        "brand": "Tesco Lotus",
+        "brand": "Lotus's",
         "brand:wikidata": "Q2378901",
-        "brand:wikipedia": "th:โลตัส (ห้างสรรพสินค้า)",
-        "name": "Tesco Lotus",
+        "brand:wikipedia": "en:Lotus's",
+        "name": "Lotus's",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
Lotus's rebranding in Malaysia and Thailand by end of the year.
https://asia.nikkei.com/Business/Retail/Tesco-disappears-from-Southeast-Asia-as-CP-renames-outlets