### PR TITLE
Island Poké

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -2756,6 +2756,18 @@
       }
     },
     {
+      "displayName": "Island Poké",
+      "locationSet": {"include": ["gb-lon.geojson", "fr"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Island Poké",
+        "brand:wikidata": "Q110694826",
+        "cuisine": "hawaiian",
+        "name": "Island Poké",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "itsu",
       "id": "itsu-56a2ff",
       "locationSet": {"include": ["gb", "us"]},


### PR DESCRIPTION
Island Poké is a franchise with locations in London and France

https://www.islandpoke.com/our-locations/
https://fr.islandpoke.com/nos-emplacements/