### PR TITLE
Update Motivate bike sharing networks

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -110,14 +110,23 @@
     },
     {
       "displayName": "Bay Wheels",
-      "id": "baywheels-97ea79",
-      "locationSet": {"include": ["us"]},
+      "id": "baywheels-e229af",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "matchNames": [
+        "bay area bike share",
+        "ford gobike"
+      ],
       "tags": {
         "amenity": "bicycle_rental",
         "brand": "Bay Wheels",
         "brand:wikidata": "Q16971391",
         "brand:wikipedia": "en:Bay Wheels",
-        "name": "Bay Wheels"
+        "name": "Bay Wheels",
+        "operator": "Motivate",
+        "operator:wikidata": "Q4735954",
+        "operator:wikipedia": "en:Motivate (company)"
       }
     },
     {
@@ -1432,21 +1441,6 @@
         "operator": "Nextbike",
         "operator:wikidata": "Q2351279",
         "operator:wikipedia": "en:Nextbike"
-      }
-    },
-    {
-      "displayName": "Ford GoBike",
-      "id": "fordgobike-e229af",
-      "locationSet": {
-        "include": ["us-ca.geojson"]
-      },
-      "tags": {
-        "amenity": "bicycle_rental",
-        "brand": "Ford GoBike",
-        "network": "Ford GoBike",
-        "operator": "Motivate",
-        "operator:wikidata": "Q4735954",
-        "operator:wikipedia": "en:Motivate (company)"
       }
     },
     {


### PR DESCRIPTION
Limited Motivate-operated bike sharing networks to their respective states. Merged Ford GoBike into Bay Wheels.

Fixes #5529.