### PR TITLE
Fabricland add wikidata

### DIFF
--- a/data/brands/shop/fabric.json
+++ b/data/brands/shop/fabric.json
@@ -15,6 +15,7 @@
       "locationSet": {"include": ["ca"]},
       "tags": {
         "brand": "Fabricland",
+        "brand:wikidata": "Q110894964",
         "name": "Fabricland",
         "shop": "fabric"
       }


### PR DESCRIPTION
Add a wikidata for Fabricland https://www.wikidata.org/wiki/Q110894964
iD doesn't show this in presets without it