### PR TITLE
Cubitts

### DIFF
--- a/data/brands/shop/optician.json
+++ b/data/brands/shop/optician.json
@@ -173,6 +173,17 @@
       }
     },
     {
+      "displayName": "Cubitts",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "brand": "Cubitts",
+        "brand:wikidata": "Q39045283",
+        "brand:wikipedia": "en:Cubitts",
+        "name": "Cubitts",
+        "shop": "optician"
+      }
+    },
+    {
       "displayName": "Écouter Voir",
       "id": "ecoutervoir-8cd79e",
       "locationSet": {"include": ["fr"]},


### PR DESCRIPTION
Cubitts has stores in Brighton, Cambridge, Leeds and London https://cubitts.com/blogs/stores