### PR TITLE
Caffè Nero countries

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -576,7 +576,7 @@
       "displayName": "Caffè Nero",
       "id": "caffenero-4a2ca5",
       "locationSet": {
-        "include": ["gb", "ie", "tr", "us"]
+        "include": ["ae", "cy", "gb", "hr", "ie", "om", "pl", "se", "tr", "us"]
       },
       "matchNames": ["cafe nero"],
       "tags": {


### PR DESCRIPTION
> runs more than 1000 coffee houses in eleven countries: the UK, Ireland, Sweden, Poland, Cyprus, Croatia, Turkey, the UAE, Oman, United States

https://en.wikipedia.org/wiki/Caff%C3%A8_Nero