### PR TITLE
Add Yeme

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -6521,6 +6521,17 @@
       }
     },
     {
+      "displayName": "Yeme",
+      "locationSet": {"include": ["sk"]},
+      "matchNames": ["independent"],
+      "tags": {
+        "brand": "Yeme",
+        "brand:wikidata": "Q108757006",
+        "name": "yeme",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Your Independent Grocer",
       "id": "yourindependentgrocer-76454b",
       "locationSet": {"include": ["ca"]},


### PR DESCRIPTION
Yeme is a Slovak supermarket chain (currently only operates 5 shops in Bratislava; a shop in Nitra is about to open).

A fixed iteration of PR #5411 which was closed without giving enough time to actually fix the error; GitHub doesn’t seem to allow updating a PR in such cases.