### PR TITLE
Citizens Advice

### DIFF
--- a/data/brands/amenity/social_facility.json
+++ b/data/brands/amenity/social_facility.json
@@ -129,6 +129,30 @@
       }
     },
     {
+      "displayName": "Citizens Advice",
+      "locationSet": {"include": ["gb"]},
+      "matchNames": [
+        "citizens advice bureau",
+        "citizens' advice bureau"
+      ],
+      "matchTags": [
+        "amenity/advice",
+        "amenity/information",
+        "office/charity",
+        "office/citizens_advice",
+        "office/government",
+        "office/lawyer",
+        "office/ngo"
+      ],
+      "tags": {
+        "amenity": "social_facility",
+        "brand": "Citizens Advice",
+        "brand:wikidata": "Q5122657",
+        "brand:wikipedia": "en:Citizens Advice",
+        "social_facility": "outreach"
+      }
+    },
+    {
       "displayName": "Deutsches Rotes Kreuz",
       "id": "deutschesroteskreuz-da0ff2",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
This resolves #5868 by adding a preset for Citizens Advice in the UK, previously known as Citizens Advice Bureau