### PR TITLE
Some more additions for matching the telephones of "Deutsche Telekom"

### DIFF
--- a/data/operators/amenity/telephone.json
+++ b/data/operators/amenity/telephone.json
@@ -141,23 +141,19 @@
       }
     },
     {
-      "displayName": "Deutsche Post",
-      "id": "deutschepost-2be02b",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "amenity": "telephone",
-        "operator": "Deutsche Post"
-      }
-    },
-    {
       "displayName": "Deutsche Telekom",
       "id": "deutschetelekom-2be02b",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["de"]},
       "matchNames": [
+        "deutsche post"
+        "deutsche post ag"
+        "post"
         "deutsche telekom ag",
         "t-com",
         "telekom deutschland",
         "telekom deutschland gmbh"
+        "telekom"
+        "telekom AG"
       ],
       "tags": {
         "amenity": "telephone",

--- a/data/operators/amenity/telephone.json
+++ b/data/operators/amenity/telephone.json
@@ -145,14 +145,14 @@
       "id": "deutschetelekom-2be02b",
       "locationSet": {"include": ["de"]},
       "matchNames": [
-        "deutsche post"
-        "deutsche post ag"
-        "post"
+        "deutsche post",
+        "deutsche post ag",
+        "post",
         "deutsche telekom ag",
         "t-com",
         "telekom deutschland",
-        "telekom deutschland gmbh"
-        "telekom"
+        "telekom deutschland gmbh",
+        "telekom",
         "telekom AG"
       ],
       "tags": {


### PR DESCRIPTION
I made two changes and hope they are okay/fit well:
- The German operator "Deutsche Post" does not operate any telephones. It's an old operator which operated them before the company was firmed to "Deutsche Telekom". So all telephones with "Deutsche Post" and "Deutsche Post AG" as operator should get updated to "Deutsche Telekom" as well, so I added it for the matching names.

- Would it be possible to enable the "Deutsche Telekom" telephone operator preset in Germany only? Deutsche Telekom operates telephones in Germany only and this would have the following advantage:
 - then also the values "Post" (for former Deutsche Post) and the values "Telekom" and "Telekom AG" can be added as matching names for the operator. In Germany, these matching names can stand for the operator "Deutsche Telekom" only, as there is no other one with one of these words in the operator's name. But in other countries, these "abbreviations" may stand for other operators. I hope it's understandable what I mean. Thank you.