### PR TITLE
Separate Haidilao Hot Pot for HK & MO and update information for CN & TW

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -6144,16 +6144,41 @@
     {
       "displayName": "海底捞火锅",
       "id": "haidilaohotpot-0a8e9b",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {"include": ["cn"], "exclude": ["hk", "mo"]},
       "matchNames": ["海底捞"],
       "tags": {
         "amenity": "restaurant",
         "brand": "海底捞火锅",
-        "brand:en": "Hai Di Lao Hot Pot",
+        "brand:en": "Haidilao Hot Pot",
         "brand:wikidata": "Q5638920",
+        "brand:zh": "海底捞火锅",
+        "brand:zh-Hans": "海底捞火锅",
+        "brand:zh-Hant": "海底撈火鍋",
         "cuisine": "chinese;hot_pot",
         "name": "海底捞火锅",
-        "name:en": "Hai Di Lao Hot Pot",
+        "name:en": "Haidilao Hot Pot",
+        "name:zh": "海底捞火锅",
+        "name:zh-Hans": "海底捞火锅",
+        "name:zh-Hant": "海底撈火鍋"
+      }
+    },
+    {
+      "displayName": "海底撈火鍋 Haidilao Hot Pot",
+      "id": "haidilaohotpot-0a8e9b",
+      "locationSet": {"include": ["hk", "mo"]},
+      "matchNames": ["海底撈"],
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "海底撈火鍋 Haidilao Hot Pot",
+        "brand:en": "Haidilao Hot Pot",
+        "brand:wikidata": "Q5638920",
+        "brand:zh": "海底撈火鍋",
+        "brand:zh-Hans": "海底捞火锅",
+        "brand:zh-Hant": "海底撈火鍋",
+        "cuisine": "chinese;hot_pot",
+        "name": "海底撈火鍋 Haidilao Hot Pot",
+        "name:en": "Haidilao Hot Pot",
+        "name:zh": "海底撈火鍋",
         "name:zh-Hans": "海底捞火锅",
         "name:zh-Hant": "海底撈火鍋"
       }
@@ -6165,12 +6190,15 @@
       "tags": {
         "amenity": "restaurant",
         "brand": "海底撈火鍋",
-        "brand:en": "Hai Di Lao Hot Pot",
+        "brand:en": "Haidilao Hot Pot",
         "brand:wikidata": "Q5638920",
         "brand:zh": "海底撈火鍋",
+        "brand:zh-Hans": "海底捞火锅",
+        "brand:zh-Hant": "海底撈火鍋",
         "cuisine": "chinese;hot_pot",
         "name": "海底撈火鍋",
-        "name:en": "Hai Di Lao Hot Pot",
+        "name:en": "Haidilao Hot Pot",
+        "name:zh": "海底撈火鍋",
         "name:zh-Hans": "海底捞火锅",
         "name:zh-Hant": "海底撈火鍋"
       }


### PR DESCRIPTION
Separate:
- Haidilao Hot Pot (HK & MO)

Update:
- Haidilao Hot Pot (CN & TW)
Update English name for Haidilao which should align with official name from [office website](https://www.haidilao.com/cn/).