### PR TITLE
ENGIE EV charging in UK has merged to Geniepoint

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -1302,7 +1302,7 @@
     {
       "displayName": "Engie",
       "id": "engie-a29737",
-      "locationSet": {"include": ["gb", "nl"]},
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Engie",
@@ -1657,7 +1657,8 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
-        "operator": "GeniePoint"
+        "operator": "GeniePoint",
+        "operator:wikidata": "Q111363966"
       }
     },
     {


### PR DESCRIPTION
Engie EV charging in the UK has merged to their existing GeniePoint brand. All locations in the UK have been adjusted in OSM. Engie still use that brand in other countries for EV charging.