### PR TITLE
Add bakery brand "Kolls" and wlan operator "MobyKlick"

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -952,7 +952,6 @@
       "tags": {
         "brand": "Kolls",
         "brand:wikidata": "Q107151170",
-        "operator": "Bäckerei Konditorei Kolls GmbH",
         "shop": "bakery"
       }
     },

--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -941,6 +941,22 @@
       }
     },
     {
+      "displayName": "Kolls",
+      "id": "kolls-3f448e",
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["kolls familienbäckerei"],
+      "matchTags": [
+        "shop/bakery",
+        "shop/confectionery"
+      ],
+      "tags": {
+        "brand": "Kolls",
+        "brand:wikidata": "Q107151170",
+        "operator": "Bäckerei Konditorei Kolls GmbH",
+        "shop": "bakery"
+      }
+    },
+    {
       "displayName": "La Mie Câline",
       "id": "lamiecaline-731a34",
       "locationSet": {"include": ["fr"]},

--- a/data/operators/internet_access/wlan.json
+++ b/data/operators/internet_access/wlan.json
@@ -24,6 +24,20 @@
         "operator:wikipedia": "en:LinkNYC",
         "tourism": "information"
       }
+    },
+    {
+      "displayName": "MobyKlick",
+      "id": "mobyklick-18a37e",
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["mobi klick", "moby click"],
+      "tags": {
+        "internet_access": "wlan",
+        "internet_access:fee": "no",
+        "internet_access:operator": "MobyKlick",
+        "internet_access:ssid": "MobyKlick",
+        "operator": "MobyKlick",
+        "operator:wikidata": "Q108024323"
+      }
     }
   ]
 }


### PR DESCRIPTION
Hi all,

This pull request adds the bakery brand Kolls, mainly used in northern Germany as in [this OSM-Feature](https://www.openstreetmap.org/node/6058479489), and the WiFi-Hotspot-Operator "MobyKlick".

If you have any questions, feel free to contact me! 🙂 

Have a nice day,
Kevin