### PR TITLE
Add Chaqwa vending machines

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -1253,9 +1253,6 @@
         "amenity": "vending_machine",
         "brand": "Chaqwa",
         "brand:wikidata": "Q109265856",
-        "manufacturer": "Coca-Cola Erfrischungsgetränke AG",
-        "manufacturer:wikidata": "Q3295867",
-        "manufacturer:wikipedia": "de:The Coca-Cola Company "
       }
     }
   ]


### PR DESCRIPTION
Chaqwa is a brand of The Coca Cola Company, so I think this should be added.


Thank you.