### PR TITLE
Growing Communities collection lockers

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -164,6 +164,18 @@
       }
     },
     {
+      "displayName": "Growing Communities",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "Growing Communities",
+        "brand:wikidata": "Q109768523",
+        "name": "Growing Communities"
+      }
+    },
+    {
       "displayName": "i郵箱",
       "id": "ibox-89f0e2",
       "locationSet": {"include": ["tw"]},


### PR DESCRIPTION
Growing Communities has collection lockers for its London fruit and veg scheme, resolves #6586  