### PR TITLE
Remove specific social facility type for Anchor

### DIFF
--- a/data/operators/amenity/social_facility.json
+++ b/data/operators/amenity/social_facility.json
@@ -93,7 +93,6 @@
         "amenity": "social_facility",
         "operator": "Anchor",
         "operator:wikidata": "Q65091469",
-        "social_facility": "group_home",
         "social_facility:for": "senior"
       }
     },


### PR DESCRIPTION
Remove specific social facility type for Anchor as they operate a variety of types, ranging from assisted living to group homes