### PR TITLE
Add Rebel Sport in New Zealand

### DIFF
--- a/data/brands/shop/sports.json
+++ b/data/brands/shop/sports.json
@@ -474,13 +474,24 @@
     },
     {
       "displayName": "Rebel",
-      "id": "rebel-e42754",
-      "locationSet": {"include": ["au", "nz"]},
+      "id": "rebel-81181e",
+      "locationSet": {"include": ["au"]},
       "tags": {
         "brand": "Rebel",
         "brand:wikidata": "Q18636397",
         "brand:wikipedia": "en:Rebel (company)",
         "name": "Rebel",
+        "shop": "sports"
+      }
+    },
+    {
+      "displayName": "Rebel Sport",
+      "id": "rebelsport-6d17d3",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "brand": "Rebel Sport",
+        "brand:wikidata": "Q110190372",
+        "name": "Rebel Sport",
         "shop": "sports"
       }
     },


### PR DESCRIPTION
#5882 was to change the name of Rebel to Rebel Sport.
There's an Australian chain (Rebel) and New Zealand chain (Rebel Sport).

Added New Zealand Rebel Sport.
Australian chain should only be offered in Australia.