### PR TITLE
Added Baltimore Police Department-operated light tower entry

### DIFF
--- a/data/operators/man_made/mast.json
+++ b/data/operators/man_made/mast.json
@@ -1,0 +1,22 @@
+{
+  "properties": {
+    "path": "operators/man_made/mast",
+    "skipCollection": true,
+    "exclude": {"generic": ["^mast"]}
+  },
+  "items": [
+    {
+      "displayName": "BPD Light Tower",
+      "id": "",
+      "locationSet": {"include": ["baltimore_and_dc.geojson"]},
+      "tags": {
+        "man_made": "mast",
+        "operator": "Baltimore Police Department",
+        "operator:short": "BPD",
+        "operator:wikidata": "Q2881660",
+        "tower:type": "lighting",
+        "tower:construction": "freestanding"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
There are no existing entries for Tag:man_made=mast, so it is possible I missed a step here in how to add this. It did look like there is at least some precedent for adding an item like this though, based on the presence of other man_made entries, and some entries for similar infrastructure.

In case it would be helpful to know what these look like, here is an image: https://commons.wikimedia.org/wiki/File:Penn-North_Light_Tower_by_Woodbrook_Ave.jpg

And the corresponding object on OSM: https://www.openstreetmap.org/node/9702020055

These are common to see permanently stationed at various intersections throughout the city. It would be helpful to have these tags grouped together with an iD preset through NSI.