### PR TITLE
Correct to Event Cinemas

### DIFF
--- a/data/brands/amenity/cinema.json
+++ b/data/brands/amenity/cinema.json
@@ -395,11 +395,10 @@
       "matchNames": ["event cinema"],
       "tags": {
         "amenity": "cinema",
-        "brand": "Event",
+        "brand": "Event Cinemas",
         "brand:wikidata": "Q5416698",
         "brand:wikipedia": "en:Event Cinemas",
-        "name": "Event",
-        "official_name": "Event Cinemas"
+        "name": "Event Cinemas"
       }
     },
     {


### PR DESCRIPTION
Correct from "Event" to "Event Cinemas" in the 'brand' and 'name' atributes, and removed the 'official_name' atribute 
Solves issue #5883 
