### PR TITLE
Cleaning network VGI

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -15163,19 +15163,6 @@
       }
     },
     {
-      "displayName": "Verkehrsgemeinschaft Region Ingolstadt",
-      "id": "verkehrsgemeinschaftregioningolstadt-3b9544",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["invg"],
-      "tags": {
-        "network": "Verkehrsgemeinschaft Region Ingolstadt",
-        "network:guid": "DE-BY-VGI",
-        "network:short": "VGI",
-        "network:wikidata": "Q99937594",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "Verkehrsgemeinschaft Rendsburg-Eckernförde",
       "id": "verkehrsgemeinschaftrendsburgeckernforde-3b9544",
       "locationSet": {"include": ["de"]},
@@ -15323,6 +15310,8 @@
       "tags": {
         "network": "Verkehrsverbund Großraum Ingolstadt",
         "network:short": "VGI",
+        "network:guid": "DE-BY-VGI",
+        "network:wikidata": "Q99937594",        
         "route": "bus"
       }
     },


### PR DESCRIPTION
2 Entries with same network VGI due to name change the last months (old name Verkehrsgemeinschaft Region Ingolstadt, new name Verkehrsverbund Großraum Ingolstadt). Remove one entry. Add missing tags to the other entry.