### PR TITLE
Update chemist.json

### DIFF
--- a/data/brands/shop/chemist.json
+++ b/data/brands/shop/chemist.json
@@ -361,6 +361,7 @@
       "locationSet": {"include": ["it"]},
       "tags": {
         "brand": "Tigotà",
+        "brand:wikidata": "Q107464330",
         "name": "Tigotà",
         "shop": "chemist"
       }


### PR DESCRIPTION
add Wikidata element to Tigotà (Italian chemist shop chain)