### PR TITLE
remove mobile phone Yettel after #6131 merged

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -1030,39 +1030,6 @@
       }
     },
     {
-      "displayName": "Yettel (Bulgaria)",
-      "id": "yettel-2a48ca",
-      "locationSet": {"include": ["bg"]},
-      "tags": {
-        "brand": "Yettel",
-        "brand:wikidata": "Q14915070",
-        "name": "Yettel",
-        "shop": "mobile_phone"
-      }
-    },
-    {
-      "displayName": "Yettel (Hungary)",
-      "id": "yettel-a62753",
-      "locationSet": {"include": ["hu"]},
-      "tags": {
-        "brand": "Yettel",
-        "brand:wikidata": "Q268578",
-        "name": "Yettel",
-        "shop": "mobile_phone"
-      }
-    },
-    {
-      "displayName": "Yettel (Serbia)",
-      "id": "yettel-6945ea",
-      "locationSet": {"include": ["rs"]},
-      "tags": {
-        "brand": "Yettel",
-        "brand:wikidata": "Q1780171",
-        "name": "Yettel",
-        "shop": "mobile_phone"
-      }
-    },
-    {
       "displayName": "Yoigo",
       "id": "yoigo-7135b5",
       "locationSet": {"include": ["es"]},


### PR DESCRIPTION
After #6131 merged, they are 2 part of Yettel in NSI:

**mobile_phone.json**
<img src="https://user-images.githubusercontent.com/42690037/172820848-4db10f3b-32bb-48eb-9b01-19dae5e147a0.png" width=350px/> 
**telecommunication.json**
<img src="https://user-images.githubusercontent.com/42690037/172820863-d725fa04-6f37-4e07-a85f-ef8a9b8118f6.png" width=350px/>

According to research from Wikipedia:

* https://en.wikipedia.org/wiki/Yettel_Bulgaria
* https://en.wikipedia.org/wiki/Yettel_Hungary
* https://en.wikipedia.org/wiki/Yettel_Serbia

I guess them are telecommunication office more than mobile phone shops  because they mainly offer mobile/fixed network, even IPTV. So I remove them in mobile_phone.json.

This may need local editor (@Dimitar5555 )'s review to confirm whether this is necessary.