### PR TITLE
Disambiguation of SECU

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -7563,7 +7563,7 @@
     {
       "displayName": "State Employees Credit Union (North Carolina)",
       "id": "stateemployeescreditunion-ea2e2d",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": [[-80, 35, 450]]},
       "tags": {
         "amenity": "bank",
         "brand": "State Employees Credit Union",
@@ -7575,7 +7575,7 @@
     },
     {
       "displayName": "State Employees Credit Union (Maryland)",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": [[-77, 39, 250]]},
       "tags": {
         "amenity": "bank",
         "brand": "State Employees Credit Union",

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -7568,7 +7568,7 @@
         "amenity": "bank",
         "brand": "State Employees Credit Union",
         "brand:wikidata": "Q7603196",
-        "brand:wikipedia": "en:State Employees Credit Union (North Carolina)",
+        "brand:wikipedia": "en:State Employees Credit Union",
         "name": "State Employees Credit Union",
         "short_name": "SECU"
       }
@@ -7582,7 +7582,7 @@
         "brand:wikidata": "Q100386180",
         "brand:wikipedia": "en:State Employees Credit Union of Maryland",
         "name": "State Employees Credit Union",
-        "short_name": "SECU MD"
+        "short_name": "SECU"
       }
     },
     {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -7561,16 +7561,28 @@
       }
     },
     {
-      "displayName": "State Employees Credit Union",
+      "displayName": "State Employees Credit Union (North Carolina)",
       "id": "stateemployeescreditunion-ea2e2d",
       "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "bank",
         "brand": "State Employees Credit Union",
         "brand:wikidata": "Q7603196",
-        "brand:wikipedia": "en:State Employees Credit Union",
+        "brand:wikipedia": "en:State Employees Credit Union (North Carolina)",
         "name": "State Employees Credit Union",
         "short_name": "SECU"
+      }
+    },
+    {
+      "displayName": "State Employees Credit Union (Maryland)",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "State Employees Credit Union",
+        "brand:wikidata": "Q100386180",
+        "brand:wikipedia": "en:State Employees Credit Union of Maryland",
+        "name": "State Employees Credit Union",
+        "short_name": "SECU MD"
       }
     },
     {


### PR DESCRIPTION
Previously SECU was only for the credit union based in North Carolina, and it has been wrongly used in OSM when mapping another credit union based in Maryland.

This PR requires review before merging, to avoid further confusion.