### PR TITLE
Corrected wikidata ID of Swiss Post

### DIFF
--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -363,8 +363,7 @@
         "operator:en": "Swiss Post",
         "operator:fr": "La Poste",
         "operator:it": "La Posta",
-        "operator:wikidata": "Q614803",
-        "operator:wikipedia": "de:Die Schweizerische Post"
+        "operator:wikidata": "Q107231758",
       }
     },
     {


### PR DESCRIPTION
Corrected wikidata ID of Swiss Post, which is [Q107231758](https://www.wikidata.org/wiki/Q107231758).

Note that [Q614803](https://www.wikidata.org/wiki/Q614803) is the Wikidata ID for "Die Schweizerische Post AG", the parent organisation of "Swiss Post" (official company name: "Post CH AG"), to which "PostFinance AG" (financial institution) and "PostAuto AG" (bus company) also belong.

By the way, `operator=*` is currently set to "Die Post", the German brand name, but it should either be set to "Die Post" in German-speaking municipalities, "La Poste" in French-speaking municipalities or "La Posta" in Italian- and Romansh-speaking municipalities. How can this be solved? Is it possible to omit `operator=*` or to add two additional entries for `operator=La Poste` and `operator=La Posta`?