### PR TITLE
updated the waterbus operator

### DIFF
--- a/data/transit/route/ferry.json
+++ b/data/transit/route/ferry.json
@@ -501,7 +501,7 @@
       "tags": {
         "network": "Waterbus Rotterdam-Drechtsteden",
         "network:wikidata": "Q1845402",
-        "operator": "Aquabus",
+        "operator": "Blue Amigo",
         "route": "ferry"
       }
     },


### PR DESCRIPTION
the operator of the waterbus changed

https://www.zuid-holland.nl/actueel/nieuws/december-2021/blue-amigo-vanaf-1-januari-nieuwe-vervoerder/