### PR TITLE
Added Everyone Active to sports_centre

### DIFF
--- a/data/brands/leisure/sports_centre.json
+++ b/data/brands/leisure/sports_centre.json
@@ -80,6 +80,18 @@
       }
     },
     {
+      "displayName": "Everyone Active (Sports and Leisure Management Ltd)",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "Everyone Active",
+        "fee": "yes",
+        "leisure": "sports_centre",
+        "operator": "Sports and Leisure Management Ltd",
+        "operator:wikidata": "Q7579805",
+        "operator:wikipedia": "en:Sports and Leisure Management Ltd"
+      }
+    },
+    {
       "displayName": "iFLY",
       "id": "ifly-ba45e1",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Everyone Active (Sports and Leisure Management Ltd) manage sports and leisure facilities on behalf of UK local authorities.