### PR TITLE
Added Rüedu

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -2758,6 +2758,17 @@
       }
     },
     {
+      "displayName": "Rüedu",
+      "locationSet": {"include": ["ch"]},
+      "tags": {
+        "brand": "Rüedu",
+        "brand:wikidata": "Q112913831",
+        "name": "Rüedu",
+        "shop": "convenience",
+        "self_service": "only"
+      }
+    },    
+    {
       "displayName": "Rutter's",
       "id": "rutters-f1e40b",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
[Rüedu](https://rüedu.ch) is a chain of small self-service stores in Switzerland, usually 'available' in containers a bit our of the city-center. Currently, there are ~20 locations, more are planned.