### PR TITLE
Create separate entries for SMART bus routes

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -10868,6 +10868,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "network": "South Metro Area Regional Transit",
+        "network:short": "SMART",
         "network:wikidata": "Q7567940",
         "network:wikipedia": "en:South Metro Area Regional Transit",
         "operator": "South Metro Area Regional Transit",
@@ -10880,6 +10881,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "network": "Suburban Mobility Authority for Regional Transportation",
+        "network:short": "SMART",
         "network:wikidata": "Q7632360",
         "network:wikipedia": "en:Suburban Mobility Authority for Regional Transportation",
         "operator": "Suburban Mobility Authority for Regional Transportation",

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -10864,10 +10864,10 @@
     },
     {
       "displayName": "South Metro Area Regional Transit",
-      "id": "smart-a5e36d",
+      "id": "southmetro-783b59",
       "locationSet": {"include": ["us"]},
       "tags": {
-        "network": "SMART",
+        "network": "South Metro Area Regional Transit",
         "network:wikidata": "Q7567940",
         "network:wikipedia": "en:South Metro Area Regional Transit",
         "operator": "South Metro Area Regional Transit",
@@ -10879,7 +10879,7 @@
       "id": "smart-add5eb",
       "locationSet": {"include": ["us"]},
       "tags": {
-        "network": "SMART",
+        "network": "Suburban Mobility Authority for Regional Transportation",
         "network:wikidata": "Q7632360",
         "network:wikipedia": "en:Suburban Mobility Authority for Regional Transportation",
         "operator": "Suburban Mobility Authority for Regional Transportation",

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -10863,11 +10863,28 @@
       }
     },
     {
-      "displayName": "SMART",
+      "displayName": "SMART (Wilsonville, OR)",
       "id": "smart-a21cc9",
       "locationSet": {"include": ["us"]},
-      "note": "SMART may refer to South Metro Area Regional Transit or Suburban Mobility Authority for Regional Transportation",
-      "tags": {"network": "SMART", "route": "bus"}
+      "tags": {
+        "network": "SMART",
+        "network:wikidata": "Q7567940",
+        "network:wikipedia": "en:South Metro Area Regional Transit",
+        "operator": "South Metro Area Regional Transit",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "SMART (Metro Detroit)",
+      "id": "smart-add5eb",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "SMART",
+        "network:wikidata": "Q7632360",
+        "network:wikipedia": "en:Suburban Mobility Authority for Regional Transportation",
+        "operator": "Suburban Mobility Authority for Regional Transportation",
+        "route": "bus"
+      }
     },
     {
       "displayName": "SMITU",

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -10863,8 +10863,8 @@
       }
     },
     {
-      "displayName": "SMART (Wilsonville, OR)",
-      "id": "smart-a21cc9",
+      "displayName": "South Metro Area Regional Transit",
+      "id": "smart-a5e36d",
       "locationSet": {"include": ["us"]},
       "tags": {
         "network": "SMART",
@@ -10875,7 +10875,7 @@
       }
     },
     {
-      "displayName": "SMART (Metro Detroit)",
+      "displayName": "Suburban Mobility Authority for Regional Transportation",
       "id": "smart-add5eb",
       "locationSet": {"include": ["us"]},
       "tags": {


### PR DESCRIPTION
Add 'smart-add5eb' for Suburban Mobility Authority for Regional Transportation and added wikidata/wikipedia and operator tags to each