### PR TITLE
IntercityHotel: no space in brand and name + include ch

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -1273,11 +1273,12 @@
       }
     },
     {
-      "displayName": "Intercity Hotel",
+      "displayName": "IntercityHotel",
       "id": "intercityhotel-036a6c",
       "locationSet": {
         "include": [
           "at",
+          "ch",
           "cn",
           "de",
           "nl",
@@ -1286,9 +1287,9 @@
         ]
       },
       "tags": {
-        "brand": "Intercity Hotel",
+        "brand": "IntercityHotel",
         "brand:wikidata": "Q73642490",
-        "name": "Intercity Hotel",
+        "name": "IntercityHotel",
         "tourism": "hotel"
       }
     },


### PR DESCRIPTION
This is how the name is spelt on the hotel's chain website and their brochures etc., as well as in their logo. Wikidata also uses this spelling.
There is an older logo where it was spelt InterCityHotel. 
Taginfo finds all 3 variants for the name tag in use, but it looks like the values where heavily influenced by NSI,so it does not really represent the mapper's choice.
I included Switzerland, because there seems to be one in Zürich.