### PR TITLE
Badenwerk and EnBW are not a power grid operator anymore

### DIFF
--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -2028,24 +2028,6 @@
       }
     },
     {
-      "displayName": "EnBW",
-      "id": "enbw-7ff171",
-      "locationSet": {"include": ["de"]},
-      "matchNames": [
-        "enbw ag",
-        "enbw regional",
-        "enbw regional ag",
-        "energie-versorgung schwaben ag",
-        "neckarwerke"
-      ],
-      "tags": {
-        "operator": "EnBW",
-        "operator:wikidata": "Q644304",
-        "operator:wikipedia": "de:EnBW Energie Baden-Württemberg",
-        "power": "substation"
-      }
-    },
-    {
       "displayName": "Endeavour Energy",
       "id": "endeavourenergy-e597e3",
       "locationSet": {"include": ["au"]},


### PR DESCRIPTION
Badenwerk has been merged with EVS to EnBW in 1996, EnBW has handed over the grid to EnBW Regional AG in 1999, which was later renamed to Netze BW GmbH.
There are still many substation with signs saying Badenwerk or EnBW Regional AG, which are actually operated by Netze BW GmbH.
I removed "enbw" from matching tags as there might be some substations e.g. in power plants that are actually operated by other EnBW companies.

_**Source**: German wikipedia sites for [Badenwerk](https://de.wikipedia.org/wiki/Badenwerk) and [Netze BW](https://de.wikipedia.org/wiki/Netze_BW)_