### PR TITLE
Change operator value for Česká pošta

### DIFF
--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -181,10 +181,10 @@
       "displayName": "Česká pošta",
       "id": "ceskaposta-aa9270",
       "locationSet": {"include": ["cz"]},
-      "matchNames": ["česká pošta sp"],
+      "matchNames": ["česká pošta"],
       "tags": {
         "amenity": "post_office",
-        "operator": "Česká pošta",
+        "operator": "Česká pošta, s.p.",
         "operator:wikidata": "Q341090",
         "operator:wikipedia": "cz:Česká pošta"
       }


### PR DESCRIPTION
Change operator="Česká pošta" to operator="Česká pošta, s.p."
per discussions at talk-cz list (https://openstreetmap.cz/talkcz/c46).
Also discussed at OSM US Slack (https://osmus.slack.com/archives/CBK3JLUJU/p1628112745023200).