### PR TITLE
Carsharing: Combine Flinkster with DB Connect GmbH

### DIFF
--- a/data/operators/amenity/car_sharing.json
+++ b/data/operators/amenity/car_sharing.json
@@ -204,11 +204,14 @@
       }
     },
     {
-      "displayName": "Deutsche Bahn Connect GmbH",
+      "displayName": "Deutsche Bahn Connect GmbH (Flinkster)",
       "id": "deutschebahnconnectgmbh-088af7",
       "locationSet": {"include": ["de"]},
+      "matchNames": ["flinkster"],
       "tags": {
         "amenity": "car_sharing",
+        "brand": "Flinkster",
+        "network": "Flinkster",
         "operator": "Deutsche Bahn Connect GmbH",
         "operator:wikidata": "Q1152100",
         "operator:wikipedia": "de:Deutsche Bahn Connect"
@@ -276,17 +279,6 @@
         "operator": "Evo",
         "operator:wikidata": "Q26553214",
         "operator:wikipedia": "en:Evo Car Share"
-      }
-    },
-    {
-      "displayName": "Flinkster",
-      "id": "flinkster-ad9787",
-      "locationSet": {"include": ["at", "de"]},
-      "tags": {
-        "amenity": "car_sharing",
-        "operator": "Flinkster",
-        "operator:wikidata": "Q1152100",
-        "operator:wikipedia": "de:Deutsche Bahn Connect"
       }
     },
     {


### PR DESCRIPTION
Flinkster is a brand and car sharing network operated by Deutsche Bahn Connect GmbH.