### PR TITLE
Mitre 10 and Mitre 10 MEGA, New Zealand

### DIFF
--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -717,6 +717,30 @@
       }
     },
     {
+      "displayName": "Mitre 10 (New Zealand)",
+      "id": "mitre10-e80948",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "brand": "Mitre 10",
+        "brand:wikidata": "Q6882394",
+        "brand:wikipedia": "en:Mitre 10 (New Zealand)",
+        "name": "Mitre 10",
+        "shop": "doityourself"
+      }
+    },
+    {
+      "displayName": "Mitre 10 MEGA",
+      "id": "mitre10mega-e80948",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "brand": "Mitre 10",
+        "brand:wikidata": "Q6882394",
+        "brand:wikipedia": "en:Mitre 10 (New Zealand)",
+        "name": "Mitre 10 MEGA",
+        "shop": "doityourself"
+      }
+    },
+    {
       "displayName": "Mr.Bricolage",
       "id": "mrbricolage-b2ed79",
       "locationSet": {"include": ["be", "fr"]},


### PR DESCRIPTION
"Mitre 10" is a chain of DIY stores in New Zealand, and "Mitre 10 MEGA" is the big-box version.
There are around 95 in total, of which 46 are MEGA.