### PR TITLE
Add London Boroughs for Libraries

### DIFF
--- a/data/operators/amenity/library.json
+++ b/data/operators/amenity/library.json
@@ -874,6 +874,62 @@
       }
     },
     {
+      "displayName": "London Borough of Hounslow",
+      "id": "londonboroughofhounslow-d8f64f",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "London Borough of Hounslow",
+        "operator:wikidata": "Q214162",
+        "ref:isil": "GB-UkHnHL"
+      }
+    },
+    {
+      "displayName": "London Borough of Merton",
+      "id": "londonboroughofmerton-d8f64f",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "London Borough of Merton",
+        "operator:wikidata": "Q32504",
+        "ref:isil": "GB-UkLoML"
+      }
+    },
+    {
+      "displayName": "London Borough of Richmond Upon Thames",
+      "id": "londonboroughofrichmonduponthames-d8f64f",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
+      "matchNames": [
+        "london borough of richmond upon thames council"
+      ],
+      "tags": {
+        "amenity": "library",
+        "operator": "London Borough of Richmond Upon Thames",
+        "operator:short": "LBRUT",
+        "operator:wikidata": "Q32515",
+        "ref:isil": "GB-UkRiBR"
+      }
+    },
+    {
+      "displayName": "London Borough of Wandsworth",
+      "id": "londonboroughofwandsworth-d8f64f",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "London Borough of Wandsworth",
+        "operator:wikidata": "Q210563",
+        "ref:isil": "GB-UkLoWCL"
+      }
+    },
+    {
       "displayName": "London Public Library",
       "id": "londonpubliclibrary-b0fd6b",
       "locationSet": {


### PR DESCRIPTION
Adds the London Boroughs of Hounslow, Merton, Wandsworth and Richmond Upon Thames to Library Operators, along with their Wikidata and their ISIL refs.