### PR TITLE
Loft is a Japanese department store brand

### DIFF
--- a/data/brands/shop/department_store.json
+++ b/data/brands/shop/department_store.json
@@ -1444,6 +1444,23 @@
       }
     },
     {
+      "displayName": "ロフト",
+      "id": "loft-289da6",
+      "locationSet": {"include": ["jp"]},
+      "matchTags": ["shop/hardware"],
+      "tags": {
+        "brand": "ロフト",
+        "brand:en": "Loft",
+        "brand:ja": "ロフト",
+        "brand:wikidata": "Q5358428",
+        "brand:wikipedia": "ja:ロフト (雑貨店)",
+        "name": "ロフト",
+        "name:en": "Loft",
+        "name:ja": "ロフト",
+        "shop": "department_store"
+      }
+    },
+    {
       "displayName": "東急ハンズ",
       "id": "tokyuhands-96cf7b",
       "locationSet": {"include": ["jp"]},

--- a/data/brands/shop/hardware.json
+++ b/data/brands/shop/hardware.json
@@ -322,22 +322,6 @@
         "name": "Хозяйственный магазин",
         "shop": "hardware"
       }
-    },
-    {
-      "displayName": "ロフト",
-      "id": "loft-289da6",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "brand": "ロフト",
-        "brand:en": "Loft",
-        "brand:ja": "ロフト",
-        "brand:wikidata": "Q5358428",
-        "brand:wikipedia": "ja:ロフト (雑貨店)",
-        "name": "ロフト",
-        "name:en": "Loft",
-        "name:ja": "ロフト",
-        "shop": "hardware"
-      }
     }
   ]
 }


### PR DESCRIPTION
Loft was incorrectly tagged as a hardware shop when it actually is a department store selling household goods

https://www.loft.co.jp/en/about_us.html
https://en.japantravel.com/tokyo/shopping-at-loft/26841
https://jw-webmagazine.com/loft-the-coolest-store-to-shop-cutting-edge-gifts-5d776944268b/