### PR TITLE
Chilango

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -1096,6 +1096,19 @@
       }
     },
     {
+      "displayName": "Chilango",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Chilango",
+        "brand:wikidata": "Q107610595",
+        "brand:wikipedia": "en:Chilango (restaurant chain)",
+        "cuisine": "mexican",
+        "name": "Chilango",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "China in Box",
       "id": "chinainbox-ffb863",
       "locationSet": {"include": ["br"]},


### PR DESCRIPTION
Chilango operates Mexican fast food locations in London, Manchester and Brighton