### PR TITLE
Add GoMart convenience stores

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1295,6 +1295,18 @@
       }
     },
     {
+      "displayName": "GoMart",
+      "locationSet": {"include": ["us-wv.geojson","us-va.geojson","us-oh.geojson","us-ky.geojson"]},
+      "matchNames": ["go mart"],
+      "tags": {
+        "shop": "convenience",
+        "brand": "GoMart",
+        "brand:wikidata": "Q5574575",
+        "brand:wikipedia": "en:GoMart",
+        "name": "GoMart"
+      }
+    },
+    {
       "displayName": "Good 2 Go",
       "id": "good2go-f1e40b",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Follow-on from GoMart gas stations. Both use the same branding and are run by the same company.