### PR TITLE
EnBW Energie Baden-Württemberg AG

### DIFF
--- a/data/operators/power/generator.json
+++ b/data/operators/power/generator.json
@@ -1463,6 +1463,7 @@
       "displayName": "EnBW Energie Baden-Württemberg AG",
       "id": "enbw-b8ae25",
       "locationSet": {"include": ["de"]},
+      "matchNames":["EnBW"],
       "tags": {
         "operator": "EnBW Energie Baden-Württemberg AG",
         "operator:wikidata": "Q644304",


### PR DESCRIPTION
The full name of the company is EnBW Energie Baden-Württemberg AG, eventhough many plants branded as EnBW are actually operated by subsidiaries e.g. EnBW Kernkraft GmbH