### PR TITLE
Add Regma (Ice cream Brand)

### DIFF
--- a/data/brands/amenity/ice_cream.json
+++ b/data/brands/amenity/ice_cream.json
@@ -675,6 +675,17 @@
         "name:en": "Meet Fresh",
         "name:zh": "鮮芋仙"
       }
+    },
+    {
+      "displayName": "Regma",
+      "locationSet": {"include": ["es"]},
+      "tags": {
+        "amenity": "ice_cream",
+        "brand": "Regma",
+        "brand:wikidata": "Q108135319",
+        "cuisine": "ice_cream",
+        "name": "Regma"
+      }
     }
   ]
 }


### PR DESCRIPTION
**Regma** is the name of a Spanish ice cream store chain.

**Website:** [regma.es](https://regma.es/)
**Wikidata:** [Q108135319](https://www.wikidata.org/wiki/Q108135319)