### PR TITLE
Add Banks, Bakeries, Opticians, Parcel lockers, and Telecoms (TW) 

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -5766,7 +5766,7 @@
       "id": "hsbc-15f112",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["hk", "mo"]
+        "exclude": ["hk", "mo", "tw"]
       },
       "tags": {
         "amenity": "bank",
@@ -12485,6 +12485,7 @@
       "displayName": "三信商業銀行",
       "id": "cotacommercialbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["三信商銀", "三信銀行", "三信", "COTA Bank"],
       "tags": {
         "amenity": "bank",
         "brand": "三信商業銀行",
@@ -12538,6 +12539,7 @@
       "displayName": "上海商業儲蓄銀行",
       "id": "shanghaicommercialandsavingsbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["上海商銀", "上海銀行", "上銀", "SCSB"],
       "tags": {
         "amenity": "bank",
         "brand": "上海商業儲蓄銀行",
@@ -12790,6 +12792,7 @@
       "displayName": "中國信託商業銀行",
       "id": "ctbcbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["中國信託", "中信銀行", "中信商銀", "中信銀", "CTCB", "CTBC"],
       "tags": {
         "amenity": "bank",
         "brand": "中國信託商業銀行",
@@ -12955,6 +12958,7 @@
       "displayName": "京城商業銀行",
       "id": "kingstownbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["京城商銀", "京城銀", "京城銀行", "KTB"],
       "tags": {
         "amenity": "bank",
         "brand": "京城商業銀行",
@@ -13040,7 +13044,7 @@
       "displayName": "元大商業銀行",
       "id": "yuantacommercialbank-47d9e2",
       "locationSet": {"include": ["tw"]},
-      "matchNames": ["大眾商業銀行"],
+      "matchNames": ["元大商銀", "元大銀行", "大眾商業銀行", "大眾商銀", "大眾銀行", "TC Bank", "Yuanta Bank"],
       "tags": {
         "amenity": "bank",
         "brand": "元大商業銀行",
@@ -13061,6 +13065,7 @@
       "displayName": "兆豐國際商業銀行",
       "id": "megainternationalcommercialbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["兆豐商銀", "兆豐銀行", "兆豐銀", "兆豐", "Mega Bank"],
       "tags": {
         "amenity": "bank",
         "brand": "兆豐國際商業銀行",
@@ -13114,6 +13119,7 @@
       "displayName": "凱基商業銀行",
       "id": "kgicommercialbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["凱基商銀", "凱基銀行", "凱基銀", "凱基", "KGI Bank", "萬泰商業銀行", "萬泰商銀", "萬泰銀行", "萬泰銀", "萬泰", "Cosmos Bank"],
       "tags": {
         "amenity": "bank",
         "brand": "凱基商業銀行",
@@ -13307,6 +13313,7 @@
       "displayName": "台中商業銀行",
       "id": "taichungbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["台中商銀", "台中銀行", "台中銀"],
       "tags": {
         "amenity": "bank",
         "brand": "台中商業銀行",
@@ -13327,6 +13334,7 @@
       "displayName": "台北富邦商業銀行",
       "id": "taipeifubonbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["台北銀行", "富邦銀行", "台北富邦銀行", "台北富邦銀", "富邦銀", "台北銀", "台北富邦", "TFC"],
       "tags": {
         "amenity": "bank",
         "brand": "台北富邦商業銀行",
@@ -13347,6 +13355,7 @@
       "displayName": "台新國際商業銀行",
       "id": "taishininternationalbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["台新銀行", "台新銀", "Taishin Bank", "TSIB"],
       "tags": {
         "amenity": "bank",
         "brand": "台新國際商業銀行",
@@ -13367,6 +13376,7 @@
       "displayName": "合作金庫商業銀行",
       "id": "taiwancooperativebank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["合作金庫銀行", "合作金庫", "合庫商銀", "合庫銀行", "合庫銀", "合庫"],
       "tags": {
         "amenity": "bank",
         "brand": "合作金庫商業銀行",
@@ -13419,6 +13429,7 @@
       "displayName": "國泰世華商業銀行",
       "id": "cathayunitedbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["國泰世華銀行", "國泰世華", "CUB"],
       "tags": {
         "amenity": "bank",
         "brand": "國泰世華商業銀行",
@@ -13526,6 +13537,7 @@
       "displayName": "安泰商業銀行",
       "id": "entiecommercialbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["安泰商銀", "安泰銀行", "Entie Bank"],
       "tags": {
         "amenity": "bank",
         "brand": "安泰商業銀行",
@@ -13609,6 +13621,7 @@
       "displayName": "彰化商業銀行",
       "id": "changhwabank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["彰化銀行", "彰化商銀", "彰銀", "CCB", "CHB"],
       "tags": {
         "amenity": "bank",
         "brand": "彰化商業銀行",
@@ -13753,6 +13766,7 @@
       "displayName": "日盛國際商業銀行",
       "id": "jihsuninternationalcommercialbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["日盛商銀", "日盛銀行", "日盛", "JihSun Bank", "寶島商業銀行", "寶島商銀", "寶島銀行", "Baodao Commercial Bank", "Baodao Bank"],
       "tags": {
         "amenity": "bank",
         "brand": "日盛國際商業銀行",
@@ -13841,6 +13855,7 @@
       "displayName": "板信商業銀行",
       "id": "bankofpanshin-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["板信商銀", "板信銀行"],
       "tags": {
         "amenity": "bank",
         "brand": "板信商業銀行",
@@ -13893,6 +13908,7 @@
       "displayName": "永豐商業銀行",
       "id": "banksinopac-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["永豐商銀", "永豐銀行", "永豐銀", "華信商業銀行", "華信商銀", "華信銀行", "建華商業銀行", "建華商銀", "建華銀行", "台北國際商銀行", "台北商銀", "北商銀"],
       "tags": {
         "amenity": "bank",
         "brand": "永豐商業銀行",
@@ -13977,6 +13993,7 @@
       "displayName": "渣打國際商業銀行",
       "id": "standardcharteredtaiwan-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["渣打銀行", "渣打", "SCB", "新竹國際商業銀行", "新竹銀行"],
       "tags": {
         "amenity": "bank",
         "brand": "渣打國際商業銀行",
@@ -14029,6 +14046,7 @@
       "displayName": "玉山商業銀行",
       "id": "esuncommercialbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["玉山銀行", "玉山銀"],
       "tags": {
         "amenity": "bank",
         "brand": "玉山商業銀行",
@@ -14048,6 +14066,7 @@
       "displayName": "瑞興商業銀行",
       "id": "taipeistarbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["瑞興商銀", "瑞興銀行", "瑞興銀", "大台北商業銀行", "大台北銀行", "Bank of Taipei", "稻江商業銀行", "稻江商銀", "稻江銀行"],
       "tags": {
         "amenity": "bank",
         "brand": "瑞興商業銀行",
@@ -14088,6 +14107,7 @@
       "displayName": "第一商業銀行",
       "id": "firstcommercialbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["第一商銀", "第一銀行", "第一銀", "一銀", "First Bank", "FCB"],
       "tags": {
         "amenity": "bank",
         "brand": "第一商業銀行",
@@ -14107,6 +14127,7 @@
       "displayName": "聯邦商業銀行",
       "id": "unionbankoftaiwan-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["聯邦商銀", "聯邦銀行", "聯邦銀", "UBOT"],
       "tags": {
         "amenity": "bank",
         "brand": "聯邦商業銀行",
@@ -14126,6 +14147,7 @@
       "displayName": "臺灣中小企業銀行",
       "id": "taiwanbusinessbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["台灣中小企業銀行", "臺灣中小企銀", "台灣中小企銀", "臺灣企銀", "台灣企銀", "臺企銀", "台企銀", "TBB"],
       "tags": {
         "amenity": "bank",
         "brand": "臺灣中小企業銀行",
@@ -14145,6 +14167,7 @@
       "displayName": "臺灣土地銀行",
       "id": "landbankoftaiwan-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["台灣土地銀行", "土地銀行", "土銀"],
       "tags": {
         "amenity": "bank",
         "brand": "臺灣土地銀行",
@@ -14166,6 +14189,7 @@
       "displayName": "臺灣新光商業銀行",
       "id": "shinkongcommercialbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["台灣新光商業銀行", "新光商銀", "新光銀行", "新光銀", "SK Bank", "SKCB"],
       "tags": {
         "amenity": "bank",
         "brand": "臺灣新光商業銀行",
@@ -14186,6 +14210,7 @@
       "displayName": "臺灣銀行",
       "id": "bankoftaiwan-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["台灣銀行", "臺銀", "台銀", "BOT", "Taiwan Bank"],
       "tags": {
         "amenity": "bank",
         "brand": "臺灣銀行",
@@ -14273,6 +14298,7 @@
       "displayName": "華南商業銀行",
       "id": "huanancommercialbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["華南商銀", "華南銀行", "華銀", "Hua Nan Bank"],
       "tags": {
         "amenity": "bank",
         "brand": "華南商業銀行",
@@ -14293,6 +14319,7 @@
       "displayName": "華泰商業銀行",
       "id": "hwataicommercialbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["華泰商銀", "華泰銀行", "Hwatai Bank"],
       "tags": {
         "amenity": "bank",
         "brand": "華泰商業銀行",
@@ -14329,6 +14356,7 @@
       "displayName": "遠東國際商業銀行",
       "id": "fareasterninternationalbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["遠東商銀", "遠東銀行", "遠東銀", "遠銀", "FEIB"],
       "tags": {
         "amenity": "bank",
         "brand": "遠東國際商業銀行",
@@ -14349,6 +14377,7 @@
       "displayName": "陽信商業銀行",
       "id": "sunnycommercialbank-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["陽信商銀", "陽信銀行", "Sunny Bank"],
       "tags": {
         "amenity": "bank",
         "brand": "陽信商業銀行",
@@ -14406,6 +14435,7 @@
       "displayName": "高雄銀行",
       "id": "bankofkaohsiung-47d9e2",
       "locationSet": {"include": ["tw"]},
+      "matchNames": ["高雄市銀行", "高雄銀", "高銀", "BOK"],
       "tags": {
         "amenity": "bank",
         "brand": "高雄銀行",
@@ -14434,6 +14464,56 @@
         "brand:wikidata": "Q11677008",
         "brand:wikipedia": "ja:鹿児島銀行",
         "name": "鹿児島銀行"
+      }
+    },
+    {
+      "displayName": "滙豐（台灣）商業銀行",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["滙豐台灣", "台灣滙豐", "滙豐銀行", "滙豐商銀", "匯豐台灣", "台灣匯豐", "匯豐銀行", "匯豐商銀", "滙豐", "匯豐", "HSBC", "HSBC Taiwan", "中華商業銀行", "中華商銀", "中華銀行"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "HSBC",
+        "brand:en": "HSBC",
+        "brand:zh": "滙豐",
+        "brand:zh-Hans": "汇丰",
+        "brand:zh-Hant": "滙豐",
+        "brand:wikidata": "Q190464",
+        "brand:wikipedia": "zh:滙豐（台灣）商業銀行",
+        "name": "滙豐（台灣）商業銀行",
+        "name:en": "HSBC Bank Taiwan",
+        "name:zh": "滙豐（台灣）商業銀行"
+      }
+    },
+    {
+      "displayName": "星展（台灣）商業銀行",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["星展銀行", "星展台灣", "台灣星展", "DBS"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "星展銀行",
+        "brand:en": "DBS Bank",
+        "brand:wikidata": "Q705417",
+        "brand:wikipedia": "zh:星展銀行",
+        "brand:zh": "星展銀行",
+        "name": "星展（台灣）商業銀行",
+        "name:en": "DBS Bank Taiwan",
+        "name:zh": "星展（台灣）商業銀行"
+      }
+    },
+    {
+      "displayName": "花旗（台灣）商業銀行",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["花旗銀行", "花旗台灣", "台灣花旗", "華僑商業銀行", "華僑銀行", "僑銀", "OCCB"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "花旗銀行",
+        "brand:en": "Citibank",
+        "brand:wikidata": "Q857063",
+        "brand:wikipedia": "zh:花旗（台灣）商業銀行",
+        "brand:zh": "花旗銀行",
+        "name": "花旗（台灣）商業銀行",
+        "name:en": "Citibank Taiwan",
+        "name:zh": "花旗（台灣）商業銀行"
       }
     }
   ]

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -14509,7 +14509,7 @@
         "brand": "花旗銀行",
         "brand:en": "Citibank",
         "brand:wikidata": "Q857063",
-        "brand:wikipedia": "zh:花旗（台灣）商業銀行",
+        "brand:wikipedia": "zh:花旗銀行",
         "brand:zh": "花旗銀行",
         "name": "花旗（台灣）商業銀行",
         "name:en": "Citibank Taiwan",

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -14469,7 +14469,7 @@
     {
       "displayName": "滙豐（台灣）商業銀行",
       "locationSet": {"include": ["tw"]},
-      "matchNames": ["滙豐台灣", "台灣滙豐", "滙豐銀行", "滙豐商銀", "匯豐台灣", "台灣匯豐", "匯豐銀行", "匯豐商銀", "滙豐", "匯豐", "HSBC", "HSBC Taiwan", "中華商業銀行", "中華商銀", "中華銀行"],
+      "matchNames": ["滙豐台灣", "台灣滙豐", "滙豐銀行", "滙豐商銀", "匯豐台灣", "台灣匯豐", "匯豐銀行", "匯豐商銀", "滙豐", "匯豐", "HSBC", "HSBC Taiwan", "HBTW", "中華商業銀行", "中華商銀", "中華銀行"],
       "tags": {
         "amenity": "bank",
         "brand": "HSBC",
@@ -14478,7 +14478,7 @@
         "brand:zh-Hans": "汇丰",
         "brand:zh-Hant": "滙豐",
         "brand:wikidata": "Q190464",
-        "brand:wikipedia": "zh:滙豐（台灣）商業銀行",
+        "brand:wikipedia": "zh:汇丰",
         "name": "滙豐（台灣）商業銀行",
         "name:en": "HSBC Bank Taiwan",
         "name:zh": "滙豐（台灣）商業銀行"

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -1,13 +1,13 @@
 {
   "properties": {
     "path": "brands/amenity/parcel_locker",
-    "exclude": {"generic": ["^parcel locker$"]}
+    "exclude": { "generic": ["^parcel locker$"] }
   },
   "items": [
     {
       "displayName": "Allegro One Box",
       "id": "allegroonebox-ce4e28",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": { "include": ["pl"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "Allegro One Box",
@@ -52,7 +52,7 @@
     {
       "displayName": "Amazon Hub Locker (Deutschland)",
       "id": "amazonhublocker-83cc4d",
-      "locationSet": {"include": ["de"]},
+      "locationSet": { "include": ["de"] },
       "matchNames": ["amazon", "amazon locker"],
       "preserveTags": ["^name"],
       "tags": {
@@ -66,11 +66,8 @@
     {
       "displayName": "Amazon Hub ロッカー",
       "id": "amazonhublocker-5c1de3",
-      "locationSet": {"include": ["jp"]},
-      "matchNames": [
-        "amazon ロッカー",
-        "アマゾン・ハブ・ロッカー"
-      ],
+      "locationSet": { "include": ["jp"] },
+      "matchNames": ["amazon ロッカー", "アマゾン・ハブ・ロッカー"],
       "preserveTags": ["^name"],
       "tags": {
         "amenity": "parcel_locker",
@@ -87,7 +84,7 @@
     {
       "displayName": "Australia Post Parcel Locker",
       "id": "australiapostparcellocker-a2f344",
-      "locationSet": {"include": ["au"]},
+      "locationSet": { "include": ["au"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "Australia Post",
@@ -99,7 +96,7 @@
     {
       "displayName": "BalíkoBOX",
       "id": "balikobox-cda9c4",
-      "locationSet": {"include": ["sk"]},
+      "locationSet": { "include": ["sk"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "BalíkoBOX",
@@ -112,7 +109,7 @@
     {
       "displayName": "Balíkomat",
       "id": "balikomat-48c9bb",
-      "locationSet": {"include": ["cz"]},
+      "locationSet": { "include": ["cz"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "Balíkomat",
@@ -127,7 +124,7 @@
     {
       "displayName": "CityPaq",
       "id": "citypaq-0d29dc",
-      "locationSet": {"include": ["es"]},
+      "locationSet": { "include": ["es"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "CityPaq",
@@ -142,7 +139,7 @@
     {
       "displayName": "Costco.com",
       "id": "costcocom-b3da58",
-      "locationSet": {"include": ["us"]},
+      "locationSet": { "include": ["us"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "Costco",
@@ -154,7 +151,7 @@
     {
       "displayName": "DHL Packstation",
       "id": "dhlpackstation-83cc4d",
-      "locationSet": {"include": ["de"]},
+      "locationSet": { "include": ["de"] },
       "matchNames": ["packstation"],
       "tags": {
         "amenity": "parcel_locker",
@@ -170,7 +167,7 @@
     {
       "displayName": "Foxpost",
       "id": "foxpost-68603c",
-      "locationSet": {"include": ["hu"]},
+      "locationSet": { "include": ["hu"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "Foxpost",
@@ -180,7 +177,7 @@
     {
       "displayName": "GLS Parcel Locker",
       "id": "glsparcellocker-6a219a",
-      "locationSet": {"include": ["001"]},
+      "locationSet": { "include": ["001"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "GLS",
@@ -192,7 +189,7 @@
     {
       "displayName": "Locker InPost",
       "id": "lockerinpost-5fab02",
-      "locationSet": {"include": ["it", "uk"]},
+      "locationSet": { "include": ["it", "uk"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "Locker InPost",
@@ -205,7 +202,7 @@
     {
       "displayName": "My Post 24",
       "id": "mypost24-237d95",
-      "locationSet": {"include": ["ch"]},
+      "locationSet": { "include": ["ch"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "My Post 24",
@@ -225,7 +222,7 @@
     {
       "displayName": "Orlen Paczka",
       "id": "orlenpaczka-ce4e28",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": { "include": ["pl"] },
       "matchTags": ["amenity/post_box"],
       "tags": {
         "amenity": "parcel_locker",
@@ -239,7 +236,7 @@
     {
       "displayName": "Ozon Box",
       "id": "ozonbox-c00268",
-      "locationSet": {"include": ["ru"]},
+      "locationSet": { "include": ["ru"] },
       "matchNames": ["постамат ozon box"],
       "matchTags": ["amenity/post_box"],
       "tags": {
@@ -253,7 +250,7 @@
     {
       "displayName": "Packeta",
       "id": "zbox-5a86e9",
-      "locationSet": {"include": ["150"]},
+      "locationSet": { "include": ["150"] },
       "preserveTags": ["^name"],
       "tags": {
         "amenity": "parcel_locker",
@@ -265,7 +262,7 @@
     {
       "displayName": "Paczkomat InPost",
       "id": "paczkomatinpost-ce4e28",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": { "include": ["pl"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "Paczkomat InPost",
@@ -278,7 +275,7 @@
     {
       "displayName": "Paket24",
       "id": "paket24-30ebd7",
-      "locationSet": {"include": ["hr"]},
+      "locationSet": { "include": ["hr"] },
       "tags": {
         "alt_name": "Paketomat",
         "amenity": "parcel_locker",
@@ -294,7 +291,7 @@
     {
       "displayName": "Pakkeboksen",
       "id": "pakkeboksen-484cac",
-      "locationSet": {"include": ["dk"]},
+      "locationSet": { "include": ["dk"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "Pakkeboksen",
@@ -310,7 +307,7 @@
     {
       "displayName": "PickPoint",
       "id": "pickpoint-c00268",
-      "locationSet": {"include": ["ru"]},
+      "locationSet": { "include": ["ru"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "PickPoint",
@@ -321,7 +318,7 @@
     {
       "displayName": "Pickup Station",
       "id": "pickupstation-cbe86d",
-      "locationSet": {"include": ["fr"]},
+      "locationSet": { "include": ["fr"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "Pickup Station",
@@ -336,7 +333,7 @@
     {
       "displayName": "Post Abholstation",
       "id": "postabholstation-82dce7",
-      "locationSet": {"include": ["at"]},
+      "locationSet": { "include": ["at"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "Post Abholstation",
@@ -351,7 +348,7 @@
     {
       "displayName": "POST PackUp",
       "id": "packup-f54db3",
-      "locationSet": {"include": ["lu"]},
+      "locationSet": { "include": ["lu"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "POST Luxembourg",
@@ -365,7 +362,7 @@
     {
       "displayName": "PS Paketomat",
       "id": "pspaketomat-8c1608",
-      "locationSet": {"include": ["si"]},
+      "locationSet": { "include": ["si"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "PS Paketomat",
@@ -380,7 +377,7 @@
     {
       "displayName": "PUDOステーション",
       "id": "pudostation-5c1de3",
-      "locationSet": {"include": ["jp"]},
+      "locationSet": { "include": ["jp"] },
       "matchTags": ["amenity/post_box"],
       "tags": {
         "alt_name": "プドー・ステーション",
@@ -398,7 +395,7 @@
     {
       "displayName": "PuntoPoste",
       "id": "puntoposte-9e279b",
-      "locationSet": {"include": ["it"]},
+      "locationSet": { "include": ["it"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "PuntoPoste",
@@ -413,7 +410,7 @@
     {
       "displayName": "Smartpost",
       "id": "smartpost-0b87cc",
-      "locationSet": {"include": ["fi"]},
+      "locationSet": { "include": ["fi"] },
       "matchTags": ["amenity/post_box"],
       "tags": {
         "amenity": "parcel_locker",
@@ -427,7 +424,7 @@
     {
       "displayName": "Speedy",
       "id": "speedy-8234c4",
-      "locationSet": {"include": ["bg"]},
+      "locationSet": { "include": ["bg"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "Speedy",
@@ -440,7 +437,7 @@
     {
       "displayName": "Еконтомат",
       "id": "econt-8234c4",
-      "locationSet": {"include": ["bg"]},
+      "locationSet": { "include": ["bg"] },
       "preserveTags": ["^name"],
       "tags": {
         "alt_name": "Еконтомат",
@@ -459,7 +456,7 @@
     {
       "displayName": "ОмниСДЭК",
       "id": "omnicdek-c00268",
-      "locationSet": {"include": ["ru"]},
+      "locationSet": { "include": ["ru"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "ОмниСДЭК",
@@ -474,7 +471,7 @@
     {
       "displayName": "Продуктомат Утконос",
       "id": "fe7623-c00268",
-      "locationSet": {"include": ["ru"]},
+      "locationSet": { "include": ["ru"] },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "Продуктомат Утконос",
@@ -484,7 +481,7 @@
     {
       "displayName": "はこぽす",
       "id": "hakopost-5c1de3",
-      "locationSet": {"include": ["jp"]},
+      "locationSet": { "include": ["jp"] },
       "matchTags": ["amenity/post_box"],
       "tags": {
         "amenity": "parcel_locker",
@@ -500,25 +497,42 @@
     },
     {
       "displayName": "i郵箱",
-      "locationSet": {"include": ["tw"]},
+      "locationSet": { "include": ["tw"] },
       "matchNames": ["i郵箱", "iBox", "EZPOST"],
       "matchTags": ["amenity/post_box"],
       "tags": {
         "amenity": "parcel_locker",
         "brand": "i郵箱",
         "brand:en": "iBox",
+        "brand:nan": "i-iû-siuⁿ",
+        "brand:nan-HJ": "i郵箱",
+        "brand:nan-POJ": "i-iû-siuⁿ",
+        "brand:nan-TL": "i-iû-siunn",
+        "brand:wikidata": "Q4375439",
+        "brand:zh": "i郵箱",
         "name": "i郵箱",
         "name:en": "iBox",
         "name:zh": "i郵箱",
         "name:zh-Hans": "i邮箱",
         "name:zh-Hant": "i郵箱",
+        "opening_hours": "24/7",
         "operator": "中華郵政",
+        "operator:en": "Chunghwa Post",
+        "operator:nan": "Tiong-hôa Iû-chèng",
+        "operator:nan-HJ": "中華郵政",
+        "operator:nan-POJ": "Tiong-hôa Iû-chèng",
+        "operator:nan-TL": "Tiong-huâ Iû-tsìng",
+        "operator:wikidata": "Q4375439",
+        "operator:wikipedia": "zh:中華郵政",
         "operator:zh": "中華郵政",
         "operator:zh-Hans": "中华邮政",
         "operator:zh-Hant": "中華郵政",
-        "operator:wikidata": "Q4375439",
-        "operator:wikipedia": "zh:中華郵政",
-        "parcel_mail_in": "yes"
+        "parcel_mail_in": "yes",
+        "parcel_pickup": "yes",
+        "payment:ep_easycard": "yes",
+        "payment:ep_icash": "yes",
+        "payment:ep_ipass": "yes",
+        "refrigerated": "no"
       }
     }
   ]

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -515,7 +515,6 @@
         "name:zh": "i郵箱",
         "name:zh-Hans": "i邮箱",
         "name:zh-Hant": "i郵箱",
-        "opening_hours": "24/7",
         "operator": "中華郵政",
         "operator:en": "Chunghwa Post",
         "operator:nan": "Tiong-hôa Iû-chèng",
@@ -528,11 +527,7 @@
         "operator:zh-Hans": "中华邮政",
         "operator:zh-Hant": "中華郵政",
         "parcel_mail_in": "yes",
-        "parcel_pickup": "yes",
-        "payment:ep_easycard": "yes",
-        "payment:ep_icash": "yes",
-        "payment:ep_ipass": "yes",
-        "refrigerated": "no"
+        "parcel_pickup": "yes"
       }
     }
   ]

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -497,6 +497,29 @@
         "name:en": "Hakopost",
         "name:ja": "はこぽす"
       }
+    },
+    {
+      "displayName": "i郵箱",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["i郵箱", "iBox", "EZPOST"],
+      "matchTags": ["amenity/post_box"],
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "i郵箱",
+        "brand:en": "iBox",
+        "name": "i郵箱",
+        "name:en": "iBox",
+        "name:zh": "i郵箱",
+        "name:zh-Hans": "i邮箱",
+        "name:zh-Hant": "i郵箱",
+        "operator": "中華郵政",
+        "operator:zh": "中華郵政",
+        "operator:zh-Hans": "中华邮政",
+        "operator:zh-Hant": "中華郵政",
+        "operator:wikidata": "Q4375439",
+        "operator:wikipedia": "zh:中華郵政",
+        "parcel_mail_in": "yes"
+      }
     }
   ]
 }

--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -2412,6 +2412,34 @@
         "name:zh": "聖安娜餅屋",
         "shop": "bakery"
       }
+    },
+    {
+      "displayName": "福利麵包",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "福利麵包",
+        "brand:en": "Florida Bakery",
+        "brand:wikidata": "Q111128271",
+        "brand:zh": "福利麵包",
+        "name": "福利麵包",
+        "name:en": "Florida Bakery",
+        "name:zh": "福利麵包",
+        "shop": "bakery"
+      }
+    },
+    {
+      "displayName": "一之軒",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "一之軒",
+        "brand:en": "Ijysheng",
+        "brand:wikidata": "Q57269686",
+        "brand:zh": "一之軒",
+        "name": "一之軒",
+        "name:en": "Ijysheng",
+        "name:zh": "一之軒",
+        "shop": "bakery"
+      }
     }
   ]
 }

--- a/data/brands/shop/optician.json
+++ b/data/brands/shop/optician.json
@@ -1173,14 +1173,85 @@
     {
       "displayName": "眼鏡市場",
       "id": "meganeichiba-3bd301",
-      "locationSet": {"include": ["jp"]},
+      "locationSet": {"include": ["jp", "tw"]},
       "tags": {
         "brand": "眼鏡市場",
+        "brand:zh": "眼鏡市場",
+        "brand:zh-Hans": "眼镜市场",
+        "brand:zh-Hant": "眼鏡市場",
         "brand:en": "Megane Ichiba",
         "brand:wikidata": "Q11343506",
         "brand:wikipedia": "ja:メガネトップ",
         "name": "眼鏡市場",
+        "name:zh": "眼鏡市場",
+        "name:zh-Hans": "眼镜市场",
+        "name:zh-Hant": "眼鏡市場",
         "name:en": "Megane Ichiba",
+        "shop": "optician"
+      }
+    },
+    {
+      "displayName": "JINS",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "JINS",
+        "brand:en": "JINS",
+        "brand:ja": "ジンズ",
+        "brand:wikidata": "Q11308974",
+        "brand:wikipedia": "ja:ジンズ",
+        "name": "JINS",
+        "name:en": "JINS",
+        "name:ja": "ジンズ",
+        "shop": "optician"
+      }
+    },
+    {
+      "displayName": "OWNDAYS",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "オンデーズ",
+        "brand:en": "OWNDAYS",
+        "brand:ja": "オンデーズ",
+        "brand:wikidata": "Q11293025",
+        "brand:wikipedia": "ja:オンデーズ",
+        "name": "オンデーズ",
+        "name:en": "OWNDAYS",
+        "name:ja": "オンデーズ",
+        "shop": "optician"
+      }
+    },
+    {
+      "displayName": "OWNDAYS",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "OWNDAYS",
+        "brand:en": "OWNDAYS",
+        "brand:ja": "オンデーズ",
+        "brand:wikidata": "Q11293025",
+        "brand:wikipedia": "ja:オンデーズ",
+        "name": "OWNDAYS",
+        "name:en": "OWNDAYS",
+        "name:ja": "オンデーズ",
+        "shop": "optician"
+      }
+    },
+    {
+      "displayName": "寶島眼鏡",
+      "id": "4570f1-b2cb2d",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "寶島眼鏡",
+        "brand:en": "Eye Smart",
+        "brand:zh": "寶島眼鏡",
+        "brand:zh-Hans": "寶島眼鏡",
+        "brand:zh-Hant": "寶島眼鏡",
+        "brand:wikidata": "Q62391741",
+        "brand:wikipedia": "zh:寶島眼鏡",
+        "name": "寶島眼鏡",
+        "name:en": "Eye Smart",
+        "name:zh": "寶島眼鏡",
+        "name:zh-Hans": "寶島眼鏡",
+        "name:zh-Hant": "寶島眼鏡",
         "shop": "optician"
       }
     }

--- a/data/brands/shop/optician.json
+++ b/data/brands/shop/optician.json
@@ -1188,9 +1188,6 @@
         "brand:wikidata": "Q11343506",
         "brand:wikipedia": "ja:メガネトップ",
         "name": "眼鏡市場",
-        "name:zh": "眼鏡市場",
-        "name:zh-Hans": "眼镜市场",
-        "name:zh-Hant": "眼鏡市場",
         "name:en": "Megane Ichiba",
         "shop": "optician"
       }

--- a/data/brands/shop/optician.json
+++ b/data/brands/shop/optician.json
@@ -1144,9 +1144,17 @@
       "locationSet": {"include": ["tw"]},
       "tags": {
         "brand": "寶島眼鏡",
+        "brand:en": "Eye Smart",
+        "brand:zh": "寶島眼鏡",
+        "brand:zh-Hans": "宝島眼镜",
+        "brand:zh-Hant": "寶島眼鏡",
         "brand:wikidata": "Q62391741",
         "brand:wikipedia": "zh:寶島眼鏡",
         "name": "寶島眼鏡",
+        "name:en": "Eye Smart",
+        "name:zh": "寶島眼鏡",
+        "name:zh-Hans": "宝島眼镜",
+        "name:zh-Hant": "寶島眼鏡",
         "shop": "optician"
       }
     },
@@ -1236,22 +1244,21 @@
       }
     },
     {
-      "displayName": "寶島眼鏡",
-      "id": "4570f1-b2cb2d",
+      "displayName": "小林眼鏡",
       "locationSet": {"include": ["tw"]},
       "tags": {
-        "brand": "寶島眼鏡",
-        "brand:en": "Eye Smart",
-        "brand:zh": "寶島眼鏡",
-        "brand:zh-Hans": "寶島眼鏡",
-        "brand:zh-Hant": "寶島眼鏡",
-        "brand:wikidata": "Q62391741",
-        "brand:wikipedia": "zh:寶島眼鏡",
-        "name": "寶島眼鏡",
-        "name:en": "Eye Smart",
-        "name:zh": "寶島眼鏡",
-        "name:zh-Hans": "寶島眼鏡",
-        "name:zh-Hant": "寶島眼鏡",
+        "brand": "小林眼鏡",
+        "brand:en": "Kobayashi Optical",
+        "brand:zh": "小林眼鏡",
+        "brand:zh-Hans": "小林眼镜",
+        "brand:zh-Hant": "小林眼鏡",
+        "brand:wikidata": "Q18652598",
+        "brand:wikipedia": "zh:小林眼鏡",
+        "name": "小林眼鏡",
+        "name:en": "Kobayashi Optical",
+        "name:zh": "Kobayashi Optical",
+        "name:zh-Hans": "小林眼镜",
+        "name:zh-Hant": "小林眼鏡",
         "shop": "optician"
       }
     }

--- a/data/brands/shop/optician.json
+++ b/data/brands/shop/optician.json
@@ -1206,7 +1206,7 @@
       }
     },
     {
-      "displayName": "OWNDAYS",
+      "displayName": "オンデーズ",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "brand": "オンデーズ",

--- a/data/brands/shop/optician.json
+++ b/data/brands/shop/optician.json
@@ -1146,14 +1146,14 @@
         "brand": "寶島眼鏡",
         "brand:en": "Eye Smart",
         "brand:zh": "寶島眼鏡",
-        "brand:zh-Hans": "宝島眼镜",
+        "brand:zh-Hans": "宝岛眼镜",
         "brand:zh-Hant": "寶島眼鏡",
         "brand:wikidata": "Q62391741",
         "brand:wikipedia": "zh:寶島眼鏡",
         "name": "寶島眼鏡",
         "name:en": "Eye Smart",
         "name:zh": "寶島眼鏡",
-        "name:zh-Hans": "宝島眼镜",
+        "name:zh-Hans": " 宝岛眼镜",
         "name:zh-Hant": "寶島眼鏡",
         "shop": "optician"
       }
@@ -1181,7 +1181,23 @@
     {
       "displayName": "眼鏡市場",
       "id": "meganeichiba-3bd301",
-      "locationSet": {"include": ["jp", "tw"]},
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "眼鏡市場",
+        "brand:en": "Megane Ichiba",
+        "brand:wikidata": "Q11343506",
+        "brand:wikipedia": "ja:メガネトップ",
+        "name": "眼鏡市場",
+        "name:zh": "眼鏡市場",
+        "name:zh-Hans": "眼镜市场",
+        "name:zh-Hant": "眼鏡市場",
+        "name:en": "Megane Ichiba",
+        "shop": "optician"
+      }
+    },
+    {
+      "displayName": "眼鏡市場 Megane Ichiba",
+      "locationSet": {"include": ["tw"]},
       "tags": {
         "brand": "眼鏡市場",
         "brand:zh": "眼鏡市場",

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -363,6 +363,51 @@
         "name:zh": "遠傳電信",
         "shop": "telecommunication"
       }
+    },
+    {
+      "displayName": "台灣大哥大",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "台灣大哥大",
+        "brand:en": "Taiwan Mobile",
+        "brand:wikidata": "Q5943259",
+        "brand:wikipedia": "zh:台灣大哥大",
+        "brand:zh": "台灣大哥大",
+        "name": "台灣大哥大",
+        "name:en": "Taiwan Mobile",
+        "name:zh": "台灣大哥大",
+        "shop": "telecommunication"
+      }
+    },
+    {
+      "displayName": "台灣之星",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "台灣之星",
+        "brand:en": "T Star",
+        "brand:wikidata": "台灣之星",
+        "brand:wikipedia": "zh:台灣之星",
+        "brand:zh": "台灣之星",
+        "name": "台灣之星",
+        "name:en": "T Star",
+        "name:zh": "台灣之星",
+        "shop": "telecommunication"
+      }
+    },
+    {
+      "displayName": "亞太電信",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "亞太電信",
+        "brand:en": "Asia Pacific Telecom",
+        "brand:wikidata": "Q10882737",
+        "brand:wikipedia": "zh:亞太電信",
+        "brand:zh": "亞太電信",
+        "name": "亞太電信",
+        "name:en": "Asia Pacific Telecom",
+        "name:zh": "亞太電信",
+        "shop": "telecommunication"
+      }
     }
   ]
 }


### PR DESCRIPTION
Changes:
modified:   data/brands/amenity/bank.json
+ HSBC, DBS, Citibank
± acronyms of existing banks
modified:   data/brands/amenity/parcel_locker.json
+ iBox
modified:   data/brands/shop/bakery.json
+ Florida, Ijysheng
modified:   data/brands/shop/optician.json
+ JINS, OWNDAYS, Kobayashi Optical
modified:   data/brands/shop/telecommunication.json
+ Taiwan Mobile, T STAR, APT