### PR TITLE
Fix typo "netwrok -> network

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -18151,7 +18151,7 @@
         "network:wikidata": "Q3462238",
         "network:wikipedia": "en:Taichung City Bus",
         "network:zh": "臺中市市區公車",
-        "network:wikipedia:zh": "zh:臺中市市區公車",
+        "network:wikipedia": "zh:臺中市市區公車",
         "route": "bus"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -18149,7 +18149,6 @@
         "network:nan-POJ": "Tâi-tiong-chhī Chhī-khu Kong-chhia",
         "network:nan-TL": "Tâi-tiong-tshī Tshī-khu Kong-tshia",
         "network:wikidata": "Q3462238",
-        "network:wikipedia": "en:Taichung City Bus",
         "network:zh": "臺中市市區公車",
         "network:wikipedia": "zh:臺中市市區公車",
         "route": "bus"

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -18151,7 +18151,7 @@
         "network:wikidata": "Q3462238",
         "network:wikipedia": "en:Taichung City Bus",
         "network:zh": "臺中市市區公車",
-        "netwrok:wikipedia": "zh:臺中市市區公車",
+        "network:wikipedia:zh": "zh:臺中市市區公車",
         "route": "bus"
       }
     },


### PR DESCRIPTION
And put it under "network:wikipedia:zh" since there is already a "network:wikipedia" tag.