### PR TITLE
Update wastewater_plant.json

### DIFF
--- a/data/operators/man_made/wastewater_plant.json
+++ b/data/operators/man_made/wastewater_plant.json
@@ -633,23 +633,14 @@
       }
     },
     {
-      "displayName": "United Utilites",
-      "id": "unitedutilites-9a5141",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "man_made": "wastewater_plant",
-        "operator": "United Utilites",
-        "operator:wikidata": "Q503038",
-        "operator:wikipedia": "en:United Utilities"
-      }
-    },
-    {
       "displayName": "United Utilities",
       "id": "unitedutilities-81f751",
       "locationSet": {"include": ["001"]},
       "tags": {
         "man_made": "wastewater_plant",
-        "operator": "United Utilities"
+        "operator": "United Utilities",
+        "operator:wikidata": "Q503038",
+        "operator:wikipedia": "en:United Utilities"
       }
     },
     {


### PR DESCRIPTION
United Utilities had a mis-spelt listing. Added the wikidata link to the correct one and removed the mis-spelt listing.