### PR TITLE
Polar charging network in UK rebranded to BP Pulse

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -2615,15 +2615,6 @@
       }
     },
     {
-      "displayName": "Polar",
-      "id": "polar-0793ce",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Polar"
-      }
-    },
-    {
       "displayName": "Porsche",
       "id": "porsche-28ff7e",
       "locationSet": {


### PR DESCRIPTION
The Polar charging network has been rebranded to BP Pulse. There are now no charging stations tagged operator=Polar, they've all been updated.