### PR TITLE
Added Brazil brands (#5202)

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -1014,6 +1014,18 @@
       }
     },
     {
+      "displayName": "Banco de Brasília",
+      "id": "bancodebrasilia-d049bf",
+      "locationSet": {"include": ["br"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "BRB",
+        "brand:wikidata": "Q4854119",
+        "brand:wikipedia": "pt:Banco de Brasília",
+        "name": "Banco de Brasília"
+      }
+    },
+    {
       "displayName": "Banco de Bogotá",
       "id": "bancodebogota-d049bf",
       "locationSet": {"include": ["co"]},

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -816,6 +816,20 @@
       }
     },
     {
+      "displayName": "China in Box",
+      "id": "chinainbox-946a0b",
+      "locationSet": {"include": ["br"],},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "China in Box",
+        "brand:wikidata": "Q18463999",
+        "brand:wikipedia": "pt:China in Box",
+        "cuisine": "chinese",
+        "name": "China in Box",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "China Wok",
       "id": "chinawok-946a0b",
       "locationSet": {
@@ -1830,6 +1844,20 @@
         "brand:wikipedia": "en:Gino's Pizza and Spaghetti",
         "cuisine": "pizza",
         "name": "Gino's Pizza & Spaghetti House",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "Giraffas",
+      "id": "giraffas-4d2ff4",
+      "locationSet": {"include": ["br"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Giraffas",
+        "brand:wikidata": "Q5563205",
+        "brand:wikipedia": "pt:Giraffas",
+        "cuisine": "burger",
+        "name": "Giraffas",
         "takeaway": "yes"
       }
     },
@@ -4459,6 +4487,20 @@
         "brand:wikipedia": "en:Spizzico",
         "cuisine": "pizza",
         "name": "Spizzico",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "Spoleto",
+      "id": "spoleto-7eb3e4",
+      "locationSet": {"include": ["br"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Spoleto",
+        "brand:wikidata": "Q7578935",
+        "brand:wikipedia": "pt:Spoleto (Restaurante)",
+        "cuisine": "italian",
+        "name": "Spoleto",
         "takeaway": "yes"
       }
     },


### PR DESCRIPTION
Closes #5202 

Adds:
- Banco de Brasília (bank)
- China in Box (chinese fast food)
- Giraffas (burger fast food)
- Spoleto (italian fast food)