### PR TITLE
GB Coop improvments

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -690,6 +690,7 @@
     },
     {
       "displayName": "Central England Co-operative",
+      "id": "centralenglandcoop-4fbfd3",
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
@@ -703,6 +704,7 @@
     },
     {
       "displayName": "Midcounties Co-operative",
+      "id": "midcountiescoop-fe00f8",
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
@@ -716,6 +718,7 @@
     },
     {
       "displayName": "Southern Co-operative",
+      "id": "southerncoop-81d078",
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
@@ -742,6 +745,7 @@
     },
     {
       "displayName": "Chelmsford Star Co-operative Society",
+      "id": "chelmsfordcoop-a7f467",
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
@@ -755,6 +759,7 @@
     },
     {
       "displayName": "Heart of England Co-operative Society",
+      "id": "heartofenglandcoop-e84bb3",
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
@@ -781,6 +786,7 @@
     },
     {
       "displayName": "Radstock Co-operative Society",
+      "id": "radstock-65ec30",
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -728,6 +728,19 @@
       }
     },
     {
+      "displayName": "CO-OP Daily",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "CO-OP Daily",
+        "brand:wikidata": "Q5329759",
+        "brand:wikipedia": "en:East of England Co-operative Society",
+        "name": "CO-OP Daily",
+        "operator": "East of England Co-operative Society",
+        "operator:wikidata": "Q5329759",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "CocciMarket",
       "id": "coccimarket-bf3eb4",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -689,6 +689,19 @@
       }
     },
     {
+      "displayName": "Central England Co-operative",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "The Co-operative Food",
+        "brand:wikidata": "Q16986583",
+        "brand:wikipedia": "en:Central England Co-operative",
+        "name": "The Co-operative Food",
+        "operator": "Central England Co-operative",
+        "operator:wikidata": "Q16986583",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "CocciMarket",
       "id": "coccimarket-bf3eb4",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -694,8 +694,7 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
-        "brand:wikidata": "Q16986583",
-        "brand:wikipedia": "en:Central England Co-operative",
+        "brand:wikidata": "Q107617274",
         "name": "The Co-operative Food",
         "operator": "Central England Co-operative",
         "operator:wikidata": "Q16986583",
@@ -708,8 +707,7 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
-        "brand:wikidata": "Q6841138",
-        "brand:wikipedia": "en:Midcounties Co-operative",
+        "brand:wikidata": "Q107617274",
         "name": "The Co-operative Food",
         "operator": "Midcounties Co-operative",
         "operator:wikidata": "Q6841138",
@@ -722,8 +720,7 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
-        "brand:wikidata": "Q7569773",
-        "brand:wikipedia": "en:Southern Co-operative",
+        "brand:wikidata": "Q107617274",
         "name": "The Co-operative Food",
         "operator": "Southern Co-operative",
         "operator:wikidata": "Q7569773",
@@ -748,8 +745,7 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
-        "brand:wikidata": "Q5089972",
-        "brand:wikipedia": "en:Chelmsford Star Co-operative Society",
+        "brand:wikidata": "Q107617274",
         "name": "The Co-operative Food",
         "operator": "Chelmsford Star Co-operative Society",
         "operator:wikidata": "Q5089972",
@@ -762,8 +758,7 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
-        "brand:wikidata": "Q5692254",
-        "brand:wikipedia": "en:Heart of England Co-operative Society",
+        "brand:wikidata": "Q107617274",
         "name": "The Co-operative Food",
         "operator": "Heart of England Co-operative Society",
         "operator:wikidata": "Q5692254",
@@ -788,8 +783,7 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
-        "brand:wikidata": "Q7281698",
-        "brand:wikipedia": "en:Radstock Co-operative Society",
+        "brand:wikidata": "Q107617274",
         "name": "The Co-operative Food",
         "operator": "Radstock Co-operative Society",
         "operator:wikidata": "Q7281698",

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -676,7 +676,8 @@
       "id": "coopfood-232829",
       "locationSet": {"include": ["gb"]},
       "matchNames": [
-        "coop"
+        "coop",
+        "The Co-operative Group"
       ],
       "tags": {
         "brand": "Co-op Food",
@@ -689,41 +690,21 @@
       }
     },
     {
-      "displayName": "Central England Co-operative",
-      "id": "centralenglandcoop-4fbfd3",
+      "displayName": "The Co-operative Food",
       "locationSet": {"include": ["gb"]},
+      "matchNames": [
+        "coop",
+        "Central England Co-operative",
+        "Midcounties Co-operative",
+        "Southern Co-operative",
+        "Chelmsford Star Co-operative Society",
+        "Heart of England Co-operative Society",
+        "Radstock Co-operative Society"
+      ],
       "tags": {
         "brand": "The Co-operative Food",
         "brand:wikidata": "Q107617274",
         "name": "The Co-operative Food",
-        "operator": "Central England Co-operative",
-        "operator:wikidata": "Q16986583",
-        "shop": "convenience"
-      }
-    },
-    {
-      "displayName": "Midcounties Co-operative",
-      "id": "midcountiescoop-fe00f8",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "brand": "The Co-operative Food",
-        "brand:wikidata": "Q107617274",
-        "name": "The Co-operative Food",
-        "operator": "Midcounties Co-operative",
-        "operator:wikidata": "Q6841138",
-        "shop": "convenience"
-      }
-    },
-    {
-      "displayName": "Southern Co-operative",
-      "id": "southerncoop-81d078",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "brand": "The Co-operative Food",
-        "brand:wikidata": "Q107617274",
-        "name": "The Co-operative Food",
-        "operator": "Southern Co-operative",
-        "operator:wikidata": "Q7569773",
         "shop": "convenience"
       }
     },
@@ -740,32 +721,6 @@
       }
     },
     {
-      "displayName": "Chelmsford Star Co-operative Society",
-      "id": "chelmsfordcoop-a7f467",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "brand": "The Co-operative Food",
-        "brand:wikidata": "Q107617274",
-        "name": "The Co-operative Food",
-        "operator": "Chelmsford Star Co-operative Society",
-        "operator:wikidata": "Q5089972",
-        "shop": "convenience"
-      }
-    },
-    {
-      "displayName": "Heart of England Co-operative Society",
-      "id": "heartofenglandcoop-e84bb3",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "brand": "The Co-operative Food",
-        "brand:wikidata": "Q107617274",
-        "name": "The Co-operative Food",
-        "operator": "Heart of England Co-operative Society",
-        "operator:wikidata": "Q5692254",
-        "shop": "convenience"
-      }
-    },
-    {
       "displayName": "Co-operative Locale",
       "locationSet": {"include": ["gg", "je"]},
       "tags": {
@@ -774,19 +729,6 @@
         "name": "Co-operative Locale",
         "operator": "Channel Islands Co-operative Society",
         "operator:wikidata": "Q5072404",
-        "shop": "convenience"
-      }
-    },
-    {
-      "displayName": "Radstock Co-operative Society",
-      "id": "radstock-65ec30",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "brand": "The Co-operative Food",
-        "brand:wikidata": "Q107617274",
-        "name": "The Co-operative Food",
-        "operator": "Radstock Co-operative Society",
-        "operator:wikidata": "Q7281698",
         "shop": "convenience"
       }
     },

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -775,8 +775,7 @@
       "locationSet": {"include": ["gg", "je"]},
       "tags": {
         "brand": "Co-operative Locale",
-        "brand:wikidata": "Q5072404",
-        "brand:wikipedia": "en:Channel Islands Co-operative Society",
+        "brand:wikidata": "Q107594899",
         "name": "Co-operative Locale",
         "operator": "Channel Islands Co-operative Society",
         "operator:wikidata": "Q5072404",

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -793,6 +793,19 @@
       }
     },
     {
+      "displayName": "Clydebank Co-operative Society",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "Clydebank Co-operative",
+        "brand:wikidata": "Q5137069",
+        "brand:wikipedia": "en:Clydebank Co-operative Society",
+        "name": "Clydebank Co-operative",
+        "operator": "Clydebank Co-operative Society",
+        "operator:wikidata": "Q5137069",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "CocciMarket",
       "id": "coccimarket-bf3eb4",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -715,6 +715,19 @@
       }
     },
     {
+      "displayName": "Southern Co-operative",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "The Co-operative Food",
+        "brand:wikidata": "Q7569773",
+        "brand:wikipedia": "en:Southern Co-operative",
+        "name": "The Co-operative Food",
+        "operator": "Southern Co-operative",
+        "operator:wikidata": "Q7569773",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "CocciMarket",
       "id": "coccimarket-bf3eb4",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -754,6 +754,19 @@
       }
     },
     {
+      "displayName": "Heart of England Co-operative Society",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "The Co-operative Food",
+        "brand:wikidata": "Q5692254",
+        "brand:wikipedia": "en:Heart of England Co-operative Society",
+        "name": "The Co-operative Food",
+        "operator": "Heart of England Co-operative Society",
+        "operator:wikidata": "Q5692254",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "CocciMarket",
       "id": "coccimarket-bf3eb4",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -676,16 +676,15 @@
       "id": "coopfood-232829",
       "locationSet": {"include": ["gb"]},
       "matchNames": [
-        "coop",
-        "cooperative food",
-        "the co-operative food",
-        "the cooperative"
+        "coop"
       ],
       "tags": {
         "brand": "Co-op Food",
         "brand:wikidata": "Q3277439",
         "brand:wikipedia": "en:Co-op Food",
         "name": "Co-op Food",
+        "operator": "The Co-operative Group",
+        "operator:wikidata": "Q117202",
         "shop": "convenience"
       }
     },

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -702,6 +702,19 @@
       }
     },
     {
+      "displayName": "Midcounties Co-operative",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "The Co-operative Food",
+        "brand:wikidata": "Q6841138",
+        "brand:wikipedia": "en:Midcounties Co-operative",
+        "name": "The Co-operative Food",
+        "operator": "Midcounties Co-operative",
+        "operator:wikidata": "Q6841138",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "CocciMarket",
       "id": "coccimarket-bf3eb4",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -767,6 +767,19 @@
       }
     },
     {
+      "displayName": "Co-operative Locale",
+      "locationSet": {"include": ["gg", "je"]},
+      "tags": {
+        "brand": "Co-operative Locale",
+        "brand:wikidata": "Q5072404",
+        "brand:wikipedia": "en:Channel Islands Co-operative Society",
+        "name": "Co-operative Locale",
+        "operator": "Channel Islands Co-operative Society",
+        "operator:wikidata": "Q5072404",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "CocciMarket",
       "id": "coccimarket-bf3eb4",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -731,12 +731,11 @@
       }
     },
     {
-      "displayName": "CO-OP Daily",
+      "displayName": "Co-op Daily",
       "locationSet": {"include": ["gb"]},
       "tags": {
-        "brand": "CO-OP Daily",
-        "brand:wikidata": "Q5329759",
-        "brand:wikipedia": "en:East of England Co-operative Society",
+        "brand": "Co-op Daily",
+        "brand:wikidata": "Q107589681",
         "name": "CO-OP Daily",
         "operator": "East of England Co-operative Society",
         "operator:wikidata": "Q5329759",

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -741,6 +741,19 @@
       }
     },
     {
+      "displayName": "Chelmsford Star Co-operative Society",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "The Co-operative Food",
+        "brand:wikidata": "Q5089972",
+        "brand:wikipedia": "en:Chelmsford Star Co-operative Society",
+        "name": "The Co-operative Food",
+        "operator": "Chelmsford Star Co-operative Society",
+        "operator:wikidata": "Q5089972",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "CocciMarket",
       "id": "coccimarket-bf3eb4",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -780,6 +780,19 @@
       }
     },
     {
+      "displayName": "Radstock Co-operative Society",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "The Co-operative Food",
+        "brand:wikidata": "Q7281698",
+        "brand:wikipedia": "en:Radstock Co-operative Society",
+        "name": "The Co-operative Food",
+        "operator": "Radstock Co-operative Society",
+        "operator:wikidata": "Q7281698",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "CocciMarket",
       "id": "coccimarket-bf3eb4",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1093,6 +1093,19 @@
       }
     },
     {
+      "displayName": "Southern Co-operative",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "The Co-operative Food",
+        "brand:wikidata": "Q7569773",
+        "brand:wikipedia": "en:Southern Co-operative",
+        "name": "The Co-operative Food",
+        "operator": "Southern Co-operative",
+        "operator:wikidata": "Q7569773",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Coccinelle Express",
       "id": "coccinelleexpress-c16b1c",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1145,6 +1145,19 @@
       }
     },
     {
+      "displayName": "Co-operative Grand Marché",
+      "locationSet": {"include": ["gg", "je"]},
+      "tags": {
+        "brand": "Co-operative Grand Marché",
+        "brand:wikidata": "Q5072404",
+        "brand:wikipedia": "en:Channel Islands Co-operative Society",
+        "name": "Co-operative Grand Marché",
+        "operator": "Channel Islands Co-operative Society",
+        "operator:wikidata": "Q5072404",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Coccinelle Express",
       "id": "coccinelleexpress-c16b1c",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1132,6 +1132,19 @@
       }
     },
     {
+      "displayName": "Heart of England Co-operative Society",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "The Co-operative Food",
+        "brand:wikidata": "Q5692254",
+        "brand:wikipedia": "en:Heart of England Co-operative Society",
+        "name": "The Co-operative Food",
+        "operator": "Heart of England Co-operative Society",
+        "operator:wikidata": "Q5692254",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Coccinelle Express",
       "id": "coccinelleexpress-c16b1c",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1071,8 +1071,7 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
-        "brand:wikidata": "Q16986583",
-        "brand:wikipedia": "en:Central England Co-operative",
+        "brand:wikidata": "Q107617274",
         "name": "The Co-operative Food",
         "operator": "Central England Co-operative",
         "operator:wikidata": "Q16986583",
@@ -1084,8 +1083,7 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
-        "brand:wikidata": "Q6841138",
-        "brand:wikipedia": "en:Midcounties Co-operative",
+        "brand:wikidata": "Q107617274",
         "name": "The Co-operative Food",
         "operator": "Midcounties Co-operative",
         "operator:wikidata": "Q6841138",
@@ -1097,8 +1095,7 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
-        "brand:wikidata": "Q7569773",
-        "brand:wikipedia": "en:Southern Co-operative",
+        "brand:wikidata": "Q107617274",
         "name": "The Co-operative Food",
         "operator": "Southern Co-operative",
         "operator:wikidata": "Q7569773",
@@ -1123,8 +1120,7 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
-        "brand:wikidata": "Q5089972",
-        "brand:wikipedia": "en:Chelmsford Star Co-operative Society",
+        "brand:wikidata": "Q107617274",
         "name": "The Co-operative Food",
         "operator": "Chelmsford Star Co-operative Society",
         "operator:wikidata": "Q5089972",
@@ -1136,8 +1132,7 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "The Co-operative Food",
-        "brand:wikidata": "Q5692254",
-        "brand:wikipedia": "en:Heart of England Co-operative Society",
+        "brand:wikidata": "Q107617274",
         "name": "The Co-operative Food",
         "operator": "Heart of England Co-operative Society",
         "operator:wikidata": "Q5692254",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1054,16 +1054,15 @@
       "id": "coopfood-a8278b",
       "locationSet": {"include": ["gb"]},
       "matchNames": [
-        "coop",
-        "cooperative food",
-        "the co-operative food",
-        "the cooperative"
+        "coop"
       ],
       "tags": {
         "brand": "Co-op Food",
         "brand:wikidata": "Q3277439",
         "brand:wikipedia": "en:Co-op Food",
         "name": "Co-op Food",
+        "operator": "The Co-operative Group",
+        "operator:wikidata": "Q117202",
         "shop": "supermarket"
       }
     },

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1115,7 +1115,20 @@
         "name": "East of England CO-OP",
         "operator": "East of England Co-operative Society",
         "operator:wikidata": "Q5329759",
-        "shop": "convenience"
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "Chelmsford Star Co-operative Society",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "The Co-operative Food",
+        "brand:wikidata": "Q5089972",
+        "brand:wikipedia": "en:Chelmsford Star Co-operative Society",
+        "name": "The Co-operative Food",
+        "operator": "Chelmsford Star Co-operative Society",
+        "operator:wikidata": "Q5089972",
+        "shop": "supermarket"
       }
     },
     {

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1106,6 +1106,19 @@
       }
     },
     {
+      "displayName": "East of England CO-OP",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "East of England CO-OP",
+        "brand:wikidata": "Q5329759",
+        "brand:wikipedia": "en:East of England Co-operative Society",
+        "name": "East of England CO-OP",
+        "operator": "East of England Co-operative Society",
+        "operator:wikidata": "Q5329759",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "Coccinelle Express",
       "id": "coccinelleexpress-c16b1c",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1054,7 +1054,8 @@
       "id": "coopfood-a8278b",
       "locationSet": {"include": ["gb"]},
       "matchNames": [
-        "coop"
+        "coop",
+        "The Co-operative Group"
       ],
       "tags": {
         "brand": "Co-op Food",
@@ -1067,38 +1068,20 @@
       }
     },
     {
-      "displayName": "Central England Co-operative",
+      "displayName": "The Co-operative Food",
       "locationSet": {"include": ["gb"]},
+      "matchNames": [
+        "coop",
+        "Central England Co-operative",
+        "Midcounties Co-operative",
+        "Southern Co-operative",
+        "Chelmsford Star Co-operative Society",
+        "Heart of England Co-operative Society"
+      ],
       "tags": {
         "brand": "The Co-operative Food",
         "brand:wikidata": "Q107617274",
         "name": "The Co-operative Food",
-        "operator": "Central England Co-operative",
-        "operator:wikidata": "Q16986583",
-        "shop": "supermarket"
-      }
-    },
-    {
-      "displayName": "Midcounties Co-operative",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "brand": "The Co-operative Food",
-        "brand:wikidata": "Q107617274",
-        "name": "The Co-operative Food",
-        "operator": "Midcounties Co-operative",
-        "operator:wikidata": "Q6841138",
-        "shop": "supermarket"
-      }
-    },
-    {
-      "displayName": "Southern Co-operative",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "brand": "The Co-operative Food",
-        "brand:wikidata": "Q107617274",
-        "name": "The Co-operative Food",
-        "operator": "Southern Co-operative",
-        "operator:wikidata": "Q7569773",
         "shop": "supermarket"
       }
     },
@@ -1112,30 +1095,6 @@
         "name": "East of England CO-OP",
         "operator": "East of England Co-operative Society",
         "operator:wikidata": "Q5329759",
-        "shop": "supermarket"
-      }
-    },
-    {
-      "displayName": "Chelmsford Star Co-operative Society",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "brand": "The Co-operative Food",
-        "brand:wikidata": "Q107617274",
-        "name": "The Co-operative Food",
-        "operator": "Chelmsford Star Co-operative Society",
-        "operator:wikidata": "Q5089972",
-        "shop": "supermarket"
-      }
-    },
-    {
-      "displayName": "Heart of England Co-operative Society",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "brand": "The Co-operative Food",
-        "brand:wikidata": "Q107617274",
-        "name": "The Co-operative Food",
-        "operator": "Heart of England Co-operative Society",
-        "operator:wikidata": "Q5692254",
         "shop": "supermarket"
       }
     },

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1080,6 +1080,19 @@
       }
     },
     {
+      "displayName": "Midcounties Co-operative",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "The Co-operative Food",
+        "brand:wikidata": "Q6841138",
+        "brand:wikipedia": "en:Midcounties Co-operative",
+        "name": "The Co-operative Food",
+        "operator": "Midcounties Co-operative",
+        "operator:wikidata": "Q6841138",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Coccinelle Express",
       "id": "coccinelleexpress-c16b1c",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1149,8 +1149,7 @@
       "locationSet": {"include": ["gg", "je"]},
       "tags": {
         "brand": "Co-operative Grand Marché",
-        "brand:wikidata": "Q5072404",
-        "brand:wikipedia": "en:Channel Islands Co-operative Society",
+        "brand:wikidata": "Q107594917",
         "name": "Co-operative Grand Marché",
         "operator": "Channel Islands Co-operative Society",
         "operator:wikidata": "Q5072404",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1067,6 +1067,19 @@
       }
     },
     {
+      "displayName": "Central England Co-operative",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "The Co-operative Food",
+        "brand:wikidata": "Q16986583",
+        "brand:wikipedia": "en:Central England Co-operative",
+        "name": "The Co-operative Food",
+        "operator": "Central England Co-operative",
+        "operator:wikidata": "Q16986583",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Coccinelle Express",
       "id": "coccinelleexpress-c16b1c",
       "locationSet": {"include": ["fr"]},


### PR DESCRIPTION
In GB there is "the coop", but it's actually a whole bunch of things (and arguably not a coop). According to [Wikipedia](https://en.wikipedia.org/wiki/Co-op_Food#List_of_UK_Co-operatives_with_food_retail_operations), there are 16 companies using it in food shops. The biggest (The Co-operative Group) rebranded to "Co-op Food" a while ago, they tend to just have The Co-operative Group logo, and a sub name on the fascia, but NSI, OSM and the company call them "Co-op Food".

However the other stores didn't go through this brand, and either still called "The Co-operative Food" or have a unique brand. NSI is pushing people from "The Co-operative Food" to "Co-op Food" which is wrong a lot of the time. This is an attempt to fix that, it should be reviewed properly and possibly needs some local experts. https://github.com/osmlab/name-suggestion-index/issues/2588 @rjw62 

This doesn't take Tamworth Co-operative into account as it doesn't have Wikipedia or Wikidata pages. It also ignores Allendale Co-op, Coniston Co-op and Grosmont Co-operative Society as they each only have 1 store.