### PR TITLE
Deutsche Telekom AG

### DIFF
--- a/data/operators/amenity/telephone.json
+++ b/data/operators/amenity/telephone.json
@@ -156,7 +156,8 @@
       ],
       "tags": {
         "amenity": "telephone",
-        "operator": "Deutsche Telekom",
+        "brand": "Deutsche Telekom",
+        "operator": "Deutsche Telekom AG",
         "operator:wikidata": "Q9396",
         "operator:wikipedia": "de:Deutsche Telekom"
       }


### PR DESCRIPTION
The preferred tagging according to [the OSM wiki](https://wiki.openstreetmap.org/wiki/DE:Tag:amenity%3Dtelephone) is to use the official company name "Deutsche Telekom AG", see also [Taginfo](https://taginfo.openstreetmap.org/search?q=Deutsche+Telekom#values). "Deutsche Telekom" can still be used as the brand name.

Strictly speaking, this is not correct though, because the public telephones are actually operated by their subsidiary "Telekom Deutschland GmbH", but this operator is currently used only [416 times](https://taginfo.openstreetmap.org/search?q=Telekom#values). 

