### PR TITLE
Fill in San Joaquin Valley Railroad detail

### DIFF
--- a/data/operators/route/railway.json
+++ b/data/operators/route/railway.json
@@ -390,9 +390,16 @@
     {
       "displayName": "San Joaquin Valley Railroad",
       "id": "sanjoaquinvalleyrailroad-954af4",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "matchNames": [
+        "sjvr"
+      ],
       "tags": {
         "operator": "San Joaquin Valley Railroad",
+        "operator:wikidata": "Q7414408",
+        "operator:wikipedia": "en:San Joaquin Valley Railroad",
         "route": "railway"
       }
     },


### PR DESCRIPTION
Adding Wikipedia and Wikidata tags, matching reporting mark of `SJVR`, and restricting location to California.