### PR TITLE
Update Taiwan City bus system

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -14275,7 +14275,6 @@
         "network": "Trieste Trasporti",
         "network:wikidata": "Q3539115",
         "network:wikipedia": "it:Trieste Trasporti",
-        "operator": "TPL FVG",
         "route": "bus"
       }
     },
@@ -17445,6 +17444,11 @@
       "tags": {
         "network": "基隆市公車",
         "network:en": "Keelung City Bus",
+        "network:nan": "Ke-lâng-chhī Kong-chhia",
+        "network:nan-HJ": "基隆市公車",
+        "network:nan-POJ": "Ke-lâng-chhī Kong-chhia",
+        "network:nan-TL": "Ke-lâng-tshī Kong-tshia",
+        "network:wikidata": "Q109376193",
         "network:zh": "基隆市公車",
         "operator": "基隆市公車處",
         "route": "bus"
@@ -17474,16 +17478,20 @@
       }
     },
     {
-      "displayName": "宜蘭公車",
+      "displayName": "宜蘭縣市區公車",
       "id": "kamalanbus-a4fa75",
       "locationSet": {"include": ["tw"]},
+      "matchNames": "宜蘭公車",
       "tags": {
-        "network": "宜蘭公車",
-        "operator": "葛瑪蘭客運",
-        "operator:en": "Kamalan Bus",
-        "operator:wikidata": "Q15905221",
-        "operator:wikipedia": "zh:葛瑪蘭客運",
-        "operator:zh": "葛瑪蘭客運",
+        "network": "宜蘭縣市區公車",
+        "network:en": "Ilan County Bus",
+        "network:nan": "Gî-lân-koān Chhī-khu Kong-chhia",
+        "network:nan-HJ": "宜蘭縣市區公車",
+        "network:nan-POJ": "Gî-lân-koān Chhī-khu Kong-chhia",
+        "network:nan-TL": "Gî-lân-kuān Tshī-khu Kong-tshia"
+        "network:wikidata": "Q15903485",
+        "network:wikipedia": "zh:宜蘭縣市區公車",
+        "network:zh": "宜蘭縣市區公車",
         "route": "bus"
       }
     },
@@ -17564,7 +17572,17 @@
       "displayName": "新北市公車",
       "id": "b4a974-a4fa75",
       "locationSet": {"include": ["tw"]},
-      "tags": {"network": "新北市公車", "route": "bus"}
+      "tags": {"network": "新北市公車",
+               "network:en": "New Taipei City Bus",
+               "network:nan": "Sin-pak-chhī Kong-chhia",
+               "network:nan-HJ": "新北市公車",
+               "network:nan-POJ": "Sin-pak-chhī Kong-chhia",
+               "network:nan-TL": "Sin-pak-tshī Kong-tshia",
+               "network:wikidata": "Q21652250",
+               "network:wikipedia": "zh:新北市公車",
+               "network:zh": "新北市公車",
+               "route": "bus"
+              }
     },
     {
       "displayName": "新巴城巴 Citybus & NWFB",
@@ -17585,11 +17603,19 @@
       }
     },
     {
-      "displayName": "新竹市區公車",
+      "displayName": "新竹市公車",
       "id": "0dc234-a4fa75",
       "locationSet": {"include": ["tw"]},
       "tags": {
-        "network": "新竹市區公車",
+        "network": "新竹市公車",
+        "network:en": "Hsinzhu City Bus",
+        "network:nan": "Sin-tek-chhī Kong-chhia",
+        "network:nan-HJ": "新竹市公車",
+        "network:nan-POJ": "Sin-tek-chhī Kong-chhia",
+        "network:nan-TL": "Sin-tik-tshī Kong-tshia",
+        "network:wikidata": "Q11083995",
+        "network:wikipedia": "zh:新竹市公車",
+        "network:zh": "新竹市公車",
         "route": "bus"
       }
     },
@@ -17629,10 +17655,21 @@
       }
     },
     {
-      "displayName": "桃園市公車",
+      "displayName": "桃園市市區公車"
+      "matchNames": "桃園市公車",
       "id": "08cd3e-a4fa75",
       "locationSet": {"include": ["tw"]},
-      "tags": {"network": "桃園市公車", "route": "bus"}
+      "tags": {"network": "桃園市市區公車",
+               "network:en": "Tauyuan City Bus",
+               "network:nan": "Thô-hn̂g-chhī Chhī-khu Kong-chhia",
+               "network:nan-HJ": "桃園市市區公車",
+               "network:nan-POJ": "Thô-hn̂g-chhī Chhī-khu Kong-chhia",
+               "network:nan-TL": "Thô-hn̂g-tshī Tshī-khu Kong-tshia",
+               "network:wikidata": "Q11112021",
+               "network:wikipedia": "zh:桃園市市區公車",
+               "network:zh": "桃園市市區公車",
+               "route": "bus"
+              }
     },
     {
       "displayName": "横浜市営バス",
@@ -17874,6 +17911,13 @@
       "locationSet": {"include": ["tw"]},
       "tags": {
         "network": "竹北市免費市民公車",
+        "network:en": "Zhube Citizen Free Bus"
+        "network:nan": "Tek-pak-chhī Bián-hùi Chhī-bîn Kong-chhia",
+        "network:nan-POJ": "Tek-pak-chhī Bián-hùi Chhī-bîn Kong-chhia",
+        "network:nan-HJ": "竹北市免費市民公車",
+        "network:nan-TL": "Tik-pak-tshī Bián-huì Tshī-bîn Kong-tshia",
+        "network:wikidata": "Q109375446",
+        "network:zh": "竹北市免費市民公車",
         "route": "bus"
       }
     },
@@ -17884,16 +17928,40 @@
       "tags": {"network": "粟生団地線", "route": "bus"}
     },
     {
-      "displayName": "臺中市公車",
+      "displayName": "臺中市市區公車",
+      "matchNames": "臺中市公車",
       "id": "0cfe02-a4fa75",
       "locationSet": {"include": ["tw"]},
-      "tags": {"network": "臺中市公車", "route": "bus"}
+      "tags": {"network": "臺中市市區公車",
+               "network:en": "Taichung City Bus",
+               "network:nan": "Tâi-tiong-chhī Chhī-khu Kong-chhia",
+               "network:nan-HJ": "臺中市市區公車",
+               "network:nan-POJ": "Tâi-tiong-chhī Chhī-khu Kong-chhia",
+               "network:nan-TL": "Tâi-tiong-tshī Tshī-khu Kong-tshia",
+               "network:wikidata": "Q3462238",
+               "netwrok:wikipedia": "zh:臺中市市區公車",
+               "network:zh": "臺中市市區公車",
+               "route": "bus"
+              }
     },
     {
-      "displayName": "臺北市公車",
+      "displayName": "臺北市市區公車",
       "id": "2a38ea-a4fa75",
       "locationSet": {"include": ["tw"]},
-      "tags": {"network": "臺北市公車", "route": "bus"}
+      "matchNames": [
+        "臺北市公車"
+      ],
+      "tags": {"network": "臺北市市區公車",
+               "network:en": "Taipei Joint Bus System",
+               "network:nan": "Tâi-pak-chhī Chhī-khu Kong-chhia",
+               "network:nan-HJ": "臺北市市區公車",
+               "network:nan-POJ": "Tâi-pak-chhī Chhī-khu Kong-chhia",
+               "network:nan-TL": "Tâi-pak-tshiī Tshī-khu Kong-tshia",
+               "network:wikipedia": "zh:臺北市市區公車",
+               "network:wikidata": "Q5972821",
+               "network:zh": "臺北市市區公車",
+               "route": "bus" 
+              }
     },
     {
       "displayName": "芦屋市内線",
@@ -18021,9 +18089,49 @@
       "tags": {
         "network": "高雄市公車",
         "network:en": "Kaohsiung City Bus",
+        "network:nan": "Ko-hiông-chhī Kong-chhia",
+        "network:nan-HJ": "高雄市公車",
+        "network:nan-POJ": "Ko-hiông-chhī Kong-chhia",
+        "network:nan-TL": "Ko-hiông-tshī Kong-tshia",
         "network:wikidata": "Q15903688",
-        "network:wikipedia": "ja:高雄市公車",
+        "network:wikipedia": "zh:高雄市公車",
+        "network:wikipedia:ja": "高雄市公車",
+        "network:wikipedia:zh": "高雄市公車",
         "network:zh": "高雄市公車",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "屏東縣市區公車",
+      "id": 
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "network": "屏東縣市區公車",
+        "network:en": "Pingtung City Bus",
+        "network:nan": "Pîn-tong-koān Chhī-khu Kong-chhia",
+        "network:nan-HJ": "屏東縣市區公車",
+        "network:nan-POJ": "Pîn-tong-koān Chhī-khu Kong-chhia",
+        "network:nan-TL": "Pîn-tong-kuān Tshī-khu Kong-tshia",
+        "network:wikidata": "Q15903688",
+        "network:wikipedia": "zh:屏東縣市區公車",
+        "network:zh": "屏東縣市區公車",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "大台南公車",
+      "id": 
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "network": "大台南公車",
+        "network:en": "Tainan City Bus",
+        "network:nan": "Tōa Tâi-lâm Kong-chhia",
+        "network:nan-HJ": "大台南公車車",
+        "network:nan-POJ": "Tōa Tâi-lâm Kong-chhia",
+        "network:nan-TL": "Tuā Tâi-lâm Kong-tshia",
+        "network:wikidata": "Q10933889",
+        "network:wikipedia": "zh:大台南公車",
+        "network:zh": "大台南公車",
         "route": "bus"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -14275,6 +14275,7 @@
         "network": "Trieste Trasporti",
         "network:wikidata": "Q3539115",
         "network:wikipedia": "it:Trieste Trasporti",
+        "operator": "TPL FVG",
         "route": "bus"
       }
     },
@@ -17481,14 +17482,14 @@
       "displayName": "宜蘭縣市區公車",
       "id": "kamalanbus-a4fa75",
       "locationSet": {"include": ["tw"]},
-      "matchNames": "宜蘭公車",
+      "matchNames": ["宜蘭公車"],
       "tags": {
         "network": "宜蘭縣市區公車",
         "network:en": "Ilan County Bus",
         "network:nan": "Gî-lân-koān Chhī-khu Kong-chhia",
         "network:nan-HJ": "宜蘭縣市區公車",
         "network:nan-POJ": "Gî-lân-koān Chhī-khu Kong-chhia",
-        "network:nan-TL": "Gî-lân-kuān Tshī-khu Kong-tshia"
+        "network:nan-TL": "Gî-lân-kuān Tshī-khu Kong-tshia",
         "network:wikidata": "Q15903485",
         "network:wikipedia": "zh:宜蘭縣市區公車",
         "network:zh": "宜蘭縣市區公車",
@@ -17572,7 +17573,8 @@
       "displayName": "新北市公車",
       "id": "b4a974-a4fa75",
       "locationSet": {"include": ["tw"]},
-      "tags": {"network": "新北市公車",
+      "tags": {
+        "network": "新北市公車",
                "network:en": "New Taipei City Bus",
                "network:nan": "Sin-pak-chhī Kong-chhia",
                "network:nan-HJ": "新北市公車",
@@ -17582,7 +17584,7 @@
                "network:wikipedia": "zh:新北市公車",
                "network:zh": "新北市公車",
                "route": "bus"
-              }
+      }
     },
     {
       "displayName": "新巴城巴 Citybus & NWFB",
@@ -17655,8 +17657,8 @@
       }
     },
     {
-      "displayName": "桃園市市區公車"
-      "matchNames": "桃園市公車",
+      "displayName": "桃園市市區公車",
+      "matchNames": ["桃園市公車"],
       "id": "08cd3e-a4fa75",
       "locationSet": {"include": ["tw"]},
       "tags": {"network": "桃園市市區公車",
@@ -17911,7 +17913,7 @@
       "locationSet": {"include": ["tw"]},
       "tags": {
         "network": "竹北市免費市民公車",
-        "network:en": "Zhube Citizen Free Bus"
+        "network:en": "Zhube Citizen Free Bus",
         "network:nan": "Tek-pak-chhī Bián-hùi Chhī-bîn Kong-chhia",
         "network:nan-POJ": "Tek-pak-chhī Bián-hùi Chhī-bîn Kong-chhia",
         "network:nan-HJ": "竹北市免費市民公車",
@@ -17929,7 +17931,7 @@
     },
     {
       "displayName": "臺中市市區公車",
-      "matchNames": "臺中市公車",
+      "matchNames": ["臺中市公車"],
       "id": "0cfe02-a4fa75",
       "locationSet": {"include": ["tw"]},
       "tags": {"network": "臺中市市區公車",
@@ -17948,9 +17950,7 @@
       "displayName": "臺北市市區公車",
       "id": "2a38ea-a4fa75",
       "locationSet": {"include": ["tw"]},
-      "matchNames": [
-        "臺北市公車"
-      ],
+      "matchNames": [        "臺北市公車"      ],
       "tags": {"network": "臺北市市區公車",
                "network:en": "Taipei Joint Bus System",
                "network:nan": "Tâi-pak-chhī Chhī-khu Kong-chhia",
@@ -18103,7 +18103,6 @@
     },
     {
       "displayName": "屏東縣市區公車",
-      "id": 
       "locationSet": {"include": ["tw"]},
       "tags": {
         "network": "屏東縣市區公車",
@@ -18120,7 +18119,6 @@
     },
     {
       "displayName": "大台南公車",
-      "id": 
       "locationSet": {"include": ["tw"]},
       "tags": {
         "network": "大台南公車",


### PR DESCRIPTION
The bus routes in Ilan are not only served by 葛瑪蘭客運, but also 國光客運 and 首都客運