### PR TITLE
Add Petit Pret

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -4159,6 +4159,16 @@
         "name:zh": "鶴茶樓",
         "takeaway": "only"
       }
+    },
+    {
+      "displayName": "Petit Pret",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "amenity": "cafe",
+        "brand": "Petit Pret",
+        "brand:wikidata": "Q111448708",
+        "name": "Petit Pret"
+      }
     }
   ]
 }


### PR DESCRIPTION
So this is a sub fascia of Pret a Manger, like Veggie Pret but not as common.

It probably could have some miscellaneous tags like `diet:vegan`, `diet:vegetarian` and `takeaway`, but I've never been to one I don't know for sure.

I'm also not sure if this should be fast food vs cafe, but currently [OSM](https://overpass-turbo.eu/s/1hjE) has it 2-1 to cafe.