### PR TITLE
Adding Jellystone Park

### DIFF
--- a/data/brands/tourism/caravan_site.json
+++ b/data/brands/tourism/caravan_site.json
@@ -100,6 +100,18 @@
         "name": "Parkdean Resorts",
         "tourism": "caravan_site"
       }
+    },
+    {
+      "displayName": "Yogi Bear's Jellystone Park",
+      "id": "jellystonepark-gh9y69",
+      "locationSet": {"include": ["ca", "us"]},
+      "tags": {
+        "brand": "Yogi Bear's Jellystone Park",
+        "brand:wikidata": "Q8054389",
+        "name": "Yogi Bear's Jellystone Park",
+        "official_name": "Yogi Bear's Jellystone Park Camp-Resorts",
+        "tourism": "caravan_site"
+      }
     }
   ]
 }


### PR DESCRIPTION
Yogi Bear's Jellystone Park Camp-Resorts is the 2nd largest campgrounds chain in North America.