### PR TITLE
Change cuisine=kebap to cuisine=kebab

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -2567,7 +2567,7 @@
       "tags": {
         "amenity": "fast_food",
         "brand": "Kebab King",
-        "cuisine": "kebap",
+        "cuisine": "kebab",
         "name": "Kebab King",
         "takeaway": "yes"
       }


### PR DESCRIPTION
Change cuisine=kebap to cuisine=kebab
According to taginfo 18122 vs 4 uses

https://taginfo.openstreetmap.org/tags/cuisine=kebab
https://taginfo.openstreetmap.org/tags/cuisine=kebap