### PR TITLE
Switch to ‘out center’ in overpass queries

### DIFF
--- a/app/src/CategoryRow.jsx
+++ b/app/src/CategoryRow.jsx
@@ -35,9 +35,7 @@ export default function CategoryRow(props) {
     let bn = tags['brand'];
     overpassQuery = `[out:json][timeout:100];
 (nwr["name"="${n}"];);
-out body;
->;
-out skel qt;
+out center;
 
 {{style:
 node,
@@ -61,9 +59,7 @@ relation[${k}=${v}][brand=${bn}][brand:wikidata=${qid}]
     qid = tags['flag:wikidata'];
     overpassQuery = `[out:json][timeout:100];
 (nwr["flag:name"="${n}"];);
-out body;
->;
-out skel qt;`;
+out center;`;
 
   } else if (t === 'operators') {
     n = item.tags.operator;
@@ -72,9 +68,7 @@ out skel qt;`;
     qid = tags['operator:wikidata'];
     overpassQuery = `[out:json][timeout:100];
 (nwr["operator"="${n}"];);
-out body;
->;
-out skel qt;
+out center;
 
 {{style:
 node,


### PR DESCRIPTION
For brands, flags, and operators, but not for transit

Advantages:

- Smaller response size
- Easier render for Leaflet's little brain
- More readable statistics for the main use case of this query:
  before, overpass turbo shows e.g. ‘pois: 64, polygons 58’.
  after, shows ‘pois: 122’ and shows a breakdown of how many of your
  pois were nodes, ways, or relations; nodes comprising the geometry of
  features are excluded.