### PR TITLE
Add Bulgarian operators

### DIFF
--- a/data/operators/amenity/fire_station.json
+++ b/data/operators/amenity/fire_station.json
@@ -3636,6 +3636,15 @@
         "amenity": "fire_station",
         "operator": "高雄市政府消防局"
       }
+    },
+    {
+      "displayName": "Министерство на вътрешните работи",
+      "locationSet": {"include": ["bg"]},
+      "tags": {
+        "amenity": "fire_station",
+        "operator": "Министерство на вътрешните работи",
+        "operator:wikidata": "Q2594388"
+      }
     }
   ]
 }

--- a/data/operators/amenity/police.json
+++ b/data/operators/amenity/police.json
@@ -3203,6 +3203,15 @@
         "operator:en": "Kagoshima Prefectural Police",
         "operator:wikidata": "Q11676846"
       }
+    },
+    {
+      "displayName": "Министерство на вътрешните работи",
+      "locationSet": {"include": ["bg"]},
+      "tags": {
+        "amenity": "police",
+        "operator": "Министерство на вътрешните работи",
+        "operator:wikidata": "Q2594388"
+      }
     }
   ]
 }

--- a/data/operators/amenity/townhall.json
+++ b/data/operators/amenity/townhall.json
@@ -1,0 +1,34 @@
+{
+  "properties": {
+    "path": "operators/amenity/townhall"
+  },
+  "items": [
+    {
+      "displayName": "Столична община",
+      "locationSet": {"include": ["bg"]},
+      "tags": {
+        "amenity": "townhall",
+        "operator": "Столична община",
+        "operator:wikidata": "Q4442915"
+      }
+    },
+    {
+      "displayName": "Община Пловдив",
+      "locationSet": {"include": ["bg"]},
+      "tags": {
+        "amenity": "townhall",
+        "operator": "Община Пловдив",
+        "operator:wikidata": "Q4365146"
+      }
+    },
+    {
+      "displayName": "Община Варна",
+      "locationSet": {"include": ["bg"]},
+      "tags": {
+        "amenity": "townhall",
+        "operator": "Община Варна",
+        "operator:wikidata": "Q748965"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
I've added `data/operators/amenity/townhall.json` for municipalities which operate districts. Let me know if I've missed something there.