### PR TITLE
Remove MyMydin

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -837,7 +837,7 @@
     {
       "displayName": "CU",
       "id": "cu-fab923",
-      "locationSet": {"include": ["kr"]},
+      "locationSet": {"include": ["kr", "my"]},
       "tags": {
         "brand": "CU",
         "brand:wikidata": "Q12580836",
@@ -1990,19 +1990,6 @@
         "brand:wikidata": "Q11342034",
         "brand:wikipedia": "ja:ミスターマックス・ホールディングス",
         "name": "MrMax",
-        "shop": "convenience"
-      }
-    },
-    {
-      "displayName": "MyMidin",
-      "id": "mymydin-3e5671",
-      "locationSet": {"include": ["my"]},
-      "matchTags": ["shop/supermarket"],
-      "tags": {
-        "brand": "Mydin",
-        "brand:wikidata": "Q6947269",
-        "brand:wikipedia": "en:Mydin",
-        "name": "MyMydin",
         "shop": "convenience"
       }
     },


### PR DESCRIPTION
Remove MyMydin，who already rebranded as Mydin Mart (more to variety store in a wholesale mode) and CU convenience store launched in Malaysia also

References
https://m.facebook.com/MydinMalaysia/photos/a.558332224201385/4336679349699968/?type=3&source=48&__tn__=EH-R
(Latest Mydin outlets with operation time)

https://m.facebook.com/pg/Malaysia.CU/about/?ref=page_internal&mt_nav=0
CU Malaysia page