### PR TITLE
Updated bicycle_rental.json

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -1644,7 +1644,7 @@
     },
     {
       "displayName": "Hamilton Bike Share",
-      "id": "hamiltonbikeshareinc-3eadaa",
+      "id": "hamiltonbikeshare-3eadaa",
       "locationSet": {"include": ["ca"]},
       "matchNames": [
         "hamilton social bicycles",
@@ -1652,6 +1652,7 @@
       ],
       "tags": {
         "amenity": "bicycle_rental",
+        "brand": "Hamilton Bike Share",
         "fee": "yes",
         "network": "Hamilton Bike Share",
         "operator": "Hamilton Bike Share Inc.",


### PR DESCRIPTION
Hamilton Bike Share didn't show up in iD because I didn't add the "brand" value.