### PR TITLE
Updates Washington, DC transit authority name in subway.json

### DIFF
--- a/data/transit/route/subway.json
+++ b/data/transit/route/subway.json
@@ -520,7 +520,8 @@
         "network": "Washington Metro",
         "network:wikidata": "Q171221",
         "network:wikipedia": "en:Washington Metro",
-        "operator": "WMATA",
+        "operator": "Washington Metropolitan Area Transit Authority",
+        "operator:short": "WMATA",
         "operator:wikidata": "Q7972051",
         "operator:wikipedia": "en:Washington Metropolitan Area Transit Authority",
         "route": "subway"


### PR DESCRIPTION
This corrects operator name from its abbreviated name to the full name according to OSM best practices in https://wiki.openstreetmap.org/wiki/Names#Abbreviation_.28don.27t_do_it.29