### PR TITLE
Fixing Typo "TER Provence-Alpes-Côte d'Azur

### DIFF
--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -1849,11 +1849,11 @@
       }
     },
     {
-      "displayName": "TER Provence - Alpes - Côte d'Azur",
+      "displayName": "TER Provence-Alpes-Côte d'Azur",
       "id": "terprovencealpescotedazur-46b9eb",
       "locationSet": {"include": ["fx"]},
       "tags": {
-        "network": "TER Provence - Alpes - Côte d'Azur",
+        "network": "TER Provence-Alpes-Côte d'Azur",
         "network:wikidata": "Q3512123",
         "network:wikipedia": "fr:TER Provence-Alpes-Côte d'Azur",
         "operator": "SNCF",


### PR DESCRIPTION
network is not "TER Provence - Alpes - Côte d'Azur" but "TER Provence-Alpes-Côte d'Azur"