### PR TITLE
Add Kuhn, a Swiss bakery chain

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -1043,6 +1043,17 @@
       }
     },
     {
+      "displayName": "Kuhn",
+      "id": "kuhn-6950bd",
+      "locationSet": {"include": ["ch"]},
+      "tags": {
+        "brand": "Kuhn",
+        "brand:wikidata": "Q111728345",
+        "name": "Kuhn",
+        "shop": "bakery"
+      }
+    },
+    {
       "displayName": "La Mie Câline",
       "id": "lamiecaline-731a34",
       "locationSet": {"include": ["fr"]},


### PR DESCRIPTION
Kuhn is a common name in Switzerland, so we’re restricting matches
to features that are already tagged as `shop=bakery`.