### PR TITLE
Improve fuel stations and bicycle rental in China

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -1798,7 +1798,7 @@
       "displayName": "K Bike",
       "id": "kbike-1bb859",
       "locationSet": {"include": ["tw"]},
-      "matchNames": ["k bike"],
+      "matchNames": ["k bike", "金門縣政府"],
       "tags": {
         "amenity": "bicycle_rental",
         "network": "K-Bike",

--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -1798,11 +1798,20 @@
       "displayName": "K Bike",
       "id": "kbike-1bb859",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["k bike"],
       "tags": {
         "amenity": "bicycle_rental",
-        "brand": "K Bike",
-        "network": "K Bike",
-        "operator": "金門縣政府"
+        "network": "K-Bike",
+        "brand": "金門公共自行車",
+        "brand:en": "K-Bike",
+        "brand:zh": "金門公共自行車",
+        "brand:wikidata": "Q30942379",
+        "brand:wikipedia": "zh:金門縣公共自行車租賃系統",
+        "name": "金門公共自行車",
+        "name:en": "K-Bike",
+        "name:zh": "金門公共自行車",
+        "operator": "金門縣政府",
+        "operator:type": "government"
       }
     },
     {
@@ -4274,26 +4283,6 @@
         "brand": "苏州东大金点物联科技有限公司",
         "name": "苏州东大金点物联科技有限公司",
         "operator": "苏州东大金点物联科技有限公司"
-      }
-    },
-    {
-      "displayName": "金門公共自行車",
-      "id": "af5935-1bb859",
-      "locationSet": {"include": ["tw"]},
-      "matchNames": ["k bike"],
-      "tags": {
-        "amenity": "bicycle_rental",
-        "brand": "金門公共自行車",
-        "brand:en": "K-Bike",
-        "brand:zh": "金門公共自行車",
-        "brand:wikidata": "Q30942379",
-        "brand:wikipedia": "zh:金門縣公共自行車租賃系統",
-        "name": "金門公共自行車",
-        "name:en": "K-Bike",
-        "name:zh": "金門公共自行車",
-        "operator": "金門縣政府",
-        "operator:type": "government",
-        "website": "https://www.k-bike.com.tw/"
       }
     },
     {

--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -4277,14 +4277,23 @@
       }
     },
     {
-      "displayName": "金門縣政府",
+      "displayName": "金門公共自行車",
       "id": "af5935-1bb859",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["k bike"],
       "tags": {
         "amenity": "bicycle_rental",
-        "brand": "金門縣政府",
-        "name": "金門縣政府",
-        "operator": "金門縣政府"
+        "brand": "金門公共自行車",
+        "brand:en": "K-Bike",
+        "brand:zh": "金門公共自行車",
+        "brand:wikidata": "Q30942379",
+        "brand:wikipedia": "zh:金門縣公共自行車租賃系統",
+        "name": "金門公共自行車",
+        "name:en": "K-Bike",
+        "name:zh": "金門公共自行車",
+        "operator": "金門縣政府",
+        "operator:type": "government",
+        "website": "https://www.k-bike.com.tw/"
       }
     },
     {

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6263,7 +6263,6 @@
         "brand:wikidata": "Q86727966",
         "brand:wikipedia": "zh:国家石油天然气管网集团",
         "brand:zh": "国家管网",
-        "fuel:lng": "yes",
         "name": "国家管网",
         "name:en": "PipeChina",
         "name:zh": "国家管网"

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6185,6 +6185,22 @@
       }
     },
     {
+      "displayName": "广西交投",
+      "locationSet": {"include": ["cn"]},
+      "matchNames": ["广西交投加油站"],
+      "tags": {
+        "amenity": "fuel",
+        "brand": "广西交投",
+        "brand:wikidata": "Q11062364",
+        "brand:wikipedia": "zh:广西交通投资集团",
+        "brand:zh": "广西交投",
+        "name": "广西交投",
+        "name:zh": "广西交投",
+        "operator": "广西交通投资集团有限公司",
+        "operator:type": "public"
+      }
+    },
+    {
       "displayName": "全國加油站",
       "id": "npc-db3418",
       "locationSet": {"include": ["tw"]},

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6082,20 +6082,25 @@
       }
     },
     {
-      "displayName": "中国海洋石油",
+      "displayName": "中国海油",
       "id": "cnooc-e4b6c0",
       "locationSet": {"include": ["cn"]},
-      "matchNames": ["中海油", "中海油加油站", "中海油站"],
+      "matchNames": [
+        "中海油",
+        "中海油加油站",
+        "中海油站",
+        "中国海洋石油"
+      ],
       "tags": {
         "amenity": "fuel",
-        "brand": "中国海洋石油",
+        "brand": "中国海油",
         "brand:en": "CNOOC",
         "brand:wikidata": "Q795354",
         "brand:wikipedia": "zh:中国海洋石油",
-        "brand:zh": "中国海洋石油",
-        "name": "中国海洋石油",
+        "brand:zh": "中国海油",
+        "name": "中国海油",
         "name:en": "CNOOC",
-        "name:zh": "中国海洋石油"
+        "name:zh": "中国海油"
       }
     },
     {


### PR DESCRIPTION
Fuel stations:
+ CNOOC: `name=` `中国海洋石油`->`中国海油`
  ![中国海油](https://user-images.githubusercontent.com/45530478/147030051-00743692-9886-470b-ba4c-65e033c7a6d3.png)
+ PipeChina: remove`fuel:lng=yes`, because it may be other fuel
+ 广西交投: new added

Bicycle rental:
+ K-Bike: more data