### PR TITLE
"Deutsche Telekom" doesn't operate any emergency=phone.

### DIFF
--- a/data/operators/emergency/phone.json
+++ b/data/operators/emergency/phone.json
@@ -240,18 +240,6 @@
       }
     },
     {
-      "displayName": "Deutsche Telekom AG",
-      "id": "deutschetelekomag-3876cc",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["deutsche telekom"],
-      "tags": {
-        "emergency": "phone",
-        "operator": "Deutsche Telekom AG",
-        "operator:wikidata": "Q9396",
-        "operator:wikipedia": "de:Deutsche Telekom"
-      }
-    },
-    {
       "displayName": "Die Autobahn GmbH des Bundes",
       "id": "dieautobahngmbhdesbundes-3876cc",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
The German company "Deutsche Telekom" does not operate any emergency=phone. Those emergency=phone's which are tagged with this operator (according to taginfo there exist 62 ones with this tagging) are **misinterpreted** as emergency-phones, but they are normal public telephones (amenity=telephone). So there shouldn't be an operator-ing in the nsi for this. See also my comment in https://github.com/osmlab/name-suggestion-index/pull/6177#issuecomment-1042733139