### PR TITLE
New -> North for North Carolina and North Dakota

### DIFF
--- a/data/flags/man_made/flagpole.json
+++ b/data/flags/man_made/flagpole.json
@@ -4410,7 +4410,7 @@
         "flag:type": "regional",
         "flag:wikidata": "Q19379",
         "man_made": "flagpole",
-        "subject": "New Carolina",
+        "subject": "North Carolina",
         "subject:wikidata": "Q1454"
       }
     },
@@ -4424,7 +4424,7 @@
         "flag:type": "regional",
         "flag:wikidata": "Q837312",
         "man_made": "flagpole",
-        "subject": "New Dakota",
+        "subject": "North Dakota",
         "subject:wikidata": "Q1207"
       }
     },


### PR DESCRIPTION
iD suggested changing the subject of the North Carolina flag in an area I was mapping from 'North Carolina' to 'New Carolina'. Was there a reason why the subject tags for North Carolina and North Dakota are 'New Carolina' and 'New Dakota'?