### PR TITLE
Remove name tags for Scout Association of HK

### DIFF
--- a/data/brands/club/scout.json
+++ b/data/brands/club/scout.json
@@ -48,24 +48,20 @@
       }
     },
     {
-      "displayName": "香港童軍總會",
+      "displayName": "香港童軍總會 Scout Association of Hong Kong",
       "id": "scoutassociationofhongkong-d7bac8",
       "locationSet": {"include": ["hk"]},
       "matchNames": ["scouts", "童軍"],
       "preserveTags": ["^name"],
       "tags": {
-        "brand": "香港童軍總會",
+        "brand": "香港童軍總會 Scout Association of Hong Kong",
         "brand:en": "Scout Association of Hong Kong",
         "brand:wikidata": "Q1883585",
         "brand:wikipedia": "zh:香港童軍總會",
         "brand:zh": "香港童軍總會",
         "brand:zh-Hans": "香港童军总会",
         "brand:zh-Hant": "香港童軍總會",
-        "club": "scout",
-        "name": "香港童軍總會 Scout Association of Hong Kong",
-        "name:en": "Scout Association of Hong Kong",
-        "name:zh": "香港童軍總會",
-        "name:zh-Hant": "香港童军总会"
+        "club": "scout"
       }
     }
   ]


### PR DESCRIPTION
It should be different name for Scout Association of Hong Kong's centre.