### PR TITLE
add some brands

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -1551,11 +1551,13 @@
     },
     {
       "displayName": "Life Pharmacy",
-      "id": "lifepharmacy-f5140f",
-      "locationSet": {"include": ["001"]},
+      "id": "lifepharmacy-8496bc",
+      "locationSet": {"include": ["nz"]},
       "tags": {
         "amenity": "pharmacy",
         "brand": "Life Pharmacy",
+        "brand:wikidata": "Q7180825",
+        "brand:wikipedia": "en:Life Pharmacy",
         "healthcare": "pharmacy",
         "name": "Life Pharmacy"
       }

--- a/data/brands/shop/department_store.json
+++ b/data/brands/shop/department_store.json
@@ -726,7 +726,7 @@
       }
     },
     {
-      "displayName": "Kmart (Australia)",
+      "displayName": "Kmart (Australia/NZ)",
       "id": "kmart-2e4a6e",
       "locationSet": {"include": ["au", "nz"]},
       "tags": {

--- a/data/brands/shop/mall.json
+++ b/data/brands/shop/mall.json
@@ -100,7 +100,7 @@
       }
     },
     {
-      "displayName": "Westfield (Australia)",
+      "displayName": "Westfield (Australia/NZ)",
       "id": "westfield-1e4415",
       "locationSet": {"include": ["au", "nz"]},
       "tags": {

--- a/data/operators/building/warehouse.json
+++ b/data/operators/building/warehouse.json
@@ -1,0 +1,60 @@
+{
+  "properties": {
+    "path": "operators/building/warehouse",
+    "exclude": {"generic": ["^warehouse$"]}
+  },
+  "items": [
+    {
+      "displayName": "Alsco",
+      "id": "alsco-a0f417",
+      "locationSet": {"include": ["001"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "building": "warehouse",
+        "name": "Alsco",
+        "operator": "Alsco",
+        "operator:wikidata": "Q60752605",
+        "operator:wikipedia": "en:Alsco"
+      }
+    },
+    {
+      "displayName": "Americold",
+      "id": "americold-a0f417",
+      "locationSet": {"include": ["001"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "building": "warehouse",
+        "name": "Americold",
+        "operator": "Americold",
+        "operator:wikidata": "Q24197334",
+        "operator:wikipedia": "en:Americold"
+      }
+    },
+    {
+      "displayName": "Mainfreight",
+      "id": "mainfreight-a0f417",
+      "locationSet": {"include": ["001"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "building": "warehouse",
+        "name": "Mainfreight",
+        "operator": "Mainfreight",
+        "operator:wikidata": "Q3278352",
+        "operator:wikipedia": "en:Mainfreight"
+      }
+    },
+    {
+      "displayName": "Toll",
+      "id": "toll-a0f417",
+      "locationSet": {"include": ["001"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "building": "warehouse",
+        "name": "Toll",
+        "operator": "Toll",
+        "operator:wikidata": "Q1674371",
+        "operator:wikipedia": "en:Toll Group"
+      }
+    }
+  ]
+}

--- a/data/operators/man_made/pipeline.json
+++ b/data/operators/man_made/pipeline.json
@@ -1,0 +1,44 @@
+{
+  "properties": {
+    "path": "operators/man_made/pipeline",
+    "exclude": {"generic": ["^pipeline$"]}
+  },
+  "items": [
+    {
+      "displayName": "First Gas",
+      "id": "firstgas-22b69e",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "man_made": "pipeline",
+        "operator": "First Gas",
+        "operator:wikidata": "Q24998649",
+        "operator:wikipedia": "en:First Gas",
+        "substance": "gas"
+      }
+    },
+    {
+      "displayName": "Powerco",
+      "id": "powerco-22b69e",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "man_made": "pipeline",
+        "operator": "Powerco",
+        "operator:wikidata": "Q7236675",
+        "operator:wikipedia": "en:Powerco",
+        "substance": "gas"
+      }
+    },
+    {
+      "displayName": "Vector",
+      "id": "vector-22b69e",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "man_made": "pipeline",
+        "operator": "Vector",
+        "operator:wikidata": "Q7917807",
+        "operator:wikipedia": "en:Vector Limited",
+        "substance": "gas"
+      }
+    }
+  ]
+}

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -5451,10 +5451,12 @@
     },
     {
       "displayName": "Vector",
-      "id": "vector-116894",
-      "locationSet": {"include": ["001"]},
+      "id": "vector-737a3a",
+      "locationSet": {"include": ["nz"]},
       "tags": {
         "operator": "Vector",
+        "operator:wikidata": "Q7917807",
+        "operator:wikipedia": "en:Vector Limited",
         "power": "line"
       }
     },


### PR DESCRIPTION
This PR adds 4 logistics companies, 3 gas pipeline operators, and 1 pharmacy chain.

I've also tweaked the `displayName` of 2 Australian brands, since the current label is a source of confusion when editing in New Zealand.