### PR TITLE
Update name of JOANN stores and add short_name tag

### DIFF
--- a/data/brands/shop/craft.json
+++ b/data/brands/shop/craft.json
@@ -63,15 +63,16 @@
       }
     },
     {
-      "displayName": "Jo-Ann",
-      "id": "joann-94ee6e",
+      "displayName": "JOANN Fabrics and Crafts",
+      "id": "joannfabricsandcrafts-94ee6e",
       "locationSet": {"include": ["us"]},
       "tags": {
-        "brand": "Jo-Ann",
+        "brand": "JOANN Fabrics and Crafts",
         "brand:wikidata": "Q6203968",
         "brand:wikipedia": "en:Jo-Ann Stores",
-        "name": "Jo-Ann",
-        "shop": "craft"
+        "name": "JOANN Fabrics and Crafts",
+        "shop": "craft",
+        "short_name": "JOANN"
       }
     },
     {


### PR DESCRIPTION
This matches other maps. Their website and signage seem to be going to just JOANN. At some point it needs to get flipped here.

Resolves part of https://github.com/osmlab/name-suggestion-index/issues/5386

Signed-off-by: Tim Smith <tsmith@chef.io>