### PR TITLE
Update vending_machine.json

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -26,13 +26,12 @@
       "displayName": "Abendzeitung",
       "id": "abendzeitung-a242c5",
       "locationSet": {"include": ["de"]},
+      "matchNames": ["AZ"],
       "tags": {
         "amenity": "vending_machine",
         "brand": "Abendzeitung",
         "brand:wikidata": "Q225076",
         "brand:wikipedia": "de:Abendzeitung",
-        "name": "Abendzeitung",
-        "short_name": "AZ",
         "vending": "newspapers"
       }
     },
@@ -80,14 +79,12 @@
       "displayName": "Bild",
       "id": "bild-a242c5",
       "locationSet": {"include": ["de"]},
+      "matchNames": ["Bild am Sonntag", "Bild-Zeitung"],
       "tags": {
-        "alt_name": "Bild am Sonntag",
         "amenity": "vending_machine",
         "brand": "Bild",
         "brand:wikidata": "Q156203",
         "brand:wikipedia": "de:Bild (Zeitung)",
-        "name": "Bild",
-        "old_name": "Bild-Zeitung",
         "vending": "newspapers"
       }
     },
@@ -146,7 +143,6 @@
         "brand": "bwegt",
         "brand:wikidata": "Q60982912",
         "brand:wikipedia": "de:Bwegt",
-        "name": "bwegt",
         "vending": "public_transport_tickets"
       }
     },
@@ -227,7 +223,6 @@
         "brand": "Deutsche Post",
         "brand:wikidata": "Q157645",
         "brand:wikipedia": "de:Deutsche Post AG",
-        "name": "Deutsche Post",
         "operator": "Deutsche Post",
         "operator:wikidata": "Q157645",
         "operator:wikipedia": "de:Deutsche Post AG",
@@ -340,18 +335,17 @@
       "displayName": "Karlsruher Verkehrsverbund",
       "id": "karlsruherverkehrsverbund-a242c5",
       "locationSet": {"include": ["de"]},
+      "matchNames": ["KVV"],
       "tags": {
         "amenity": "vending_machine",
         "brand": "Karlsruher Verkehrsverbund",
         "brand:wikidata": "Q1733986",
         "brand:wikipedia": "de:Karlsruher Verkehrsverbund",
-        "name": "Karlsruher Verkehrsverbund",
         "network": "Karlsruher Verkehrsverbund",
         "network:guid": "DE-BW-KVV",
         "network:short": "KVV",
         "network:wikidata": "Q1733986",
         "network:wikipedia": "de:Karlsruher Verkehrsverbund",
-        "short_name": "KVV",
         "vending": "public_transport_tickets"
       }
     },
@@ -648,13 +642,12 @@
       "displayName": "Süddeutsche Zeitung",
       "id": "suddeutschezeitung-a242c5",
       "locationSet": {"include": ["de"]},
+      "matchNames": ["SZ"],
       "tags": {
         "amenity": "vending_machine",
         "brand": "Süddeutsche Zeitung",
         "brand:wikidata": "Q158870",
         "brand:wikipedia": "de:Süddeutsche Zeitung",
-        "name": "Süddeutsche Zeitung",
-        "short_name": "SZ",
         "vending": "newspapers"
       }
     },
@@ -684,7 +677,6 @@
         "brand": "tz",
         "brand:wikidata": "Q264205",
         "brand:wikipedia": "de:Tz",
-        "name": "tz",
         "vending": "newspapers"
       }
     },
@@ -712,7 +704,6 @@
       "tags": {
         "amenity": "vending_machine",
         "brand": "VVO Fahrausweise",
-        "name": "VVO Fahrausweise",
         "vending": "public_transport_tickets"
       }
     },


### PR DESCRIPTION
Remove `name=*` tags from German brands. See discussion in the [German OSM forum](https://forum.openstreetmap.org/viewtopic.php?id=75088).