### PR TITLE
Add electronics for Hong Kong

### DIFF
--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -1551,7 +1551,7 @@
       "locationSet": {"include": ["hk"]},
       "tags": {
         "brand": "豐澤 Fortress",
-        "brand:en" "Fortress",
+        "brand:en": "Fortress",
         "brand:wikidata": "Q15904138",
         "brand:wikipedia": "zh:豐澤電器",
         "brand:zh": "豐澤",
@@ -1566,7 +1566,7 @@
       "locationSet": {"include": ["hk"]},
       "tags": {
         "brand": "百老滙 Broadway",
-        "brand:en" "Broadway",
+        "brand:en": "Broadway",
         "brand:wikidata": "Q15899930",
         "brand:wikipedia": "zh:百老滙攝影器材",
         "brand:zh": "百老滙",
@@ -1581,7 +1581,7 @@
       "locationSet": {"include": ["hk"]},
       "tags": {
         "brand": "中原電器 Chung Yuen Electrical",
-        "brand:en" "Chung Yuen Electrical",
+        "brand:en": "Chung Yuen Electrical",
         "brand:wikidata": "Q10872623",
         "brand:wikipedia": "zh:中原電器",
         "brand:zh": "中原電器",

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -1545,6 +1545,51 @@
         "name:ja": "駿河屋",
         "shop": "electronics"
       }
+    },
+    {
+      "displayName": "豐澤 Fortress",
+      "locationSet": {"include": ["hk"]},
+      "tags": {
+        "brand": "豐澤 Fortress",
+        "brand:en" "Fortress",
+        "brand:wikidata": "Q15904138",
+        "brand:wikipedia": "zh:豐澤電器",
+        "brand:zh": "豐澤",
+        "name": "豐澤 Fortress",
+        "name:en": "Fortress",
+        "name:zh": "豐澤",
+        "shop": "electronics"
+      }
+    },
+    {
+      "displayName": "百老滙 Broadway",
+      "locationSet": {"include": ["hk"]},
+      "tags": {
+        "brand": "百老滙 Broadway",
+        "brand:en" "Broadway",
+        "brand:wikidata": "Q15899930",
+        "brand:wikipedia": "zh:百老滙攝影器材",
+        "brand:zh": "百老滙",
+        "name": "百老滙 Broadway",
+        "name:en": "Broadway",
+        "name:zh": "百老滙",
+        "shop": "electronics"
+      }
+    },
+    {
+      "displayName": "中原電器 Chung Yuen Electrical",
+      "locationSet": {"include": ["hk"]},
+      "tags": {
+        "brand": "中原電器 Chung Yuen Electrical",
+        "brand:en" "Chung Yuen Electrical",
+        "brand:wikidata": "Q10872623",
+        "brand:wikipedia": "zh:中原電器",
+        "brand:zh": "中原電器",
+        "name": "中原電器 Chung Yuen Electrical",
+        "name:en": "Chung Yuen Electrical",
+        "name:zh": "中原電器",
+        "shop": "electronics"
+      }
     }
   ]
 }


### PR DESCRIPTION
Add 
- 豐澤 Fortress
- 百老滙 Broadway
- 中原電器 Chung Yuen Electrical