### PR TITLE
Remove redundant word flag from Australian indigenous flags

### DIFF
--- a/data/flags/man_made/flagpole.json
+++ b/data/flags/man_made/flagpole.json
@@ -189,12 +189,12 @@
       }
     },
     {
-      "displayName": "AU - Australian Aboriginal Flag",
+      "displayName": "AU - Australian Aboriginal",
       "id": "australianaboriginalflag-e5dc93",
       "locationSet": {"include": ["001"]},
       "tags": {
         "country": "AU",
-        "flag:name": "Australian Aboriginal Flag",
+        "flag:name": "Australian Aboriginal",
         "flag:type": "indigenous",
         "flag:wikidata": "Q1285625",
         "man_made": "flagpole",
@@ -203,12 +203,12 @@
       }
     },
     {
-      "displayName": "AU - Torres Strait Islander Flag",
+      "displayName": "AU - Torres Strait Islander",
       "id": "torresstraitislanderflag-e5dc93",
       "locationSet": {"include": ["001"]},
       "tags": {
         "country": "AU",
-        "flag:name": "Torres Strait Islander Flag",
+        "flag:name": "Torres Strait Islander",
         "flag:type": "indigenous",
         "flag:wikidata": "Q462621",
         "man_made": "flagpole",


### PR DESCRIPTION
A small fix for the PR #5856 removing redundant word flag 