### PR TITLE
Hackney Tennis

### DIFF
--- a/data/operators/leisure/pitch.json
+++ b/data/operators/leisure/pitch.json
@@ -1,0 +1,21 @@
+{
+  "properties": {
+    "path": "operators/leisure/pitch",
+    "exclude": {"generic": ["^pitch$"]}
+  },
+  "items": [
+    {
+      "displayName": "Hackney Tennis",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
+      "tags": {
+        "leisure": "pitch",
+        "operator": "Hackney Tennis",
+        "operator:wikidata": "Q111630138",
+        "reservation": "required",
+        "sport": "tennis"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Hackney Tennis is a not for profit operating tennis courts in the borough of Hackney for which a booking is required