### PR TITLE
add Woodies diy shop

### DIFF
--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -35,6 +35,19 @@
       }
     },
     {
+      "displayName": "Woodie's",
+      "id": "",
+      "locationSet": {"include": ["ie"]},
+	    "matchNames": ["woodies diy", "atlantic homecare"],
+      "tags": {
+        "brand": "Woodie's",
+        "brand:wikidata": "Q25344847",
+		    "brand:wikipedia": "en:Woodie's DIY",
+        "name": "Woodie's",
+        "shop": "doityourself"
+      }
+    },
+    {
       "displayName": "B&Q",
       "id": "bandq-092aaf",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Wikipedia is still "Woodie's DIY" but im looking to get that changed as they have rebranded to just "Woodie's"