### PR TITLE
Add LADOT-operated routes

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -3319,7 +3319,7 @@
     }
     {
       "displayName": "DASH",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["lausd_los_angeles.geojson"]},
       "tags": {
         "network": "DASH", 
         "route": "bus",

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -3316,7 +3316,7 @@
       "locationSet": {"include": ["us"]},
       "note": "There are at least 4 different bus networks in US named 'DASH.' They should be split.",
       "tags": {"network": "DASH", "route": "bus"}
-    }
+    },
     {
       "displayName": "DASH",
       "locationSet": {"include": ["lausd_los_angeles.geojson"]},

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -2854,6 +2854,7 @@
       "locationSet": {"include": ["us-ca.geojson"]},
       "tags": {
         "network": "Commuter Express",
+        "network:wikidata": "Q112028995",
         "route": "bus",
         "operator": "Los Angeles Department of Transportation",
         "operator:wikidata": "Q3259703"
@@ -3321,7 +3322,8 @@
       "displayName": "DASH",
       "locationSet": {"include": ["lausd_los_angeles.geojson"]},
       "tags": {
-        "network": "DASH", 
+        "network": "DASH",
+        "network:wikidata": "Q112028960",
         "route": "bus",
         "operator": "Los Angeles Department of Transportation",
         "operator:wikidata": "Q3259703"

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -3319,7 +3319,7 @@
       "tags": {"network": "DASH", "route": "bus"}
     },
     {
-      "displayName": "DASH",
+      "displayName": "DASH (Los Angeles)",
       "locationSet": {"include": ["lausd_los_angeles.geojson"]},
       "tags": {
         "network": "DASH",

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -2851,7 +2851,7 @@
     {
       "displayName": "Commuter Express",
       "id": "commuterexpress-a21cc9",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-ca.geojson"]},
       "tags": {
         "network": "Commuter Express",
         "route": "bus",

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -2854,7 +2854,9 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "network": "Commuter Express",
-        "route": "bus"
+        "route": "bus",
+        "operator": "Los Angeles Department of Transportation",
+        "operator:wikidata": "Q3259703"
       }
     },
     {
@@ -3314,6 +3316,16 @@
       "locationSet": {"include": ["us"]},
       "note": "There are at least 4 different bus networks in US named 'DASH.' They should be split.",
       "tags": {"network": "DASH", "route": "bus"}
+    }
+    {
+      "displayName": "DASH",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "network": "DASH", 
+        "route": "bus",
+        "operator": "Los Angeles Department of Transportation",
+        "operator:wikidata": "Q3259703"
+      }
     },
     {
       "displayName": "DBUS",


### PR DESCRIPTION
Adds two Los Angeles bus systems operated by the Los Angeles Department of Transportation, DASH and Commuter Express. They don't have individual wikidata items, but I added the operator wikidata item.