### PR TITLE
Added Duncans to brand/shop/alcohol in au

### DIFF
--- a/data/brands/shop/alcohol.json
+++ b/data/brands/shop/alcohol.json
@@ -141,6 +141,16 @@
       }
     },
     {
+      "displayName": "Duncan's",
+      "id": "duncans-cb3c62",
+      "locationSet": {"include": ["au"]},
+      "tags": {
+        "brand": "Duncan's",
+        "name": "Duncan's",
+        "shop": "alcohol"
+      }
+    },
+    {
       "displayName": "Duży Ben",
       "id": "duzyben-48eb32",
       "locationSet": {"include": ["pl"]},


### PR DESCRIPTION
Duncans is a liquor retailer in Australia, as such I have added it to brands/shop/alcohol then run `npm run build` to generate an id for it. There does not appear to be a wikipedia page or a wikidata entry for it, but they do have a website as proof of its existence:
https://www.duncans.com.au/
