### PR TITLE
upgrade to id-tagging-schema version 3.2.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@ideditor/nsi-collector": "^1.0.20220115",
     "@mapbox/geojson-area": "^0.2.2",
     "@mapbox/geojson-rewind": "^0.5.0",
-    "@openstreetmap/id-tagging-schema": "~3.1.0",
+    "@openstreetmap/id-tagging-schema": "~3.2.0",
     "c8": "^7.7.3",
     "chalk": "5.0.0",
     "clear": "^0.1.0",


### PR DESCRIPTION
This affects for example the new `amenity=parcel_locker` brands which currently fall back to use the generic "amenity" preset. See https://github.com/osmlab/name-suggestion-index/pull/6020#pullrequestreview-846237942