### PR TITLE
Adding Raiffeisen Switzerland

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -7622,6 +7622,16 @@
         "brand:wikidata": "Q7283806",
         "name": "Raiffeisen Bank"
       }
+    },    {
+      "displayName": "Raiffeisen (Schweiz)",
+      "locationSet": {"include": ["ch"]},
+      "matchNames": ["raiffeisen"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "Raiffeisen",
+        "brand:wikidata": "Q681189",
+        "name": "Raiffeisen"
+      }
     },
     {
       "displayName": "Raiffeisen Bank (Shqipëri)",


### PR DESCRIPTION
[Today I saw](https://www.openstreetmap.org/changeset/122365222) that a Raiffeisen bank was not (correctly) available in Go Map!! as suggested name.
This pull request aims to remedy this. 