### PR TITLE
Add Hong Kong banks

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -13959,10 +13959,31 @@
         "brand:zh-Hant": "招商永隆銀行",
         "brand:zh-Hans": "招商永隆银行",
         "name": "招商永隆銀行 CMB Wing Lung Bank",
-        "name:en": "CMB Wing Lung Bankk",
+        "name:en": "CMB Wing Lung Bank",
         "name:zh": "招商永隆銀行",
         "name:zh-Hans": "招商永隆銀行",
         "name:zh-Hant": "招商永隆银行"
+      }
+    },
+    {
+      "displayName": "大新銀行",
+      "id": "",
+      "locationSet": {"include": ["hk"]},
+      "matchNames": ["大新"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "大新銀行",
+        "brand:en": "Dah Sing Bank",
+        "brand:wikidata": "Q5208707",
+        "brand:wikipedia": "en:Dah Sing Bank",
+        "brand:zh": "大新銀行",
+        "brand:zh-Hant": "大新銀行",
+        "brand:zh-Hans": "大新银行",
+        "name": "大新銀行 Dah Sing Bank",
+        "name:en": "Dah Sing Bank",
+        "name:zh": "大新銀行",
+        "name:zh-Hans": "大新銀行",
+        "name:zh-Hant": "大新银行"
       }
     }
   ]

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -5664,7 +5664,7 @@
     {
       "displayName": "HSBC (Global)",
       "id": "hsbc-b7a026",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["001"],"exclude":["hk","mo"]},
       "tags": {
         "amenity": "bank",
         "brand": "HSBC",

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -5686,6 +5686,27 @@
       }
     },
     {
+      "displayName": "香港上海滙豐銀行",
+      "id": "",
+      "locationSet": {"include": ["hk", "mo"]},
+      "matchNames": ["hsbc", "滙豐"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "香港上海滙豐銀行",
+        "brand:en": "HSBC",
+        "brand:wikidata": "Q190464",
+        "brand:wikipedia": "en:HSBC",
+        "brand:zh": "香港上海滙豐銀行",
+        "brand:zh-Hant": "香港上海滙豐銀行",
+        "brand:zh-Hans": "香港上海汇丰银行",
+        "name": "滙豐銀行 HSBC",
+        "name:en": "HSBC",
+        "name:zh": "滙豐銀行"
+        "name:zh-Hant": "滙豐銀行",
+        "name:zh-Hans": "汇丰银行"
+      }
+    },
+    {
       "displayName": "Huntington Bank",
       "id": "huntingtonbank-ea2e2d",
       "locationSet": {"include": ["us"]},
@@ -13858,6 +13879,48 @@
         "name:zh": "中國銀行",
         "name:zh-Hans": "中国银行",
         "name:zh-Hant": "中國銀行"
+      }
+    },
+    {
+      "displayName": "渣打銀行",
+      "id": "",
+      "locationSet": {"include": ["hk"]},
+      "matchNames": ["渣打"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "渣打銀行",
+        "brand:en": "Standard Chartered",
+        "brand:wikidata": "Q548278",
+        "brand:wikipedia": "en:Standard Chartered",
+        "brand:zh": "渣打銀行",
+        "brand:zh-Hant": "渣打銀行",
+        "brand:zh-Hans": "渣打银行",
+        "name": "渣打銀行 Standard Chartered",
+        "name:en": "Standard Chartered",
+        "name:zh": "渣打銀行",
+        "name:zh-Hans": "渣打銀行",
+        "name:zh-Hant": "渣打银行"
+      }
+    },
+    {
+      "displayName": "恒生銀行",
+      "id": "",
+      "locationSet": {"include": ["hk", "mo"]},
+      "matchNames": ["恒生"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "恒生銀行",
+        "brand:en": "Hang Seng Bank",
+        "brand:wikidata": "Q1575470",
+        "brand:wikipedia": "en:Hang Seng Bank",
+        "brand:zh": "恒生銀行",
+        "brand:zh-Hant": "恒生銀行",
+        "brand:zh-Hans": "恒生银行",
+        "name": "恒生銀行 Hang Seng Bank",
+        "name:en": "Hang Seng Bank",
+        "name:zh": "恒生銀行",
+        "name:zh-Hans": "恒生銀行",
+        "name:zh-Hant": "恒生银行"
       }
     }
   ]

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -8515,7 +8515,7 @@
     {
       "displayName": "Standard Chartered",
       "id": "standardchartered-b7a026",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["001"], "exclude": ["hk"]},
       "matchNames": ["standard chartered bank"],
       "tags": {
         "amenity": "bank",

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -13927,7 +13927,7 @@
       "displayName": "創興銀行",
       "id": "",
       "locationSet": {"include": ["hk", "mo"]},
-      "matchNames": ["創興銀行"],
+      "matchNames": ["創興"],
       "tags": {
         "amenity": "bank",
         "brand": "創興銀行",
@@ -13942,6 +13942,27 @@
         "name:zh": "創興銀行",
         "name:zh-Hans": "創興銀行",
         "name:zh-Hant": "创兴银行"
+      }
+    },
+    {
+      "displayName": "招商永隆銀行",
+      "id": "",
+      "locationSet": {"include": ["hk"]},
+      "matchNames": ["永隆銀行", "永隆"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "招商永隆銀行",
+        "brand:en": "CMB Wing Lung Bank",
+        "brand:wikidata": "Q8025114",
+        "brand:wikipedia": "en:Wing Lung Bank",
+        "brand:zh": "招商永隆銀行",
+        "brand:zh-Hant": "招商永隆銀行",
+        "brand:zh-Hans": "招商永隆银行",
+        "name": "招商永隆銀行 CMB Wing Lung Bank",
+        "name:en": "CMB Wing Lung Bankk",
+        "name:zh": "招商永隆銀行",
+        "name:zh-Hans": "招商永隆銀行",
+        "name:zh-Hant": "招商永隆银行"
       }
     }
   ]

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -13922,6 +13922,27 @@
         "name:zh-Hans": "恒生銀行",
         "name:zh-Hant": "恒生银行"
       }
+    },
+    {
+      "displayName": "創興銀行",
+      "id": "",
+      "locationSet": {"include": ["hk", "mo"]},
+      "matchNames": ["創興銀行"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "創興銀行",
+        "brand:en": "Chong Hing Bank",
+        "brand:wikidata": "Q5104600",
+        "brand:wikipedia": "en:Chong Hing Bank",
+        "brand:zh": "創興銀行",
+        "brand:zh-Hant": "創興銀行",
+        "brand:zh-Hans": "创兴银行",
+        "name": "創興銀行 Chong Hing Bank",
+        "name:en": "Chong Hing Bank",
+        "name:zh": "創興銀行",
+        "name:zh-Hans": "創興銀行",
+        "name:zh-Hant": "创兴银行"
+      }
     }
   ]
 }

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -5701,7 +5701,7 @@
         "brand:zh-Hans": "香港上海汇丰银行",
         "name": "滙豐銀行 HSBC",
         "name:en": "HSBC",
-        "name:zh": "滙豐銀行"
+        "name:zh": "滙豐銀行",
         "name:zh-Hant": "滙豐銀行",
         "name:zh-Hans": "汇丰银行"
       }


### PR DESCRIPTION
Add Hong Kong's banks information
- HSBC (滙豐銀行) (HK, MO)
- Standard Chartard (渣打銀行) (HK)
- Hang Seng Bank (恒生銀行) (HK, MO)
- Chong Hing Bank (創興銀行) (HK, MO)
- CMB Wing Lung Bank (招商永隆銀行) (HK)
- Dah Sing Bank (大新銀行) (HK)