### PR TITLE
Oslo Bysykkel correct operator to UIP Oslo Bysykkel AS + Add wikidata to Bergen Bysykkel

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -197,7 +197,9 @@
       "tags": {
         "amenity": "bicycle_rental",
         "brand": "Bergen Bysykkel",
+        "brand:wikidata": "Q109288835",
         "network": "Bergen Bysykkel",
+        "network:wikidata": "Q109288835",
         "operator": "Urban Infrastructure Partner AS"
       }
     },


### PR DESCRIPTION
Source: https://oslobysykkel.no/om

> Hvem står bak Oslo Bysykkel?
UIP Oslo Bysykkel AS er operatøren som eier og utvikler og driver bysykkeltjenesten i Oslo.

-> Translate: `UIP Oslo Bysykkel AS is the operator that owns and develops and runs the citybike service in Oslo.`


Also changed Brand from `Bysykkel` to `Oslo Bysykkel` to better fit the sister brand in Bergen: `Bergen Bysykkel`
+ added wikidata entry for Bergen Bysykkel