### PR TITLE
Update bank.json

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -4609,11 +4609,10 @@
       "id": "eurobank-319ecc",
       "locationSet": {
         "include": [
-          "bg",
-          "gb-eng",
+          "cy"
           "gr",
-          "lu",
-          "q644636"
+          "gb",
+          "lu"
         ]
       },
       "matchNames": ["eurobank ergasias"],
@@ -7206,7 +7205,7 @@
       "displayName": "Piraeus Bank",
       "id": "piraeusbank-b02ca6",
       "locationSet": {
-        "include": ["bg", "cy", "gr", "ro", "ua"]
+        "include": ["gr"]
       },
       "tags": {
         "amenity": "bank",
@@ -7492,7 +7491,7 @@
       }
     },
     {
-      "displayName": "Raiffeisen banka",
+      "displayName": "Raiffeisen banka Slovensko",
       "id": "raiffeisenbanka-6a1dfb",
       "locationSet": {"include": ["sk"]},
       "matchNames": [
@@ -7523,41 +7522,42 @@
       }
     },
     {
-      "displayName": "Raiffeisenbank (Magyarország)",
+      "displayName": "Raiffeisen Bank (Magyarország)",
       "id": "raiffeisenbank-60884a",
       "locationSet": {"include": ["hu"]},
       "matchNames": ["raiffeisen"],
       "tags": {
         "amenity": "bank",
-        "brand": "Raiffeisenbank",
+        "brand": "Raiffeisen Bank",
         "brand:wikidata": "Q16522506",
-        "name": "Raiffeisenbank"
+        "brandwikipedia": "hu:Raiffeisen Bank (Magyarország)",
+        "name": "Raiffeisen Bank"
       }
     },
     {
-      "displayName": "Raiffeisenbank (România)",
+      "displayName": "Raiffeisen Bank (România)",
       "id": "raiffeisenbank-9a9a30",
       "locationSet": {"include": ["ro"]},
       "matchNames": ["raiffeisen"],
       "tags": {
         "amenity": "bank",
-        "brand": "Raiffeisenbank",
+        "brand": "Raiffeisen Bank",
         "brand:wikidata": "Q7283806",
         "brand:wikipedia": "ro:Raiffeisen Bank România",
-        "name": "Raiffeisenbank"
+        "name": "Raiffeisen Bank"
       }
     },
     {
-      "displayName": "Raiffeisenbank (Shqipëri)",
+      "displayName": "Raiffeisen Bank (Shqipëri)",
       "id": "raiffeisenbank-c53f64",
       "locationSet": {"include": ["al"]},
       "matchNames": ["raiffeisen"],
       "tags": {
         "amenity": "bank",
-        "brand": "Raiffeisenbank",
+        "brand": "Raiffeisen Bank",
         "brand:wikidata": "Q2127541",
         "brand:wikipedia": "sq:Raiffeisen Bank Shqipëri",
-        "name": "Raiffeisenbank"
+        "name": "Raiffeisen Bank"
       }
     },
     {
@@ -7578,13 +7578,13 @@
       }
     },
     {
-      "displayName": "Raiffeisenbank (Србија)",
+      "displayName": "Raiffeisen banka Srbije",
       "id": "raiffeisenbank-e9ea45",
       "locationSet": {"include": ["rs"]},
       "matchNames": ["raiffeisen"],
       "tags": {
         "amenity": "bank",
-        "brand": "Raiffeisenbank",
+        "brand": "Raiffeisen bank",
         "brand:wikidata": "Q7283807",
         "brand:wikipedia": "en:Raiffeisen Bank (Serbia)",
         "name": "Raiffeisenbank"
@@ -7624,7 +7624,7 @@
       "displayName": "RBS",
       "id": "rbs-9493f2",
       "locationSet": {
-        "include": ["gb", "je", "ro"]
+        "include": ["gb", "je"]
       },
       "tags": {
         "amenity": "bank",


### PR DESCRIPTION
Piraeus Bank closed all subsidiaries a few years ago.
Correct Raiffeisen names.
RBS closed Romanian subsidiary in 2015.