### PR TITLE
Choose a more specific iD preset for govt offices

### DIFF
--- a/scripts/build_index.js
+++ b/scripts/build_index.js
@@ -656,13 +656,16 @@ function checkItems(t) {
             if (!tags['subject:wikidata']) { warnMissingTag.push([display(item), 'subject:wikidata']); }
           }
           break;
+        case 'office/government':
+          if (!tags.vending) { warnMissingTag.push([display(item), 'government']); }
+          break;
         case 'shop/beauty':
           if (!tags.beauty) { warnMissingTag.push([display(item), 'beauty']); }
           break;
       }
 
       // Warn if OSM tags contain odd punctuation or spacing..
-      ['beauty', 'cuisine', 'gambling', 'training', 'vending'].forEach(osmkey => {
+      ['beauty', 'cuisine', 'gambling', 'government', 'training', 'vending'].forEach(osmkey => {
         const val = tags[osmkey];
         if (val && oddChars.test(val)) {
           warnFormatTag.push([display(item), `${osmkey} = ${val}`]);

--- a/scripts/build_index.js
+++ b/scripts/build_index.js
@@ -656,9 +656,6 @@ function checkItems(t) {
             if (!tags['subject:wikidata']) { warnMissingTag.push([display(item), 'subject:wikidata']); }
           }
           break;
-        case 'office/government':
-          if (!tags.vending) { warnMissingTag.push([display(item), 'government']); }
-          break;
         case 'shop/beauty':
           if (!tags.beauty) { warnMissingTag.push([display(item), 'beauty']); }
           break;

--- a/scripts/dist_files.js
+++ b/scripts/dist_files.js
@@ -229,7 +229,7 @@ function buildIDPresets() {
 
       // Sometimes we can choose a more specific iD preset then `key/value`..
       // Attempt to match a `key/value/extravalue`
-      const tryKeys = ['beauty', 'clothes', 'cuisine', 'healthcare:speciality', 'religion', 'social_facility', 'sport', 'vending'];
+      const tryKeys = ['beauty', 'clothes', 'cuisine', 'government', 'healthcare:speciality', 'religion', 'social_facility', 'sport', 'vending'];
       tryKeys.forEach(osmkey => {
         if (preset) return;    // matched one already
         const val = tags[osmkey];


### PR DESCRIPTION
Also added warning if `office=government` is missing `government=*` or the value contains odd punction/spacing

Edit: removed warning for missing `government=*` tag since I noticed some operate more than one type of govt office