### PR TITLE
add Wikidata entry to Der Mann

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -614,6 +614,7 @@
       "locationSet": {"include": ["at"]},
       "tags": {
         "brand": "Der Mann",
+        "brand:wikidata": "Q74356398",
         "name": "Der Mann",
         "shop": "bakery"
       }


### PR DESCRIPTION
Quite minor, but I noticed that while there is no Wikipedia article, there is a Wikidata entry for the brand.