### PR TITLE
Giraffe Stop

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -2340,6 +2340,20 @@
       }
     },
     {
+      "displayName": "Giraffe Stop",
+      "locationSet": {
+        "include": ["ae", "es", "gb"]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Giraffe",
+        "brand:wikidata": "Q5564102",
+        "cuisine": "international;burger",
+        "name": "Giraffe Stop",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Gold Star Chili",
       "id": "goldstarchili-4d2ff4",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Giraffe has a sub-brand called Giraffe Stop that is more like a fast food restaurant where you need to order at the counter https://boparanrestaurantgroup.co.uk/giraffe-stop/