### PR TITLE
Add TotalEnergies

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -4460,6 +4460,18 @@
       }
     },
     {
+      "displayName": "TotalEnergies",
+      "id": "totalenergies-b3d110",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "amenity": "fuel",
+        "brand": "TotalEnergies",
+        "brand:wikidata": "Q154037",
+        "brand:wikipedia": "de:TotalEnergies",
+        "name": "TotalEnergies"
+      }
+    },
+    {
       "displayName": "Total Access",
       "id": "totalaccess-3772a0",
       "locationSet": {"include": ["fr"]},


### PR DESCRIPTION
Some Total stations in Germany seem to use the TotalEnergies brand now.