### PR TITLE
Changes to Econt

### DIFF
--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -9,7 +9,7 @@
         "^kantor( pos)?$",
         "^po[sš]t[aeo]$",
         "^post\\s?(agentur|filiale|office|partner|stelle)?$",
-        "^главпочтамт|еконт$",
+        "^главпочтамт$",
         "^по(чт|шт|щ)а$",
         "^почтовое отделение$",
         "^اداره پست$",
@@ -1401,7 +1401,7 @@
       "displayName": "Еконт",
       "id": "27c606-03f0fb",
       "locationSet": {"include": ["bg"]},
-      "matchNames": ["econt", "ekont"],
+      "matchNames": ["econt", "ekont", "еконт"],
       "tags": {
         "amenity": "post_office",
         "operator": "Еконт Експрес ЕООД",


### PR DESCRIPTION
Removed `еконт` from the generic names and added it to `matchNames`.