### PR TITLE
LA Metro wiki tags

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -6731,20 +6731,39 @@
       }
     },
     {
-      "displayName": "Metro Limited",
-      "id": "metrolimited-a21cc9",
+      "displayName": "Metro Express (Los Angeles)",
       "locationSet": {"include": ["us"]},
       "tags": {
-        "network": "Metro Limited",
+        "network": "Metro Express",
+        "operator": "Los Angeles County Metropolitan Transportation Authority",
+        "operator:wikidata": "Q3259702",
+        "operator:wikipedia": "en:Los Angeles County Metropolitan Transportation Authority",
         "route": "bus"
       }
     },
     {
-      "displayName": "Metro Local",
+      "displayName": "Metro Limited (Los Angeles)",
+      "id": "metrolimited-a21cc9",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "Metro Limited",
+        "operator": "Los Angeles County Metropolitan Transportation Authority",
+        "operator:wikidata": "Q3259702",
+        "operator:wikipedia": "en:Los Angeles County Metropolitan Transportation Authority",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Metro Local (Los Angeles)",
       "id": "metrolocal-a21cc9",
       "locationSet": {"include": ["us"]},
       "tags": {
         "network": "Metro Local",
+        "network:wikidata": "Q77610",
+        "network:wikipedia": "en:Metro Local"
+        "operator": "Los Angeles County Metropolitan Transportation Authority",
+        "operator:wikidata": "Q3259702",
+        "operator:wikipedia": "en:Los Angeles County Metropolitan Transportation Authority",
         "route": "bus"
       }
     },
@@ -6754,6 +6773,11 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "network": "Metro Rapid",
+        "network:wikidata": "Q75436",
+        "network:wikipedia": "en:Metro Rapid",
+        "operator": "Los Angeles County Metropolitan Transportation Authority",
+        "operator:wikidata": "Q3259702",
+        "operator:wikipedia": "en:Los Angeles County Metropolitan Transportation Authority",
         "route": "bus"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -6760,7 +6760,7 @@
       "tags": {
         "network": "Metro Local",
         "network:wikidata": "Q77610",
-        "network:wikipedia": "en:Metro Local"
+        "network:wikipedia": "en:Metro Local",
         "operator": "Los Angeles County Metropolitan Transportation Authority",
         "operator:wikidata": "Q3259702",
         "operator:wikipedia": "en:Los Angeles County Metropolitan Transportation Authority",


### PR DESCRIPTION
Added operator wiki tags for Metro Local, Metro Rapid, Metro Limited, and Metro Express networks, and network wiki tags for the former two. Also set the display name to include disambiguation of which Metro system the tags correspond to.