### PR TITLE
Exclude Bulgaria from Unicredit Bank

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -8630,7 +8630,7 @@
     {
       "displayName": "UniCredit Bank",
       "id": "unicreditbank-b7a026",
-      "locationSet": {"include": ["001"], "exclude: ["bg"]},
+      "locationSet": {"include": ["001"], "exclude": ["bg"]},
       "matchNames": [
         "unicredit",
         "unicredit banca"

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -8630,7 +8630,7 @@
     {
       "displayName": "UniCredit Bank",
       "id": "unicreditbank-b7a026",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["001"], "exclude: ["bg"]},
       "matchNames": [
         "unicredit",
         "unicredit banca"


### PR DESCRIPTION
Unicredit operates under the Unicredit Bulbank brand in Bulgaria.