### PR TITLE
Amend police.json for police forces in TW

### DIFF
--- a/data/operators/amenity/police.json
+++ b/data/operators/amenity/police.json
@@ -2789,7 +2789,7 @@
         "operator": "臺北市政府警察局",
         "operator:en": "Taipei City Police Department",
         "oeprator:wikidata": "Q15903297",
-        "operator:wikipedia": "zh:臺北市政府警察局"
+        "operator:wikipedia": "zh:臺北市政府警察局",
         "operator:zh": "臺北市政府警察局"
       }
     },
@@ -2800,10 +2800,10 @@
       "tags": {
         "amenity": "police",
         "operator": "新北市政府警察局",      
-        "operator:en": "Taipei City Police Department",
+        "operator:en": "New Taipei City Police Department",
         "oeprator:wikidata": "Q11081385",
-        "operator:wikipedia": "zh:臺北市政府警察局"
-        "operator:zh": "新北市政府警察局",  
+        "operator:wikipedia": "zh:新北市政府警察局",
+        "operator:zh": "新北市政府警察局"
       }
     },
     {
@@ -2815,8 +2815,8 @@
         "operator": "桃園市政府警察局",      
         "operator:en": "Taoyuan Police Department",
         "oeprator:wikidata": "Q15907660",
-        "operator:wikipedia": "zh:桃園市政府警察局"
-        "operator:zh": "桃園市政府警察局",  
+        "operator:wikipedia": "zh:桃園市政府警察局",
+        "operator:zh": "桃園市政府警察局"
       }
     },
     {
@@ -2828,8 +2828,8 @@
         "operator": "臺中市政府警察局",      
         "operator:en": "Taichung City Police Department",
         "oeprator:wikidata": "Q15897177",
-        "operator:wikipedia": "zh:臺中市政府警察局"
-        "operator:zh": "臺中市政府警察局",  
+        "operator:wikipedia": "zh:臺中市政府警察局",
+        "operator:zh": "臺中市政府警察局"
       }
     },
     {
@@ -2841,8 +2841,8 @@
         "operator": "臺南市政府警察局",      
         "operator:en": "Tainan City Police Department",
         "oeprator:wikidata": "Q15904106",
-        "operator:wikipedia": "zh:臺南市政府警察局"
-        "operator:zh": "臺南市政府警察局",  
+        "operator:wikipedia": "zh:臺南市政府警察局",
+        "operator:zh": "臺南市政府警察局"
       }
     },
     {
@@ -2854,8 +2854,8 @@
         "operator": "高雄市政府警察局",      
         "operator:en": "Kaohsiung City Police Department",
         "oeprator:wikidata": "Q15900495",
-        "operator:wikipedia": "zh:高雄市政府警察局"
-        "operator:zh": "高雄市政府警察局",  
+        "operator:wikipedia": "zh:高雄市政府警察局",
+        "operator:zh": "高雄市政府警察局"
       }
     }
   ]

--- a/data/operators/amenity/police.json
+++ b/data/operators/amenity/police.json
@@ -2713,7 +2713,7 @@
         "operator:wikipedia": "jp:鹿児島県警察"
       }
     },
-    {
+      {
       "displayName": "海巡署",
       "id": "coastguardadministration-c45d37",
       "locationSet": {"include": ["tw"]},
@@ -2778,14 +2778,15 @@
         "operator:wikipedia": "zh:內政部警政署國道公路警察局",
         "operator:zh": "國道公路警察局"
       }
-    },{
+    },
+    {
       "displayName": "臺北市政府警察局",
       "id": "0e7388-c45d37",
       "locationSet": {"include": ["tw"]},
       "matchNames": ["tcpd", "taipei police", "臺北市警察", "台北市警察", "臺北市警局", "台北市警局", "臺北警察", "台北警察", "北市警察", "北市警局"],
       "tags": {
         "amenity": "police",
-        "operator": "臺北市政府警察局"
+        "operator": "臺北市政府警察局",
         "operator:en": "Taipei City Police Department",
         "oeprator:wikidata": "Q15903297",
         "operator:wikipedia": "zh:臺北市政府警察局"
@@ -2856,6 +2857,6 @@
         "operator:wikipedia": "zh:高雄市政府警察局"
         "operator:zh": "高雄市政府警察局",  
       }
-    },
+    }
   ]
 }

--- a/data/operators/amenity/police.json
+++ b/data/operators/amenity/police.json
@@ -2693,28 +2693,6 @@
       }
     },
     {
-      "displayName": "海巡署",
-      "id": "coastguardadministration-c45d37",
-      "locationSet": {"include": ["tw"]},
-      "tags": {
-        "amenity": "police",
-        "operator": "海巡署",
-        "operator:en": "Coast Guard Administration",
-        "operator:wikidata": "Q698822",
-        "operator:wikipedia": "zh:海洋委員會海巡署",
-        "operator:zh": "海巡署"
-      }
-    },
-    {
-      "displayName": "臺北市政府警察局",
-      "id": "0e7388-c45d37",
-      "locationSet": {"include": ["tw"]},
-      "tags": {
-        "amenity": "police",
-        "operator": "臺北市政府警察局"
-      }
-    },
-    {
       "displayName": "那覇警察署",
       "id": "8e766a-ae5e65",
       "locationSet": {"include": ["jp"]},
@@ -2734,6 +2712,150 @@
         "operator:wikidata": "Q11676846",
         "operator:wikipedia": "jp:鹿児島県警察"
       }
-    }
+    },
+    {
+      "displayName": "海巡署",
+      "id": "coastguardadministration-c45d37",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["cga", "海巡"],
+      "tags": {
+        "amenity": "police",
+        "operator": "海巡署",
+        "operator:en": "Coast Guard Administration",
+        "operator:wikidata": "Q698822",
+        "operator:wikipedia": "zh:海洋委員會海巡署",
+        "operator:zh": "海巡署"
+      }
+    },
+    {
+      "displayName": "刑事警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["cib", "刑警"],
+      "tags": {
+        "amenity": "police",
+        "operator": "刑事警察局",
+        "operator:en": "Criminal Investigation Bureau",
+        "operator:wikidata": "Q10891306",
+        "operator:wikipedia": "zh:內政部警政署刑事警察局",
+        "operator:zh": "刑事警察局"
+      }
+    },    
+    {
+      "displayName": "鐵路警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["rp", "rpb", "路警"],
+      "tags": {
+        "amenity": "police",
+        "operator": "鐵路警察局",
+        "operator:en": "Railway Police Bureau",
+        "operator:wikidata": "Q10891310",
+        "operator:wikipedia": "zh:內政部警政署鐵路警察局",
+        "operator:zh": "鐵路警察局"
+      }
+    },
+    {
+      "displayName": "航空警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["ap" ,"apb", "航警"],
+      "tags": {
+        "amenity": "police",
+        "operator": "航空警察局",
+        "operator:en": "Aviation Police Bureau",
+        "operator:wikidata": "Q15912145",
+        "operator:wikipedia": "zh:內政部警政署航空警察局",
+        "operator:zh": "航空警察局"
+      }
+    },    
+    {
+      "displayName": "國道公路警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["nhp", "nhpb", "國道警察"],
+      "tags": {
+        "amenity": "police",
+        "operator": "國道公路警察局",
+        "operator:en": "National Highway Police Bureau",
+        "operator:wikidata": "Q10891307",
+        "operator:wikipedia": "zh:內政部警政署國道公路警察局",
+        "operator:zh": "國道公路警察局"
+      }
+    },{
+      "displayName": "臺北市政府警察局",
+      "id": "0e7388-c45d37",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["tcpd", "taipei police", "臺北市警察", "台北市警察", "臺北市警局", "台北市警局", "臺北警察", "台北警察", "北市警察", "北市警局"],
+      "tags": {
+        "amenity": "police",
+        "operator": "臺北市政府警察局"
+        "operator:en": "Taipei City Police Department",
+        "oeprator:wikidata": "Q15903297",
+        "operator:wikipedia": "zh:臺北市政府警察局"
+        "operator:zh": "臺北市政府警察局"
+      }
+    },
+    {
+      "displayName": "新北市政府警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["ntpd", "ntpc police", "新北市警察", "新北市警局", "新北警察", "新北警局"],
+      "tags": {
+        "amenity": "police",
+        "operator": "新北市政府警察局",      
+        "operator:en": "Taipei City Police Department",
+        "oeprator:wikidata": "Q11081385",
+        "operator:wikipedia": "zh:臺北市政府警察局"
+        "operator:zh": "新北市政府警察局",  
+      }
+    },
+    {
+      "displayName": "桃園市政府警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["typd", "taoyuan police", "桃園市警察", "桃園市警局", "桃園警察", "桃市警局"],
+      "tags": {
+        "amenity": "police",
+        "operator": "桃園市政府警察局",      
+        "operator:en": "Taoyuan Police Department",
+        "oeprator:wikidata": "Q15907660",
+        "operator:wikipedia": "zh:桃園市政府警察局"
+        "operator:zh": "桃園市政府警察局",  
+      }
+    },
+    {
+      "displayName": "臺中市政府警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["tcpb", "taichung police", "臺中市警察", "台中市警察", "臺中市警局", "台中市警局", "臺中警察", "台中警察", "中市警察", "中市警"],
+      "tags": {
+        "amenity": "police",
+        "operator": "臺中市政府警察局",      
+        "operator:en": "Taichung City Police Department",
+        "oeprator:wikidata": "Q15897177",
+        "operator:wikipedia": "zh:臺中市政府警察局"
+        "operator:zh": "臺中市政府警察局",  
+      }
+    },
+    {
+      "displayName": "臺南市政府警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["tnpd", "taian police", "臺南市警察", "台南市警察", "臺南市警局", "台南市警局", "臺南警察", "台南警察", "南市警察", "南市警局"],
+      "tags": {
+        "amenity": "police",
+        "operator": "臺南市政府警察局",      
+        "operator:en": "Tainan City Police Department",
+        "oeprator:wikidata": "Q15904106",
+        "operator:wikipedia": "zh:臺南市政府警察局"
+        "operator:zh": "臺南市政府警察局",  
+      }
+    },
+    {
+      "displayName": "高雄市政府警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["kcpd", "kmph", "kaohsiung police", "高雄市警察", "高雄市警局", "高雄警察", "高市警察", "高市警局"],
+      "tags": {
+        "amenity": "police",
+        "operator": "高雄市政府警察局",      
+        "operator:en": "Kaohsiung City Police Department",
+        "oeprator:wikidata": "Q15900495",
+        "operator:wikipedia": "zh:高雄市政府警察局"
+        "operator:zh": "高雄市政府警察局",  
+      }
+    },
   ]
 }


### PR DESCRIPTION
Add/modifying law enforcement agencies in Taiwan

National agencies
±海巡署 Coast Guard Administration
+刑事警察局 Criminal Investigation Bureau
+鐵路警察局 Railway Police Bureau
+國道公路警察局 National Highway Police Bureau
+航空警察局 Aviation Police Bureau

Local agencies of the Special Municipalities
±臺北市政府警察局 Taipei City
+新北市政府警察局 New Taipei City
+桃園市政府警察局 Taoyuan City
+臺中市政府警察局 Taichung City
+臺南市政府警察局 Tainan City
+高雄市政府警察局 Kaohsiung City