### PR TITLE
Fix Bee-Line bus network operator.

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -1374,7 +1374,7 @@
         "network": "Bee-Line",
         "network:wikidata": "Q4879491",
         "network:wikipedia": "en:Bee-Line Bus System",
-        "operator": "Worchester County",
+        "operator": "Westchester County Department of Public Works and Transportation",
         "route": "bus"
       }
     },


### PR DESCRIPTION
The error was introduced in 0d83311f23f0b69aeed6961186b9d882af4b8377. See [the wikipedia page](https://en.wikipedia.org/wiki/Bee-Line_Bus_System) for confirmation.