### PR TITLE
More New Zealand brands

### DIFF
--- a/data/brands/shop/alcohol.json
+++ b/data/brands/shop/alcohol.json
@@ -490,6 +490,17 @@
       }
     },
     {
+      "displayName": "The Bottle-O",
+      "id": "thebottleo-a2b828",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "brand": "The Bottle-O",
+        "brand:wikidata": "Q111015122",
+        "name": "The Bottle-O",
+        "shop": "alcohol"
+      }
+    },
+    {
       "displayName": "Thirsty Camel",
       "id": "thirstycamel-cb3c62",
       "locationSet": {"include": ["au"]},

--- a/data/brands/shop/butcher.json
+++ b/data/brands/shop/butcher.json
@@ -84,6 +84,17 @@
       }
     },
     {
+      "displayName": "Mad Butcher",
+      "id": "madbutcher-79ce66",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "brand": "Mad Butcher",
+        "brand:wikidata": "Q111015152",
+        "name": "Mad Butcher",
+        "shop": "butcher"
+      }
+    },
+    {
       "displayName": "Omaha Steaks",
       "id": "omahasteaks-523a1c",
       "locationSet": {"include": ["us"]},

--- a/data/brands/shop/outdoor.json
+++ b/data/brands/shop/outdoor.json
@@ -261,8 +261,19 @@
     },
     {
       "displayName": "Mountain Warehouse",
-      "id": "mountainwarehouse-cbf787",
-      "locationSet": {"include": ["gb", "pl"]},
+      "id": "mountainwarehouse-19caf6",
+      "locationSet": {
+        "include": [
+          "at",
+          "ca",
+          "de",
+          "gb",
+          "ie",
+          "nz",
+          "pl",
+          "us"
+        ]
+      },
       "tags": {
         "brand": "Mountain Warehouse",
         "brand:wikidata": "Q6925414",

--- a/data/brands/shop/pawnbroker.json
+++ b/data/brands/shop/pawnbroker.json
@@ -24,8 +24,25 @@
     },
     {
       "displayName": "Cash Converters",
-      "id": "cashconverters-07d800",
-      "locationSet": {"include": ["001"]},
+      "id": "cashconverters-1c62e9",
+      "locationSet": {
+        "include": [
+          "ae",
+          "au",
+          "be",
+          "ch",
+          "es",
+          "fr",
+          "lu",
+          "my",
+          "na",
+          "nz",
+          "pt",
+          "sg",
+          "uk",
+          "za"
+        ]
+      },
       "tags": {
         "brand": "Cash Converters",
         "brand:wikidata": "Q5048645",

--- a/data/brands/shop/shoes.json
+++ b/data/brands/shop/shoes.json
@@ -1135,6 +1135,17 @@
       }
     },
     {
+      "displayName": "Number One Shoes",
+      "id": "numberoneshoes-4d7d7d",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "brand": "Number One Shoes",
+        "brand:wikidata": "Q111015103",
+        "name": "Number One Shoes",
+        "shop": "shoes"
+      }
+    },
+    {
       "displayName": "Office",
       "id": "office-b22ec7",
       "locationSet": {


### PR DESCRIPTION
Add New Zealand stores:

- _Number One Shoes_
- _The Bottle-O_
- _Mad Butcher_

Specify countries (and add New Zealand) for:

- _Mountain Warehouse_ (missing countries)
- _Cash Converters_ (previously 001)