### PR TITLE
Add Pizza Express matchName (with the space)

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -3272,6 +3272,7 @@
       "displayName": "PizzaExpress",
       "id": "pizzaexpress-2fabb0",
       "locationSet": {"include": ["001"]},
+      "matchNames": ["pizza express"],
       "tags": {
         "amenity": "restaurant",
         "brand": "PizzaExpress",


### PR DESCRIPTION
I don't know if this is better fixed in iD and other using libraries, so they offer any suggestions which match what was typed with all whitespace removed iff they don't have any existing suggestions to offer.

So `U P S` would also match UPS without me needing to add a matchName for it.

Although I'd accept that situations like this one seem to be fairly rare.