### PR TITLE
Update JOSM presets link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Currently used in:
 - [RapiD](https://github.com/facebookincubator/RapiD)
 - [iD](https://github.com/openstreetmap/iD) (see above)
 - [Vespucci](http://vespucci.io/tutorials/name_suggestions/)
-- [JOSM presets](https://josm.openstreetmap.de/wiki/Help/Preferences/Map#TaggingPresets) available
+- [JOSM presets](https://josm.openstreetmap.de/wiki/Help/Preferences/TaggingPresetPreference) available
 - [Osmose](http://osmose.openstreetmap.fr/en/errors/?item=3130)
 - [osmfeatures](https://github.com/westnordost/osmfeatures)
 - [Go Map!!](https://github.com/bryceco/GoMap)


### PR DESCRIPTION
Old link redirects to the Map Projection page
Corrected to Tagging Presets page