### PR TITLE
Remove MOE of China

### DIFF
--- a/data/operators/amenity/school.json
+++ b/data/operators/amenity/school.json
@@ -16,7 +16,8 @@
         "^privé(e)?$",
         "^religious$",
         "^school$",
-        "^学校$"
+        "^学校$",
+        "^中华人民共和国教育部"
       ]
     }
   },
@@ -26596,20 +26597,6 @@
       "tags": {
         "amenity": "school",
         "operator": "世田谷区教育委員会"
-      }
-    },
-    {
-      "displayName": "中华人民共和国教育部直属学校",
-      "id": "ministryofeducationofthepeoplesrepublicofchina-cad3ca",
-      "locationSet": {"include": ["cn"]},
-      "matchNames": ["教育部"],
-      "tags": {
-        "amenity": "school",
-        "operator": "中华人民共和国教育部",
-        "operator:en": "Ministry of Education of the People's Republic of China",
-        "operator:wikidata": "Q1042167",
-        "operator:wikipedia": "zh:中华人民共和国教育部",
-        "operator:zh": "中华人民共和国教育部"
       }
     },
     {

--- a/data/operators/amenity/university.json
+++ b/data/operators/amenity/university.json
@@ -4,7 +4,7 @@
     "skipCollection": true,
     "preserveTags": ["^name"],
     "exclude": {
-      "generic": ["^university$", "^大学$"]
+      "generic": ["^university$", "^大学$","^中华人民共和国教育部"]
     }
   },
   "items": [
@@ -30,20 +30,6 @@
       "tags": {
         "amenity": "university",
         "operator": "东北林业大学"
-      }
-    },
-    {
-      "displayName": "中华人民共和国教育部直属高等学校",
-      "id": "ministryofeducationofthepeoplesrepublicofchina-40d673",
-      "locationSet": {"include": ["cn"]},
-      "matchNames": ["教育部"],
-      "tags": {
-        "amenity": "university",
-        "operator": "中华人民共和国教育部",
-        "operator:en": "Ministry of Education of the People's Republic of China",
-        "operator:wikidata": "Q1042167",
-        "operator:wikipedia": "zh:中华人民共和国教育部",
-        "operator:zh": "中华人民共和国教育部"
       }
     }
   ]


### PR DESCRIPTION
According to OSM wiki：

> Owner or brand name aren't necessarily the operator
>
> An operator isn't necessarily the owner of the map feature. Many chains (store, restaurants...) use a [franchise](https://en.wikipedia.org/wiki/Franchising) system, where the brand does not operate the point-of-presence.
>
> For example, a lot of transport and communication networks had been built by public administrations and are now operated by private companies. In some places, the national government retains ownership of the infrastructure, as in power grids and railways. Power grids may be operated and maintained by a private entity, while the underlying infrastructure (lines, towers, poles, substations) remain under the ownership of the national government (e.g. in the Philippines). Railways may still be owned and maintained by the national government (e.g. the UK, most of Western Europe, South Korea), but trains using them may be operated by different companies.
>
> ——[Key:operator#How_to_use](https://wiki.openstreetmap.org/wiki/Key:operator#How_to_use)

And the defination of it：

>中央部门（或单位）所属高等学校，简称中央部委直属高校或中央部属高校，是中华人民共和国高等学校中公立学校的一种。

>由国务院组成部门、直属机构、直属事业单位等中央部门（或单位）在全中国范围内直属管理。

> ——[中央部属高校(ministry-owned university)](https://zh.wikipedia.org/wiki/%E4%B8%AD%E5%A4%AE%E9%83%A8%E5%B1%9E%E9%AB%98%E6%A0%A1)

So some mapper in China community think those 2 entry polute OSM data with wrong operator, and think this should be tagged as `owner=MOE`

**Thanks to other maintainers for reviewing this PR. I need your advice, I don't know whether this is correct.**

This PR is similar to #6323 
