### PR TITLE
Added First Choice Liquor to brands/shop/alcohol in au region

### DIFF
--- a/data/brands/shop/alcohol.json
+++ b/data/brands/shop/alcohol.json
@@ -162,6 +162,18 @@
       }
     },
     {
+      "displayName": "First Choice Liquor",
+      "id": "firstchoiceliquor-cb3c62",
+      "locationSet": {"include": ["au"]},
+      "tags": {
+        "brand": "First Choice Liquor",
+        "brand:wikidata": "Q4596269",
+        "brand:wikipedia": "en:First Choice Liquor",
+        "name": "First Choice Liquor",
+        "shop": "alcohol"
+      }
+    },
+    {
       "displayName": "Gall & Gall",
       "id": "gallandgall-e09280",
       "locationSet": {"include": ["nl"]},


### PR DESCRIPTION
First Choice Liquor is an Australian liquor retailer. As such, I have added it to the list of shop/alcohol brands, including its Wikipedia and Wikidata entries, and run `npm run build` to generate an id for it