### PR TITLE
SCT charity shops

### DIFF
--- a/data/brands/shop/charity.json
+++ b/data/brands/shop/charity.json
@@ -402,6 +402,18 @@
       }
     },
     {
+      "displayName": "SCT (Spitalfields Crypt Trust)",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
+      "tags": {
+        "brand": "Spitalfields Crypt Trust",
+        "brand:wikidata": "Q107463316",
+        "name": "SCT",
+        "shop": "charity"
+      }
+    },
+    {
       "displayName": "Sense",
       "id": "sense-b7b967",
       "locationSet": {"include": ["gb"]},


### PR DESCRIPTION
Spitalfields Crypt Trust has charity shops in London that are simply named SCT

https://www.sct.org.uk/charity-shops/locations/