### PR TITLE
Changed name for DIY chain in Italy

### DIFF
--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -216,7 +216,6 @@
       "tags": {
         "brand": "Bricoman",
         "brand:wikidata": "Q2925142",
-        "brand:wikipedia": "fr:Bricoman",
         "name": "Bricoman",
         "shop": "doityourself"
       }
@@ -229,7 +228,6 @@
       "tags": {
         "brand": "Bricoman",
         "brand:wikidata": "Q2925142",
-        "brand:wikipedia": "fr:Bricoman",
         "name": "Tecnomat",
         "shop": "doityourself"
       }

--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -226,8 +226,8 @@
         "include": ["it"]
       },
       "tags": {
-        "brand": "Bricoman",
-        "brand:wikidata": "Q2925142",
+        "brand": "Tecnomat",
+        "brand:wikidata": "Q111716870",
         "name": "Tecnomat",
         "shop": "doityourself"
       }

--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -211,13 +211,26 @@
       "displayName": "Bricoman",
       "id": "bricoman-5e1049",
       "locationSet": {
-        "include": ["fr", "it", "pl"]
+        "include": ["fr", "pl"]
       },
       "tags": {
         "brand": "Bricoman",
         "brand:wikidata": "Q2925142",
-        "brand:wikipedia": "it:Bricoman",
+        "brand:wikipedia": "fr:Bricoman",
         "name": "Bricoman",
+        "shop": "doityourself"
+      }
+    },
+    {
+      "displayName": "Tecnomat",
+      "locationSet": {
+        "include": ["it"]
+      },
+      "tags": {
+        "brand": "Bricoman",
+        "brand:wikidata": "Q2925142",
+        "brand:wikipedia": "fr:Bricoman",
+        "name": "Tecnomat",
         "shop": "doityourself"
       }
     },


### PR DESCRIPTION
Bricoman changed name in Italy to Tecnomat (see https://www.gdoweek.it/bricoman-cambia-nome-e-diventa-tecnomat/); changed to fr.wiki since it's a French brand