### PR TITLE
Updated Mobil and GO Transit

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -2849,8 +2849,8 @@
       "tags": {
         "amenity": "fuel",
         "brand": "Mobil",
-        "brand:wikidata": "Q109676002",
-        "brand:wikipedia": "ja:モービル (ブランド)",
+        "brand:wikidata": "Q3088656",
+        "brand:wikipedia": "en:Mobil",
         "name": "Mobil"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -4664,7 +4664,7 @@
     {
       "displayName": "GO Transit",
       "id": "gotransit-50b470",
-      "locationSet": {"include": ["ca"]},
+      "locationSet": {"include": ["ca-on.geojson"]},
       "matchNames": ["go bus"],
       "tags": {
         "network": "GO Transit",
@@ -5112,7 +5112,7 @@
     {
       "displayName": "Hamilton Street Railway",
       "id": "hamiltonstreetrailway-50b470",
-      "locationSet": {"include": ["ca"]},
+      "locationSet": {"include": ["ca-on.geojson"]},
       "matchNames": ["hsr"],
       "tags": {
         "network": "Hamilton Street Railway",

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -596,7 +596,7 @@
     {
       "displayName": "GO Transit",
       "id": "gotransit-11f910",
-      "locationSet": {"include": ["ca"]},
+      "locationSet": {"include": ["ca-on.geojson"]},
       "matchNames": ["go train"],
       "tags": {
         "network": "GO Transit",


### PR DESCRIPTION
Updated the Wikidata and Wikipedia tags used for Mobil petrol stations outside of Japan; restricted the use of GO Transit train and bus routes to Ontario, Canada (`ca-on.geojson`).