### PR TITLE
Add "barclays bank plc" to matchNames for Barclays

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -2427,7 +2427,10 @@
       "displayName": "Barclays",
       "id": "barclays-b7a026",
       "locationSet": {"include": ["001"]},
-      "matchNames": ["barclays bank"],
+      "matchNames": [
+        "barclays bank",
+        "barclays bank plc"
+      ],
       "tags": {
         "amenity": "bank",
         "brand": "Barclays",


### PR DESCRIPTION
Barclays Bank PLC is the legal name for Barclays, and is set as the operator for many Barclays banks and ATMs (e.g. https://www.openstreetmap.org/changeset/17460725)