### PR TITLE
Stadtmobil is a brand not an operator

### DIFF
--- a/data/operators/amenity/car_sharing.json
+++ b/data/operators/amenity/car_sharing.json
@@ -538,24 +538,79 @@
       }
     },
     {
-      "displayName": "stadtmobil",
-      "id": "stadtmobil-088af7",
+      "displayName": "Stadtmobil Karlsruhe",
+      "id": "stadtmobilKarlsruhe-088af7",
       "locationSet": {"include": ["de"]},
-      "matchNames": [
-        "stadtmobil carsharing gmbh & co. kg",
-        "stadtmobil carsharing-station",
-        "stadtmobil hannover gmbh",
-        "stadtmobil rhein-neckar",
-        "stadtmobil rhein-neckar ag",
-        "stadtmobil rhein-ruhr gmbh",
-        "stadtmobil stuttgart",
-        "stadtmobil südbaden"
-      ],
       "tags": {
         "amenity": "car_sharing",
-        "operator": "stadtmobil",
-        "operator:wikidata": "Q2327629",
-        "operator:wikipedia": "de:Stadtmobil"
+        "brand": "Stadtmobil",
+        "brand:wikidata": "Q2327629",
+        "brand:wikipedia": "de:Stadtmobil",
+        "network": "Stadtmobil Karlsruhe",
+        "operator": "Stadtmobil Carsharing GmbH & Co. KG",
+      }
+    },
+    {
+      "displayName": "Stadtmobil Hannover",
+      "id": "stadtmobilHannover-088af7",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "amenity": "car_sharing",
+        "brand": "Stadtmobil",
+        "brand:wikidata": "Q2327629",
+        "brand:wikipedia": "de:Stadtmobil",
+        "network": "Stadtmobil Hannover",
+        "operator": "Stadtmobil Hannover GmbH"
+      }
+    },
+    {
+      "displayName": "Stadtmobil Rhein-Neckar",
+      "id": "stadtmobilRheinNeckar-088af7",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "amenity": "car_sharing",
+        "brand": "Stadtmobil",
+        "brand:wikidata": "Q2327629",
+        "brand:wikipedia": "de:Stadtmobil",
+        "network": "Stadtmobil Rhein-Neckar",
+        "operator": "Stadtmobil Rhein-Neckar AG"
+      }
+    },
+    {
+      "displayName": "Stadtmobil Rhein-Ruhr",
+      "id": "stadtmobilKarlsruhe-088af7",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "amenity": "car_sharing",
+        "brand": "Stadtmobil",
+        "brand:wikidata": "Q2327629",
+        "brand:wikipedia": "de:Stadtmobil",
+        "network": "Stadtmobil Rhein-Ruhr",
+        "operator": "Stadtmobil Rhein-Ruhr GmbH"
+      }
+    },
+    {
+      "displayName": "Stadtmobil Stuttgart",
+      "id": "stadtmobilStuttgart-088af7",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "amenity": "car_sharing",
+        "brand": "Stadtmobil",
+        "brand:wikidata": "Q2327629",
+        "brand:wikipedia": "de:Stadtmobil",
+        "network": "Stadtmobil Stuttgart",
+        "operator": "stadtmobil carsharing AG"
+      }
+    },
+    {
+      "displayName": "Stadtmobil Südbaden",
+      "id": "stadtmobilSüdbaden-088af7",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "amenity": "car_sharing",
+        "brand": "Stadtmobil Südbaden",
+        "network": "Stadtmobil Südbaden",
+        "operator": "Stadtmobil Südbaden AG"
       }
     },
     {


### PR DESCRIPTION
The Stadtmobil brand is used by several independant operators per city using the same brand and booking systems, but e.g. different pricing. 
Stadtmobil Südbaden is a different brand.