### PR TITLE
Don't change Econt parcel locker's name

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -235,6 +235,7 @@
       "displayName": "Еконтомат",
       "id": "econt-8234c4",
       "locationSet": {"include": ["bg"]},
+      "preserveTags": ["^name"],
       "tags": {
         "alt_name": "Еконтомат",
         "alt_name:bg": "Еконтомат",
@@ -243,6 +244,9 @@
         "brand": "Еконт",
         "brand:wikidata": "Q12279603",
         "brand:wikipedia": "bg:Еконт Експрес",
+        "name": "Еконт",
+        "name:bg": "Еконт",
+        "name:en": "Econt",
         "parcel_mail_in": "yes"
       }
     },

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -243,9 +243,6 @@
         "brand": "Еконт",
         "brand:wikidata": "Q12279603",
         "brand:wikipedia": "bg:Еконт Експрес",
-        "name": "Еконт",
-        "name:bg": "Еконт",
-        "name:en": "Econt",
         "parcel_mail_in": "yes"
       }
     },


### PR DESCRIPTION
After some investigation, I've found out that all of them have specific names which should be preserved.