### PR TITLE
Create leisure/park and other public land operator categories

### DIFF
--- a/data/operators/boundary/aboriginal_lands.json
+++ b/data/operators/boundary/aboriginal_lands.json
@@ -1,0 +1,22 @@
+{
+  "properties": {
+    "path": "operators/boundary/aboriginal_lands",
+    "skipCollection": true,
+    "exclude": {"generic": ["^aboriginal lands$"]}
+  },
+  "items": [
+    {
+      "displayName": "Bureau of Indian Affairs",
+      "id": "bureauofindianaffairs-9a1c88",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "boundary": "aboriginal_lands",
+        "operator": "Bureau of Indian Affairs",
+        "operator:short": "BIA",
+        "operator:type": "public",
+        "operator:wikidata": "Q1010563",
+        "operator:wikipedia": "en:Bureau of Indian Affairs"
+      }
+    }
+  ]
+}

--- a/data/operators/boundary/national_park.json
+++ b/data/operators/boundary/national_park.json
@@ -1,0 +1,25 @@
+{
+  "properties": {
+    "path": "operators/boundary/national_park",
+    "exclude": {"generic": ["^national park$"]}
+  },
+  "items": [
+    {
+      "displayName": "National Park Service",
+      "id": "nationalparkservice-918b1c",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "boundary": "national_park",
+        "operator": "National Park Service",
+        "operator:short": "NPS",
+        "operator:type": "public",
+        "operator:wikidata": "Q308439",
+        "operator:wikipedia": "en:National Park Service",
+        "ownership": "national",
+        "protect_class": "2",
+        "protect_title": "National Park",
+        "protected": "perpetuity"
+      }
+    }
+  ]
+}

--- a/data/operators/boundary/protected_area.json
+++ b/data/operators/boundary/protected_area.json
@@ -1,0 +1,93 @@
+{
+  "properties": {
+    "path": "operators/boundary/protected_area",
+    "exclude": {"generic": ["^protected area$"]}
+  },
+  "items": [
+    {
+      "displayName": "National Monument (BLM)",
+      "id": "bureauoflandmanagement-167f6a",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "boundary": "protected_area",
+        "operator": "Bureau of Land Management",
+        "operator:short": "BLM",
+        "operator:type": "public",
+        "operator:wikidata": "Q1010556",
+        "operator:wikipedia": "en:Bureau of Land Management",
+        "ownership": "national",
+        "protect_class": "3",
+        "protect_title": "National Monument",
+        "protected": "perpetuity"
+      }
+    },
+    {
+      "displayName": "National Monument (FWS)",
+      "id": "unitedstatesfishandwildlifeservice-167f6a",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "boundary": "protected_area",
+        "operator": "United States Fish and Wildlife Service",
+        "operator:short": "FWS",
+        "operator:type": "public",
+        "operator:wikidata": "Q674113",
+        "operator:wikipedia": "en:United States Fish and Wildlife Service",
+        "ownership": "national",
+        "protect_class": "3",
+        "protect_title": "National Monument",
+        "protected": "perpetuity"
+      }
+    },
+    {
+      "displayName": "National Monument (NOS)",
+      "id": "nationaloceanservice-167f6a",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "boundary": "protected_area",
+        "operator": "National Ocean Service",
+        "operator:short": "NOS",
+        "operator:type": "public",
+        "operator:wikidata": "Q1891156",
+        "operator:wikipedia": "en:National Ocean Service",
+        "ownership": "national",
+        "protect_class": "3",
+        "protect_title": "National Monument",
+        "protected": "perpetuity"
+      }
+    },
+    {
+      "displayName": "National Monument (NPS)",
+      "id": "nationalparkservice-167f6a",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "boundary": "protected_area",
+        "operator": "National Park Service",
+        "operator:short": "NPS",
+        "operator:type": "public",
+        "operator:wikidata": "Q308439",
+        "operator:wikipedia": "en:National Park Service",
+        "ownership": "national",
+        "protect_class": "3",
+        "protect_title": "National Monument",
+        "protected": "perpetuity"
+      }
+    },
+    {
+      "displayName": "National Monument (USFS)",
+      "id": "unitedstatesforestservice-167f6a",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "boundary": "protected_area",
+        "operator": "United States Forest Service",
+        "operator:short": "USFS",
+        "operator:type": "public",
+        "operator:wikidata": "Q1891156",
+        "operator:wikipedia": "en:United States Forest Service",
+        "ownership": "national",
+        "protect_class": "3",
+        "protect_title": "National Monument",
+        "protected": "perpetuity"
+      }
+    }
+  ]
+}

--- a/data/operators/leisure/nature_reserve.json
+++ b/data/operators/leisure/nature_reserve.json
@@ -1,0 +1,21 @@
+{
+  "properties": {
+    "path": "operators/leisure/nature_reserve",
+    "skipCollection": true,
+    "exclude": {
+      "generic": [
+        "^natural area$",
+        "^nature park$",
+        "^open space$"
+      ]
+    }
+  },
+  "items": [
+    {
+      "templateSource": "operators/leisure/park",
+      "templateTags": {
+        "leisure": "nature_reserve"
+      }
+    }
+  ]
+}

--- a/data/operators/leisure/park.json
+++ b/data/operators/leisure/park.json
@@ -1,0 +1,21 @@
+{
+  "properties": {
+    "path": "operators/leisure/park",
+    "exclude": {"generic": ["^park$"]}
+  },
+  "items": [
+    {
+      "displayName": "National Park Service",
+      "id": "nationalparkservice-059b34",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "leisure": "park",
+        "operator": "National Park Service",
+        "operator:short": "NPS",
+        "operator:type": "public",
+        "operator:wikidata": "Q308439",
+        "operator:wikipedia": "en:National Park Service"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Re: #4769 

Not sure how I would be able to create separate entries to national monuments and other types of protected areas operated by the same department. For example, when adding National Wildlife Refuges (operated by FWS), running build gives an error as the two have the same operator. If this isn't possible I could just make these entries less specific (National Park Service, Bureau of Land Management, etc.).