### PR TITLE
Added french details on the Habitat retail chain

### DIFF
--- a/data/brands/shop/furniture.json
+++ b/data/brands/shop/furniture.json
@@ -531,13 +531,7 @@
         "brand": "Habitat",
         "brand:wikidata": "Q689059",
         "brand:wikipedia": "fr:Habitat (entreprise)",
-        "contact:facebook": "https://www.facebook.com/HabitatFR",
-        "contact:instagram": "https://www.instagram.com/habitat_france/",
-        "contact:youtube": "https://www.youtube.com/channel/UClXokHyj0j5gjTjhj32IcpA/",
         "name": "Habitat",
-        "ref:FR:NAF": "4759A",
-        "ref:FR:SIREN": "389389545",
-        "ref:vatin": "FR72389389545",
         "shop": "furniture",
         "website": "https://www.habitat.fr/"
       }

--- a/data/brands/shop/furniture.json
+++ b/data/brands/shop/furniture.json
@@ -532,8 +532,7 @@
         "brand:wikidata": "Q689059",
         "brand:wikipedia": "fr:Habitat (entreprise)",
         "name": "Habitat",
-        "shop": "furniture",
-        "website": "https://www.habitat.fr/"
+        "shop": "furniture"
       }
     },
     {

--- a/data/brands/shop/furniture.json
+++ b/data/brands/shop/furniture.json
@@ -507,7 +507,6 @@
           "be",
           "de",
           "es",
-          "fr",
           "gr",
           "is",
           "lu",
@@ -519,10 +518,28 @@
       "note": "No 'gb'. Original UK Habitat Q689059 has split from the Int'l Habitat Group and only operates 4 stores, see #4920",
       "tags": {
         "brand": "Habitat",
-        "brand:wikidata": "Q28232260",
-        "brand:wikipedia": "en:Groupe Habitat",
+        "brand:wikidata": "Q689059",
+        "brand:wikipedia": "en:Habitat (retailer)",
         "name": "Habitat",
         "shop": "furniture"
+      }
+    },
+    {
+      "displayName": "Habitat (France)",
+      "locationSet": {"include": ["fr"]},
+      "tags": {
+        "brand": "Habitat",
+        "brand:wikidata": "Q689059",
+        "brand:wikipedia": "fr:Habitat (entreprise)",
+        "contact:facebook": "https://www.facebook.com/HabitatFR",
+        "contact:instagram": "https://www.instagram.com/habitat_france/",
+        "contact:youtube": "https://www.youtube.com/channel/UClXokHyj0j5gjTjhj32IcpA/",
+        "name": "Habitat",
+        "ref:FR:NAF": "4759A",
+        "ref:FR:SIREN": "389389545",
+        "ref:vatin": "FR72389389545",
+        "shop": "furniture",
+        "website": "https://www.habitat.fr/"
       }
     },
     {


### PR DESCRIPTION
Created a french specific version for the Habitat retail chain, including french exclusive tags. Removed France from the locationSet of "Habitat (non-Uk)" and corrected the wikidata now aiming to the retail rather than the group.