### PR TITLE
#5561  Posten Norge move operator=Posten to Brand

### DIFF
--- a/data/brands/amenity/post_office.json
+++ b/data/brands/amenity/post_office.json
@@ -1,0 +1,151 @@
+{
+  "properties": {
+    "path": "brands/amenity/post_office",
+    "preserveTags": ["^name"],
+    "exclude": {"generic": ["^post office$"]}
+  },
+  "items": [
+    {
+      "displayName": "Agence Communale",
+      "id": "agencecommunale-27cb18",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "post_office",
+        "brand": "Agence Communale",
+        "name": "Agence Communale"
+      }
+    },
+    {
+      "displayName": "Agence Postale",
+      "id": "agencepostale-27cb18",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "post_office",
+        "brand": "Agence Postale",
+        "name": "Agence Postale"
+      }
+    },
+    {
+      "displayName": "CDEK",
+      "id": "cdek-27cb18",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "post_office",
+        "brand": "CDEK",
+        "name": "CDEK"
+      }
+    },
+    {
+      "displayName": "DHL Express Easy",
+      "id": "dhlexpresseasy-27cb18",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "post_office",
+        "brand": "DHL Express Easy",
+        "name": "DHL Express Easy"
+      }
+    },
+    {
+      "displayName": "Grupo ZOOM",
+      "id": "grupozoom-27cb18",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "post_office",
+        "brand": "Grupo ZOOM",
+        "name": "Grupo ZOOM"
+      }
+    },
+    {
+      "displayName": "JRS Express",
+      "id": "jrsexpress-27cb18",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "post_office",
+        "brand": "JRS Express",
+        "name": "JRS Express"
+      }
+    },
+    {
+      "displayName": "Poçt ATS",
+      "id": "poctats-27cb18",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "post_office",
+        "brand": "Poçt ATS",
+        "name": "Poçt ATS"
+      }
+    },
+    {
+      "displayName": "Postbank Finanzcenter",
+      "id": "postbankfinanzcenter-27cb18",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "post_office",
+        "brand": "Postbank Finanzcenter",
+        "name": "Postbank Finanzcenter"
+      }
+    },
+    {
+      "displayName": "Poste annexe",
+      "id": "posteannexe-27cb18",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "post_office",
+        "brand": "Poste annexe",
+        "name": "Poste annexe"
+      }
+    },
+    {
+      "displayName": "Poste Annexe",
+      "id": "posteannexe-27cb18",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "post_office",
+        "brand": "Poste Annexe",
+        "name": "Poste Annexe"
+      }
+    },
+    {
+      "displayName": "Posten (Norge)",
+      "id": "posten-0526a8",
+      "locationSet": {"include": ["no"]},
+      "note": "Posten is the brand, not the operator of post offices https://github.com/osmlab/name-suggestion-index/issues/5561",
+      "tags": {
+        "amenity": "post_office",
+        "brand": "Posten",
+        "brand:wikidata": "Q1815701",
+        "brand:wikipedia": "no:Posten Norge"
+      }
+    },
+    {
+      "displayName": "Relais La Poste",
+      "id": "relaislaposte-27cb18",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "post_office",
+        "brand": "Relais La Poste",
+        "name": "Relais La Poste"
+      }
+    },
+    {
+      "displayName": "Relais Poste",
+      "id": "relaisposte-27cb18",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "post_office",
+        "brand": "Relais Poste",
+        "name": "Relais Poste"
+      }
+    },
+    {
+      "displayName": "Европочта",
+      "id": "4e1752-27cb18",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "post_office",
+        "brand": "Европочта",
+        "name": "Европочта"
+      }
+    }
+  ]
+}

--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -1058,18 +1058,6 @@
       }
     },
     {
-      "displayName": "Posten (Norge)",
-      "id": "posten-03f567",
-      "locationSet": {"include": ["no"]},
-      "note": "Posten is the brand, not the operator of post offices https://github.com/osmlab/name-suggestion-index/issues/5561",
-      "tags": {
-        "amenity": "post_office",
-        "brand": "Posten",
-        "brand:wikidata": "Q1815701",
-        "brand:wikipedia": "no:Posten Norge"
-      }
-    },
-    {
       "displayName": "Postes Canada",
       "id": "postescanada-d8ff35",
       "locationSet": {

--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -1061,11 +1061,12 @@
       "displayName": "Posten (Norge)",
       "id": "posten-03f567",
       "locationSet": {"include": ["no"]},
+      "note": "Posten is the brand, not the operator of post offices https://github.com/osmlab/name-suggestion-index/issues/5561",
       "tags": {
         "amenity": "post_office",
-        "operator": "Posten",
-        "operator:wikidata": "Q1815701",
-        "operator:wikipedia": "no:Posten Norge"
+        "brand": "Posten",
+        "brand:wikidata": "Q1815701",
+        "brand:wikipedia": "no:Posten Norge"
       }
     },
     {


### PR DESCRIPTION
Closes #5561

Hmm I don't understand why operator is readded when I run `npm run build`
![image](https://user-images.githubusercontent.com/5204006/138846648-ba41faf9-9655-4005-9c72-73cb81aec0da.png)
-> Change after I run `npm run build`


EDIT: Happens because it is located in the operators section. The correct would be to have Posten in the brands sections as each food store is operating the Posten post_office

If I add it to the brands section and run Build, lots of other postal services are added to this file as well with duplicate ids. Is this correct?