### PR TITLE
Add Tuolumne County Transit

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -14351,7 +14351,6 @@
       "tags": {
         "network": "Tuolumne County Transit",
         "network:wikidata": "Q14509110",
-        "network:wikipedia": "nl:Tuolumne County Transit",
         "route": "bus"
       }
     },


### PR DESCRIPTION
This PR adds Tuolumne County Transit to the list of bus routes.