### PR TITLE
Ministop, Japan locations

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -2176,7 +2176,7 @@
     {
       "displayName": "Ministop",
       "id": "ministop-4d6b4b",
-      "locationSet": {"include": ["001", "ja", "ph", "cn", "vn", "kz"]},
+      "locationSet": {"include": ["ph", "cn", "vn", "kz"]},
       "tags": {
         "brand": "Ministop",
         "brand:wikidata": "Q1038929",

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -2176,7 +2176,7 @@
     {
       "displayName": "Ministop",
       "id": "ministop-4d6b4b",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["001", "ja", "ph", "cn", "vn", "kz"]},
       "tags": {
         "brand": "Ministop",
         "brand:wikidata": "Q1038929",

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -4442,9 +4442,11 @@
       "tags": {
         "brand": "미니스톱",
         "brand:ko": "미니스톱",
+        "brand:en": "Ministop",
         "brand:wikidata": "Q1038929",
-        "brand:wikipedia": "en:Ministop",
+        "brand:wikipedia": "ko:미니스톱",
         "name": "미니스톱",
+        "name:en": "Ministop",
         "name:ko": "미니스톱",
         "shop": "convenience"
       }


### PR DESCRIPTION
Ministop operates in Japan, Philippines, China, Vietnam and Kazakhstan

https://en.wikipedia.org/wiki/Ministop#International_operations

Not sure what does "001" mean so left as-is.