### PR TITLE
Add Wienerroither bakery chain

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -1727,6 +1727,15 @@
       }
     },
     {
+      "displayName": "Wienerroither",
+      "locationSet": {"include": ["at"]},
+      "tags": {
+        "brand": "Wienerroither",
+        "name": "Wienerroither",
+        "shop": "bakery"
+      }
+    },
+    {
       "displayName": "Wiener Feinbäcker Heberer",
       "id": "wienerfeinbackerheberer-3f448e",
       "locationSet": {"include": ["de"]},

--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -1731,6 +1731,7 @@
       "locationSet": {"include": ["at"]},
       "tags": {
         "brand": "Wienerroither",
+        "brand:wikidata": "Q110474658",
         "name": "Wienerroither",
         "shop": "bakery"
       }


### PR DESCRIPTION
Wienerroither is a bakery chain which can be found in Carinthia/Austria:
https://www.wienerroither.com/filialen