### PR TITLE
Electronic toll collection operators in Texas

### DIFF
--- a/data/operators/highway/toll_gantry.json
+++ b/data/operators/highway/toll_gantry.json
@@ -1,0 +1,132 @@
+{
+  "properties": {
+    "path": "operators/highway/toll_gantry",
+    "preserveTags": ["^name"],
+    "exclude": {"generic": ["^toll gantry$"]}
+  },
+  "items": [
+    {
+      "displayName": "Central Texas Regional Mobility Authority",
+      "id": "centraltexasregionalmobilityauthority-2ee94d",
+      "locationSet": {
+        "include": ["us-tx.geojson"]
+      },
+      "tags": {
+        "highway": "toll_gantry",
+        "operator": "Central Texas Regional Mobility Authority",
+        "operator:short": "Mobility Authority",
+        "operator:wikidata": "Q2504323",
+        "payment:license_plate": "yes",
+        "payment:txtag": "yes"
+      }
+    },
+    {
+      "displayName": "Fort Bend County Toll Road Authority",
+      "id": "fortbendcountytollroadauthority-2ee94d",
+      "locationSet": {
+        "include": ["us-tx.geojson"]
+      },
+      "tags": {
+        "highway": "toll_gantry",
+        "operator": "Fort Bend County Toll Road Authority",
+        "operator:short": "FBCTRA",
+        "operator:wikidata": "Q5470803",
+        "payment:ez_tag": "yes",
+        "payment:license_plate": "no"
+      }
+    },
+    {
+      "displayName": "Harris County Toll Road Authority",
+      "id": "harriscountytollroadauthority-2ee94d",
+      "locationSet": {
+        "include": ["us-tx.geojson"]
+      },
+      "tags": {
+        "highway": "toll_gantry",
+        "operator": "Harris County Toll Road Authority",
+        "operator:short": "HCTRA",
+        "operator:wikidata": "Q5664855",
+        "payment:ez_tag": "yes"
+      }
+    },
+    {
+      "displayName": "Montgomery County Toll Road Authority",
+      "id": "montgomerycountytollroadauthority-2ee94d",
+      "locationSet": {
+        "include": ["us-tx.geojson"]
+      },
+      "tags": {
+        "highway": "toll_gantry",
+        "operator": "Montgomery County Toll Road Authority",
+        "operator:short": "MCTRA",
+        "operator:wikidata": "Q19877037",
+        "payment:ez_tag": "yes",
+        "payment:license_plate": "no"
+      }
+    },
+    {
+      "displayName": "North East Texas Regional Mobility Authority",
+      "id": "northeasttexasregionalmobilityauthority-2ee94d",
+      "locationSet": {
+        "include": ["us-tx.geojson"]
+      },
+      "tags": {
+        "highway": "toll_gantry",
+        "operator": "North East Texas Regional Mobility Authority",
+        "operator:short": "NET RMA",
+        "operator:wikidata": "Q2504347",
+        "payment:license_plate": "yes",
+        "payment:txtag": "yes"
+      }
+    },
+    {
+      "displayName": "North Texas Tollway Authority",
+      "id": "northtexastollwayauthority-2ee94d",
+      "locationSet": {
+        "include": ["us-tx.geojson"]
+      },
+      "matchNames": ["tolltag"],
+      "tags": {
+        "highway": "toll_gantry",
+        "operator": "North Texas Tollway Authority",
+        "operator:short": "NTTA",
+        "operator:wikidata": "Q13416600",
+        "payment:license_plate": "yes",
+        "payment:tolltag": "yes",
+        "payment:txtag": "yes"
+      }
+    },
+    {
+      "displayName": "SH 130 Concession Company",
+      "id": "sh130concessioncompany-2ee94d",
+      "locationSet": {
+        "include": ["us-tx.geojson"]
+      },
+      "tags": {
+        "highway": "toll_gantry",
+        "operator": "SH 130 Concession Company",
+        "operator:wikidata": "Q112700341",
+        "payment:license_plate": "yes",
+        "payment:txtag": "yes"
+      }
+    },
+    {
+      "displayName": "Toll Operations Division of the Texas Department of Transportation",
+      "id": "tolloperationsdivisionofthetexasdepartmentoftransportation-2ee94d",
+      "locationSet": {
+        "include": ["us-tx.geojson"]
+      },
+      "matchNames": [
+        "txdot toll operations division"
+      ],
+      "tags": {
+        "highway": "toll_gantry",
+        "operator": "Toll Operations Division of the Texas Department of Transportation",
+        "operator:short": "TxDOT TOD",
+        "operator:wikidata": "Q112700221",
+        "payment:license_plate": "yes",
+        "payment:txtag": "yes"
+      }
+    }
+  ]
+}

--- a/data/operators/highway/toll_gantry.json
+++ b/data/operators/highway/toll_gantry.json
@@ -11,10 +11,11 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
+      "matchNames": ["mobility authority"],
       "tags": {
         "highway": "toll_gantry",
         "operator": "Central Texas Regional Mobility Authority",
-        "operator:short": "Mobility Authority",
+        "operator:short": "CTRMA",
         "operator:wikidata": "Q2504323",
         "payment:license_plate": "yes",
         "payment:txtag": "yes"


### PR DESCRIPTION
Added entries for each of the authorities that operate electronic toll collection (ETC) facilities in Texas. These are the companies or agencies that operate the infrastructure, as opposed to the back-office and collections operations.

I’ve included payment options that, to the best of my knowledge, are always signposted as being accepted at each of the ETC points in these systems. These tags aren’t meant to be exhaustive. I didn’t tag ETC systems that are interoperable but not signposted, such as Pikepass or TollTag outside of NTTA’s service area. These interoperability agreements can sometimes be too nuanced for this index to include. In some cases, I explicitly tagged that pay-by-mail is not accepted.

As a first pass, all these operators are currently scoped to the entire state of Texas, but they can be refined afterwards.

Fixes #6677 and fixes #6679.