### PR TITLE
Update Wikipedia language for De Lijn in bus.json (#5201)

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -3312,9 +3312,9 @@
       "locationSet": {"include": ["be", "nl"]},
       "tags": {
         "network": "DLAn",
-        "operator": "De Lijn", 
-        "operator:wikidata": "Q614819",
-        "operator:wikipedia": "nl:De Lijn",
+        "network:wikidata": "Q614819",
+        "network:wikipedia": "nl:De Lijn",
+        "operator": "De Lijn",
         "route": "bus"
       }
     },
@@ -3323,10 +3323,10 @@
       "id": "dlli-a315fc",
       "locationSet": {"include": ["be", "nl"]},
       "tags": {
-        "network": "DLLi",
-        "operator": "De Lijn", 
-        "operator:wikidata": "Q614819",
-        "operator:wikipedia": "nl:De Lijn",
+        "network": "DLLi", 
+        "network:wikidata": "Q614819",
+        "network:wikipedia": "nl:De Lijn",
+        "operator": "De Lijn",
         "route": "bus"
       }
     },
@@ -3336,9 +3336,9 @@
       "locationSet": {"include": ["be", "nl"]},
       "tags": {
         "network": "DLOV",
-        "operator": "De Lijn", 
-        "operator:wikidata": "Q614819",
-        "operator:wikipedia": "nl:De Lijn",
+        "network:wikidata": "Q614819",
+        "network:wikipedia": "nl:De Lijn",
+        "operator": "De Lijn",
         "route": "bus"
       }
     },
@@ -3348,9 +3348,9 @@
       "locationSet": {"include": ["be"]},
       "tags": {
         "network": "DLVB",
-        "operator": "De Lijn", 
-        "operator:wikidata": "Q614819",
-        "operator:wikipedia": "nl:De Lijn",
+        "network:wikidata": "Q614819",
+        "network:wikipedia": "nl:De Lijn",
+        "operator": "De Lijn",
         "route": "bus"
       }
     },
@@ -3360,9 +3360,9 @@
       "locationSet": {"include": ["be"]},
       "tags": {
         "network": "DLWV",
-        "operator": "De Lijn", 
-        "operator:wikidata": "Q614819",
-        "operator:wikipedia": "nl:De Lijn",
+        "network:wikidata": "Q614819",
+        "network:wikipedia": "nl:De Lijn",
+        "operator": "De Lijn",
         "route": "bus"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -3312,8 +3312,9 @@
       "locationSet": {"include": ["be", "nl"]},
       "tags": {
         "network": "DLAn",
-        "network:wikidata": "Q614819",
-        "network:wikipedia": "fr:De Lijn",
+        "operator": "De Lijn", 
+        "operator:wikidata": "Q614819",
+        "operator:wikipedia": "nl:De Lijn",
         "route": "bus"
       }
     },
@@ -3323,8 +3324,9 @@
       "locationSet": {"include": ["be", "nl"]},
       "tags": {
         "network": "DLLi",
-        "network:wikidata": "Q614819",
-        "network:wikipedia": "fr:De Lijn",
+        "operator": "De Lijn", 
+        "operator:wikidata": "Q614819",
+        "operator:wikipedia": "nl:De Lijn",
         "route": "bus"
       }
     },
@@ -3334,8 +3336,9 @@
       "locationSet": {"include": ["be", "nl"]},
       "tags": {
         "network": "DLOV",
-        "network:wikidata": "Q614819",
-        "network:wikipedia": "fr:De Lijn",
+        "operator": "De Lijn", 
+        "operator:wikidata": "Q614819",
+        "operator:wikipedia": "nl:De Lijn",
         "route": "bus"
       }
     },
@@ -3345,8 +3348,9 @@
       "locationSet": {"include": ["be"]},
       "tags": {
         "network": "DLVB",
-        "network:wikidata": "Q614819",
-        "network:wikipedia": "fr:De Lijn",
+        "operator": "De Lijn", 
+        "operator:wikidata": "Q614819",
+        "operator:wikipedia": "nl:De Lijn",
         "route": "bus"
       }
     },
@@ -3356,8 +3360,9 @@
       "locationSet": {"include": ["be"]},
       "tags": {
         "network": "DLWV",
-        "network:wikidata": "Q614819",
-        "network:wikipedia": "fr:De Lijn",
+        "operator": "De Lijn", 
+        "operator:wikidata": "Q614819",
+        "operator:wikipedia": "nl:De Lijn",
         "route": "bus"
       }
     },


### PR DESCRIPTION
Closes #5201 

Changed Wikipedia tag prefix from 'fr' to 'nl'

Also added operator tags and changed prefix of wikidata/wikipedia from network to operator.