### PR TITLE
add burger to braums' list of cuisines

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -462,7 +462,7 @@
         "brand": "Braum's",
         "brand:wikidata": "Q4958263",
         "brand:wikipedia": "en:Braum's",
-        "cuisine": "ice_cream",
+        "cuisine": "ice_cream;burger",
         "name": "Braum's",
         "shop": "dairy",
         "takeaway": "yes"


### PR DESCRIPTION
Braums serves burgers as well as ice cream (gotta use the whole cow, y'know)