### PR TITLE
official branding is TK instead of less common TKK

### DIFF
--- a/data/brands/office/insurance.json
+++ b/data/brands/office/insurance.json
@@ -1018,13 +1018,14 @@
       "displayName": "Techniker Krankenkasse",
       "id": "technikerkrankenkasse-422e71",
       "locationSet": {"include": ["de"]},
+      "matchNames": ["Die Techniker"],
       "tags": {
         "brand": "Techniker Krankenkasse",
         "brand:wikidata": "Q607531",
         "brand:wikipedia": "de:Techniker Krankenkasse",
         "insurance": "health",
         "name": "Techniker Krankenkasse",
-        "short_name": "TKK",
+        "short_name": "TK",
         "office": "insurance"
       }
     },


### PR DESCRIPTION
#5151 as @kjonosm commented official branding is rather TK instead of less common TKK. 
Also added match_name Die Techniker now. 

Thanks @kjonosm

Please review.. 