### PR TITLE
Add more UK Library operators and their ISIL refs

### DIFF
--- a/data/operators/amenity/library.json
+++ b/data/operators/amenity/library.json
@@ -14,6 +14,17 @@
   },
   "items": [
     {
+      "displayName": "Aberdeen City Council",
+      "id": "aberdeencitycouncil-ecb85d",
+      "locationSet": {"include": ["gb-sct"]},
+      "tags": {
+        "amenity": "library",
+        "operator": "Aberdeen City Council",
+        "operator:wikidata": "Q2425849",
+        "ref:isil": "GB-UK-AbCCL"
+      }
+    },
+    {
       "displayName": "Ajuntament de València",
       "id": "ajuntamentdevalencia-9284e0",
       "locationSet": {"include": ["001"]},
@@ -240,6 +251,19 @@
         "operator:short": "BGSU",
         "operator:type": "university",
         "operator:wikidata": "Q895457"
+      }
+    },
+    {
+      "displayName": "Brighton & Hove City Council",
+      "id": "brightonandhovecitycouncil-5f562a",
+      "locationSet": {
+        "include": ["gb-south-east-coast.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Brighton & Hove City Council",
+        "operator:wikidata": "Q16953725",
+        "ref:isil": "GB-UkBtBHCL"
       }
     },
     {
@@ -493,7 +517,8 @@
       "tags": {
         "amenity": "library",
         "operator": "Devon County Council",
-        "operator:wikidata": "Q6385990"
+        "operator:wikidata": "Q6385990",
+        "ref:isil": "GB-UkExDL"
       }
     },
     {
@@ -523,7 +548,8 @@
       "tags": {
         "amenity": "library",
         "operator": "Dorset Council",
-        "operator:wikidata": "Q55609905"
+        "operator:wikidata": "Q55609905",
+        "ref:isil": "GB-UkDorDL"
       }
     },
     {
@@ -1121,6 +1147,17 @@
       }
     },
     {
+      "displayName": "Newport City Council",
+      "id": "newportcitycouncil-e31f47",
+      "locationSet": {"include": ["gb-wls"]},
+      "tags": {
+        "amenity": "library",
+        "operator": "Newport City Council",
+        "operator:wikidata": "Q16998902",
+        "ref:isil": "GB-WlNeCL"
+      }
+    },
+    {
       "displayName": "Norfolk County Council",
       "id": "norfolkcountycouncil-088e6d",
       "locationSet": {
@@ -1253,11 +1290,15 @@
     },
     {
       "displayName": "Oxfordshire County Council",
-      "id": "oxfordshirecountycouncil-70004d",
-      "locationSet": {"include": ["gb"]},
+      "id": "oxfordshirecountycouncil-03a231",
+      "locationSet": {
+        "include": ["gb-south-central.geojson"]
+      },
       "tags": {
         "amenity": "library",
-        "operator": "Oxfordshire County Council"
+        "operator": "Oxfordshire County Council",
+        "operator:wikidata": "Q6386253",
+        "ref:isil": "GB-UkOxOLS"
       }
     },
     {
@@ -1298,11 +1339,15 @@
     },
     {
       "displayName": "Plymouth City Council",
-      "id": "plymouthcitycouncil-9284e0",
-      "locationSet": {"include": ["001"]},
+      "id": "plymouthcitycouncil-71a7a0",
+      "locationSet": {
+        "include": ["gb-devon-cornwall.geojson"]
+      },
       "tags": {
         "amenity": "library",
-        "operator": "Plymouth City Council"
+        "operator": "Plymouth City Council",
+        "operator:wikidata": "Q7205775",
+        "ref:isil": "GB-UkPlL"
       }
     },
     {


### PR DESCRIPTION
Add Aberdeen, Newport and Brighton & Hove City Councils, and add ISIL refs to Devon, Dorset, Oxfordshire and Plymouth councils