### PR TITLE
French home appliance chain PRO&Cie

### DIFF
--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -769,6 +769,19 @@
       }
     },
     {
+      "displayName": "Power",
+      "locationSet": {
+        "include": ["fr"]
+      },
+      "tags": {
+        "brand": "Pro&Cie",
+        "brand:wikidata": "Q3406142",
+        "brand:wikipedia": "fr:PRO&Cie",
+        "name": "PRO&Cie",
+        "shop": "electronics"
+      }
+    },
+    {
       "displayName": "RadioShack",
       "id": "radioshack-9377b7",
       "locationSet": {"include": ["001"]},

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -757,9 +757,7 @@
     {
       "displayName": "Power",
       "id": "power-9765c4",
-      "locationSet": {
-        "include": ["dk", "fi", "no", "se"]
-      },
+      "locationSet": {"include": ["dk", "fi", "no", "se"]},
       "tags": {
         "brand": "Power",
         "brand:wikidata": "Q20857751",
@@ -769,12 +767,10 @@
       }
     },
     {
-      "displayName": "Power",
-      "locationSet": {
-        "include": ["fr"]
-      },
+      "displayName": "PRO&Cie",
+      "locationSet": {"include": ["fr"]},
       "tags": {
-        "brand": "Pro&Cie",
+        "brand": "PRO&Cie",
         "brand:wikidata": "Q3406142",
         "brand:wikipedia": "fr:PRO&Cie",
         "name": "PRO&Cie",


### PR DESCRIPTION
One store location in Martinique, so used "fr" locationSet.