### PR TITLE
TRAID clothes recycling containers

### DIFF
--- a/data/brands/amenity/recycling.json
+++ b/data/brands/amenity/recycling.json
@@ -209,7 +209,7 @@
       "tags": {
         "amenity": "recycling",
         "brand": "TRAID",
-        "brand:wikidata": "Q66581837",
+        "brand:wikidata": "Q109717195",
         "name": "TRAID",
         "recycling_type": "container",
         "recycling:clothes": "yes",

--- a/data/brands/amenity/recycling.json
+++ b/data/brands/amenity/recycling.json
@@ -202,6 +202,19 @@
         "brand:ru": "Экобокс",
         "name": "Экобокс"
       }
+    },
+    {
+      "displayName": "TRAID",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "amenity": "recycling",
+        "brand": "TRAID",
+        "brand:wikidata": "Q66581837",
+        "name": "TRAID",
+        "recycling_type": "container",
+        "recycling:clothes": "yes",
+        "recycling:shoes": "yes"
+      }
     }
   ]
 }


### PR DESCRIPTION
This is a preset for the TRAID clothes recycling containers of which there are over 1500 in the UK https://www.traid.org.uk/clothes-donations/find-a-bank/