### PR TITLE
Lotte Duty Free

### DIFF
--- a/data/brands/shop/department_store.json
+++ b/data/brands/shop/department_store.json
@@ -834,6 +834,20 @@
       }
     },
     {
+      "displayName": "Lotte Duty Free",
+      "locationSet": {"include": ["au", "gu", "kr", "jp", "nz", "th", "vn"]},
+      "tags": {
+        "brand": "Lotte Duty Free",
+        "brand:wikidata": "Q12594196",
+        "duty_free": "yes",
+        "name": "Lotte Duty Free",
+        "name:en": "Lotte Duty Free",
+        "name:jp": "ロッテ免税",
+        "name:ko": "롯데면세점",
+        "shop": "department_store"
+      }
+    },
+    {
       "displayName": "M&S Outlet",
       "id": "mandsoutlet-03e633",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Lotte Duty Free operates duty free stores in international airports in Australia, Guam, Japan, Korea, New Zealand, Thailand and Vietnam