### PR TITLE
Remove period from Drakes name

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1861,14 +1861,14 @@
       }
     },
     {
-      "displayName": "Drakes.",
+      "displayName": "Drakes",
       "id": "drakes-c254c9",
       "locationSet": {"include": ["au"]},
       "tags": {
-        "brand": "Drakes.",
+        "brand": "Drakes",
         "brand:wikidata": "Q48988077",
         "brand:wikipedia": "en:Drakes Supermarkets",
-        "name": "Drakes.",
+        "name": "Drakes",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
I wasn't sure on the policy on styling of logos and how that translates to the name fields. In this case the full stop isn't used as an abbreviation and while one part of the logo includes a full stop but another part of the logo and [the website text](https://drakes.com.au/about/) refer to the company as "Drakes Supermarkets" without the period.