### PR TITLE
McDonald's in France have unique names

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -3528,6 +3528,19 @@
       }
     },
     {
+      "displayName": "McDonald's (France)",
+      "id": "mcdonalds-e4dee6",
+      "locationSet": {"include": ["fr"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "McDonald's",
+        "brand:wikidata": "Q38076",
+        "brand:wikipedia": "fr:McDonald's",
+        "cuisine": "burger",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Mei & Mei",
       "id": "meiandmei-f48b39",
       "locationSet": {

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -3516,7 +3516,10 @@
     {
       "displayName": "McDonald's",
       "id": "mcdonalds-658eea",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": ["001"],
+        "exclude": ["fr"]
+      },
       "tags": {
         "amenity": "fast_food",
         "brand": "McDonald's",


### PR DESCRIPTION
In France (at least), McDonald's restaurants have unique/quasi-unique, public-facing names. They can be visible [here](https://www.restaurants.mcdonalds.fr/).

This PR creates a France-specific item that uses the french wikipedia article, does not suggest an incomplete name, while keeping  the other NSI goodies.