### PR TITLE
Unify EnBW

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -1133,16 +1133,17 @@
       }
     },
     {
-      "displayName": "EnBW",
+      "displayName": "EnBW Energie Baden-Württemberg AG",
       "id": "enbw-1299a8",
       "locationSet": {"include": ["de"]},
       "matchNames": [
-        "enbw energie baden-württemberg ag",
+        "enbw",
+        "enbw energie baden-württemberg",
         "energie baden-württemberg ag"
       ],
       "tags": {
         "amenity": "charging_station",
-        "operator": "EnBW",
+        "operator": "EnBW Energie Baden-Württemberg AG",
         "operator:wikidata": "Q644304",
         "operator:wikipedia": "de:EnBW Energie Baden-Württemberg"
       }

--- a/data/operators/power/plant.json
+++ b/data/operators/power/plant.json
@@ -367,11 +367,14 @@
       }
     },
     {
-      "displayName": "EnBW",
+      "displayName": "EnBW Energie Baden-Württemberg AG",
       "id": "enbw-e6c8aa",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["enbw"],
       "tags": {
-        "operator": "EnBW",
+        "operator": "EnBW Energie Baden-Württemberg AG",
+        "operator:wikidata": "Q644304",
+        "operator:wikipedia": "de:EnBW Energie Baden-Württemberg",
         "power": "plant"
       }
     },


### PR DESCRIPTION
The same name should be used for all amenities operated by EnBW.

There are also some entries for `EnBW`/`EnBW AG` in https://github.com/osmlab/name-suggestion-index/blob/main/data/operators/power/substation.json which should not be there. EnBW does not operate any electricity transmission infrastructure anymore, these are now operated either by TransnetBW GmbH or Netze BW GmbH. `enbw` is listed as `exclude` in this file, not sure why it still gets added.