### PR TITLE
add matching of synonyms and fix a duplicate of "Deutsche Telekom" te…

### DIFF
--- a/data/operators/amenity/telephone.json
+++ b/data/operators/amenity/telephone.json
@@ -153,7 +153,12 @@
       "displayName": "Deutsche Telekom",
       "id": "deutschetelekom-2be02b",
       "locationSet": {"include": ["001"]},
-      "matchNames": ["deutsche telekom ag"],
+      "matchNames": [
+        "deutsche telekom ag",
+        "t-com",
+        "telekom deutschland"
+        "telekom deutschland gmbh"
+      ],
       "tags": {
         "amenity": "telephone",
         "operator": "Deutsche Telekom",
@@ -521,15 +526,6 @@
       }
     },
     {
-      "displayName": "T-Com",
-      "id": "tcom-2be02b",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "amenity": "telephone",
-        "operator": "T-Com"
-      }
-    },
-    {
       "displayName": "Telecom",
       "id": "telecom-2be02b",
       "locationSet": {"include": ["001"]},
@@ -626,18 +622,6 @@
       "tags": {
         "amenity": "telephone",
         "operator": "Telekom Austria"
-      }
-    },
-    {
-      "displayName": "Telekom Deutschland",
-      "id": "telekomdeutschland-2be02b",
-      "locationSet": {"include": ["001"]},
-      "matchNames": ["telekom deutschland gmbh"],
-      "tags": {
-        "amenity": "telephone",
-        "operator": "Telekom Deutschland",
-        "operator:wikidata": "Q2401704",
-        "operator:wikipedia": "de:Telekom Deutschland"
       }
     },
     {


### PR DESCRIPTION
…lephone operator

- The public phones in Germany are operated by Deutsche Telekom. "Telekom Deutschland GmbH" is a subdivision, but the telephone's operator is still "Deutsche Telekom" There aren't two operators "Deutsche Telekom" and "Telekom Deutschland GmbH", it is one.
- "T-Com" is the old name of the operator, phones tagged with that should be updated to "Deutsche Telekom".