### PR TITLE
Update bank.json

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -2544,7 +2544,6 @@
       "displayName": "BCC Roma",
       "id": "bccroma-7b36b5",
       "locationSet": {"include": ["it"]},
-      "matchNames": ["bcc"],
       "tags": {
         "amenity": "bank",
         "brand": "BCC Roma",


### PR DESCRIPTION
Removed matchname from BCC Roma: in Italy there are quite a lot of BCC and only a few are part of BBC Roma brand. Since I don't think there's the ability to limit for just a region but the NSI only works on national scale I think it's better to delete the matchname