### PR TITLE
Add Costco Tire and Hearing Aid Centers

### DIFF
--- a/data/brands/shop/hearing_aids.json
+++ b/data/brands/shop/hearing_aids.json
@@ -51,6 +51,18 @@
       }
     },
     {
+      "displayName": "Costco Hearing Aid Center",
+      "id": "costcohearingaidcenter-5b6831",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "brand": "Costco",
+        "brand:wikidata": "Q715583",
+        "brand:wikipedia": "en:Costco",
+        "name": "Costco Hearing Aid Center",
+        "shop": "hearing_aids"
+      }
+    },
+    {
       "displayName": "Entendre",
       "id": "entendre-400e82",
       "locationSet": {"include": ["fx"]},

--- a/data/brands/shop/tyres.json
+++ b/data/brands/shop/tyres.json
@@ -99,6 +99,18 @@
       }
     },
     {
+      "displayName": "Costco Tire Center",
+      "id": "costcotirecenter-5b6831",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "brand": "Costco",
+        "brand:wikidata": "Q715583",
+        "brand:wikipedia": "en:Costco",
+        "name": "Costco Tire Center",
+        "shop": "tyres"
+      }
+    },
+    {
       "displayName": "Dekkmann",
       "id": "dekkmann-3a2f39",
       "locationSet": {"include": ["no"]},


### PR DESCRIPTION
Other 'centers' inside of Costco, which include the pharmacy, food court, and optician, are already in the NSI