### PR TITLE
Split TAB for Australia and New Zealand

### DIFF
--- a/data/brands/shop/bookmaker.json
+++ b/data/brands/shop/bookmaker.json
@@ -131,11 +131,26 @@
       }
     },
     {
-      "displayName": "TAB",
-      "id": "tab-52c000",
-      "locationSet": {"include": ["au", "nz"]},
+      "displayName": "TAB (Australia)",
+      "id": "tab-21679e",
+      "locationSet": {
+        "include": ["au"],
+        "exclude": ["au-wa.geojson"]
+      },
       "tags": {
         "brand": "TAB",
+        "brand:wikidata": "Q110288149",
+        "name": "TAB",
+        "shop": "bookmaker"
+      }
+    },
+    {
+      "displayName": "TAB (New Zealand)",
+      "id": "tab-c21655",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "brand": "TAB",
+        "brand:wikidata": "Q110288070",
         "name": "TAB",
         "shop": "bookmaker"
       }


### PR DESCRIPTION
TAB is a bookmaker in both Australia and New Zealand.

They are different companies.