### PR TITLE
Rename "Фиалка Аптека" → "Фиалка"

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -3176,6 +3176,7 @@
       "displayName": "Фиалка",
       "id": "fialka-288c27",
       "locationSet": {"include": ["ru"]},
+      "matchNames": ["Фиалка Аптека"],
       "tags": {
         "amenity": "pharmacy",
         "brand": "Фиалка",

--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -3173,18 +3173,18 @@
       }
     },
     {
-      "displayName": "Фиалка Аптека",
+      "displayName": "Фиалка",
       "id": "fialka-288c27",
       "locationSet": {"include": ["ru"]},
       "tags": {
         "amenity": "pharmacy",
-        "brand": "Фиалка Аптека",
-        "brand:ru": "Фиалка Аптека",
+        "brand": "Фиалка",
+        "brand:ru": "Фиалка",
         "brand:wikidata": "Q109995996",
         "healthcare": "pharmacy",
-        "name": "Фиалка Аптека",
+        "name": "Фиалка",
         "name:en": "Fialka",
-        "name:ru": "Фиалка Аптека"
+        "name:ru": "Фиалка"
       }
     },
     {


### PR DESCRIPTION
We conferred in the Russian-language chat https://t.me/ruosm, despite the fact that sometimes the word "Аптека" ("Pharmacy") appears in the logo, it would be correct not to use it.