### PR TITLE
London Wildlife Trust

### DIFF
--- a/data/operators/leisure/nature_reserve.json
+++ b/data/operators/leisure/nature_reserve.json
@@ -51,6 +51,18 @@
       }
     },
     {
+      "displayName": "London Wildlife Trust",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
+      "tags": {
+        "leisure": "nature_reserve",
+        "operator": "London Wildlife Trust",
+        "operator:wikidata": "Q6671026",
+        "operator:wikipedia": "en:London Wildlife Trust"
+      }
+    },
+    {
       "displayName": "Open Space Institute",
       "id": "openspaceinstitute-b9cbaf",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
London Wildlife Trust operates 36 nature reserves in London

https://www.wildlondon.org.uk/explore-our-nature-reserves