### PR TITLE
LEON has vegan and vegetarian options, no longer operating in the US

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -3130,7 +3130,6 @@
         "cuisine": "burger;sandwich",
         "name": "LEON",
         "takeaway": "yes",
-        "diet:vegetarian": "yes",
         "diet:vegan": "yes"
       }
     },

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -3120,7 +3120,7 @@
       "displayName": "LEON",
       "id": "leon-315484",
       "locationSet": {
-        "include": ["ch", "gb", "ie", "nl", "us"]
+        "include": ["ch", "gb", "ie", "nl"]
       },
       "tags": {
         "amenity": "fast_food",
@@ -3129,7 +3129,9 @@
         "brand:wikipedia": "en:Leon Restaurants",
         "cuisine": "burger;sandwich",
         "name": "LEON",
-        "takeaway": "yes"
+        "takeaway": "yes",
+        "diet:vegetarian": "yes",
+        "diet:vegan": "yes"
       }
     },
     {


### PR DESCRIPTION
LEON has vegan and vegetarian options on its menu https://leon.co/menu/

It has also pulled out of the US market https://www.thecaterer.com/news/leon-pulls-america-states-market-pandemic-toll-2021