### PR TITLE
Fix typo

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -4606,7 +4606,7 @@
     {
       "displayName": "Milavitsa",
       "id": "milavitsa-b561cd",
-      "locationSet": {"include": ["be"]},
+      "locationSet": {"include": ["by"]},
       "tags": {
         "brand": "Milavitsa",
         "brand:be": "Мілавіца",


### PR DESCRIPTION
Should be "by" for Belarus. It's a local brand with a retail chain https://shop.milavitsa.by/#/shops