### PR TITLE
Moved PubliBike from brand to operator

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -2504,21 +2504,6 @@
       }
     },
     {
-      "displayName": "PubliBike",
-      "id": "publibike-61df48",
-      "locationSet": {"include": ["ch"]},
-      "tags": {
-        "amenity": "bicycle_rental",
-        "brand": "PubliBike",
-        "brand:wikidata": "Q3555363",
-        "brand:wikipedia": "de:PubliBike",
-        "network": "PubliBike",
-        "network:wikidata": "Q3555363",
-        "network:wikipedia": "de:PubliBike",
-        "operator": "PubliBike"
-      }
-    },
-    {
       "displayName": "Radomski Rower Miejski",
       "id": "radomskirowermiejski-4d145c",
       "locationSet": {"include": ["pl"]},
@@ -3450,17 +3435,6 @@
       }
     },
     {
-      "displayName": "Velohauptstadt",
-      "id": "velohauptstadt-61df48",
-      "locationSet": {"include": ["ch"]},
-      "tags": {
-        "amenity": "bicycle_rental",
-        "brand": "Velohauptstadt",
-        "network": "Velohauptstadt",
-        "operator": "PubliBike"
-      }
-    },
-    {
       "displayName": "Vélolib",
       "id": "velolib-d06f5d",
       "locationSet": {"include": ["fx"]},
@@ -3753,17 +3727,6 @@
         "brand": "Zielonogórski Rower Miejski",
         "network": "Zielonogórski Rower Miejski",
         "operator": "Nextbike Polska"
-      }
-    },
-    {
-      "displayName": "Züri Velo",
-      "id": "zurivelo-61df48",
-      "locationSet": {"include": ["ch"]},
-      "tags": {
-        "amenity": "bicycle_rental",
-        "brand": "Züri Velo",
-        "network": "Züri Velo",
-        "operator": "PubliBike"
       }
     },
     {

--- a/data/operators/amenity/bicycle_rental.json
+++ b/data/operators/amenity/bicycle_rental.json
@@ -1,0 +1,46 @@
+{
+  "properties": {
+    "path": "operators/amenity/bicycle_rental",
+    "exclude": {
+      "generic": [
+        "^bicycle rental$",
+        "^bike sharing$"
+      ]
+    }
+  },
+  "items": [
+    {
+      "displayName": "PubliBike",
+      "locationSet": {"include": ["ch"]},
+      "tags": {
+        "amenity": "bicycle_rental",
+        "operator": "PubliBike",
+        "operator:wikidata": "Q3555363",
+        "operator:wikipedia": "de:PubliBike",
+      }
+    },
+    {
+      "displayName": "Velohauptstadt",
+      "locationSet": {"include": ["ch"]},
+      "matchNames": ["Velo Bern"],
+      "tags": {
+        "amenity": "bicycle_rental",
+        "network": "Velohauptstadt",
+        "operator": "PubliBike",
+        "operator:wikidata": "Q3555363",
+        "operator:wikipedia": "de:PubliBike",
+      }
+    },
+    {
+      "displayName": "Züri Velo",
+      "locationSet": {"include": ["ch"]},
+      "tags": {
+        "amenity": "bicycle_rental",
+        "network": "Züri Velo",
+        "operator": "PubliBike",
+        "operator:wikidata": "Q3555363",
+        "operator:wikipedia": "de:PubliBike",
+      }
+    },
+  ]
+}


### PR DESCRIPTION
PubliBike is an operator (a company), not a brand. Besides, the networks operator by PubliBike are called "Lausanne-Morges", "Agglo Fribourg-Freiburg", "Lugano-Malcantone", "Sion", "Sierre", "Région de Nyon", "Velohauptstadt" and "Züri Velo". There isn't a network called "PubliBike".