### PR TITLE
Match against Energie Fitness

### DIFF
--- a/data/brands/leisure/fitness_centre.json
+++ b/data/brands/leisure/fitness_centre.json
@@ -201,6 +201,7 @@
       "locationSet": {
         "include": ["bh", "gb", "ie"]
       },
+      "matchNames": ["energie fitness"],
       "tags": {
         "brand": "énergie Fitness",
         "brand:wikidata": "Q109855553",


### PR DESCRIPTION
I noticed many of the existing entries for énergie Fitness use the name Energie Fitness eg https://www.openstreetmap.org/node/6484557587