### PR TITLE
Update BurgerFuel

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -591,22 +591,6 @@
       }
     },
     {
-      "displayName": "Burger Fuel",
-      "id": "burgerfuel-ba88db",
-      "locationSet": {
-        "include": ["ae", "iq", "nz", "sa", "us"]
-      },
-      "tags": {
-        "amenity": "fast_food",
-        "brand": "Burger Fuel",
-        "brand:wikidata": "Q4998537",
-        "brand:wikipedia": "en:Burger Fuel",
-        "cuisine": "burger",
-        "name": "Burger Fuel",
-        "takeaway": "yes"
-      }
-    },
-    {
       "displayName": "Burger King",
       "id": "burgerking-890dec",
       "locationSet": {
@@ -677,6 +661,22 @@
         "brand:wikipedia": "en:BurgerFi",
         "cuisine": "burger",
         "name": "BurgerFi",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "BurgerFuel",
+      "id": "burgerfuel-ba88db",
+      "locationSet": {
+        "include": ["ae", "iq", "nz", "sa", "us"]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "BurgerFuel",
+        "brand:wikidata": "Q4998537",
+        "brand:wikipedia": "en:BurgerFuel",
+        "cuisine": "burger",
+        "name": "BurgerFuel",
         "takeaway": "yes"
       }
     },


### PR DESCRIPTION
There's no space in the name according to [their website](https://www.burgerfuel.com).

Have already updated both Wikidata and Wikipedia (en).