### PR TITLE
Update post_office.json

### DIFF
--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -973,13 +973,13 @@
       }
     },
     {
-      "displayName": "Poste italiane",
+      "displayName": "Poste Italiane",
       "id": "posteitaliane-b5464b",
       "locationSet": {"include": ["it"]},
       "matchNames": ["poste italiane spa"],
       "tags": {
         "amenity": "post_office",
-        "operator": "Poste italiane",
+        "operator": "Poste Italiane",
         "operator:wikidata": "Q495026",
         "operator:wikipedia": "en:Poste italiane"
       }


### PR DESCRIPTION
After discussing it with the italian community, we agreed that the most common name of the italian post operator has the Capital letter, so "Poste Italiane" instead of "Poste italiane"