### PR TITLE
Add missing cuisine tag

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -3495,7 +3495,10 @@
       "tags": {
         "amenity": "restaurant",
         "brand": "Santa Lucia",
-        "name": "Santa Lucia"
+        "brand:wikidata": "Q110419156",
+        "cuisine": "pizza;italian",
+        "name": "Santa Lucia",
+        "oven": "wood_fired"
       }
     },
     {


### PR DESCRIPTION
Add cuisine for #5934 for Santa Lucia, a restaurant in Switzerland.
Their drawcard seems to be pizza in wood-fired ovens; however, they also do pasta (hence the `pizza;italian` combination).

I checked the website (or menu) for each of the branches and they all have wood-fired ovens.
`oven=wood_fired` is rarely used in combination with `cuisine=pizza;italian` (17 nodes/ways), is slightly better with just `cuisine=italian` (31), but `cuisine=pizza` is the clear winner (378).

Are we happy enough to continue with `cuisine=pizza;italian` or should one of the others be used?