### PR TITLE
Add missing bus networks in Oregon

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -1895,6 +1895,18 @@
       }
     },
     {
+      "displayName": "Canby Area Transit",
+      "id": "canbyareatransit-783b59",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "CAT",
+        "network:wikidata": "Q5031301",
+        "network:wikipedia": "en:Canby Area Transit",
+        "operator": "City of Canby",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "Cape Town IRT",
       "id": "capetownirt-4d0252",
       "locationSet": {"include": ["za"]},
@@ -2577,6 +2589,18 @@
         "network": "Codiac Transpo",
         "network:wikidata": "Q2981688",
         "network:wikipedia": "en:Codiac Transpo",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Columbia Area Transit",
+      "id": "columbiaareatransit-783b59",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "CAT",
+        "network:wikidata": "Q96375303",
+        "network:wikipedia": "en:Columbia Area Transit",
+        "operator": "Hood River County Transportation District",
         "route": "bus"
       }
     },
@@ -8372,6 +8396,19 @@
       }
     },
     {
+      "displayName": "Oregon POINT",
+      "id": "oregonpoint-783b59",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "Public Oregon Intercity Transit",
+        "network:short": "POINT",
+        "network:wikidata": "Q19877418",
+        "network:wikipedia": "en:Oregon POINT",
+        "operator": "Oregon Department of Transportation",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "ordinaire",
       "id": "ordinaire-e384d8",
       "locationSet": {"include": ["tg"]},
@@ -11252,6 +11289,18 @@
         "network:wikipedia": "en:Sound Transit Express",
         "operator:wikidata": "Q3965367",
         "operator:wikipedia": "en:Sound Transit",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "South Clackamas Transportation District",
+      "id": "southclackamastransportationdistrict-a21cc9",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "SCTD",
+        "network:wikidata": "Q7566833",
+        "network:wikipedia": "en:South Clackamas Transportation District",
+        "operator": "South Clackamas Transportation District"
         "route": "bus"
       }
     },
@@ -15265,6 +15314,18 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "network": "Xpress",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Yamhill County Transit",
+      "id": "yamhillcountytransit-783b59",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "YCTA",
+        "network:wikidata": "Q60770365",
+        "network:wikipedia": "en:Yamhill County Transit",
+        "operator": "Yamhill County Transit Area",
         "route": "bus"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -11300,7 +11300,7 @@
         "network": "SCTD",
         "network:wikidata": "Q7566833",
         "network:wikipedia": "en:South Clackamas Transportation District",
-        "operator": "South Clackamas Transportation District"
+        "operator": "South Clackamas Transportation District",
         "route": "bus"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -1899,7 +1899,8 @@
       "id": "canbyareatransit-783b59",
       "locationSet": {"include": ["us"]},
       "tags": {
-        "network": "CAT",
+        "network": "Canby Area Transit",
+        "network:short": "CAT",
         "network:wikidata": "Q5031301",
         "network:wikipedia": "en:Canby Area Transit",
         "operator": "City of Canby",
@@ -2597,7 +2598,8 @@
       "id": "columbiaareatransit-783b59",
       "locationSet": {"include": ["us"]},
       "tags": {
-        "network": "CAT",
+        "network": "Columbia Area Transit",
+        "network:short": "CAT",
         "network:wikidata": "Q96375303",
         "network:wikipedia": "en:Columbia Area Transit",
         "operator": "Hood River County Transportation District",


### PR DESCRIPTION
It's recommended to modify the locationSet of Canby Area Transit and Columbia Area Transit as they both have the same network value. I'm not sure how add a specific area for the locationSet, so I just left it as 'us' for now.

These missing networks were found from this category page on Wikipedia:
https://en.wikipedia.org/wiki/Category:Transit_agencies_in_Oregon