### PR TITLE
Big Bite Norwegian fast food sandwich chain

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -292,6 +292,19 @@
       }
     },
     {
+      "displayName": "Big Bite",
+      "id": "bigbite-86f814",
+      "locationSet": {"include": ["no"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Big Bite",
+        "brand:wikidata": "Q11960977",
+        "brand:wikipedia": "no:Big Bite",
+        "cuisine": "sandwich",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Big Fernand",
       "id": "bigfernand-8ddd61",
       "locationSet": {


### PR DESCRIPTION
71 stores in Norway, going over all stores now and adding to OpenStreetMap
https://www.bigbite.no/om-oss

https://www.wikidata.org/wiki/Q11960977
https://no.wikipedia.org/wiki/Big_Bite