### PR TITLE
Update furniture.json

### DIFF
--- a/data/brands/shop/furniture.json
+++ b/data/brands/shop/furniture.json
@@ -946,7 +946,7 @@
       "displayName": "Mömax",
       "id": "momax-7c4ff3",
       "locationSet": {
-        "include": ["at", "de", "hu", "si"]
+        "include": ["at", "bg", "ch", "cz", "de", "hr", "hu", "pl", "ro", "rs", "se", "si", "sk"]
       },
       "tags": {
         "brand": "Mömax",
@@ -1422,7 +1422,7 @@
       "displayName": "XXXLutz",
       "id": "xxxlutz-7a4d3d",
       "locationSet": {
-        "include": ["at", "cz", "de", "sk"]
+        "include": ["at", "bg", "ch", "cz", "de", "hr", "hu", "pl", "ro", "rs", "se", "si", "sk"]
       },
       "tags": {
         "brand": "XXXLutz",


### PR DESCRIPTION
Updated country list where XXXLutz / Momax operating.
Mömax is Austrian. The wikipedia article in hungarian is limited and refers only to local subsidiary.