### PR TITLE
Exclude Stadtmobil from car sharing operators

### DIFF
--- a/data/brands/amenity/car_sharing.json
+++ b/data/brands/amenity/car_sharing.json
@@ -77,6 +77,7 @@
           "stadtmobil-rhein-neckar.geojson"
         ]
       },
+      "matchNames": ["stadtmobil rhein-neckar"],
       "tags": {
         "amenity": "car_sharing",
         "brand": "Stadtmobil",
@@ -111,6 +112,7 @@
           "stadtmobil-stuttgart.geojson"
         ]
       },
+      "matchNames": ["stadtmobil stuttgart"],
       "tags": {
         "amenity": "car_sharing",
         "brand": "Stadtmobil",

--- a/data/operators/amenity/car_sharing.json
+++ b/data/operators/amenity/car_sharing.json
@@ -1,7 +1,11 @@
 {
   "properties": {
     "path": "operators/amenity/car_sharing",
-    "exclude": {"generic": ["^car sharing$"]}
+    "exclude": {
+      "generic": [
+        "^car sharing$", 
+        "^stadtmobil$"
+      ]}
   },
   "items": [
     {
@@ -523,24 +527,6 @@
       "tags": {
         "amenity": "car_sharing",
         "operator": "Stadtauto carsharing"
-      }
-    },
-    {
-      "displayName": "stadtmobil Rhein-Neckar",
-      "id": "stadtmobilrheinneckar-8163ad",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "amenity": "car_sharing",
-        "operator": "stadtmobil Rhein-Neckar"
-      }
-    },
-    {
-      "displayName": "Stadtmobil Stuttgart",
-      "id": "stadtmobilstuttgart-8163ad",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "amenity": "car_sharing",
-        "operator": "Stadtmobil Stuttgart"
       }
     },
     {


### PR DESCRIPTION
Stadtmobil is already in car sharing brands, but is apparently still added by some bot.
I hope it works like that.