### PR TITLE
Fix Czech wiki prefix, unify South Moravian networks and operators

### DIFF
--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -186,7 +186,7 @@
         "amenity": "post_office",
         "operator": "Česká pošta, s.p.",
         "operator:wikidata": "Q341090",
-        "operator:wikipedia": "cz:Česká pošta"
+        "operator:wikipedia": "cs:Česká pošta"
       }
     },
     {

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -3253,11 +3253,11 @@
       "tags": {"network": "CWL", "route": "bus"}
     },
     {
-      "displayName": "cz:IDS JMK",
+      "displayName": "IDS JMK",
       "id": "czidsjmk-1bafda",
       "locationSet": {"include": ["cz"]},
       "tags": {
-        "network": "cz:IDS JMK",
+        "network": "IDS JMK",
         "route": "bus"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -3253,15 +3253,6 @@
       "tags": {"network": "CWL", "route": "bus"}
     },
     {
-      "displayName": "IDS JMK",
-      "id": "czidsjmk-1bafda",
-      "locationSet": {"include": ["cz"]},
-      "tags": {
-        "network": "IDS JMK",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "Daladala",
       "id": "daladala-68e977",
       "locationSet": {"include": ["tz"]},

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -218,10 +218,10 @@
       "tags": {
         "network": "IDS JMK",
         "network:wikidata": "Q12020731",
-        "network:wikipedia": "cz:Integrovaný dopravní systém Jihomoravského kraje",
-        "operator": "Dopravní podnik města Brna",
+        "network:wikipedia": "cs:Integrovaný dopravní systém Jihomoravského kraje",
+        "operator": "DPMB",
         "operator:wikidata": "Q3700534",
-        "operator:wikipedia": "cz:Dopravní podnik města Brna",
+        "operator:wikipedia": "cs:Dopravní podnik města Brna",
         "route": "tram"
       }
     },

--- a/data/transit/route/trolleybus.json
+++ b/data/transit/route/trolleybus.json
@@ -67,7 +67,7 @@
         "network": "IDS JMK",
         "network:wikidata": "Q12020731",
         "network:wikipedia": "cs:Integrovaný dopravní systém Jihomoravského kraje",
-        "operator": "Dopravní podnik města Brna",
+        "operator": "DPMB",
         "operator:wikidata": "Q3700534",
         "operator:wikipedia": "cs:Dopravní podnik města Brna",
         "route": "trolleybus"


### PR DESCRIPTION
- `cz:` wikipedia prefix is invalid, it should be `cs:`
- `cz:IDS JMK` network in `bus.json`, but `trolleybus.json` and `tram.json` were not using this prefix -> prefix removed
- `Dopravní podnik města Brna` in `trolleybus.json` and `tram.json` changed to `DPMB`
  - we have [706 objects](https://overpass-turbo.eu/s/1ejm) and only 36 objects of them was with fullname `Dopravní podnik města Brna`
  - those 36 object were edited by iD editor, and as those rules are not applied to the bus routes, renaming to the fullname would causing inconsistend name convention
