### PR TITLE
[nz] add Department of Conservation

### DIFF
--- a/data/operators/boundary/protected_area.json
+++ b/data/operators/boundary/protected_area.json
@@ -304,6 +304,16 @@
       }
     },
     {
+      "displayName": "Department of Conservation",
+      "id": "departmentofconservation-997671",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "boundary": "protected_area",
+        "operator": "Department of Conservation",
+        "operator:wikidata": "Q1191417"
+      }
+    },
+    {
       "displayName": "Department of Environment, Water and Natural Resources (South Australia)",
       "id": "departmentofenvironmentwaterandnaturalresourcessouthaustralia-7f8cf5",
       "locationSet": {"include": ["001"]},

--- a/data/operators/tourism/camp_site.json
+++ b/data/operators/tourism/camp_site.json
@@ -17,6 +17,16 @@
         "operator:wikipedia": "en:Appalachian Mountain Club",
         "tourism": "camp_site"
       }
+    },
+    {
+      "displayName": "Department of Conservation",
+      "id": "departmentofconservation-b76ca8",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "operator": "Department of Conservation",
+        "operator:wikidata": "Q1191417",
+        "tourism": "camp_site"
+      }
     }
   ]
 }

--- a/data/operators/tourism/wilderness_hut.json
+++ b/data/operators/tourism/wilderness_hut.json
@@ -1,0 +1,19 @@
+{
+  "properties": {
+    "path": "operators/tourism/wilderness_hut",
+    "skipCollection": true,
+    "exclude": {"generic": ["^wilderness_hut$"]}
+  },
+  "items": [
+    {
+      "displayName": "Department of Conservation",
+      "id": "departmentofconservation-5df9f2",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "operator": "Department of Conservation",
+        "operator:wikidata": "Q1191417",
+        "tourism": "wilderness_hut"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
DOC operates 200 campsites, 1000 huts, and >10000 conservation areas in New Zealand.

I deliberately haven't added `operator:wikipedia` to avoid unnecessary tags.