### PR TITLE
Fix typo in operator for Stadtmobil Karlsruhe

### DIFF
--- a/data/brands/amenity/car_sharing.json
+++ b/data/brands/amenity/car_sharing.json
@@ -49,7 +49,7 @@
         "brand:wikidata": "Q2327629",
         "brand:wikipedia": "de:Stadtmobil",
         "network": "Stadtmobil Karlsruhe",
-        "operator": "Stadtmobil Carsharing GmbH & Co. KG"
+        "operator": "Stadtmobil CarSharing GmbH & Co. KG"
       }
     },
     {


### PR DESCRIPTION
Source: https://karlsruhe.stadtmobil.de/impressum/