### PR TITLE
Change brand for Woolworths Petrol

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -4680,7 +4680,7 @@
       "locationSet": {"include": ["au"]},
       "tags": {
         "amenity": "fuel",
-        "brand": "Caltex",
+        "brand": "Ampol",
         "brand:wikidata": "Q5023980",
         "brand:wikipedia": "en:EG Australia",
         "name": "Woolworths Petrol"


### PR DESCRIPTION
Ampol is the new name for Caltex in Australia.  
They remain the fuel supplier to Euro Garages Australia (who are taking forever to remove the Woolworths Petrol name anywhere....)