### PR TITLE
PreserveTags name for some more brands in Norway

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -5484,6 +5484,7 @@
       "locationSet": {
         "include": ["dk", "fi", "gb", "no", "se"]
       },
+      "preserveTags": ["^name"],
       "tags": {
         "amenity": "bank",
         "brand": "Handelsbanken",

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -3623,10 +3623,10 @@
     },
     {
       "displayName": "McDonald's",
-      "id": "mcdonalds-d68def",
+      "id": "mcdonalds-d300c3",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["fr"]
+        "exclude": ["fr", "no"]
       },
       "tags": {
         "amenity": "fast_food",
@@ -3648,6 +3648,21 @@
         "brand": "McDonald's",
         "brand:wikidata": "Q38076",
         "brand:wikipedia": "fr:McDonald's",
+        "cuisine": "burger",
+        "name": "McDonald's",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "McDonald's (Norge)",
+      "id": "mcdonalds-86f814",
+      "locationSet": {"include": ["no"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "McDonald's",
+        "brand:wikidata": "Q38076",
+        "brand:wikipedia": "en:McDonald's",
         "cuisine": "burger",
         "name": "McDonald's",
         "takeaway": "yes"

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -4569,11 +4569,12 @@
       "locationSet": {
         "include": ["dk", "no", "se"]
       },
+      "preserveTags": ["^name"],
       "tags": {
         "amenity": "fast_food",
         "brand": "Pizzabakeren",
         "brand:wikidata": "Q11995777",
-        "brand:wikipedia": "da:Pizzabakeren",
+        "brand:wikipedia": "no:Pizzabakeren",
         "cuisine": "pizza",
         "name": "Pizzabakeren",
         "takeaway": "yes"

--- a/data/brands/shop/sports.json
+++ b/data/brands/shop/sports.json
@@ -297,10 +297,10 @@
     },
     {
       "displayName": "Intersport",
-      "id": "intersport-a47cfc",
+      "id": "intersport-1e16af",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["de"]
+        "exclude": ["de", "no"]
       },
       "tags": {
         "brand": "Intersport",
@@ -319,6 +319,19 @@
         "brand": "Intersport",
         "brand:wikidata": "Q666888",
         "brand:wikipedia": "de:Intersport",
+        "name": "Intersport",
+        "shop": "sports"
+      }
+    },
+    {
+      "displayName": "Intersport (Norge)",
+      "id": "intersport-6faf2d",
+      "locationSet": {"include": ["no"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Intersport",
+        "brand:wikidata": "Q666888",
+        "brand:wikipedia": "en:Intersport",
         "name": "Intersport",
         "shop": "sports"
       }


### PR DESCRIPTION
As per issue [#5500](https://github.com/osmlab/name-suggestion-index/issues/5500) we would like to preserve name for brands in Scandinavian countries.

Pizzabakeren:
- Also changed wikipedia to the norwegian version (danish, swedish and norwegian is readable for all countries). As it contains tiny bit more info and the brand is originally Norwegian.

Intersport:
- Created a new for entry for Norway

McDonald's:
- Created a new entry for Norway similar to france's entry, but with english wikipedia

Handelsbanken:
- Checked against handelsbanken's websites and cross referenced to how handelsbanken is displayed outside of norway as well. And the largest majority of bank locations have name: "Handelsbanken [Location]" -> Therefor included preserveTags name for all countries.