### PR TITLE
Fix country code on UK flag

### DIFF
--- a/data/flags/man_made/flagpole.json
+++ b/data/flags/man_made/flagpole.json
@@ -1772,6 +1772,21 @@
       }
     },
     {
+      "displayName": "GB - United Kingdom",
+      "id": "unionjack-e5dc93",
+      "locationSet": {"include": ["001"]},
+      "matchNames": ["great britain", "uk"],
+      "tags": {
+        "country": "GB",
+        "flag:name": "Union Jack",
+        "flag:type": "national",
+        "flag:wikidata": "Q83278",
+        "man_made": "flagpole",
+        "subject": "United Kingdom",
+        "subject:wikidata": "Q145"
+      }
+    },
+    {
       "displayName": "GE - Georgia (Country)",
       "id": "georgia-e5dc93",
       "locationSet": {"include": ["001"]},
@@ -3927,21 +3942,6 @@
         "man_made": "flagpole",
         "subject": "Uganda",
         "subject:wikidata": "Q1036"
-      }
-    },
-    {
-      "displayName": "UK - United Kingdom",
-      "id": "unionjack-e5dc93",
-      "locationSet": {"include": ["001"]},
-      "matchNames": ["gb", "great britain"],
-      "tags": {
-        "country": "UK",
-        "flag:name": "Union Jack",
-        "flag:type": "national",
-        "flag:wikidata": "Q83278",
-        "man_made": "flagpole",
-        "subject": "United Kingdom",
-        "subject:wikidata": "Q145"
       }
     },
     {


### PR DESCRIPTION
The `country` key is set to an ISO&nbsp;3166-1&nbsp;alpha-2 code. The canonical code for the United Kingdom is `GB`, even though `UK` is reserved for the same purpose. `GB` also predominates in OSM usage. The build script insists that the name of the preset include the country code, not an alias, so the preset is now named “GB – United Kingdom”, not “UK – United Kingdom”. (Otherwise, the build script would’ve turned it into “GB – UK – United Kingdom”.)