### PR TITLE
Add Veritas in Belgium

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -6402,6 +6402,17 @@
       }
     },
     {
+      "displayName": "Veritas",
+      "locationSet": {"include": ["be", "lu"]},
+      "tags": {
+        "brand": "Veritas",
+        "brand:wikidata": "Q56239194",
+        "brand:wikipedia": "nl:Veritas (winkel)",
+        "operator": "Veritas NV",
+        "shop": "clothes;sewing"
+      }
+    },
+    {
       "displayName": "Vero Moda",
       "id": "veromoda-3937bd",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Adds Veritas which is a clothing and sewing store in Belgium.

It seems that `npm run build` removes the _sewing_ tag, 
I don't know if it is possible to have multiple values or is there another method to represent multiple values?
