### PR TITLE
Update pub.json

### DIFF
--- a/data/brands/amenity/pub.json
+++ b/data/brands/amenity/pub.json
@@ -6,8 +6,8 @@
       "generic": [
         "^(bar|bistro|pub)$",
         "^(commercial )?hotel$",
-        "bistrot",
-        "irish pub"
+        "^bistrot$",
+        "^irish pub$"
       ],
       "named": [
         "^(black horse|coach and horses|cross keys|crown inn|kings arms|kings head|new inn)$",


### PR DESCRIPTION
Fix generic regular expression so all pubs with name containing "Irish Pub" or "Bistrot" are not matched and flagged as "Pub has suspicious name XYZ Irish Pub" - regular expression should start with ^ and end with $

Fixes #6068 