### PR TITLE
Set cinema name to Dendy

### DIFF
--- a/data/brands/amenity/cinema.json
+++ b/data/brands/amenity/cinema.json
@@ -375,14 +375,16 @@
       }
     },
     {
-      "displayName": "Dendy Cinemas",
+      "displayName": "Dendy",
       "id": "dendycinemas-1a8a27",
       "locationSet": {"include": ["au"]},
+      "matchNames": ["dendy cinema"],
       "tags": {
         "amenity": "cinema",
         "brand": "Dendy Cinemas",
         "brand:wikidata": "Q22907727",
-        "brand:wikipedia": "en:Dendy Cinemas"
+        "brand:wikipedia": "en:Dendy Cinemas",
+        "name": "Dendy"
       }
     },
     {


### PR DESCRIPTION
This corrects the name to be Dendy to be consistent with the brand and existing mapped cinemas

https://www.openstreetmap.org/node/5279285921
https://www.openstreetmap.org/node/5279285921

It also adds a match name for instances like this  https://www.openstreetmap.org/node/657853225