### PR TITLE
Bakery "Ihr Landbäcker" (DE): Add Wikidata

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -895,6 +895,7 @@
       "locationSet": {"include": ["de"]},
       "tags": {
         "brand": "Ihr Landbäcker",
+        "brand:wikidata": "Q111022612",
         "name": "Ihr Landbäcker",
         "shop": "bakery"
       }


### PR DESCRIPTION
Created a new Wikidata item for `Ihr Landbäcker` (regional bakery chain in Germany) and linked it.