### PR TITLE
add "Netto Getränke-Discount"

### DIFF
--- a/data/brands/shop/beverages.json
+++ b/data/brands/shop/beverages.json
@@ -176,6 +176,18 @@
       }
     },
     {
+      "displayName": "Netto Getränke-Discount",
+      "id": "nettomarkendiscount-0a839e",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "brand": "Netto Getränke-Discount",
+        "brand:wikidata": "Q879858",
+        "brand:wikipedia": "de:Netto Marken-Discount",
+        "name": "Netto Getränke-Discount",
+        "shop": "beverages"
+      }
+    },
+    {
       "displayName": "Orterer Getränkemarkt",
       "id": "orterergetrankemarkt-c4cb62",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
The German supermarket chain "Netto" does also have some beverages shops which are under the name "Netto Getränke-Discount", see for example https://www.netto-online.de/filialen/dortmund/rahmer-str-312/5712

The chain/brand etc. are the same as for "Netto Marken-Discount".
Netto has three shops:
- Netto Marken-Discount (supermarket, is already in the nsi)
- Netto City (supermarket, is already in the nsi)
- Netto Getränke-Discount (which I added here)