### PR TITLE
Waldorf Astoria opening hotel in Australia

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -2502,6 +2502,7 @@
       "locationSet": {
         "include": [
           "ae",
+          "au",
           "cn",
           "de",
           "eg",


### PR DESCRIPTION
Waldorf Astoria is opening a hotel in Sydney, Australia 

https://www.broadsheet.com.au/national/travel/article/australias-first-waldorf-astoria-hotel-coming-sydney