### PR TITLE
Planet Organic

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -5016,6 +5016,20 @@
       }
     },
     {
+      "displayName": "Planet Organic",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
+      "tags": {
+        "brand": "Planet Organic",
+        "brand:wikidata": "Q24298870",
+        "brand:wikipedia": "en:Planet Organic",
+        "organic": "only",
+        "name": "Planet Organic",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Plaza Vea",
       "id": "plazavea-986a24",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Planet Organic an organic only supermarket with shops spread over London

https://www.planetorganic.com/pages/our-stores