### PR TITLE
Distinction between ALDI Nord and ALDI Süd

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -3433,6 +3433,18 @@
         "shop": "clothes"
       }
     },
+	{
+      "displayName": "Kult",
+      "locationSet": {
+        "include": ["de"]
+      },
+      "tags": {
+        "brand": "Kult",
+        "brand:wikidata": "Q107083144",
+        "name": "Kult",
+        "shop": "clothes"
+      }
+    },
     {
       "displayName": "La Compagnie des Petits",
       "id": "lacompagniedespetits-658d81",

--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -1191,6 +1191,7 @@
       },
       "tags": {
         "brand": "Cecil",
+		"brand:wikidata": "Q101246192",
         "name": "Cecil",
         "shop": "clothes"
       }

--- a/data/brands/shop/shoes.json
+++ b/data/brands/shop/shoes.json
@@ -934,6 +934,17 @@
         "shop": "shoes"
       }
     },
+	{
+      "displayName": "MyShoes",
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["My Shoes"],
+      "tags": {
+        "brand": "MyShoes",
+        "brand:wikidata": "Q107091147",
+        "name": "MyShoes",
+        "shop": "shoes"
+      }
+    },
     {
       "displayName": "Naturalizer",
       "id": "naturalizer-856a0b",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -195,60 +195,58 @@
       }
     },
     {
-      "displayName": "Aldi Nord",
-      "id": "aldinord-0a839e",
-      "locationSet": {"include": ["de","fr","es","pt","pl","dk","be","nl","lu"]},
+      "displayName": "ALDI",
+      "locationSet": {
+        "include": ["au", "cn", "ch", "gb", "hu", "ie", "it", "us"],
+		"exclude": ["de"]
+      },
+	  "note": "countries in which ALDI Süd group is active",
       "tags": {
-        "brand": "Aldi Nord",
-		"brand:fr": "Aldi",
-		"brand:es": "Aldi",
-		"brand:pt": "Aldi",
-		"brand:pl": "Aldi",
-		"brand:dk": "Aldi",
-		"brand:be": "Aldi",
-		"brand:nl": "Aldi",
-		"brand:lu": "Aldi",
+        "brand": "ALDI",
+        "brand:wikidata": "Q41171672",
+        "brand:wikipedia": "en:Aldi",
+        "name": "ALDI",
+        "shop": "supermarket"
+      }
+    },
+	{
+      "displayName": "ALDI",
+      "locationSet": {
+        "include": ["be", "dk", "fr", "lu", "nl", "pl", "es", "pt"],
+		"exclude": ["de"]
+      },
+	  "note": "countries in which ALDI Nord group is active",
+      "tags": {
+        "brand": "ALDI",
         "brand:wikidata": "Q41171373",
         "brand:wikipedia": "en:Aldi",
-        "name": "Aldi",
-		"name:de": "Aldi Nord",
-		"name:fr": "Aldi",
-		"name:es": "Aldi",
-		"name:pt": "Aldi",
-		"name:pl": "Aldi",
-		"name:dk": "Aldi",
-		"name:be": "Aldi",
-		"name:nl": "Aldi",
-		"name:lu": "Aldi",
+        "name": "ALDI",
         "shop": "supermarket"
       }
     },
     {
-      "displayName": "Aldi Süd",
-      "id": "aldisud-0a839e",
-      "locationSet": {"include": ["de","us","gb","ie","au","ch","cn","hu","it"]},
+      "displayName": "ALDI Nord",
+      "id": "aldinord-0a839e",
+      "locationSet": {"include": ["de"]},
+	  "note": "German ALDI Nord branding",
       "tags": {
-        "brand": "Aldi Süd",
-		"brand:us": "Aldi",
-		"brand:gb": "Aldi",
-		"brand:ie": "Aldi",
-		"brand:au": "Aldi",
-		"brand:ch": "Aldi",
-		"brand:cn": "Aldi",
-		"brand:hu": "Aldi",
-		"brand:it": "Aldi",
+        "brand": "ALDI Nord",
+        "brand:wikidata": "Q41171373",
+        "brand:wikipedia": "en:Aldi",
+        "name": "ALDI Nord",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "ALDI Süd",
+      "id": "aldisud-0a839e",
+      "locationSet": {"include": ["de"]},
+	  "note": "German ALDI Süd branding",
+      "tags": {
+        "brand": "ALDI Süd",
         "brand:wikidata": "Q41171672",
         "brand:wikipedia": "en:Aldi",
-        "name": "Aldi",
-		"name:de": "Aldi Süd",
-		"name:us": "Aldi",
-		"name:gb": "Aldi",
-		"name:ie": "Aldi",
-		"name:au": "Aldi",
-		"name:ch": "Aldi",
-		"name:cn": "Aldi",
-		"name:hu": "Aldi",
-		"name:it": "Aldi",
+        "name": "ALDI Süd",
         "shop": "supermarket"
       }
     },

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -195,7 +195,7 @@
       }
     },
     {
-      "displayName": "ALDI",
+      "displayName": "ALDI (ALDI Süd group)",
       "locationSet": {
         "include": ["au", "cn", "ch", "gb", "hu", "ie", "it", "us"],
 		"exclude": ["de"]
@@ -210,7 +210,7 @@
       }
     },
 	{
-      "displayName": "ALDI",
+      "displayName": "ALDI (ALDI Nord group)",
       "locationSet": {
         "include": ["be", "dk", "fr", "lu", "nl", "pl", "es", "pt"],
 		"exclude": ["de"]

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -195,40 +195,60 @@
       }
     },
     {
-      "displayName": "Aldi",
-      "id": "aldi-883bfe",
-      "locationSet": {
-        "include": ["150", "au", "us"]
-      },
-      "tags": {
-        "brand": "Aldi",
-        "brand:wikidata": "Q125054",
-        "brand:wikipedia": "en:Aldi",
-        "name": "Aldi",
-        "shop": "supermarket"
-      }
-    },
-    {
       "displayName": "Aldi Nord",
       "id": "aldinord-0a839e",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {"include": ["de","fr","es","pt","pl","dk","be","nl","lu"]},
       "tags": {
         "brand": "Aldi Nord",
+		"brand:fr": "Aldi",
+		"brand:es": "Aldi",
+		"brand:pt": "Aldi",
+		"brand:pl": "Aldi",
+		"brand:dk": "Aldi",
+		"brand:be": "Aldi",
+		"brand:nl": "Aldi",
+		"brand:lu": "Aldi",
         "brand:wikidata": "Q41171373",
         "brand:wikipedia": "en:Aldi",
-        "name": "Aldi Nord",
+        "name": "Aldi",
+		"name:de": "Aldi Nord",
+		"name:fr": "Aldi",
+		"name:es": "Aldi",
+		"name:pt": "Aldi",
+		"name:pl": "Aldi",
+		"name:dk": "Aldi",
+		"name:be": "Aldi",
+		"name:nl": "Aldi",
+		"name:lu": "Aldi",
         "shop": "supermarket"
       }
     },
     {
       "displayName": "Aldi Süd",
       "id": "aldisud-0a839e",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {"include": ["de","us","gb","ie","au","ch","cn","hu","it"]},
       "tags": {
         "brand": "Aldi Süd",
+		"brand:us": "Aldi",
+		"brand:gb": "Aldi",
+		"brand:ie": "Aldi",
+		"brand:au": "Aldi",
+		"brand:ch": "Aldi",
+		"brand:cn": "Aldi",
+		"brand:hu": "Aldi",
+		"brand:it": "Aldi",
         "brand:wikidata": "Q41171672",
         "brand:wikipedia": "en:Aldi",
-        "name": "Aldi Süd",
+        "name": "Aldi",
+		"name:de": "Aldi Süd",
+		"name:us": "Aldi",
+		"name:gb": "Aldi",
+		"name:ie": "Aldi",
+		"name:au": "Aldi",
+		"name:ch": "Aldi",
+		"name:cn": "Aldi",
+		"name:hu": "Aldi",
+		"name:it": "Aldi",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
There is no legal company or common brand named **ALDI**, it's either ALDI **Nord** or ALDI **Süd**

This are two completely independent companies with own branding. In each country stores are either operated by ALDI Nord **or** ALDI Süd, but never mixed. In Germany there's the so called "ALDI equator": all stores in Northern Germany belong to ALDI Nord, all stores in Southern Germany belong to ALDI Süd.

Thus removed the (misleading) general ALDI entity and assigned each country to either Aldi Süd or ALDI Nord