### PR TITLE
Add SITP (Bogotá)

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -11593,6 +11593,17 @@
       }
     },
     {
+      "displayName": "SITP",
+      "id": "sitp-53ae69",
+      "locationSet": {"include": ["co"]},
+      "tags": {
+        "network": "SITP",
+        "network:wikidata": "Q6129638",
+        "network:wikipedia": "es:Sistema Integrado de Transporte de Bogotá",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "SITU",
       "id": "situ-2ef076",
       "locationSet": {"include": ["br"]},


### PR DESCRIPTION
Since no one calls this bus network by the full name, and the abbreviation is used officially everywhere, I decided to leave it like that