### PR TITLE
Add banks in Hong Kong

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -1706,7 +1706,7 @@
     {
       "displayName": "Bangkok Bank",
       "id": "bangkokbank-b7a026",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["001"], "exclude": ["th", "hk"]},
       "tags": {
         "amenity": "bank",
         "brand": "Bangkok Bank",
@@ -3811,7 +3811,7 @@
     {
       "displayName": "Citibank",
       "id": "citibank-b7a026",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["001"], "exclude": ["hk"]},
       "tags": {
         "amenity": "bank",
         "brand": "Citibank",
@@ -7646,7 +7646,7 @@
         "amenity": "bank",
         "brand": "Raiffeisen Bank",
         "brand:wikidata": "Q16522506",
-        "brandwikipedia": "hu:Raiffeisen Bank (Magyarország)",
+        "brand:wikipedia": "hu:Raiffeisen Bank (Magyarország)",
         "name": "Raiffeisen Bank"
       }
     },
@@ -12502,7 +12502,7 @@
     {
       "displayName": "中信银行",
       "id": "chinaciticbank-da74c0",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {"include": ["cn"], "exclude": ["hk"]},
       "tags": {
         "amenity": "bank",
         "brand": "中信银行",
@@ -12513,6 +12513,25 @@
         "name": "中信银行",
         "name:en": "China CITIC Bank",
         "name:zh": "中信银行"
+      }
+    },
+    {
+      "displayName": "中信銀行（國際） China CITIC Bank International",
+      "locationSet": {"include": ["hk"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "中信銀行 China CITIC Bank",
+        "brand:en": "China CITIC Bank",
+        "brand:wikidata": "Q38960",
+        "brand:wikipedia": "zh:中信银行",
+        "brand:zh": "中信銀行",
+        "brand:zh-Hans": "中信银行",
+        "brand:zh-Hant": "中信銀行",
+        "name": "中信銀行（國際） China CITIC Bank International",
+        "name:en": "China CITIC Bank International",
+        "name:zh": "中信銀行（國際）",
+        "name:zh-Hans": "中信银行（国际）",
+        "name:zh-Hant": "中信銀行（國際）"
       }
     },
     {
@@ -12552,7 +12571,7 @@
     {
       "displayName": "中国工商银行",
       "id": "industrialandcommercialbankofchina-da74c0",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {"include": ["cn"], "exclude": ["hk"]},
       "matchNames": ["工商银行", "工行"],
       "tags": {
         "amenity": "bank",
@@ -12567,9 +12586,29 @@
       }
     },
     {
+      "displayName": "中國工商銀行（亞洲） Industrial and Commercial Bank of China (Asia)",
+      "locationSet": {"include": ["hk"]},
+      "matchNames": ["工商銀行", "工行", "工銀亞洲", "工銀（亞洲）", "工銀", "ICBC", "ICBC (Asia)"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "中國工商銀行",
+        "brand:en": "Industrial and Commercial Bank of China",
+        "brand:wikidata": "Q26463",
+        "brand:wikipedia": "zh:中国工商银行",
+        "brand:zh": "中國工商銀行",
+        "brand:zh-Hans": "中国工商银行",
+        "brand:zh-Hant": "中國工商銀行",
+        "name": "中國工商銀行（亞洲） ICBC (Asia)",
+        "name:en": "ICBC (Asia)",
+        "name:zh": "中國工商銀行（亞洲）",
+        "name:zh-Hans": "中國工商銀行（亞洲）",
+        "name:zh-Hant": "中國工商銀行（亞洲）"
+      }
+    },
+    {
       "displayName": "中国建设银行",
       "id": "chinaconstructionbank-da74c0",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {"include": ["cn"], "exclude": ["hk"]},
       "matchNames": ["建行", "建设银行"],
       "tags": {
         "amenity": "bank",
@@ -12581,6 +12620,26 @@
         "name": "中国建设银行",
         "name:en": "China Construction Bank",
         "name:zh": "中国建设银行"
+      }
+    },
+    {
+      "displayName": "中國建設銀行（亞洲） China Construction Bank (Asia)",
+      "locationSet": {"include": ["hk"]},
+      "matchNames": ["建行", "建行亞洲", "建行（亞洲）", "建設銀行", "CCB", "CCB (Asia)"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "中國建設銀行 China Construction Bank",
+        "brand:en": "China Construction Bank",
+        "brand:wikidata": "Q26299",
+        "brand:wikipedia": "zh:中国建设银行",
+        "brand:zh": "中國建設銀行",
+        "brand:zh-Hans": "中国建设银行",
+        "brand:zh-Hant": "中國建設銀行",
+        "name": "中國建設銀行（亞洲） CCB (Asia)",
+        "name:en": "CCB (Asia)",
+        "name:zh": "中國建設銀行（亞洲）",
+        "name:zh-Hans": "中国建设银行（亚洲）",
+        "name:zh-Hant": "中國建設銀行（亞洲）"
       }
     },
     {
@@ -12693,7 +12752,7 @@
       ],
       "tags": {
         "amenity": "bank",
-        "brand": "中國銀行",
+        "brand": "中國銀行 Bank of China",
         "brand:en": "Bank of China",
         "brand:wikidata": "Q790068",
         "brand:wikipedia": "en:Bank of China",
@@ -12710,7 +12769,7 @@
     {
       "displayName": "交通银行",
       "id": "bankofcommunications-da74c0",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {"include": ["cn"], "exclude": ["hk"]},
       "matchNames": ["交行"],
       "tags": {
         "amenity": "bank",
@@ -12722,6 +12781,25 @@
         "name": "交通银行",
         "name:en": "Bank of Communications",
         "name:zh": "交通银行"
+      }
+    },
+    {
+      "displayName": "交通銀行 Bank of Communications",
+      "locationSet": {"include": ["hk"]},
+      "matchNames": ["交行"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "交通銀行 Bank of Communications",
+        "brand:wikidata": "Q806680",
+        "brand:wikipedia": "zh:交通銀行",
+        "brand:en": "Bank of Communications",
+        "brand:zh-Hans": "交通银行",
+        "brand:zh-Hant": "交通銀行",
+        "name": "交通銀行 Bank of Communications",
+        "name:en": "Bank of Communications",
+        "name:zh": "交通銀行",
+        "name:zh-Hans": "交通银行",
+        "name:zh-Hant": "交通銀行"
       }
     },
     {
@@ -12904,13 +12982,13 @@
       }
     },
     {
-      "displayName": "創興銀行",
+      "displayName": "創興銀行 Chong Hing Bank",
       "id": "chonghingbank-075cf6",
       "locationSet": {"include": ["hk", "mo"]},
       "matchNames": ["創興"],
       "tags": {
         "amenity": "bank",
-        "brand": "創興銀行",
+        "brand": "創興銀行 Chong Hing Bank",
         "brand:en": "Chong Hing Bank",
         "brand:wikidata": "Q5104600",
         "brand:wikipedia": "en:Chong Hing Bank",
@@ -13221,13 +13299,13 @@
       }
     },
     {
-      "displayName": "大新銀行",
+      "displayName": "大新銀行 Dah Sing Bank",
       "id": "dahsingbank-442838",
       "locationSet": {"include": ["hk"]},
       "matchNames": ["大新"],
       "tags": {
         "amenity": "bank",
-        "brand": "大新銀行",
+        "brand": "大新銀行 Dah Sing Bank",
         "brand:en": "Dah Sing Bank",
         "brand:wikidata": "Q5208707",
         "brand:wikipedia": "en:Dah Sing Bank",
@@ -13377,13 +13455,13 @@
       }
     },
     {
-      "displayName": "恒生銀行",
+      "displayName": "恒生銀行 Hang Seng Bank",
       "id": "hangsengbank-075cf6",
       "locationSet": {"include": ["hk", "mo"]},
       "matchNames": ["恒生"],
       "tags": {
         "amenity": "bank",
-        "brand": "恒生銀行",
+        "brand": "恒生銀行 Hang Seng Bank",
         "brand:en": "Hang Seng Bank",
         "brand:wikidata": "Q1575470",
         "brand:wikipedia": "en:Hang Seng Bank",
@@ -13414,13 +13492,13 @@
       }
     },
     {
-      "displayName": "招商永隆銀行",
+      "displayName": "招商永隆銀行 CMB Wing Lung Bank",
       "id": "cmbwinglungbank-442838",
       "locationSet": {"include": ["hk"]},
       "matchNames": ["永隆", "永隆銀行"],
       "tags": {
         "amenity": "bank",
-        "brand": "招商永隆銀行",
+        "brand": "招商永隆銀行 CMB Wing Lung Bank",
         "brand:en": "CMB Wing Lung Bank",
         "brand:wikidata": "Q8025114",
         "brand:wikipedia": "en:Wing Lung Bank",
@@ -13520,20 +13598,20 @@
       }
     },
     {
-      "displayName": "東亞銀行",
+      "displayName": "東亞銀行 Bank of East Asia",
       "id": "bankofeastasia-442838",
       "locationSet": {"include": ["hk"]},
       "matchNames": ["bea", "東亞"],
       "tags": {
         "amenity": "bank",
-        "brand": "東亞銀行",
+        "brand": "東亞銀行 Bank of East Asia",
         "brand:en": "Bank of East Asia",
         "brand:wikidata": "Q806679",
         "brand:wikipedia": "zh:東亞銀行",
         "brand:zh-Hans": "东亚银行",
         "brand:zh-Hant": "東亞銀行",
         "name": "東亞銀行 BEA",
-        "name:en": "Bank of East Asia",
+        "name:en": "BEA",
         "name:zh-Hans": "东亚银行",
         "name:zh-Hant": "東亞銀行"
       }
@@ -13706,13 +13784,13 @@
       }
     },
     {
-      "displayName": "渣打銀行",
+      "displayName": "渣打銀行 Standard Chartered",
       "id": "standardchartered-442838",
       "locationSet": {"include": ["hk"]},
-      "matchNames": ["渣打"],
+      "matchNames": ["渣打", "SC"],
       "tags": {
         "amenity": "bank",
-        "brand": "渣打銀行",
+        "brand": "渣打銀行 Standard Chartered",
         "brand:en": "Standard Chartered",
         "brand:wikidata": "Q548278",
         "brand:wikipedia": "en:Standard Chartered",
@@ -14081,6 +14159,86 @@
         "brand:wikidata": "Q11677008",
         "brand:wikipedia": "ja:鹿児島銀行",
         "name": "鹿児島銀行"
+      }
+    },
+    {
+      "displayName": "花旗銀行 Citibank",
+      "locationSet": {"include": ["hk"]},
+      "matchNames": ["花旗", "Citi"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "花旗銀行 Citibank",
+        "brand:en": "Citibank",
+        "brand:wikidata": "Q857063",
+        "brand:wikipedia": "en:Citibank",
+        "brand:zh": "花旗銀行",
+        "brand:zh-Hans": "花旗银行",
+        "brand:zh-Hant": "花旗銀行",
+        "name": "花旗銀行 Citibank",
+        "name:en": "Citibank",
+        "name:zh": "花旗銀行",
+        "name:zh-Hans": "花旗银行",
+        "name:zh-Hant": "花旗銀行",
+        "short_name": "Citi"
+      }
+    },
+    {
+      "displayName": "南洋商業銀行 Nanyang Commercial Bank",
+      "locationSet": {"include": ["hk"]},
+      "matchNames": ["南洋商業", "NCB"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "南洋商業銀行 Nanyang Commercial Bank",
+        "brand:en": "Nanyang Commercial Bank",
+        "brand:wikidata": "Q3335816",
+        "brand:wikipedia": "zh:南洋商業銀行",
+        "brand:zh": "南洋商業銀行",
+        "brand:zh-Hans": "南洋商业银行",
+        "brand:zh-Hant": "南洋商業銀行",
+        "name": "南洋商業銀行 NCB",
+        "name:en": "NCB",
+        "name:zh": "南洋商業銀行",
+        "name:zh-Hans": "南洋商业银行",
+        "name:zh-Hant": "南洋商業銀行"
+      }
+    },
+    {
+      "displayName": "華僑永亨銀行 OCBC Wing Hang Bank",
+      "locationSet": {"include": ["hk"]},
+      "matchNames": ["華僑", "華僑銀行", "永亨", "永亨銀行", "OCBC", "Wing Hang Bank"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "華僑永亨銀行 OCBC Wing Hang Bank",
+        "brand:en": "OCBC Wing Hang Bank",
+        "brand:wikidata": "Q837147",
+        "brand:wikipedia": "zh:華僑永亨銀行 (香港)",
+        "brand:zh": "華僑永亨銀行",
+        "brand:zh-Hans": "华侨永亨银行",
+        "brand:zh-Hant": "華僑永亨銀行",
+        "name": "華僑永亨銀行 OCBC Wing Hang Bank",
+        "name:en": "OCBC Wing Hang Bank",
+        "name:zh": "華僑永亨銀行",
+        "name:zh-Hans": "华侨永亨银行",
+        "name:zh-Hant": "華僑永亨銀行"
+      }
+    },
+    {
+      "displayName": "盤谷銀行 Bangkok Bank",
+      "locationSet": {"include": ["hk"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "盤谷銀行 Bangkok Bank",
+        "brand:en": "Bangkok Bank",
+        "brand:wikidata": "Q806483",
+        "brand:wikipedia": "en:Bangkok Bank",
+        "brand:zh": "盤谷銀行",
+        "brand:zh-Hans": "盘谷银行",
+        "brand:zh-Hant": "盤谷銀行",
+        "name": "盤谷銀行 Bangkok Bank",
+        "name:en": "Bangkok Bank",
+        "name:zh": "盤谷銀行",
+        "name:zh-Hans": "盘谷银行",
+        "name:zh-Hant": "盤谷銀行"
       }
     }
   ]

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -13611,9 +13611,10 @@
         "brand:zh-Hans": "东亚银行",
         "brand:zh-Hant": "東亞銀行",
         "name": "東亞銀行 BEA",
-        "name:en": "BEA",
+        "name:en": "Bank of East Asia",
         "name:zh-Hans": "东亚银行",
-        "name:zh-Hant": "東亞銀行"
+        "name:zh-Hant": "東亞銀行",
+        "short_name": "BEA"
       }
     },
     {
@@ -14196,10 +14197,11 @@
         "brand:zh-Hans": "南洋商业银行",
         "brand:zh-Hant": "南洋商業銀行",
         "name": "南洋商業銀行 NCB",
-        "name:en": "NCB",
+        "name:en": "Nanyang Commercial Bank",
         "name:zh": "南洋商業銀行",
         "name:zh-Hans": "南洋商业银行",
-        "name:zh-Hant": "南洋商業銀行"
+        "name:zh-Hant": "南洋商業銀行",
+        "short_name": "NCB"
       }
     },
     {


### PR DESCRIPTION
Added
- 中信銀行（國際） China CITIC Bank International
- 中國工商銀行（亞洲） Industrial and Commercial Bank of China (Asia)
- 中國建設銀行（亞洲） China Construction Bank (Asia)
- 交通銀行 Bank of Communications
- 花旗銀行 Citibank
- 南洋商業銀行 Nanyang Commercial Bank
- 華僑永亨銀行 OCBC Wing Hang Bank
- 盤谷銀行 Bangkok Bank