### PR TITLE
California Welcome Centers

### DIFF
--- a/data/brands/tourism/information.json
+++ b/data/brands/tourism/information.json
@@ -1,0 +1,24 @@
+{
+  "properties": {
+    "path": "brands/tourism/information",
+    "preserveTags": ["^name"],
+    "exclude": {"generic": ["^information$"]}
+  },
+  "items": [
+    {
+      "displayName": "California Welcome Center",
+      "id": "californiawelcomecenter-e8e4ed",
+      "locationSet": {
+        "include": ["california.geojson"]
+      },
+      "tags": {
+        "brand": "California Welcome Center",
+        "brand:wikidata": "Q108415255",
+        "information": "office",
+        "name": "California Welcome Center",
+        "short_name": "CWC",
+        "tourism": "information"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Added [California Welcome Centers](https://www.visitcalifornia.com/welcome-centers/), a network of independently operated welcome centers across the state that has coherent branding (including standardized freeway signage).

This is the first `tourism=information` entry in the repository. `npm run build` wants to bring in a lot of things that don’t look like chains, so I’ve omitted those entries from this PR.