### PR TITLE
extended rabbittransit to MD

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -10317,7 +10317,7 @@
       "displayName": "rabbittransit",
       "id": "rabbittransit-d71276",
       "locationSet": {
-        "include": ["us-pa.geojson"]
+        "include": ["us-pa.geojson", "us-md.geojson"]
       },
       "tags": {
         "network": "rabbittransit",


### PR DESCRIPTION
This transit operator is based in Pennsylvania but also has stops in northern Maryland. See: https://www.rabbittransit.org/routes/route-83s/