### PR TITLE
Update Chargefox locationSet and matchNames

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -538,7 +538,8 @@
     {
       "displayName": "Chargefox",
       "id": "chargefox-943805",
-      "locationSet": {"include": ["au"]},
+      "locationSet": {"include": ["au", "nz"]},
+      "matchNames": ["chargefox"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Chargefox",


### PR DESCRIPTION
Update Chargefox locationSet to correctly match network operating regions 
add matchNames 'chargefox'