### PR TITLE
Australian and New Zealand brands

### DIFF
--- a/data/brands/shop/department_store.json
+++ b/data/brands/shop/department_store.json
@@ -711,8 +711,8 @@
     },
     {
       "displayName": "Kmart (Australia)",
-      "id": "kmart-c93bbd",
-      "locationSet": {"include": ["au"]},
+      "id": "kmart-2e4a6e",
+      "locationSet": {"include": ["au", "nz"]},
       "tags": {
         "brand": "Kmart",
         "brand:wikidata": "Q6421682",

--- a/data/brands/shop/houseware.json
+++ b/data/brands/shop/houseware.json
@@ -56,6 +56,17 @@
       }
     },
     {
+      "displayName": "Briscoes",
+      "id": "briscoes-1d32aa",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "brand": "Briscoes",
+        "brand:wikidata": "Q110190653",
+        "name": "Briscoes",
+        "shop": "houseware"
+      }
+    },
+    {
       "displayName": "BSS Group",
       "id": "bssgroup-81bc6e",
       "locationSet": {"include": ["gb", "ie"]},

--- a/data/brands/shop/outdoor.json
+++ b/data/brands/shop/outdoor.json
@@ -324,6 +324,18 @@
       }
     },
     {
+      "displayName": "Torpedo7",
+      "id": "torpedo7-f40221",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "brand": "Torpedo7",
+        "brand:wikidata": "Q110221600",
+        "brand:wikipedia": "en:Torpedo7",
+        "name": "Torpedo7",
+        "shop": "outdoor"
+      }
+    },
+    {
       "displayName": "Trespass",
       "id": "trespass-290058",
       "locationSet": {

--- a/data/brands/shop/stationery.json
+++ b/data/brands/shop/stationery.json
@@ -260,6 +260,18 @@
       }
     },
     {
+      "displayName": "Warehouse Stationery",
+      "id": "warehousestationery-a34cb3",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "brand": "Warehouse Stationery",
+        "brand:wikidata": "Q110221565",
+        "brand:wikipedia": "en:Warehouse Stationery",
+        "name": "Warehouse Stationery",
+        "shop": "stationery"
+      }
+    },
+    {
       "displayName": "Глобус",
       "id": "d19aa5-8bfff1",
       "locationSet": {"include": ["001"]},

--- a/data/brands/shop/toys.json
+++ b/data/brands/shop/toys.json
@@ -451,6 +451,17 @@
       }
     },
     {
+      "displayName": "Toyworld",
+      "id": "toyworld-03114e",
+      "locationSet": {"include": ["au", "nz"]},
+      "tags": {
+        "brand": "Toyworld",
+        "brand:wikidata": "Q95923071",
+        "name": "Toyworld",
+        "shop": "toys"
+      }
+    },
+    {
       "displayName": "Toyzz Shop",
       "id": "toyzzshop-a17e1f",
       "locationSet": {"include": ["tr"]},

--- a/data/operators/emergency/phone.json
+++ b/data/operators/emergency/phone.json
@@ -643,7 +643,8 @@
       "locationSet": {"include": ["nz"]},
       "tags": {
         "emergency": "phone",
-        "operator": "University of Canterbury"
+        "operator": "University of Canterbury",
+        "operator:wikidata": "Q432475"
       }
     },
     {


### PR DESCRIPTION
Add a few New Zealand brands.
Update operator _University of Canterbury_ emergency phones to include QID.

Toyworld is the same chain for both AU and NZ. Same for Kmart.