### PR TITLE
Add missing indonesian bank (permata, artos, Central Asia)

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -1670,6 +1670,18 @@
       }
     },
     {
+      "displayName": "Bank Artos Indonesia",
+      "id": "bankartosindonesia-aa7852",
+      "locationSet": {"include": ["id"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "Bank Artos Indonesia",
+        "brand:wikidata": "Q12474471",
+        "brand:wikipedia": "en:Bank Artos Indonesia",
+        "name": "Bank Artos Indonesia"
+      }
+    },
+    {
       "displayName": "Bank Austria",
       "id": "bankaustria-694ab5",
       "locationSet": {"include": ["at"]},
@@ -1691,6 +1703,18 @@
         "brand:wikidata": "Q9165001",
         "brand:wikipedia": "pl:Bank Polskiej Spółdzielczości",
         "name": "Bank BPS"
+      }
+    },
+    {
+      "displayName": "Bank Central Asia",
+      "id": "bankcentralasia-aa7852",
+      "locationSet": {"include": ["id"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "Bank Central Asia",
+        "brand:wikidata": "Q806626",
+        "brand:wikipedia": "en:Bank Central Asia",
+        "name": "Bank Central Asia"
       }
     },
     {
@@ -1960,6 +1984,18 @@
         "brand:wikidata": "Q806642",
         "brand:wikipedia": "pl:Bank Polska Kasa Opieki",
         "name": "Bank Pekao"
+      }
+    },
+    {
+      "displayName": "Bank Permata",
+      "id": "bankpermata-aa7852",
+      "locationSet": {"include": ["id"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "Bank Permata",
+        "brand:wikidata": "Q4855963",
+        "brand:wikipedia": "en:Permata Bank",
+        "name": "Bank Permata"
       }
     },
     {


### PR DESCRIPTION
This PR will add missing Indonesian bank:
- Bank Permata
- Bank Artos Indonesia
- Bank Central Asia