### PR TITLE
Discard 'ABC Store'

### DIFF
--- a/data/brands/shop/alcohol.json
+++ b/data/brands/shop/alcohol.json
@@ -6,7 +6,8 @@
         "^((разливное|живое) )?пиво$",
         "^(alcohol|beer|liquor)( store)?$",
         "^(botiller|licorer)[ií]a$"
-      ]
+      ],
+      "named": ["^abc store$"]
     }
   },
   "items": [
@@ -19,16 +20,6 @@
         "brand": "1. day",
         "brand:wikidata": "Q108149927",
         "name": "1. day",
-        "shop": "alcohol"
-      }
-    },
-    {
-      "displayName": "ABC Store",
-      "id": "abcstore-91a82c",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "brand": "ABC Store",
-        "name": "ABC Store",
         "shop": "alcohol"
       }
     },

--- a/dist/filtered/brands_discard.json
+++ b/dist/filtered/brands_discard.json
@@ -4778,6 +4778,7 @@
   "office/religion|Presbytère": 51,
   "office/religion|社務所": 95,
   "office/telecommunication|مخابرات": 54,
+  "shop/alcohol|ABC Store": 51,
   "shop/alcohol|Botilleria": 116,
   "shop/alcohol|Liquor Store": 79,
   "shop/alcohol|Живое пиво": 183,

--- a/dist/filtered/brands_keep.json
+++ b/dist/filtered/brands_keep.json
@@ -2439,7 +2439,6 @@
   "office/telecommunication|中華電信": 96,
   "shop/agrarian|Felleskjøpet": 105,
   "shop/agrarian|Granngården": 60,
-  "shop/alcohol|ABC Store": 51,
   "shop/alcohol|Alko": 317,
   "shop/alcohol|Bargain Booze": 198,
   "shop/alcohol|BC Liquor Store": 103,


### PR DESCRIPTION
ABC Store is a generic name used in [Alcohol Beverage Control (ABC) states](https://en.wikipedia.org/wiki/Alcoholic_beverage_control_state).

> Most of these states have an "Alcoholic Beverage Control" (ABC) board and run liquor stores called ABC stores or state stores.