### PR TITLE
Add wikidata to London Boroughs for Schools

### DIFF
--- a/data/operators/amenity/school.json
+++ b/data/operators/amenity/school.json
@@ -14171,20 +14171,30 @@
     },
     {
       "displayName": "London Borough of Islington",
-      "id": "londonboroughofislington-26e9df",
-      "locationSet": {"include": ["gb"]},
+      "id": "londonboroughofislington-657027",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
       "tags": {
         "amenity": "school",
-        "operator": "London Borough of Islington"
+        "operator": "London Borough of Islington",
+        "operator:wikidata": "Q205817"
       }
     },
     {
       "displayName": "London Borough of Richmond Upon Thames",
-      "id": "londonboroughofrichmonduponthames-26e9df",
-      "locationSet": {"include": ["gb"]},
+      "id": "londonboroughofrichmonduponthames-657027",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
+      "matchNames": [
+        "london borough of richmond upon thames council"
+      ],
       "tags": {
         "amenity": "school",
-        "operator": "London Borough of Richmond Upon Thames"
+        "operator": "London Borough of Richmond Upon Thames",
+        "operator:short": "LBRUT",
+        "operator:wikidata": "Q32515"
       }
     },
     {


### PR DESCRIPTION
Adds missing wikidata for the London Boroughs of Islington and Richmond Upon Thames, as well as updating their location sets to be just within London