### PR TITLE
Correct network name Mistral

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -7883,7 +7883,7 @@
       "displayName": "Mistral",
       "id": "reseaumistral-add5eb",
       "locationSet": {"include": ["fx"]},
-      "matchNames": ["mistral"],
+      "matchNames": ["mistral","Réseau Mistral"],
       "tags": {
         "network": "Mistral",
         "network:wikidata": "Q3456576",

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -7880,6 +7880,18 @@
       }
     },
     {
+      "displayName": "Mistral",
+      "id": "reseaumistral-add5eb",
+      "locationSet": {"include": ["fx"]},
+      "matchNames": ["mistral"],
+      "tags": {
+        "network": "Mistral",
+        "network:wikidata": "Q3456576",
+        "network:wikipedia": "fr:Réseau Mistral",
+        "route": "bus"
+      }
+    },    
+    {
       "displayName": "MITS",
       "id": "mits-a21cc9",
       "locationSet": {"include": ["us"]},
@@ -10468,18 +10480,6 @@
       "locationSet": {"include": ["fx"]},
       "tags": {
         "network": "Réseau interurbain Nouvelle-Aquitaine",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "Réseau Mistral",
-      "id": "reseaumistral-add5eb",
-      "locationSet": {"include": ["fx"]},
-      "matchNames": ["mistral"],
-      "tags": {
-        "network": "Réseau Mistral",
-        "network:wikidata": "Q3456576",
-        "network:wikipedia": "fr:Réseau Mistral",
         "route": "bus"
       }
     },


### PR DESCRIPTION
The name for the network Mistral is "Mistral" and not "Network Mistral".