### PR TITLE
fix Улыбка радуги

### DIFF
--- a/data/brands/shop/chemist.json
+++ b/data/brands/shop/chemist.json
@@ -526,7 +526,10 @@
       "locationSet": {"include": ["ru"]},
       "tags": {
         "brand": "Улыбка радуги",
+        "brand:ru": "Улыбка радуги",
+        "brand:wikidata": "Q109734104",
         "name": "Улыбка радуги",
+        "name:ru": "Улыбка радуги",
         "shop": "chemist"
       }
     },


### PR DESCRIPTION
«Улыбка радуги» — it's shop=chemist, not shop=cosmetic.
I move «Улыбка радуги» from cosmetics.json