### PR TITLE
Shorten DisplayNames, smaller scope for Morongo Basin MBTA

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -7050,7 +7050,7 @@
       }
     },
     {
-      "displayName": "MBTA (Massachusetts Bay Transportation Authority)",
+      "displayName": "MBTA (Massachusetts)",
       "id": "mbta-e17ae4",
       "locationSet": {
         "include": [[-71, 42, 100]]
@@ -7066,10 +7066,10 @@
       }
     },
     {
-      "displayName": "MBTA (Morongo Basin Transit Authority)",
-      "id": "mbta-62dc11",
+      "displayName": "MBTA (Morongo Basin)",
+      "id": "mbta-8a1512",
       "locationSet": {
-        "include": ["us-ca.geojson"]
+        "include": [[-116.4, 34.1, 40]]
       },
       "matchNames": [
         "morongo basin transit authority"

--- a/data/transit/route/subway.json
+++ b/data/transit/route/subway.json
@@ -171,7 +171,7 @@
       }
     },
     {
-      "displayName": "MBTA",
+      "displayName": "MBTA (Massachusetts)",
       "id": "mbta-8e6d4a",
       "locationSet": {
         "include": [[-71, 42, 100]]

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -863,7 +863,7 @@
       }
     },
     {
-      "displayName": "MBTA",
+      "displayName": "MBTA (Massachusetts)",
       "id": "mbta-a0abcc",
       "locationSet": {
         "include": [[-71, 42, 100]]

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -300,7 +300,7 @@
       }
     },
     {
-      "displayName": "MBTA",
+      "displayName": "MBTA (Massachusetts)",
       "id": "mbta-98eeec",
       "locationSet": {
         "include": [[-71, 42, 100]]

--- a/data/transit/route/trolleybus.json
+++ b/data/transit/route/trolleybus.json
@@ -123,7 +123,7 @@
       }
     },
     {
-      "displayName": "MBTA",
+      "displayName": "MBTA (Massachusetts)",
       "id": "mbta-73386d",
       "locationSet": {
         "include": [[-71, 42, 100]]


### PR DESCRIPTION
This is just a followup to #5593 
- use shorter display names so they won't be cut off in iD: "MBTA (Massachusetts)" and "MBTA (Morongo Basin)"
- uses the same  "MBTA (Massachusetts)" display name on the other transit routes (subway, train, tram, trolleybus)
- based on their [system map](https://mbtabus.com/), scope the"MBTA (Morongo Basin)" item [a bit smaller](https://location-conflation.com/?locationSet=%7B%20include%3A%20%5B%5B-116.4%2C%2034.1%2C%2040%20%5D%5D%20%7D%0A), instead of all of California