### PR TITLE
Removed Exelon as a generation company.

### DIFF
--- a/data/operators/power/generator.json
+++ b/data/operators/power/generator.json
@@ -1059,10 +1059,12 @@
     {
       "displayName": "Constellation",
       "id": "constellation-19ecba",
-      "locationSet": {"include": ["us"]},
-      "matchNames": ["contellation"],
+      "locationSet": {"include": ["us","ca","uk"]},
+      "matchNames": ["contellation", "exelon", "exelon group"],
       "tags": {
         "operator": "Constellation",
+        "operator:wikidata": "Q259195",
+        "operator:wikipedia": "Constellation_(energy_company)",
         "power": "generator"
       }
     },
@@ -2190,18 +2192,6 @@
       "locationSet": {"include": ["de"]},
       "tags": {
         "operator": "EWO Solarpark III KG",
-        "power": "generator"
-      }
-    },
-    {
-      "displayName": "Exelon",
-      "id": "exelon-19ecba",
-      "locationSet": {"include": ["us"]},
-      "matchNames": ["exelon group"],
-      "tags": {
-        "operator": "Exelon",
-        "operator:wikidata": "Q1383669",
-        "operator:wikipedia": "en:Exelon",
         "power": "generator"
       }
     },


### PR DESCRIPTION
Exelon and Constellation have recently separated (https://www.constellationenergy.com/newsroom/2022/constellation-launches-as-largest-u-s--clean-energy-company-afte.html).  Constellation retains the generation side of the business while Exelon retains the distribution side of the business.