### PR TITLE
HF Hotels

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -1085,6 +1085,16 @@
       }
     },
     {
+      "displayName": "HF Hotels",
+      "locationSet": {"include": ["pt"]},
+      "tags": {
+        "brand": "HF Hotels",
+        "brand:wikidata": "Q112650431",
+        "name": "HF",
+        "tourism": "hotel"
+      }
+    },
+    {
       "displayName": "Hilton",
       "id": "hilton-779ccb",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
HF Hotels has hotels in Porto and Lisbon that have a name prefixed with HF ie HF Tuela Porto, HF Ipenema Park