### PR TITLE
Hermanos Colombian Coffee Roasters

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -1295,6 +1295,20 @@
       }
     },
     {
+      "displayName": "Hermanos Colombian Coffee Roasters",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
+      "tags": {
+        "amenity": "cafe",
+        "brand": "Hermanos Colombian Coffee Roasters",
+        "brand:wikidata": "Q110408643",
+        "cuisine": "coffee_shop",
+        "name": "Hermanos Colombian Coffee Roasters",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Highlands Coffee",
       "id": "highlandscoffee-fd99aa",
       "locationSet": {"include": ["vn"]},


### PR DESCRIPTION
Hermanos Colombian Coffee Roasters that has cafes across London

https://hermanoscoffeeroasters.com/blogs/news/visiting-us