### PR TITLE
add Amscot

### DIFF
--- a/data/brands/shop/money_lender.json
+++ b/data/brands/shop/money_lender.json
@@ -29,6 +29,18 @@
       }
     },
     {
+      "displayName": "Amscot",
+      "id": "amscot-f9c954",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "brand": "Amscot",
+        "brand:wikidata": "Q4748779",
+        "brand:wikipedia": "en:Amscot Financial",
+        "name": "Amscot",
+        "shop": "money_lender"
+      }
+    },
+    {
       "displayName": "California Check Cashing Stores",
       "id": "californiacheckcashingstores-f9c954",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Amscot provides financial services in Florida and has hundreds of locations.

The Wikipedia says the company is "Amscot Financial" but I've never seen it advertised that way it usually says "Amscot - The Money Superstore". So I think just writing it as Amscot is fine.

This is my first addition to this repo and one thing that wasn't clear from the guide is how the "id" field was set so I just tried to follow the other patterns.

Cheers