### PR TITLE
Improve precision and accuracy of location sets

### DIFF
--- a/data/operators/amenity/fire_station.json
+++ b/data/operators/amenity/fire_station.json
@@ -224,7 +224,7 @@
       "displayName": "Chicago Fire Department",
       "id": "chicagofiredepartment-79af54",
       "locationSet": {
-        "include": [[-87.65, 41.9, 35]]
+        "include": [[-87.73, 41.83, 27]]
       },
       "tags": {
         "amenity": "fire_station",
@@ -236,7 +236,7 @@
       "displayName": "Cincinnati Fire Department",
       "id": "cincinnatifiredepartment-2acc13",
       "locationSet": {
-        "include": [[-84.5, 39.16]]
+        "include": [[-84.54, 39.11, 16]]
       },
       "tags": {
         "amenity": "fire_station",
@@ -849,7 +849,7 @@
       "displayName": "Kansas City Fire Department",
       "id": "kansascityfiredepartment-8e1536",
       "locationSet": {
-        "include": [[-94.5653, 39.1167, 15]],
+        "include": [[-94.58, 39.1, 32]],
         "exclude": ["us-ks.geojson"]
       },
       "tags": {
@@ -934,7 +934,7 @@
       "displayName": "Los Angeles County Fire Department",
       "id": "losangelescountyfiredepartment-7d64c3",
       "locationSet": {
-        "include": [[-118, 33.85, 110]]
+        "include": [[-118.28, 33.84, 123]]
       },
       "matchNames": ["lacfd", "lacofd"],
       "note": "This is the 'county' fire dept (differernt from the one listed below).",
@@ -948,7 +948,7 @@
       "displayName": "Los Angeles Fire Department",
       "id": "losangelesfiredepartment-434f0c",
       "locationSet": {
-        "include": [[-118, 33.85, 80]]
+        "include": [[-118.39, 34, 39]]
       },
       "matchNames": [
         "la city fire",
@@ -998,7 +998,7 @@
       "displayName": "Milwaukee Fire Department",
       "id": "milwaukeefiredepartment-fe5bf1",
       "locationSet": {
-        "include": [[-87.9, 43.05]]
+        "include": [[-87.98, 43.06, 17]]
       },
       "tags": {
         "amenity": "fire_station",
@@ -1037,7 +1037,7 @@
       "displayName": "Minneapolis Fire Department",
       "id": "minneapolisfiredepartment-b6303c",
       "locationSet": {
-        "include": [[-93.36, 45, 55]]
+        "include": [[-93.27, 44.97, 10]]
       },
       "tags": {
         "amenity": "fire_station",
@@ -1690,7 +1690,7 @@
       "displayName": "Santa Clara County Fire Department",
       "id": "santaclaracountyfiredepartment-76bab0",
       "locationSet": {
-        "include": [[-121.95, 37.35, 25]]
+        "include": [[-121.7, 37.2, 51]]
       },
       "matchNames": ["sccfd"],
       "tags": {


### PR DESCRIPTION
Reduced radius where it was unnecessarily large; Increased radius in cases where a portion of the city or county was outside this circle.

Attempted to manually check against the overpass turbo links on nsi.guide that these locations were correct; also checked the station maps of Santa Clara, Los Angeles, that there are stations outside the existing radius.