### PR TITLE
Rename BKK charging station to Eviny

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -319,21 +319,6 @@
       }
     },
     {
-      "displayName": "BKK",
-      "id": "bkk-476d58",
-      "locationSet": {"include": ["no"]},
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "BKK",
-        "brand:wikidata": "Q4891601",
-        "brand:wikipedia": "no:Eviny",
-        "name": "BKK",
-        "operator": "BKK",
-        "operator:wikidata": "Q4891601",
-        "operator:wikipedia": "no:Eviny"
-      }
-    },
-    {
       "displayName": "BKK Nett AS for Hordaland fylkeskommune",
       "id": "bkknettasforhordalandfylkeskommune-476d58",
       "locationSet": {"include": ["no"]},
@@ -1443,6 +1428,22 @@
         "amenity": "charging_station",
         "operator": "Evie Networks",
         "operator:wikidata": "Q105795220"
+      }
+    },
+    {
+      "displayName": "Eviny",
+      "id": "eviny-476d58",
+      "locationSet": {"include": ["no"]},
+      "matchNames": ["bkk"],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Eviny",
+        "brand:wikidata": "Q4891601",
+        "brand:wikipedia": "no:Eviny",
+        "name": "Eviny",
+        "operator": "Eviny",
+        "operator:wikidata": "Q4891601",
+        "operator:wikipedia": "no:Eviny"
       }
     },
     {


### PR DESCRIPTION
BKK AS was split into multiple companies where the company for responsible charging stations was renamed to Eviny in autumn 2021. So all physical chargers have now been rebranded.

https://www.eviny.no/ladestasjoner

<strike>When I run `npm run build` BKK is added again in the charging stations file 🤔 </strike>
- Fixed by adding `matchNames: ["bkk"]`
- And lots of other unrelated changes occur

So I have not run `build` in my PR