### PR TITLE
Update old transport service names

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -918,19 +918,18 @@
       }
     },
     {
-      "displayName": "Autobuses Urbano de Burgos",
-      "id": "autobusesurbanodeburgos-cbced8",
+      "displayName": "Transporte urbano de Burgos",
+      "id": "transporteurbanodeburgos-cbced8",
       "locationSet": {"include": ["es"]},
       "matchNames": [
         "transporte urbano de burgos"
       ],
       "tags": {
-        "network": "Autobuses Urbano de Burgos",
-        "network:short": "AB",
+        "network": "Transporte urbano de Burgos",
         "network:wikidata": "Q6391113",
-        "network:wikipedia": "es:Autobuses Urbanos de Burgos",
-        "operator": "Servicio de Accesibilidad, Movilidad y Transportes",
-        "operator:short": "SAMYT",
+        "network:wikipedia": "es:Transporte urbano de Burgos",
+        "operator": "Servicio Municipalizado de Movilidad y Transportes",
+        "operator:short": "SMYT",
         "route": "bus"
       }
     },


### PR DESCRIPTION
May I try a few changes in order to have the new version of ID more comfortable with our bus routes? I have fixed some references in Wikipedia and Wikidata and I hope I made this pull request in a proper way…

I'm not sure if the "id" change in line 922 is appropriate. Even though it shouldn't be visible, it inherits a tiny old misspelling,.

David