### PR TITLE
fix typo - diet:vegitarian

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -5478,7 +5478,7 @@
         "brand:wikidata": "Q108118332",
         "cuisine": "american",
         "diet:vegan": "yes",
-        "diet:vegitarian": "only",
+        "diet:vegetarian": "only",
         "name": "Veggie Pret",
         "takeaway": "yes"
       }


### PR DESCRIPTION
Note that I have not verified other parts of commit that introduced this bug.

Problem caught by Ivan, thanks for reporting!

Note: I was unable to run `npm run build` (I did `npm install`):

```
> name-suggestion-index@6.0.20210918 build
> run-s build:features build:index


> name-suggestion-index@6.0.20210918 build:features
> node scripts/build_features.js

internal/modules/run_main.js:54
    internalBinding('errors').triggerUncaughtException(
                              ^

Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only file and data URLs are supported by the default ESM loader
    at Loader.defaultResolve [as _resolve] (internal/modules/esm/resolve.js:669:11)
    at Loader.resolve (internal/modules/esm/loader.js:97:40)
    at Loader.getModuleJob (internal/modules/esm/loader.js:243:28)
    at ModuleWrap.<anonymous> (internal/modules/esm/module_job.js:42:40)
    at link (internal/modules/esm/module_job.js:41:36) {
  code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
}
ERROR: "build:features" exited with 1.
```