### PR TITLE
Add Mochinut amenity/fast_food

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -4045,6 +4045,19 @@
       }
     },
     {
+      "displayName": "Mochinut",
+      "id": "mochinut-4d2ff4",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Mochinut",
+        "brand:wikidata": "Q112757409",
+        "cuisine": "donut;bubble_tea",
+        "name": "Mochinut",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "MOD Pizza",
       "id": "modpizza-9cbad3",
       "locationSet": {


### PR DESCRIPTION
Mochinut is a donut and boba place in the United States. It is planning
in the future to expand to South Korea and Thailand, but is not there at
the moment.