### PR TITLE
Restrict Northwest Bank to states (IN, NY, OH, PA)

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -6864,7 +6864,7 @@
     {
       "displayName": "Northwest Bank",
       "id": "northwestbank-ea2e2d",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-in.geojson","us-ny.geojson","us-oh.geojson","us-pa.geojson"]},
       "tags": {
         "amenity": "bank",
         "brand": "Northwest Bank",


### PR DESCRIPTION
Fairly generic name, distinct from the following (at least):

- one in IA and NE
- one in Rockford, IL
- one in ID, OR, UT, and WA