### PR TITLE
Add Yeme

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -6521,6 +6521,17 @@
       }
     },
     {
+      "displayName": "Yeme",
+      "locationSet": {"include": ["sk"]},
+      "matchNames": ["independent"],
+      "tags": {
+        "brand": "Yeme",
+        "brand:wikidata": "Q29446893",
+        "name": "yeme",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Your Independent Grocer",
       "id": "yourindependentgrocer-76454b",
       "locationSet": {"include": ["ca"]},


### PR DESCRIPTION
Yeme is a Slovak supermarket chain (currently only operates 5 shops in Bratislava).