### PR TITLE
Sklaventis in Cyprus

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -7130,7 +7130,7 @@
     {
       "displayName": "Σκλαβενίτης",
       "id": "sklavenitis-37450e",
-      "locationSet": {"include": ["gr"]},
+      "locationSet": {"include": ["cy", "gr"]},
       "tags": {
         "brand": "Σκλαβενίτης",
         "brand:el": "Σκλαβενίτης",


### PR DESCRIPTION
Sklaventis (Σκλαβενίτης) also operates in Cyprus
https://el.wikipedia.org/wiki/%CE%A3%CE%BA%CE%BB%CE%B1%CE%B2%CE%B5%CE%BD%CE%AF%CF%84%CE%B7%CF%82