### PR TITLE
Add bus networks in Northwest Oregon

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -10650,7 +10650,7 @@
         "network:short": "SETD",
         "network:wikidata": "Q7641258",
         "network:wikipedia": "en:Sunset Empire Transportation District",
-        "operator": "NW Connector",
+        "operator": "Clatsop County",
         "route": "bus"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -1256,6 +1256,18 @@
       }
     },
     {
+      "displayName": "Benton Area Transit",
+      "id": "bentonareatransit-add5eb",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "Benton Area Transit",
+        "network:short": "BAT",
+        "network:wikidata": "Q107667956",
+        "operator": "Benton County",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "berdskpt",
       "id": "berdskpt-15dd1a",
       "locationSet": {"include": ["ru"]},
@@ -2098,6 +2110,19 @@
       "id": "cats-a21cc9",
       "locationSet": {"include": ["us"]},
       "tags": {"network": "CATS", "route": "bus"}
+    },
+    {
+      "displayName": "CC Rider",
+      "id": "ccrider-add5eb",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "Columbia County Rider",
+        "network:short": "CC Rider",
+        "network:wikidata": "Q107667623",
+        "network:wikipedia": "en:Columbia County Rider",
+        "operator": "Columbia County",
+        "route": "bus"
+      }
     },
     {
       "displayName": "CCVUSP",
@@ -6064,6 +6089,18 @@
       },
       "tags": {
         "network": "Limburg",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Lincoln County Transit",
+      "id": "lct-add5eb",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "Lincoln County Transit",
+        "network:short": "LCT",
+        "network:wikidata": "Q107667781",
+        "operator": "Lincoln County",
         "route": "bus"
       }
     },
@@ -10605,6 +10642,19 @@
       }
     },
     {
+      "displayName": "SETD",
+      "id": "setd-add5eb",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "Sunset Empire Transportation District",
+        "network:short": "SETD",
+        "network:wikidata": "Q7641258",
+        "network:wikipedia": "en:Sunset Empire Transportation District",
+        "operator": "NW Connector",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "SETRAM",
       "id": "setram-add5eb",
       "locationSet": {"include": ["fx"]},
@@ -12153,6 +12203,19 @@
         "network:wikidata": "Q60851796",
         "network:wikipedia": "fr:Transports en commun de Pontarlier",
         "operator": "Keolis Monts-Jura",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "TCTD",
+      "id": "tctd-add5eb",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "Tillamook County Transportation District",
+        "network:short": "TCTD",
+        "network:wikidata": "Q7802245",
+        "network:wikipedia": "en:Tillamook County Transportation District",
+        "operator": "Tillamook County",
         "route": "bus"
       }
     },


### PR DESCRIPTION
Includes transit agencies of Benton, Clatsop, Columbia, Lincoln, and Tillamook counties.
