### PR TITLE
Add charging station network charge.brussels

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -580,6 +580,18 @@
       }
     },
     {
+      "displayName": "charge.brussels",
+      "locationSet": {"include": [[4.376, 50.844, 10]]},
+      "tags": {
+        "amenity": "charging_station",
+        "network": "charge.brussels",
+        "network:wikidata": "Q109923471",
+        "name": "charge.brussels",
+        "operator": "PitPoint",
+        "operator:wikidata": "Q109923423"
+      }
+    },
+    {
       "displayName": "Charging the Regions",
       "id": "centralvictoriangreenhousealliance-6c573b",
       "locationSet": {


### PR DESCRIPTION
Added [charge.brussels](https://www.charge.brussels/en/network-status/) charging station network.