### PR TITLE
Add more European parcel lockers

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -192,7 +192,7 @@
         "operator:it": "La Posta",
         "operator:rm": "La Posta",
         "operator:wikidata": "Q614803",
-        "operator:wikipedia": "de:Die Schweizerische Post"
+        "operator:wikipedia": "de:Die Schweizerische Post",
         "parcel_mail_in": "yes"
       }
     },

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -96,6 +96,36 @@
       }
     },
     {
+      "displayName": "Balíkomat",
+      "id": "balikomat",
+      "locationSet": {"include": ["cz"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "Balíkomat",
+        "brand:wikidata": "Q110748819",
+        "name": "Balíkomat",
+        "operator": "Correos",
+        "operator:wikidata": "Q776605",
+        "operator:wikipedia": "es:Correos (España)",
+        "parcel_mail_in": "yes"
+      }
+    },
+    {
+      "displayName": "CityPaq",
+      "id": "citypaq",
+      "locationSet": {"include": ["es"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "CityPaq",
+        "brand:wikidata": "Q110748819",
+        "name": "CityPaq",
+        "operator": "Correos",
+        "operator:wikidata": "Q776605",
+        "operator:wikipedia": "es:Correos (España)",
+        "parcel_mail_in": "yes"
+      }
+    },
+    {
       "displayName": "DHL Packstation",
       "id": "dhlpackstation-83cc4d",
       "locationSet": {"include": ["de"]},
@@ -131,6 +161,39 @@
         "brand:wikidata": "Q366182",
         "brand:wikipedia": "en:GLS Group",
         "name": "GLS Parcel Locker"
+      }
+    },
+    {
+      "displayName": "Locker InPost",
+      "id": "lockerinpost",
+      "locationSet": {"include": ["it","uk"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "InPost",
+        "brand:wikidata": "Q3182097",
+        "brand:wikipedia": "en:InPost",
+        "name": "Locker InPost",
+        "parcel_mail_in": "yes"
+      }
+    },
+    {
+      "displayName": "My Post 24",
+      "id": "mypost24",
+      "locationSet": {"include": ["ch"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "My Post 24",
+        "brand:wikidata": "Q110748685",
+        "name": "My Post 24",
+        "operator": "Die Post",
+        "operator:de": "Die Post",
+        "operator:en": "Swiss Post",
+        "operator:fr": "La Poste",
+        "operator:it": "La Posta",
+        "operator:rm": "La Posta",
+        "operator:wikidata": "Q614803",
+        "operator:wikipedia": "de:Die Schweizerische Post"
+        "parcel_mail_in": "yes"
       }
     },
     {
@@ -175,6 +238,38 @@
       }
     },
     {
+      "displayName": "Paket24",
+      "id": "paket24",
+      "locationSet": {"include": ["hr"]},
+      "matchNames": ["Paketomat"],
+      "tags": {
+        "amenity": "parcel_locker",
+        "alt_name": "Paketomat",
+        "brand": "Paket24",
+        "brand:wikidata": "Q110748166",
+        "name": "Paket24",
+        "operator": "Hrvatska pošta",
+        "operator:wikidata": "Q507289",
+        "operator:wikipedia": "hr:Hrvatska pošta",
+        "parcel_mail_in": "yes"
+      }
+    },
+    {
+      "displayName": "Pakkeboksen",
+      "id": "pakkeboksen",
+      "locationSet": {"include": ["da"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "Pakkeboksen",
+        "brand:wikidata": "Q12309164",
+        "name": "Pakkeboksen",
+        "operator": "PostNord Danmark",
+        "operator:wikidata": "Q1334647",
+        "operator:wikipedia": "da:PostNord Danmark",
+        "parcel_mail_in": "yes"
+      }
+    },
+    {
       "displayName": "PickPoint",
       "id": "pickpoint-c00268",
       "locationSet": {"include": ["ru"]},
@@ -183,6 +278,36 @@
         "brand": "PickPoint",
         "brand:wikidata": "Q110276197",
         "name": "PickPoint"
+      }
+    },
+    {
+      "displayName": "Pickup Station",
+      "id": "pickupstation",
+      "locationSet": {"include": ["fr"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "Pickup Station",
+        "brand:wikidata": "Q110748562",
+        "name": "Pickup Station",
+        "operator": "La Poste",
+        "operator:wikidata": "Q373724",
+        "operator:wikipedia": "fr:La Poste (entreprise française)",
+        "parcel_mail_in": "yes"
+      }
+    },
+    {
+      "displayName": "Post Abholstation",
+      "id": "postabholstation",
+      "locationSet": {"include": ["at"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "Post Abholstation",
+        "brand:wikidata": "Q110748491",
+        "name": "Post Abholstation",
+        "operator": "Österreichische Post",
+        "operator:wikidata": "Q1763505",
+        "operator:wikipedia": "de:Österreichische Post",
+        "parcel_mail_in": "yes"
       }
     },
     {
@@ -215,6 +340,36 @@
         "name": "PUDOステーション",
         "name:en": "PUDO Station",
         "name:ja": "PUDOステーション"
+      }
+    },
+    {
+      "displayName": "PS Paketomat",
+      "id": "pspaketomat",
+      "locationSet": {"include": ["sl"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "PS Paketomat",
+        "brand:wikidata": "Q110748273",
+        "name": "PS Paketomat",
+        "operator": "Pošta Slovenije",
+        "operator:wikidata": "Q6522631",
+        "operator:wikipedia": "sl:Pošta Slovenije",
+        "parcel_mail_in": "yes"
+      }
+    },
+    {
+      "displayName": "PuntoPoste",
+      "id": "puntoposte",
+      "locationSet": {"include": ["it"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "PuntoPoste",
+        "brand:wikidata": "Q110748322",
+        "name": "PuntoPoste",
+        "operator": "Poste Italiane",
+        "operator:wikidata": "Q495026",
+        "operator:wikipedia": "it:Poste Italiane",
+        "parcel_mail_in": "yes"
       }
     },
     {

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -345,7 +345,7 @@
     {
       "displayName": "PS Paketomat",
       "id": "pspaketomat",
-      "locationSet": {"include": ["sl"]},
+      "locationSet": {"include": ["si"]},
       "tags": {
         "amenity": "parcel_locker",
         "brand": "PS Paketomat",

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -102,11 +102,11 @@
       "tags": {
         "amenity": "parcel_locker",
         "brand": "Balíkomat",
-        "brand:wikidata": "Q110748819",
+        "brand:wikidata": "Q110748952",
         "name": "Balíkomat",
-        "operator": "Correos",
-        "operator:wikidata": "Q776605",
-        "operator:wikipedia": "es:Correos (España)",
+        "operator": "Česká pošta",
+        "operator:wikidata": "Q341090",
+        "operator:wikipedia": "cs:Česká pošta",
         "parcel_mail_in": "yes"
       }
     },
@@ -257,7 +257,7 @@
     {
       "displayName": "Pakkeboksen",
       "id": "pakkeboksen",
-      "locationSet": {"include": ["da"]},
+      "locationSet": {"include": ["dk"]},
       "tags": {
         "amenity": "parcel_locker",
         "brand": "Pakkeboksen",


### PR DESCRIPTION
Adding the following parcel locker brands:

- Balíkomat (CZ)
- CityPaq (ES)
- InPost (IT, UK)
- My Post 24 (CH)
- Paket24 (HR)
- Pakkeboksen (DK)
- Pickup Station (FR)
- Post Abholstation (AT)
- PS Paketomat (SL)
- PuntoPoste (IT)