### PR TITLE
Added Shoppers (Baltimore/DC area supermarket chain)

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -5404,6 +5404,17 @@
       }
     },
     {
+      "displayName": "Shoppers Food & Pharmacy",
+      "id": "",
+      "locationSet": {"include": ["baltimore_and_dc.geojson"]},
+      "tags": {
+        "brand:": "Shoppers",
+        "brand:wikidata": "Q7501183",
+        "name": "Shoppers Food & Pharmacy",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Shoprite (Africa)",
       "id": "shoprite-56f959",
       "locationSet": {

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -5408,7 +5408,7 @@
       "id": "",
       "locationSet": {"include": ["baltimore_and_dc.geojson"]},
       "tags": {
-        "brand:": "Shoppers",
+        "brand": "Shoppers",
         "brand:wikidata": "Q7501183",
         "name": "Shoppers Food & Pharmacy",
         "shop": "supermarket"


### PR DESCRIPTION
Added Shoppers (Baltimore/DC area supermarket chain). Logo can be derived from Facebook/Twitter pages on the Wikidata. "id" field is blank in my pull request