### PR TITLE
Move China Post from operator to brand

### DIFF
--- a/data/brands/amenity/post_office.json
+++ b/data/brands/amenity/post_office.json
@@ -140,6 +140,23 @@
       }
     },
     {
+      "displayName": "中国邮政",
+      "id": "chinapost-1c81b5",
+      "locationSet": {"include": ["cn"]},
+      "matchNames": ["ems", "邮政", "邮政速递", "中国邮政速递", "中国邮政速递物流"],
+      "tags": {
+        "amenity": "post_office",
+        "name": "中国邮政",
+        "name:en": "China Post",
+        "name:zh": "中国邮政",
+        "brand": "中国邮政",
+        "brand:en": "China Post",
+        "brand:wikidata": "Q1066476",
+        "brand:wikipedia": "zh:中国邮政",
+        "brand:zh": "中国邮政"
+      }
+    },
+    {
       "displayName": "德邦快递",
       "locationSet": {"include": ["cn"]},
       "matchNames": ["德邦", "德邦物流"],

--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -1564,20 +1564,6 @@
       }
     },
     {
-      "displayName": "中国邮政",
-      "id": "chinapost-1c81b5",
-      "locationSet": {"include": ["cn"]},
-      "matchNames": ["ems", "邮政", "邮政速递", "中国邮政速递", "中国邮政速递物流"],
-      "tags": {
-        "amenity": "post_office",
-        "operator": "中国邮政",
-        "operator:en": "China Post",
-        "operator:wikidata": "Q1066476",
-        "operator:wikipedia": "zh:中国邮政",
-        "operator:zh": "中国邮政"
-      }
-    },
-    {
       "displayName": "中華郵政",
       "id": "chunghwapost-feb726",
       "locationSet": {"include": ["tw"]},


### PR DESCRIPTION
China Post should be a brand instead of an operator.

Each sub post offices named `China Post`(中国邮政), like the following photo. In Beijing, it named `China Post`, in Canton, it named `China Post`, everywhere it named `China Post`.

![image](https://user-images.githubusercontent.com/45530478/147106876-3998443a-84c8-4e19-8e44-8df062eef021.png)

Different from other post offices, eg Chunghwa Post, in Taipei there is sub post offices named `Nangang Post Office`(南港郵局) in Nangang district ,and `Xinzhuang Post Office`(新莊郵局) in Xinzhuang district, New Taipei like the following photo, and more. So `Chunghwa Post` is an operator.

![image](https://user-images.githubusercontent.com/45530478/147108283-736da1e7-551d-4403-881f-0c7573b38a4f.png)

But `China Post` always named `China Post`, so it should be a brand.
