### PR TITLE
Update fast_food.json

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -2234,7 +2234,6 @@
       "id": "harveys-e49d2e",
       "locationSet": {"include": ["ca"]},
       "tags": {
-        "alt_name": "Harveh's",
         "amenity": "fast_food",
         "brand": "Harvey's",
         "brand:wikidata": "Q1466184",


### PR DESCRIPTION
Remove "Harveh's" alternate name from Harvey's. Looks like this was a name used in a short-lived marketing campaign https://twitter.com/harveyscanada/status/1397284046359642121 - do we really want the iD validator automatically suggesting this as a correction? When I use the iD editor I always ignore this correction.