### PR TITLE
Limit "Продуктовий" to Ukraine

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -4112,7 +4112,7 @@
     {
       "displayName": "Продуктовий",
       "id": "337654-4d6b4b",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["ua"]},
       "tags": {
         "brand": "Продуктовий",
         "name": "Продуктовий",


### PR DESCRIPTION
This name looks like a typo in "Продуктовый" (common Russian name for convenience stores), and often pops up when searching for a type. This will fix the issue for russian users.

[This overpass query](http://overpass-turbo.eu/?Q=%5Bout%3Ajson%5D%5Btimeout%3A250%5D%3B%0A(%0A%20%20node%5B%22name%22%3D%22%D0%9F%D1%80%D0%BE%D0%B4%D1%83%D0%BA%D1%82%D0%BE%D0%B2%D0%B8%D0%B9%22%5D%3B%0A%20%20way%5B%22name%22%3D%22%D0%9F%D1%80%D0%BE%D0%B4%D1%83%D0%BA%D1%82%D0%BE%D0%B2%D0%B8%D0%B9%22%5D%3B%0A)%3B%0Aout%20body%3B%0A%3E%3B%0Aout%20skel%20qt%3B&C=48.8916;30.49156;5) confirms it's an Ukrainian brand.