### PR TITLE
EnBW is not a power grid operator

### DIFF
--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -4745,7 +4745,7 @@
       "displayName": "TransnetBW GmbH",
       "id": "transnetbwgmbh-116894",
       "locationSet": {"include": ["001"]},
-      "matchnames": {"enbw transportnetze ag"},
+      "matchNames": ["enbw transportnetze ag"],
       "tags": {
         "operator": "TransnetBW GmbH",
         "power": "line",

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -3,7 +3,7 @@
     "path": "operators/power/line",
     "exclude": {
       "generic": ["^line$"],
-      "named": ["national grid et"]
+      "named": ["national grid et", "enbw"]
     }
   },
   "items": [
@@ -366,18 +366,6 @@
         "operator": "Axpo",
         "operator:wikidata": "Q679525",
         "operator:wikipedia": "de:Axpo Power",
-        "power": "line"
-      }
-    },
-    {
-      "displayName": "Badenwerk AG",
-      "id": "badenwerkag-d5e323",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["badenwerk"],
-      "tags": {
-        "operator": "Badenwerk AG",
-        "operator:wikidata": "Q798945",
-        "operator:wikipedia": "de:Badenwerk",
         "power": "line"
       }
     },
@@ -1650,33 +1638,6 @@
       "locationSet": {"include": ["ar"]},
       "tags": {
         "operator": "Empresa Provincial de la Energía de Santa Fe",
-        "power": "line"
-      }
-    },
-    {
-      "displayName": "EnBW",
-      "id": "enbw-d5e323",
-      "locationSet": {"include": ["de"]},
-      "matchNames": [
-        "enbw ag",
-        "enbw regional",
-        "enbw regional ag",
-        "energie-versorgung schwaben ag",
-        "neckarwerke"
-      ],
-      "tags": {
-        "operator": "EnBW",
-        "operator:wikidata": "Q644304",
-        "operator:wikipedia": "de:EnBW Energie Baden-Württemberg",
-        "power": "line"
-      }
-    },
-    {
-      "displayName": "EnBW Transportnetze AG",
-      "id": "enbwtransportnetzeag-d5e323",
-      "locationSet": {"include": ["de"]},
-      "tags": {
-        "operator": "EnBW Transportnetze AG",
         "power": "line"
       }
     },
@@ -3344,12 +3305,16 @@
       }
     },
     {
-      "displayName": "Netze BW",
+      "displayName": "Netze BW GmbH",
       "id": "netzebw-d5e323",
       "locationSet": {"include": ["de"]},
-      "matchNames": ["netze bw gmbh"],
+      "matchNames": ["netze bw",
+        "enbw regional",
+        "enbw regional ag",
+        "energie-versorgung schwaben ag",
+        "neckarwerke"],
       "tags": {
-        "operator": "Netze BW",
+        "operator": "Netze BW GmbH",
         "operator:wikidata": "Q16854888",
         "operator:wikipedia": "de:Netze BW",
         "power": "line"
@@ -4780,9 +4745,12 @@
       "displayName": "TransnetBW GmbH",
       "id": "transnetbwgmbh-116894",
       "locationSet": {"include": ["001"]},
+      "matchnames": {"enbw transportnetze ag"},
       "tags": {
         "operator": "TransnetBW GmbH",
-        "power": "line"
+        "power": "line",
+        "wikipedia": "de:TransnetBW",
+        "wikidata": "Q1672772"
       }
     },
     {

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -3,7 +3,13 @@
     "path": "operators/power/line",
     "exclude": {
       "generic": ["^line$"],
-      "named": ["national grid et", "enbw"]
+      "named": [
+        "national grid et", 
+        "enbw",
+        "enbw ag",
+        "badenwerk",
+        "badenwerk ag"
+      ]
     }
   },
   "items": [

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -5,6 +5,10 @@
       "generic": [
         "^stadtwerke$",
         "^sub_?station$"
+      ],
+      "named": [
+        "enbw", 
+        "enbw ag"
       ]
     }
   },
@@ -6690,6 +6694,19 @@
         "operator": "TransGrid",
         "operator:wikidata": "Q7833620",
         "operator:wikipedia": "en:TransGrid",
+        "power": "substation"
+      }
+    },
+    {
+      "displayName": "Transnet BW",
+      "id": "transnetbw-1266b7",
+      "locationSet": {
+        "include": ["de"]
+      },
+      "tags": {
+        "operator": "Transnet BW GmbH",
+        "operator:wikidata": "Q1672772",
+        "operator:wikipedia": "de:TransnetBW",
         "power": "substation"
       }
     },

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -7,8 +7,10 @@
         "^sub_?station$"
       ],
       "named": [
-        "enbw", 
-        "enbw ag"
+        "enbw",
+        "enbw ag",
+        "badenwerk",
+        "badenwerk ag"
       ]
     }
   },

--- a/data/operators/route/power.json
+++ b/data/operators/route/power.json
@@ -1,8 +1,10 @@
 {
   "properties": {
     "path": "operators/route/power",
-    "exclude": {"generic": ["^power$"]},
-    "named": ["enbw"]
+    "exclude": {
+      "generic": ["^power$"],
+      "named": ["enbw"]
+    }
   },
   "items": [
     {

--- a/data/operators/route/power.json
+++ b/data/operators/route/power.json
@@ -3,7 +3,12 @@
     "path": "operators/route/power",
     "exclude": {
       "generic": ["^power$"],
-      "named": ["enbw"]
+      "named": [
+        "enbw",
+        "enbw ag",
+        "badenwerk",
+        "badenwerk ag"
+      ]
     }
   },
   "items": [

--- a/data/operators/route/power.json
+++ b/data/operators/route/power.json
@@ -1,7 +1,8 @@
 {
   "properties": {
     "path": "operators/route/power",
-    "exclude": {"generic": ["^power$"]}
+    "exclude": {"generic": ["^power$"]},
+    "named": ["enbw"]
   },
   "items": [
     {
@@ -278,17 +279,6 @@
       }
     },
     {
-      "displayName": "EnBW",
-      "id": "enbw-6070b7",
-      "locationSet": {"include": ["de"]},
-      "tags": {
-        "operator": "EnBW",
-        "operator:wikidata": "Q644304",
-        "operator:wikipedia": "de:EnBW Energie Baden-Württemberg",
-        "route": "power"
-      }
-    },
-    {
       "displayName": "Enea",
       "id": "enea-99d878",
       "locationSet": {"include": ["pl"]},
@@ -541,12 +531,12 @@
       }
     },
     {
-      "displayName": "Netze BW",
+      "displayName": "Netze BW GmbH",
       "id": "netzebw-6070b7",
       "locationSet": {"include": ["de"]},
-      "matchNames": ["netze bw gmbh"],
+      "matchNames": ["netze bw"],
       "tags": {
-        "operator": "Netze BW",
+        "operator": "Netze BW GmbH",
         "operator:wikidata": "Q16854888",
         "operator:wikipedia": "de:Netze BW",
         "route": "power"


### PR DESCRIPTION
The EnBW power grid was split into Netze BW GmbH and TransnetBW GmbH in 1997. See also #5537 