### PR TITLE
Don't hide focus indicator

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -27,7 +27,6 @@ body {
 /* global styles */
 h1, h2, h3  { margin: 0; }
 a { text-decoration: none; }
-:focus             { outline-color: transparent; outline-style: none; }
 a:visited, a       { color: #67e; font-weight: bold; }
 a:hover, a:active  { color: #56a; }
 .dark a:visited, .dark a       { color: #88c; font-weight: bold; }


### PR DESCRIPTION
Doesn't seem to serve any purpose other than to make keyboard navigation more difficult.