### PR TITLE
Add Lecot a hardware seller in Belgium

### DIFF
--- a/data/brands/shop/hardware.json
+++ b/data/brands/shop/hardware.json
@@ -121,6 +121,17 @@
       }
     },
     {
+      "displayName": "Lecot",
+      "locationSet": {"include": ["be", "nl"]},
+      "tags": {
+        "brand": "Lecot",
+        "brand:website": "https://lecot.be",
+        "name": "Lecot",
+        "brand:wikidata": "Q108272936",
+        "shop": "hardware"
+      }
+    },
+    {
       "displayName": "Proper Job",
       "id": "properjob-a55f89",
       "locationSet": {"include": ["gb"]},


### PR DESCRIPTION
There are already 14 shops mapped out of a little more than 60 in Belgium. There is also one store in the Netherlands.