### PR TITLE
Australian and New Zealand brands

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -1042,8 +1042,8 @@
     },
     {
       "displayName": "Chicken Treat",
-      "id": "chickentreat-4d2ff4",
-      "locationSet": {"include": ["us"]},
+      "id": "chickentreat-d43c69",
+      "locationSet": {"include": ["au"]},
       "tags": {
         "amenity": "fast_food",
         "brand": "Chicken Treat",

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -3109,6 +3109,7 @@
       "tags": {
         "amenity": "fuel",
         "brand": "npd",
+        "brand:wikidata": "Q110922616",
         "name": "npd"
       }
     },

--- a/data/brands/leisure/fitness_centre.json
+++ b/data/brands/leisure/fitness_centre.json
@@ -139,6 +139,17 @@
       }
     },
     {
+      "displayName": "CityFitness",
+      "id": "cityfitness-745622",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "brand": "CityFitness",
+        "brand:wikidata": "Q110923303",
+        "leisure": "fitness_centre",
+        "name": "CityFitness"
+      }
+    },
+    {
       "displayName": "Clever fit",
       "id": "cleverfit-1d011d",
       "locationSet": {

--- a/data/brands/shop/erotic.json
+++ b/data/brands/shop/erotic.json
@@ -55,6 +55,17 @@
       }
     },
     {
+      "displayName": "Peaches & Cream",
+      "id": "peachesandcream-a6d61a",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "brand": "Peaches & Cream",
+        "brand:wikidata": "Q110923243",
+        "name": "Peaches & Cream",
+        "shop": "erotic"
+      }
+    },
+    {
       "displayName": "Pulse and Cocktails",
       "id": "pulseandcocktails-7c5775",
       "locationSet": {"include": ["gb"]},

--- a/data/brands/shop/houseware.json
+++ b/data/brands/shop/houseware.json
@@ -70,6 +70,7 @@
       "displayName": "Briscoes",
       "id": "briscoes-1d32aa",
       "locationSet": {"include": ["nz"]},
+      "matchTags": ["shop/department_store"],
       "tags": {
         "brand": "Briscoes",
         "brand:wikidata": "Q110190653",


### PR DESCRIPTION
Add:

 - _CityFitness_ (leisure/fitness_centre)
 - _Peaches & Cream_ (shop/erotic)

Fixes for:
 - _npd_ (missing wikidata)
 - _Chicken Treat_ (wrong country)
 - _Briscoes_ (tag match)