### PR TITLE
Auchan localization in Rusia (Ашан)

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -7057,11 +7057,12 @@
     {
       "displayName": "Ашан",
       "id": "auchan-992584",
-      "locationSet": {"include": ["ru", "ua"]},
+      "locationSet": {"include": ["ru"]},
+      "matchNames": ["Auchan"],
       "tags": {
         "brand": "Ашан",
         "brand:en": "Auchan",
-        "brand:wikidata": "Q758603",
+        "brand:wikidata": "Q110053013",
         "brand:wikipedia": "ru:Auchan",
         "name": "Ашан",
         "name:en": "Auchan",


### PR DESCRIPTION
I have created a separate entry for a subsidiary of Auchan in Russia -- Q110053013. It has a different legal form, a localized logo, and other social media accounts.