### PR TITLE
Update Deutsche Bahn ticket machines

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -274,12 +274,9 @@
         "brand": "Deutsche Bahn",
         "brand:wikidata": "Q9322",
         "brand:wikipedia": "de:Deutsche Bahn",
-        "name": "Deutsche Bahn",
-        "official_name": "Deutsche Bahn AG",
-        "operator": "Deutsche Bahn",
-        "operator:wikidata": "Q9322",
-        "operator:wikipedia": "de:Deutsche Bahn",
-        "short_name": "DB",
+        "operator": "DB Vertrieb GmbH",
+        "operator:wikidata": "Q1152124",
+        "operator:wikipedia": "de:DB Vertrieb",
         "vending": "public_transport_tickets"
       }
     },


### PR DESCRIPTION
The ticket vending machines branded as Deutsche Bahn are operated by DB Vertrieb GmbH, a subsidiary of Deutsche Bahn.
They don't have any names usually.