### PR TITLE
Stadtwerke Karlsruhe Netzservice GmbH

### DIFF
--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -5748,6 +5748,10 @@
       "displayName": "Stadtwerke Karlsruhe Netzservice GmbH",
       "id": "stadtwerkekarlsruhe-7ff171",
       "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "stadtwerke karlsruhe",
+        "stadtwerke karlsruhe gmbh" 
+      ],
       "tags": {
         "operator": "Stadtwerke Karlsruhe Netzservice GmbH",
         "operator:wikidata": "Q2328532",


### PR DESCRIPTION
Stadtwerke Karlsruhe Netzservice GmbH is the operator of the grid, using the Stadtwerke Karlsruhe brand.
