### PR TITLE
Distinguish Hudson, Hudson News, Hudson Booksellers

### DIFF
--- a/data/brands/shop/books.json
+++ b/data/brands/shop/books.json
@@ -368,6 +368,17 @@
       }
     },
     {
+      "displayName": "Hudson Booksellers",
+      "id": "hudsonbooksellers-285257",
+      "locationSet": {"include": ["ca", "us"]},
+      "tags": {
+        "brand": "Hudson Booksellers",
+        "brand:wikidata": "Q111534550",
+        "name": "Hudson Booksellers",
+        "shop": "books"
+      }
+    },
+    {
       "displayName": "Hugendubel",
       "id": "hugendubel-65e1d5",
       "locationSet": {"include": ["de"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1440,6 +1440,17 @@
       }
     },
     {
+      "displayName": "Hudson",
+      "id": "hudson-16ec4d",
+      "locationSet": {"include": ["ca", "us"]},
+      "tags": {
+        "brand": "Hudson",
+        "brand:wikidata": "Q111534515",
+        "name": "Hudson",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "Hursts",
       "id": "hursts-232829",
       "locationSet": {"include": ["gb"]},

--- a/data/brands/shop/newsagent.json
+++ b/data/brands/shop/newsagent.json
@@ -34,15 +34,15 @@
       }
     },
     {
-      "displayName": "Hudson",
-      "id": "hudson-a0252c",
+      "displayName": "Hudson News",
+      "id": "hudsonnews-a0252c",
       "locationSet": {"include": ["ca", "us"]},
-      "matchNames": ["hudson news"],
+      "matchNames": ["hudson"],
       "tags": {
-        "brand": "Hudson",
-        "brand:wikidata": "Q5928682",
-        "brand:wikipedia": "en:Hudson Group",
-        "name": "Hudson",
+        "brand": "Hudson News",
+        "brand:wikidata": "Q5928787",
+        "brand:wikipedia": "ja:ハドソン・ニュース",
+        "name": "Hudson News",
         "shop": "newsagent"
       }
     },


### PR DESCRIPTION
Hudson and Hudson News are distinct brands. Hudson is a convenience store chain while Hudson News is a newsstand chain. The parent company [considers](https://www.hudsongroup.com/about-us/our-retail-brands) Hudson to be a complement to the venerable Hudson News format, even if the former seems to be taking over the latter in raw numbers. Recently, I encountered this distinction at Harry Reid International Airport in Las Vegas, which has multiple locations of both brands. In Terminal C, there was [a Hudson](https://www.openstreetmap.org/node/2432759301) just 5&nbsp;yards away from [a larger Hudson News](https://www.openstreetmap.org/node/9652693238), one gate down and on the other side of the hallway, and another Hudson was visible off in the distance.

<img src="https://user-images.githubusercontent.com/1231218/162527494-88c9bd13-893a-4289-b2ac-4d8dab012bf9.jpg" width="350" alt="Hudson"> <img src="https://user-images.githubusercontent.com/1231218/162527512-a3cfe836-d092-42ee-bcf4-31cdd57259d2.jpg" width="350" alt="Hudson News">

The two brands have some overlap in their offerings, but the latter is a larger store format with less of a focus on travel essentials. Only Hudson News had periodicals out in front, but not many. Hudson (the company) also owns two airport bookstore chains, Hudson Booksellers and Ink by Hudson.

6c592f9c5f28680b5c06a336fdaca7e4cdf17bbd for #2372 added Hudson News as `shop=newsagent` based on existing usage in OSM. #2811 added Hudson as `shop=convenience`, noting that many Hudson News locations were being converted to Hudson locations. 1b5ea1777fafca0ec076a0881f38e1f3ffcca632 merged the two entries, keeping `shop=newsagent` `name=Hudson`. This PR essentially reverts that part of 1b5ea1777fafca0ec076a0881f38e1f3ffcca632.

These entries had been linked to a Wikidata item about [the company formerly known as Hudson Group](https://www.wikidata.org/wiki/Q5928682), although Wikidata had a separate item for [Hudson News](https://www.wikidata.org/wiki/Q5928787). I changed the Hudson News entry to link to that Wikidata item (and the associated Japanese Wikipedia article). I also created Wikidata items for [Hudson](https://www.wikidata.org/wiki/Q111534515), [Hudson Booksellers](https://www.wikidata.org/wiki/Q111534550), and [Ink by Hudson](https://www.wikidata.org/wiki/Q111534597), although I didn’t add an NSI entry for the last chain, which only has three locations so far.

I’m not sure what will happen to existing POIs. Will iD offer to rename “Hudson” to “Hudson News”, or will it offer to change it from `shop=newsagent` to `shop=convenience`? Or will it do nothing because the company’s QID will no longer be used by any entry?

/cc @tas50 @bhousel