### PR TITLE
Remove US from FNB (South Africa) and add FNBO

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -4944,6 +4944,7 @@
           "us-wv.geojson"
         ]
       },
+      "matchNames": ["fnb"],
       "tags": {
         "amenity": "bank",
         "brand": "First National Bank",
@@ -5159,16 +5160,9 @@
     },
     {
       "displayName": "FNB (South Africa)",
-      "id": "fnb-ae9657",
+      "id": "fnb-154feb",
       "locationSet": {
-        "include": [
-          "bw",
-          "mz",
-          "na",
-          "us",
-          "za",
-          "zm"
-        ]
+        "include": ["bw", "mz", "na", "za", "zm"]
       },
       "tags": {
         "amenity": "bank",

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -5174,6 +5174,18 @@
       }
     },
     {
+      "displayName": "FNBO",
+      "id": "fnbo-ea2e2d",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "FNBO",
+        "brand:wikidata": "Q5453412",
+        "name": "FNBO",
+        "official_name": "First National Bank of Omaha"
+      }
+    },
+    {
       "displayName": "ForteBank",
       "id": "fortebank-033b31",
       "locationSet": {"include": ["kz"]},

--- a/data/brands/office/estate_agent.json
+++ b/data/brands/office/estate_agent.json
@@ -538,7 +538,7 @@
     },
     {
       "displayName": "Nestenn",
-      "id": "nestenn-08bb13",
+      "id": "nestenn-b7bc37",
       "locationSet": {"include": ["fx"]},
       "tags": {
         "brand": "Nestenn",


### PR DESCRIPTION
We're overwriting US First National Bank locations with FNB from South Africa.

Signed-off-by: Tim Smith <tsmith@chef.io>