### PR TITLE
Mildreds plant-based restaurants in London

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -2560,6 +2560,19 @@
       }
     },
     {
+      "displayName": "Mildreds",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "Mildreds",
+        "brand:wikidata": "Q110694603",
+        "diet:vegan": "only",
+        "name": "Mildreds"
+      }
+    },
+    {
       "displayName": "Miller & Carter",
       "id": "millerandcarter-9b5453",
       "locationSet": {"include": ["gb"]},


### PR DESCRIPTION
Mildreds has restaurants in London that are 100% plant based / vegan https://www.mildreds.co.uk/