### PR TITLE
London Farmers' Market

### DIFF
--- a/data/operators/amenity/marketplace.json
+++ b/data/operators/amenity/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "properties": {
+    "path": "operators/amenity/marketplace",
+    "exclude": {
+      "generic": []
+    }
+  },
+  "items": [
+    {
+      "displayName": "London Farmers' Market",
+      "locationSet": {"include": ["gb-lon.geojson"]},
+      "tags": {
+        "amenity": "marketplace",
+        "operator": "London Farmers' Market",
+        "operator:wikidata": "Q6670360",
+        "operator:wikipedia": "en:London Farmers' Markets"
+      }
+    }
+  ]
+}

--- a/data/operators/amenity/marketplace.json
+++ b/data/operators/amenity/marketplace.json
@@ -13,7 +13,8 @@
         "amenity": "marketplace",
         "operator": "London Farmers' Market",
         "operator:wikidata": "Q6670360",
-        "operator:wikipedia": "en:London Farmers' Markets"
+        "operator:wikipedia": "en:London Farmers' Markets",
+        "organic": "yes"
       }
     }
   ]


### PR DESCRIPTION
London Farmers' Market operates food markets across London https://www.lfm.org.uk/