### PR TITLE
AU/NZ brands

### DIFF
--- a/data/brands/leisure/amusement_arcade.json
+++ b/data/brands/leisure/amusement_arcade.json
@@ -5,6 +5,29 @@
   },
   "items": [
     {
+      "displayName": "Timezone",
+      "id": "timezone-bbc11e",
+      "locationSet": {
+        "include": [
+          "au",
+          "id",
+          "in",
+          "nz",
+          "ph",
+          "sg",
+          "vn"
+        ]
+      },
+      "matchTags": ["shop/video_games"],
+      "tags": {
+        "brand": "Timezone",
+        "brand:wikidata": "Q12521502",
+        "brand:wikipedia": "en:Timezone (video arcades)",
+        "leisure": "amusement_arcade",
+        "name": "Timezone"
+      }
+    },
+    {
       "displayName": "アドアーズ",
       "id": "adores-c3bbfb",
       "locationSet": {"include": ["jp"]},

--- a/data/brands/shop/bicycle.json
+++ b/data/brands/shop/bicycle.json
@@ -8,6 +8,7 @@
       "displayName": "99 Bikes",
       "id": "99bikes-0d00fa",
       "locationSet": {"include": ["au", "nz"]},
+      "matchNames": ["bike barn"],
       "tags": {
         "brand": "99 Bikes",
         "brand:wikidata": "Q110288298",

--- a/data/brands/shop/books.json
+++ b/data/brands/shop/books.json
@@ -763,6 +763,7 @@
       "displayName": "Whitcoulls",
       "id": "whitcoulls-fe66a8",
       "locationSet": {"include": ["nz"]},
+      "matchTags": ["shop/stationery"],
       "tags": {
         "brand": "Whitcoulls",
         "brand:wikidata": "Q7994237",

--- a/data/brands/shop/books.json
+++ b/data/brands/shop/books.json
@@ -760,6 +760,18 @@
       }
     },
     {
+      "displayName": "Whitcoulls",
+      "id": "whitcoulls-fe66a8",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "brand": "Whitcoulls",
+        "brand:wikidata": "Q7994237",
+        "brand:wikipedia": "en:Whitcoulls",
+        "name": "Whitcoulls",
+        "shop": "books"
+      }
+    },
+    {
       "displayName": "WHSmith",
       "id": "whsmith-4d39b8",
       "locationSet": {

--- a/data/operators/leisure/park.json
+++ b/data/operators/leisure/park.json
@@ -440,6 +440,7 @@
       "tags": {
         "leisure": "park",
         "operator": "Christchurch City Council",
+        "operator:short": "CCC",
         "operator:type": "government",
         "operator:wikidata": "Q5109064",
         "operator:wikipedia": "en:Christchurch City Council"


### PR DESCRIPTION
_99 Bikes_ replaced _Bike Barn_ in NZ.

Add _Whitcoulls_ (NZ) and _Timezone_ (8 countries).