### PR TITLE
name correction Banco24horas

### DIFF
--- a/data/brands/amenity/atm.json
+++ b/data/brands/amenity/atm.json
@@ -23,7 +23,7 @@
         "brand": "Banco24Horas",
         "brand:wikidata": "Q4854069",
         "brand:wikipedia": "pt:Banco24Horas",
-        "name": "Branco24Horas"
+        "name": "Banco24Horas"
       }
     },
     {


### PR DESCRIPTION
correction of the name of the Banco24Horas that was Branco24Horas
Banco = Bank
Branco = White