### PR TITLE
add "Tobaccoland" cigarette vending machine

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -635,6 +635,22 @@
       }
     },
     {
+      "displayName": "Tobaccoland",
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["tobaccoland"],
+      "tags": {
+        "amenity": "vending_machine",
+        "brand": "tobaccoland",
+        "brand:wikidata": "Q1439872",
+        "brand:wikipedia": "de:Tobaccoland Automatengesellschaft",
+        "operator": "Tobaccoland Automatengesellschaft",
+        "operator:wikidata": "Q1439872",
+        "operator:wikipedia": "de:Tobaccoland Automatengesellschaft",
+        "min_age": "18",
+        "vending": "cigarettes"
+      }
+    },
+    {
       "displayName": "tz",
       "id": "tz-a242c5",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
Tobaccoland is a very common operator of cigarette vending machines in Germany. The wikidata are here: https://www.wikidata.org/wiki/Q1439872