### PR TITLE
Merge "Empresa Brasileira de Correios e Telégrafos" into Correios

### DIFF
--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -223,6 +223,11 @@
       "displayName": "Correios",
       "id": "correios-e82118",
       "locationSet": {"include": ["br"]},
+      "matchNames": [
+        "ebct",
+        "ect",
+        "empresa brasileira de correios e telégrafos"
+      ],
       "tags": {
         "amenity": "post_office",
         "operator": "Correios",
@@ -435,19 +440,6 @@
         "operator": "Emirates Post",
         "operator:wikidata": "Q5372577",
         "operator:wikipedia": "en:Emirates Post"
-      }
-    },
-    {
-      "displayName": "Empresa Brasileira de Correios e Telégrafos",
-      "id": "empresabrasileiradecorreiosetelegrafos-e82118",
-      "locationSet": {"include": ["br"]},
-      "matchNames": ["ect"],
-      "tags": {
-        "amenity": "post_office",
-        "operator": "Empresa Brasileira de Correios e Telégrafos",
-        "operator:wikidata": "Q3375004",
-        "operator:wikipedia": "pt:Empresa Brasileira de Correios e Telégrafos",
-        "short_name": "EBCT"
       }
     },
     {


### PR DESCRIPTION
"Empresa Brasileira de Correios e Telégrafos" and Correios are the same company, but was duplicated. I deleted the first one and kept Correios, as it's the brand name currently used.

@arch0345 Could you review it please?