### PR TITLE
Force LF for end-of-line

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Force LF line endings for all text files
+* text eol=lf
+
+# These filetypes are binary
+*.png binary
+*.gif binary


### PR DESCRIPTION
I was running in to the same issue as #4983 when using Windows.

Git stores files in the repository as either LF or CRLF, and by default converts them all to CRLF on Windows. When committing back, they're returned to whichever line ending they originally had (or set if the file is new).

When checking out the repo on Windows, the line endings were switching from LF to CRLF, `npm run build` would convert them back to LF, and then hundreds of files would be marked as modified.

Users can optionally set the `core.autocrlf` option from `true` to `false` or `input`, but this isn't really a great solution as it requires every Windows user to both know about the setting and to change it.

This PR sets all text files to use the LF line-ending on all systems (Windows, Linux, MacOS, etc.) using the [gitattributes file](https://www.git-scm.com/docs/gitattributes). Images have to be explicitly specified as binary, as for some reason they're detected as text. 

Users may need to force a reset of the line endings locally:
```
git rm --cached -r .
git reset --hard
```
or they can just delete their local repo and clone again.

This will unfortunately mean that Windows users cannot use Notepad to view files, but anything even slightly smarter (like Notepad++, or much more likely Visual Studio Code) won't have any issues.