### PR TITLE
Add: Marco's Pizza

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -2905,7 +2905,6 @@
     },
     {
       "displayName": "Marco's Pizza",
-      "id": "marcospizza-70373b",
       "locationSet": {
         "include": ["bs", "pr", "us"]
       },

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -2904,6 +2904,23 @@
       }
     },
     {
+      "displayName": "Marco's Pizza",
+      "id": "marcospizza-70373b",
+      "locationSet": {
+        "include": ["bs", "pr", "us"]
+      },
+      "matchNames": ["marcos"],
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Marco's Pizza",
+        "brand:wikidata": "Q6757382",
+        "brand:wikipedia": "en:Marco's Pizza",
+        "cuisine": "pizza",
+        "name": "Marco's Pizza",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Marrybrown",
       "id": "marrybrown-9b2018",
       "locationSet": {


### PR DESCRIPTION
- I acknowledge that all my contributions will be made under the project's license.
- I only edited the data/brands/amentity/fast_food.json file.
-- Added notable pizza chain (1,000 stores across 34 states in the US, Puerto Rico, & Bahamas).