### PR TITLE
Adding BG&E and SMECO to power lines

### DIFF
--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -459,6 +459,7 @@
       "locationSet": {"include": ["us"]},
       "matchNames": ["bg&e", "bge"],
       "tags": {
+        "frequency": "60",
         "operator": "Baltimore Gas and Electric",
         "operator:wikidata": "Q4852862",
         "operator:wikipedia": "en:Baltimore Gas and Electric",

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -453,6 +453,18 @@
         "power": "line"
       }
     },
+        {
+      "displayName": "Baltimore Gas & Electric",
+      "id": "baltimoregasandelectric-777c2a",
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["bg&e", "bge"],
+      "tags": {
+        "operator": "Baltimore Gas and Electric",
+        "operator:wikidata": "Q4852862",
+        "operator:wikipedia": "en:Baltimore Gas and Electric",
+        "power": "line"
+      }
+    },
     {
       "displayName": "Bonneville Power Administration",
       "id": "bonnevillepoweradministration-b654b4",

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -4326,6 +4326,19 @@
         "power": "line"
       }
     },
+        {
+      "displayName": "Southern Maryland Electric Cooperative",
+      "id": "southernmarylandelectriccooperative-8222ce",
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["smeco"],
+      "tags": {
+        "frequency": "60",
+        "operator": "Southern Maryland Electric Cooperative",
+        "operator:wikidata": "Q7570123",
+        "operator:wikipedia": "en:Southern Maryland Electric Cooperative",
+        "power": "line"
+      }
+    },
     {
       "displayName": "SP Transmission",
       "id": "sptransmission-116894",

--- a/data/operators/power/minor_line.json
+++ b/data/operators/power/minor_line.json
@@ -10,19 +10,6 @@
       "templateTags": {"power": "minor_line"}
     },
     {
-      "displayName": "Baltimore Gas & Electric",
-      "id": "baltimoregasandelectric-8222ce",
-      "locationSet": {"include": ["us"]},
-      "matchNames": ["bg&e", "bge"],
-      "tags": {
-        "frequency": "60",
-        "operator": "Baltimore Gas and Electric",
-        "operator:wikidata": "Q4852862",
-        "operator:wikipedia": "en:Baltimore Gas and Electric",
-        "power": "minor_line"
-      }
-    },
-    {
       "displayName": "Hydro Ottawa",
       "id": "hydroottawa-5b3431",
       "locationSet": {"include": ["ca"]},
@@ -30,19 +17,6 @@
         "operator": "Hydro Ottawa",
         "operator:wikidata": "Q3143710",
         "operator:wikipedia": "en:Hydro Ottawa",
-        "power": "minor_line"
-      }
-    },
-    {
-      "displayName": "Southern Maryland Electric Cooperative",
-      "id": "southernmarylandelectriccooperative-8222ce",
-      "locationSet": {"include": ["us"]},
-      "matchNames": ["smeco"],
-      "tags": {
-        "frequency": "60",
-        "operator": "Southern Maryland Electric Cooperative",
-        "operator:wikidata": "Q7570123",
-        "operator:wikipedia": "en:Southern Maryland Electric Cooperative",
         "power": "minor_line"
       }
     },

--- a/data/operators/power/pole.json
+++ b/data/operators/power/pole.json
@@ -10,19 +10,6 @@
       "templateTags": {"power": "pole"}
     },
     {
-      "displayName": "Baltimore Gas & Electric",
-      "id": "baltimoregasandelectric-777c2a",
-      "locationSet": {"include": ["us"]},
-      "matchNames": ["bg&e", "bge"],
-      "tags": {
-        "operator": "Baltimore Gas and Electric",
-        "operator:wikidata": "Q4852862",
-        "operator:wikipedia": "en:Baltimore Gas and Electric",
-        "power": "pole",
-        "utility": "power"
-      }
-    },
-    {
       "displayName": "Hydro Ottawa",
       "id": "hydroottawa-a3e8de",
       "locationSet": {"include": ["ca"]},
@@ -31,19 +18,6 @@
         "operator:wikidata": "Q3143710",
         "operator:wikipedia": "en:Hydro Ottawa",
         "power": "pole"
-      }
-    },
-    {
-      "displayName": "Southern Maryland Electric Cooperative",
-      "id": "southernmarylandelectriccooperative-777c2a",
-      "locationSet": {"include": ["us"]},
-      "matchNames": ["smeco"],
-      "tags": {
-        "operator": "Southern Maryland Electric Cooperative",
-        "operator:wikidata": "Q7570123",
-        "operator:wikipedia": "en:Southern Maryland Electric Cooperative",
-        "power": "pole",
-        "utility": "power"
       }
     },
     {


### PR DESCRIPTION
The last update to add Baltimore Gas and Electric and Southern Maryland Electric Cooperative to minor_line and poles worked quite well.  I've found places where these operators should be added to power lines as well.