### PR TITLE
Add MIKA Hundetoiletten

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -1285,6 +1285,16 @@
         "name:ja": "明治",
         "vending": "food"
       }
+    },
+    {
+      "displayName": "MIKA Hundetoiletten",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "amenity": "vending_machine",
+        "brand": "MIKA",
+        "brand:wikidata": "Q109336084",
+        "vending": "excrement_bags"
+      }
     }
   ]
 }


### PR DESCRIPTION
These things are bought by city councils, park/zoo owners etc. They all have a clear branding. MIKA themselves state, currently over 1000 citys and councils are using these.