### PR TITLE
Add Yettel

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -780,7 +780,7 @@
     {
       "displayName": "Telenor",
       "id": "telenor-ee5434",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["001"], "exclude": ["hu", "rs", "bg"]},
       "note": "https://github.com/osmlab/name-suggestion-index/issues/5500",
       "preserveTags": ["^name"],
       "tags": {

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -167,7 +167,7 @@
     {
       "displayName": "Telenor",
       "id": "telenor-33bf96",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["001"], "exclude": ["hu", "rs", "bg"]},
       "tags": {
         "brand": "Telenor",
         "brand:wikidata": "Q14915070",
@@ -320,6 +320,36 @@
         "name": "遠傳電信",
         "name:en": "FarEasTone",
         "name:zh": "遠傳電信",
+        "shop": "telecommunication"
+      }
+    },
+    {
+      "displayName": "Yettel Bulgaria",
+      "locationSet": {"include": ["bg"]},
+      "tags": {
+        "brand": "Yettel",
+        "brand:wikidata": "Q14915070",
+        "name": "Yettel",
+        "shop": "telecommunication"
+      }
+    },
+    {
+      "displayName": "Yettel Hungary",
+      "locationSet": {"include": ["rs"]},
+      "tags": {
+        "brand": "Yettel",
+        "brand:wikidata": "Q268578",
+        "name": "Yettel",
+        "shop": "telecommunication"
+      }
+    },
+    {
+      "displayName": "Yettel Serbia",
+      "locationSet": {"include": ["rs"]},
+      "tags": {
+        "brand": "Yettel",
+        "brand:wikidata": "Q1780171",
+        "name": "Yettel",
         "shop": "telecommunication"
       }
     }

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -326,6 +326,8 @@
     {
       "displayName": "Yettel Bulgaria",
       "locationSet": {"include": ["bg"]},
+      "matchTags": ["shop/mobile_phones"],
+      "matchNames": ["GloBul", "Глобул", "Telenor", "Теленор"],
       "tags": {
         "brand": "Yettel",
         "brand:wikidata": "Q14915070",
@@ -335,7 +337,9 @@
     },
     {
       "displayName": "Yettel Hungary",
-      "locationSet": {"include": ["rs"]},
+      "locationSet": {"include": ["hu"]},
+      "matchTags": ["shop/mobile_phones"],
+      "matchNames": ["Telenor"],
       "tags": {
         "brand": "Yettel",
         "brand:wikidata": "Q268578",
@@ -346,6 +350,8 @@
     {
       "displayName": "Yettel Serbia",
       "locationSet": {"include": ["rs"]},
+      "matchTags": ["shop/mobile_phones"],
+      "matchNames": ["Telenor", "Теленор"],
       "tags": {
         "brand": "Yettel",
         "brand:wikidata": "Q1780171",


### PR DESCRIPTION
Yettel is going to launch on 01.03.2022 in Hungary, Serbia and Bulgaria. So far it's been branded as Telenor.