### PR TITLE
Update bicycle_rental.json

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -1648,11 +1648,11 @@
       "tags": {
         "amenity": "bicycle_rental",
         "brand": "Hamilton Bike Share",
+        "brand:wikidata": "Q109332552",
         "fee": "yes",
         "network": "Hamilton Bike Share",
         "operator": "Hamilton Bike Share Inc.",
-        "operator:type": "private_non_profit",
-        "operator:wikidata": "Q109332552"
+        "operator:type": "private_non_profit"
       }
     },
     {


### PR DESCRIPTION
Changed `"operator":"wikidata"` to `"brand":"wikidata"` for Hamilton Bike Share so it will show up in iD.