### PR TITLE
Ole & Steen bakeries in England and New York

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -1386,6 +1386,22 @@
       }
     },
     {
+      "displayName": "Ole & Steen",
+      "locationSet": {
+        "include": [
+          "gb-eng",
+          "new_york_city.geojson"
+        ]
+      },
+      "tags": {
+        "brand": "Ole & Steen",
+        "brand:wikidata": "Q12323572",
+        "brand:wikipedia": "en:Ole & Steen",
+        "name": "Ole & Steen",
+        "shop": "bakery"
+      }
+    },
+    {
       "displayName": "Oskroba",
       "id": "oskroba-839c38",
       "locationSet": {"include": ["pl"]},


### PR DESCRIPTION
The Danish bakery brand Lagkagehuset operates in London, Oxford and New York under the brand name Ole & Steen

https://oleandsteen.co.uk/stores
https://oleandsteen.us/stores