### PR TITLE
fix Rossmann name

### DIFF
--- a/data/brands/shop/chemist.json
+++ b/data/brands/shop/chemist.json
@@ -329,16 +329,16 @@
       }
     },
     {
-      "displayName": "ROSSMANN",
+      "displayName": "Rossmann",
       "id": "rossmann-6513f7",
       "locationSet": {
         "include": ["cz", "de", "hu", "pl"]
       },
       "tags": {
-        "brand": "ROSSMANN",
+        "brand": "Rossmann",
         "brand:wikidata": "Q316004",
         "brand:wikipedia": "de:Rossmann (Handelskette)",
-        "name": "ROSSMANN",
+        "name": "Rossmann",
         "shop": "chemist"
       }
     },


### PR DESCRIPTION
stylistic capitalization is uniformly used in marketing materials (typically also with red color and embedded horseman symbol).

It is ignored by people outside Rossmann, and therefore should not be put into `name` tag.

Fixes #5510