### PR TITLE
e.dis -> E.DIS Netz GmbH

### DIFF
--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -1207,16 +1207,15 @@
       }
     },
     {
-      "displayName": "e.dis",
+      "displayName": "E.DIS Netz GmbH",
       "id": "edis-d5e323",
       "locationSet": {"include": ["de"]},
       "matchNames": [
-        "e.dis netz gmbh",
         "e.on edis",
         "e.on edis ag"
       ],
       "tags": {
-        "operator": "e.dis",
+        "operator": "E.DIS Netz GmbH",
         "operator:wikidata": "Q1273411",
         "operator:wikipedia": "de:E.DIS",
         "power": "line"

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -1532,16 +1532,15 @@
       }
     },
     {
-      "displayName": "e.dis",
+      "displayName": "E.DIS Netz GmbH",
       "id": "edis-fc3a87",
       "locationSet": {"include": ["001"]},
       "matchNames": [
-        "e.dis netz gmbh",
         "e.on edis",
         "e.on edis ag"
       ],
       "tags": {
-        "operator": "e.dis",
+        "operator": "E.DIS Netz GmbH",
         "operator:wikidata": "Q1273411",
         "operator:wikipedia": "de:E.DIS",
         "power": "substation"

--- a/data/operators/route/power.json
+++ b/data/operators/route/power.json
@@ -177,16 +177,15 @@
       }
     },
     {
-      "displayName": "e.dis",
+      "displayName": "E.DIS Netz GmbH",
       "id": "edis-6070b7",
       "locationSet": {"include": ["de"]},
       "matchNames": [
-        "e.dis netz gmbh",
         "e.on edis",
         "e.on edis ag"
       ],
       "tags": {
-        "operator": "e.dis",
+        "operator": "E.DIS Netz GmbH",
         "operator:wikidata": "Q1273411",
         "operator:wikipedia": "de:E.DIS",
         "route": "power"


### PR DESCRIPTION
E.DIS Netz GmbH is the subsidiary of E.DIS that operates the power grid. 
Spelling according to the *Impressum* on their website. This is also the preferred tagging of the majority of mappers according to [taginfo](https://taginfo.openstreetmap.org/search?q=dis#values). I didn't touch the wikidata and wikipedia tags as I could not find a wikidata page for E.DIS Netz GmbH.