### PR TITLE
Add wikidata to pharmacy «Вита» (Vita).

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -2548,6 +2548,7 @@
       "tags": {
         "amenity": "pharmacy",
         "brand": "Вита Центральная",
+        "brand:wikidata": "Q109810737",
         "healthcare": "pharmacy",
         "name": "Вита Центральная"
       }
@@ -2559,6 +2560,7 @@
       "tags": {
         "amenity": "pharmacy",
         "brand": "Вита Экспресс",
+        "brand:wikidata": "Q109810737",
         "healthcare": "pharmacy",
         "name": "Вита Экспресс"
       }


### PR DESCRIPTION
The pharmacy Вита (Vita) has two formats of pharmacy: Вита Центральная (Vita Central —  big shop format) and Вита Экспресс (Vita Express — small format).
I create https://www.wikidata.org/wiki/Q109810737 for this brand.