### PR TITLE
Update exchange.json

### DIFF
--- a/data/operators/telecom/exchange.json
+++ b/data/operators/telecom/exchange.json
@@ -132,7 +132,6 @@
         "telekom"
       ],
       "tags": {
-        "name": "Deutsche Telekom AG",
         "operator": "Deutsche Telekom AG",
         "operator:wikidata": "Q9396",
         "operator:wikipedia": "de:Deutsche Telekom",


### PR DESCRIPTION
Remove `name=*` for "Deutsche Telekom AG". See discussion in the [German OSM forum](https://forum.openstreetmap.org/viewtopic.php?id=75088).