### PR TITLE
Remove name tags for Hong Kong Red Cross

### DIFF
--- a/data/brands/healthcare/blood_donation.json
+++ b/data/brands/healthcare/blood_donation.json
@@ -122,12 +122,7 @@
         "brand:zh": "香港紅十字會",
         "brand:zh-Hans": "香港红十字会",
         "brand:zh-Hant": "香港紅十字會",
-        "healthcare": "blood_donation",
-        "name": "香港紅十字會 Hong Kong Red Cross",
-        "name:en": "Hong Kong Red Cross",
-        "name:zh": "香港紅十字會",
-        "name:zh-Hans": "香港红十字会",
-        "name:zh-Hant": "香港紅十字會"
+        "healthcare": "blood_donation"
       }
     }
   ]


### PR DESCRIPTION
The name tag for Hong Kong Red Cross should be used the Donor Centre's name.
https://www.redcross.org.hk/en/Service_Directory/BTS.html