### PR TITLE
Stadtwerke Heidelberg Netze GmbH

### DIFF
--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -5692,6 +5692,7 @@
       "displayName": "Stadtwerke Heidelberg Netze GmbH",
       "id": "stadtwerkeheidelberg-7ff171",
       "locationSet": {"include": ["de"]},
+      "matchNames": ["Stadtwerke Heidelberg"],
       "tags": {
         "operator": "Stadtwerke Heidelberg Netze GmbH",
         "operator:wikidata": "Q48180711",


### PR DESCRIPTION
Stadtwerke Heidelberg Netze GmbH is the operator of the grid, using the Stadtwerke Heidelberg brand.