### PR TITLE
Add missing Indian Cinema (INOX Leisure Limited, PVR Cinemas)

### DIFF
--- a/data/brands/amenity/cinema.json
+++ b/data/brands/amenity/cinema.json
@@ -445,6 +445,19 @@
       }
     },
     {
+      "displayName": "INOX Leisure Limited",
+      "id": "inoxleisurelimited-aa55a2",
+      "locationSet": { "include": ["in"]},
+      "matchNames": ["inox"],
+      "tags": {
+        "amenity": "cinema",
+        "brand": "INOX Leisure Limited",
+        "brand:wikidata": "Q5972349",
+        "brand:wikipedia": "en:INOX Leisure Limited",
+        "name": "PVR Cinemas"
+      }
+    },
+    {
       "displayName": "Kinepolis",
       "id": "kinepolis-bc363a",
       "locationSet": {
@@ -666,6 +679,19 @@
         "brand:wikidata": "Q3060526",
         "brand:wikipedia": "fr:Les cinémas Pathé Gaumont",
         "name": "Pathé Gaumont"
+      }
+    },
+    {
+      "displayName": "PVR Cinemas",
+      "id": "pvrcinemas-aa55a2",
+      "locationSet": { "include": ["in"]},
+      "matchNames": ["pvr"],
+      "tags": {
+        "amenity": "cinema",
+        "brand": "PVR Cinemas",
+        "brand:wikidata": "Q3359908",
+        "brand:wikipedia": "en:PVR Cinemas",
+        "name": "PVR Cinemas"
       }
     },
     {


### PR DESCRIPTION
Added the missing Indian cinema brands INOX Leisure Limited and PVR Cinemas in data/brands/amenity/