### PR TITLE
Add missing bus networks in the Pacific Northwest

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -1134,14 +1134,25 @@
       }
     },
     {
-      "displayName": "BAT (Brockton Area Transit)",
+      "displayName": "BAT (Massachusetts)",
       "id": "bat-a21cc9",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["-71, 42.1"]},
       "tags": {
         "network": "BAT",
         "network:wikidata": "Q4972867",
         "network:wikipedia": "en:Brockton Area Transit Authority",
         "operator": "Brockton Area Transit Authority",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "BAT (Klamath Falls)",
+      "id": "bat-6eac88",
+      "locationSet": {"include": ["-121.8, 42.2"]},
+      "tags": {
+        "network": "BAT",
+        "network:wikidata": "Q107898188",
+        "operator": "Basin Area Transit",
         "route": "bus"
       }
     },
@@ -2084,13 +2095,7 @@
       }
     },
     {
-      "displayName": "CAT",
-      "id": "cat-a21cc9",
-      "locationSet": {"include": ["us"]},
-      "tags": {"network": "CAT", "route": "bus"}
-    },
-    {
-      "displayName": "CAT (Canby Area Transit)",
+      "displayName": "CAT (Canby)",
       "id": "cat-85ea0e",
       "locationSet": {
         "include": [[-122.690556, 45.266111, 250]]
@@ -2104,7 +2109,7 @@
       }
     },
     {
-      "displayName": "CAT (Columbia Area Transit)",
+      "displayName": "CAT (Hood River)",
       "id": "cat-755fdf",
       "locationSet": {
         "include": [[-121.649444, 45.5175, 250]]
@@ -2223,6 +2228,17 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "network": "Ceredigion",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "CET",
+      "id": "cet-85ea0e",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "CET",
+        "network:wikidata": "Q107900782",
+        "operator": "Cascades East Transit",
         "route": "bus"
       }
     },
@@ -5426,6 +5442,18 @@
       }
     },
     {
+      "displayName": "Josephine County Transit",
+      "id": "josephinecountytransit-783b59",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "Josephine County Transit",
+        "network:short": "JCT"
+        "network:wikidata": "Q107899789",
+        "operator": "Josephine County",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "JTA",
       "id": "jta-a21cc9",
       "locationSet": {"include": ["us"]},
@@ -5505,6 +5533,17 @@
       "locationSet": {"include": ["lt"]},
       "tags": {
         "network": "Kauno m. savivaldybė",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Kayak Public Transit",
+      "id": "kayakpublictransit-393f24",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "Kayak Public Transit",
+        "network:wikidata": "Q107901212",
+        "operator": "Confederated Tribes of the Umatilla Indian Reservation",
         "route": "bus"
       }
     },
@@ -10017,6 +10056,18 @@
       }
     },
     {
+      "displayName": "RiverCities Transit (Washington)",
+      "id": "rivercitiestransit-a21cc9",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "RiverCities Transit",
+        "network:wikidata": "Q28451877",
+        "network:wikipedia": "en:RiverCities Transit (Washington)",
+        "operator": "RiverCities Transit",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "RMTD",
       "id": "rmtd-a21cc9",
       "locationSet": {"include": ["us"]},
@@ -10479,6 +10530,18 @@
         "network:short": "SVV",
         "network:wikidata": "Q1254319",
         "network:wikipedia": "de:Salzburger Verkehrsverbund",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Sandy Area Metro",
+      "id": "sandyareametro-a21cc9",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "Sandy Area Metro",
+        "network:short": "SAM",
+        "network:wikidata": "Q107901414",
+        "operator": "City of Sandy",
         "route": "bus"
       }
     },
@@ -13814,6 +13877,18 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "network": "UMass Lowell",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "UTrans",
+      "id": "utrans-783b59",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "UTrans",
+        "network:short": "UPTD"
+        "network:wikidata": "Q107900150",
+        "operator": "Umpqua Public Transportation District",
         "route": "bus"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -5447,7 +5447,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "network": "Josephine County Transit",
-        "network:short": "JCT"
+        "network:short": "JCT",
         "network:wikidata": "Q107899789",
         "operator": "Josephine County",
         "route": "bus"
@@ -13886,7 +13886,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "network": "UTrans",
-        "network:short": "UPTD"
+        "network:short": "UPTD",
         "network:wikidata": "Q107900150",
         "operator": "Umpqua Public Transportation District",
         "route": "bus"

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -1136,7 +1136,7 @@
     {
       "displayName": "BAT (Massachusetts)",
       "id": "bat-a21cc9",
-      "locationSet": {"include": ["-71, 42.1"]},
+      "locationSet": {"include": [[-71.0, 42.1]]},
       "tags": {
         "network": "BAT",
         "network:wikidata": "Q4972867",
@@ -1148,7 +1148,7 @@
     {
       "displayName": "BAT (Klamath Falls)",
       "id": "bat-6eac88",
-      "locationSet": {"include": ["-121.8, 42.2"]},
+      "locationSet": {"include": [[-121.8, 42.2]]},
       "tags": {
         "network": "BAT",
         "network:wikidata": "Q107898188",

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -5443,11 +5443,11 @@
       }
     },
     {
-      "displayName": "Josephine County Transit",
-      "id": "josephinecountytransit-783b59",
+      "displayName": "Josephine Community Transit",
+      "id": "josephinecommunitytransit-783b59",
       "locationSet": {"include": ["us"]},
       "tags": {
-        "network": "Josephine County Transit",
+        "network": "Josephine Community Transit",
         "network:short": "JCT",
         "network:wikidata": "Q107899789",
         "operator": "Josephine County",

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -2114,6 +2114,7 @@
       "locationSet": {
         "include": [[-121.649444, 45.5175, 250]]
       },
+      "matchNames": ["CAT"],
       "tags": {
         "network": "CAT",
         "network:wikidata": "Q96375303",


### PR DESCRIPTION
Modified displayName and locationSet of Brockton Area Transit

Removed blank entry 'CAT' as two other networks I added in previous PRs have the same name. Also shortened displayNames of these networks (location instead of unabbreviated name)