### PR TITLE
Update public_bookcase.json

### DIFF
--- a/data/brands/amenity/public_bookcase.json
+++ b/data/brands/amenity/public_bookcase.json
@@ -67,7 +67,7 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "public_bookcase",
-        "brand": "Minibieb.nl",
+        "brand": "Minibieb",
         "name": "Minibieb"
       }
     },

--- a/data/brands/amenity/public_bookcase.json
+++ b/data/brands/amenity/public_bookcase.json
@@ -19,6 +19,17 @@
       }
     },
     {
+      "displayName": "Official BookCrossing Zone (OBCZ)",
+      "id": "bookcrossing-6e8312",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "public_bookcase",
+        "brand": "BookCrossing",
+        "brand:wikidata": "Q324286"
+        "name": "OBCZ"
+      }
+    },
+    {
       "displayName": "Bücherzelle",
       "id": "bucherzelle-6e8312",
       "locationSet": {"include": ["001"]},
@@ -26,6 +37,17 @@
         "amenity": "public_bookcase",
         "brand": "Bücherzelle",
         "name": "Bücherzelle"
+      }
+    },
+    {
+      "displayName": "KinderzwerfboekStation",
+      "id": "kinderzwerfboek-6e8312",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "public_bookcase",
+        "brand": "Kinderzwerfboek",
+        "name": "KinderzwerfboekStation",
+        "books": "children"
       }
     },
     {
@@ -37,6 +59,16 @@
         "brand": "Little Free Library",
         "brand:wikidata": "Q6650101",
         "name": "Little Free Library"
+      }
+    },
+    {
+      "displayName": "Minibieb",
+      "id": "minibieb-6e8312",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "public_bookcase",
+        "brand": "Minibieb.nl",
+        "name": "Minibieb"
       }
     },
     {

--- a/data/brands/amenity/public_bookcase.json
+++ b/data/brands/amenity/public_bookcase.json
@@ -25,7 +25,7 @@
       "tags": {
         "amenity": "public_bookcase",
         "brand": "BookCrossing",
-        "brand:wikidata": "Q324286"
+        "brand:wikidata": "Q324286",
         "name": "OBCZ"
       }
     },


### PR DESCRIPTION
Added Official BookCrossing Zone (OBCZ), KinderzwerfboekStation, Minibieb

Noteably, KinderzwerfboekStations don't have to be exclusively children books. However, a similar thing applies to the name tag, where the name is not required to be "KinderzwerfboekStation".