### PR TITLE
Add brand:wikidata=* and brand:wikipedia for the "Deutsche Telekom" o…

### DIFF
--- a/data/operators/amenity/telephone.json
+++ b/data/operators/amenity/telephone.json
@@ -156,6 +156,8 @@
       "tags": {
         "amenity": "telephone",
         "brand": "Deutsche Telekom",
+        "brand:wikidata": "Q9396",
+        "brand:wikipedia": "de:Deutsche Telekom",
         "operator": "Deutsche Telekom AG",
         "operator:wikidata": "Q9396",
         "operator:wikipedia": "de:Deutsche Telekom"


### PR DESCRIPTION
…perator.

As brand=* has been added for the "Deutsche Telekom" telephone operator, there should have also to be brand:wikidata=* and brand:wikipedia=* for this.