### PR TITLE
Add BottleDrop bottle return vending machines

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -168,6 +168,23 @@
       }
     },
     {
+      "displayName": "BottleDrop",
+      "id": "bottledrop-f8d7ba",
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["bottle drop"],
+      "note": "To be used for self-service stations at partner retailers",
+      "tags": {
+        "amenity": "vending_machine",
+        "brand": "BottleDrop",
+        "brand:wikidata": "Q107673127",
+        "name": "BottleDrop",
+        "operator": "Oregon Beverage Recycling Cooperative",
+        "recycling:cans": "yes",
+        "recycling:glass_bottles": "yes",
+        "recycling:plastic_bottles": "yes"
+      }
+    },
+    {
       "displayName": "bwegt",
       "id": "bwegt-ceeccb",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
BottleDrop is a bottle return service in Oregon that refunds bottle deposits. I already added entries for recycling centers and payment terminals relating to this brand in #5166. Would using bottle return vending machines for partner retailers make more sense than recycling centers?