### PR TITLE
Shorten displayName for SMART (Oregon)

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -11144,7 +11144,7 @@
       }
     },
     {
-      "displayName": "SMART (South Metro Area Regional Transit)",
+      "displayName": "SMART (Oregon)",
       "id": "smart-7b4374",
       "locationSet": {
         "include": [[-122.8, 45.3]]


### PR DESCRIPTION
Adding the unabbreviated name in parenthesis makes it difficult to see what bus route relation(s) a way is in when using RapiD, so I changed it to Oregon to distinguish it from the SMART in Detroit