### PR TITLE
Greek and Turkish names for Bank of Cyprus

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -1966,7 +1966,7 @@
         "brand:wikidata": "Q806678",
         "brand:wikipedia": "en:Bank of Cyprus",
         "name": "Bank of Cyprus",
-        "name:tr": "Kıbrıs Bankası"
+        "name:tr": "Kıbrıs Bankası",
         "name:el": "Τράπεζα Κύπρου"
       }
     },

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -1965,7 +1965,9 @@
         "brand": "Bank of Cyprus",
         "brand:wikidata": "Q806678",
         "brand:wikipedia": "en:Bank of Cyprus",
-        "name": "Bank of Cyprus"
+        "name": "Bank of Cyprus",
+        "name:tr": "Kıbrıs Bankası"
+        "name:el": "Τράπεζα Κύπρου"
       }
     },
     {


### PR DESCRIPTION
Cyprus uses Greek and Turkish languages.

https://en.wikipedia.org/wiki/Bank_of_Cyprus