### PR TITLE
Added Tyrepower to Australian tyre shops

### DIFF
--- a/data/brands/shop/tyres.json
+++ b/data/brands/shop/tyres.json
@@ -308,6 +308,16 @@
       }
     },
     {
+      "displayName": "Tyrepower",
+      "id": "tyrepower-6139cc",
+      "locationSet": {"include": ["au"]},
+      "tags": {
+        "brand": "Tyrepower",
+        "name": "Tyrepower",
+        "shop": "tyres"
+      }
+    },
+    {
       "displayName": "Vergölst",
       "id": "vergolst-24681a",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
Added Australian tyre shop Tyrepower. No wiki item for this one yet, but evidence it exists:

https://www.tyrepower.com.au/