### PR TITLE
Add EP: (ElectronicPartner)

### DIFF
--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -331,6 +331,20 @@
       }
     },
     {
+      "displayName": "EP:",
+      "id": "ep-a53b66",
+      "locationSet": {
+        "include": ["at", "ch", "de", "nl"]
+      },
+      "matchNames": ["electronicpartner"],
+      "matchTags": ["shop/radiotechnics"],
+      "tags": {
+        "brand": "EP:",
+        "brand:wikidata": "Q110271192",
+        "shop": "electronics"
+      }
+    },
+    {
       "displayName": "Euronics",
       "id": "euronics-9377b7",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Website: https://www.ep.de

I'm not sure if `brand` should be set to "EP:" (with colon) which would be more accurate but might cause issues (?).