### PR TITLE
Patty & Bun burger restaurants

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -2834,6 +2834,19 @@
       }
     },
     {
+      "displayName": "Patty & Bun",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "Patty & Bun",
+        "brand:wikidata": "Q110103854",
+        "cuisine": "burger",
+        "diet:vegan": "yes",
+        "name": "Patty & Bun",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "P.F. Chang's",
       "id": "pfchangs-f036fe",
       "locationSet": {


### PR DESCRIPTION
Patty & Bun burger restaurants, which have a dedicated plant based menu https://www.pattyandbun.co.uk/plant-based-vegan-gluten-free-vegetarian