### PR TITLE
Shorten name of State Savings Bank of Ukraine

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -10136,6 +10136,7 @@
       "tags": {
         "amenity": "bank",
         "brand": "Ощадбанк",
+        "brand:uk": "Ощадбанк",
         "brand:en": "Oschadbank",
         "brand:wikidata": "Q4340839",
         "brand:wikipedia": "uk:Ощадбанк",

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -10140,7 +10140,11 @@
         "brand:wikidata": "Q4340839",
         "brand:wikipedia": "uk:Ощадбанк",
         "name": "Ощадбанк",
-        "name:en": "State Savings Bank of Ukraine"
+        "name:en": "Oschadbank",
+        "short_name": "АТ \"Ощадбанк\"",
+        "short_name:en": "JSC \"Oschadbank\"",
+        "official_name": "Акціонерне товариство \"Державний ощадний банк України\"",
+        "official_name:en": "Joint Stock Company \"State Savings Bank of Ukraine\""
       }
     },
     {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -10136,14 +10136,17 @@
       "tags": {
         "amenity": "bank",
         "brand": "Ощадбанк",
-        "brand:en": "State Savings Bank of Ukraine",
+        "brand:en": "Oschadbank",
         "brand:wikidata": "Q4340839",
         "brand:wikipedia": "uk:Ощадбанк",
         "name": "Ощадбанк",
+        "name:uk": "Ощадбанк",
         "name:en": "Oschadbank",
         "short_name": "АТ \"Ощадбанк\"",
+        "short_name:uk": "АТ \"Ощадбанк\"",
         "short_name:en": "JSC \"Oschadbank\"",
         "official_name": "Акціонерне товариство \"Державний ощадний банк України\"",
+        "official_name:uk": "Акціонерне товариство \"Державний ощадний банк України\"",
         "official_name:en": "Joint Stock Company \"State Savings Bank of Ukraine\""
       }
     },


### PR DESCRIPTION
During discussion the Ukrainian community in [Telegram](https://t.me/osmUA) decide replace "State Savings Bank of Ukraine" with shorter name "Oshadbank" and add the full name to official_name:en. ATMs have already been updated [CS 115248505](https://www.openstreetmap.org/changeset/115248505)