### PR TITLE
Added Chinese to T&T Supermarket: Almost all stores post the Chinese

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -5813,14 +5813,17 @@
       }
     },
     {
-      "displayName": "T&T Supermarket",
+      "displayName": "大統華 T&T Supermarket",
       "id": "tandtsupermarket-76454b",
       "locationSet": {"include": ["ca"]},
       "tags": {
         "brand": "T&T Supermarket",
         "brand:wikidata": "Q837893",
         "brand:wikipedia": "en:T & T Supermarket",
-        "name": "T&T Supermarket",
+        "name": "大統華 T&T Supermarket",
+        "name:zh-Hant": "大統華",
+        "name:zh-Hans": "大统华",
+        "name:en": "T&T Supermarket",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
Pretty much all stores post the Chinese name before the English name, therefore adding the Chinese name before the English name on OSM would be more accurate.