### PR TITLE
Pizza Union

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -4391,6 +4391,20 @@
       }
     },
     {
+      "displayName": "Pizza Union",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
+      "matchTags": ["amenity/restaurant"],
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Pizza Union",
+        "brand:wikidata": "Q110473017",
+        "cuisine": "pizza",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Pizzabakeren",
       "id": "pizzabakeren-4d7dcd",
       "locationSet": {


### PR DESCRIPTION
Pizza Union has locations around London. I've added a restaurant match tag as often it's been incorrectly tagged as such, when actually it is fast food as you have to order at the counter, tables are first come first served and they even advertise themselves as "superfast pizza".