### PR TITLE
Remove vending=cigarettes from Tobaccoland's operator

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -668,7 +668,6 @@
         "operator": "Tobaccoland Automatengesellschaft",
         "operator:wikidata": "Q1439872",
         "operator:wikipedia": "de:Tobaccoland Automatengesellschaft",
-        "vending": "cigarettes"
       }
     },
     {


### PR DESCRIPTION
Hi,
here I removed vending=cigarettes from the Tobaccoland's operator, because it was noticed that Tobaccoland does operate vending machines which sell cigarettes _only_, but this company operates also vending machines which sell cigarettes but also some **other** things like condoms or something else, see https://www.openstreetmap.org/node/4405601460 for example.

So the vending-value should then be vending=cigarettes;condoms, and as there may also exist some other value combinations on Tobaccoland's vending machines which aren't _vending=cigarettes_ only, the NSI shouldn't propose to update the vending=* value to _vending=cigarettes_ at those. I hope it's understandable what I mean. So I removed the vending=cigarettes value for this brand, as the same way was chosen for the "Selecta" brand too, for example, because this brand does also have vending machines selling different/several different things.