### PR TITLE
changes on German brands

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1845,6 +1845,17 @@
       }
     },
     {
+      "displayName": "EDEKA aktiv markt",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "brand": "Edeka",
+        "brand:wikidata": "Q701755",
+        "brand:wikipedia": "de:Edeka",
+        "name": "EDEKA aktiv markt",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Edeka xpress",
       "id": "edekaxpress-0a839e",
       "locationSet": {"include": ["de"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1904,6 +1904,18 @@
       }
     },
     {
+      "displayName": "Elli",
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["Elli-Markt"],
+      "tags": {
+        "brand": "Elli",
+        "brand:wikidata": "Q701755",
+        "brand:wikipedia": "de:Edeka",
+        "name": "Elli",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "EMTÉ",
       "id": "emte-5811b5",
       "locationSet": {"include": ["nl"]},

--- a/data/brands/shop/wine.json
+++ b/data/brands/shop/wine.json
@@ -8,6 +8,7 @@
       "displayName": "Jacques’ Wein-Depot",
       "id": "jacquesweindepot-f93b7c",
       "locationSet": {"include": ["at", "de"]},
+      "matchTags": ["shop/alcohol", "shop/beverages"],
       "tags": {
         "brand": "Jacques’ Wein-Depot",
         "brand:wikidata": "Q1678150",


### PR DESCRIPTION
added 2 EDEKA sub-brands, which are used for in various regions / various shop formats
also added common matchTags for Jacques Weindepot