### PR TITLE
Updated and added Irish Rail services

### DIFF
--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -444,11 +444,11 @@
       }
     },
     {
-      "displayName": "Dublin Commuter",
-      "id": "dublincommuter-73b98a",
+      "displayName": "Commuter",
+      "id": "",
       "locationSet": {"include": ["ie"]},
       "tags": {
-        "network": "Dublin Commuter",
+        "network": "Commuter",
         "network:wikidata": "Q5155093",
         "network:wikipedia": "en:Commuter (Iarnród Éireann)",
         "operator": "Iarnród Éireann",
@@ -456,6 +456,20 @@
         "operator:wikipedia": "en:Iarnród Éireann",
         "route": "train"
       }
+    },
+    { 
+      "displayName": "InterCity",
+      "id": "",
+      "locationSet": {"include": ["ie"]},
+      "tags": {
+        "network": "InterCity",
+        "network:wikidata": "Q6044834",
+        "network:wikipedia": "en:InterCity (Iarnród Éireann)",
+        "operator": "Iarnród Éireann",
+        "operator:wikidata": "Q73043",
+        "operator:wikipedia": "en:Iarnród Éireann",
+        "route": "train"
+	    }
     },
     {
       "displayName": "Eurobahn",

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -447,6 +447,7 @@
       "displayName": "Commuter",
       "id": "",
       "locationSet": {"include": ["ie"]},
+      "matchNames": ["dublin commuter"],
       "tags": {
         "network": "Commuter",
         "network:wikidata": "Q5155093",


### PR DESCRIPTION
Updated the Iarnród Éireann (Irish Rail) Commuter service. This service exists outside of Dublin so it shouldn't be the Dublin Commuter. Also added the InterCity service.