### PR TITLE
Change Petrol English name

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -5523,11 +5523,11 @@
       "tags": {
         "amenity": "fuel",
         "brand": "Петрол",
-        "brand:en": "Petrol AD",
+        "brand:en": "Petrol",
         "brand:wikidata": "Q24315",
         "brand:wikipedia": "en:Petrol AD",
         "name": "Петрол",
-        "name:en": "Petrol AD"
+        "name:en": "Petrol"
       }
     },
     {


### PR DESCRIPTION
I'm not sure if it will cause any conflicts because `Petrol` is considered a generic name.