### PR TITLE
Localize catering brands in Hong Kong and Taiwan

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -8472,7 +8472,7 @@
         "brand:zh": "大家樂",
         "brand:zh-Hans": "大家乐",
         "brand:zh-Hant": "大家樂",
-        "cuisine": "hong_kong",
+        "cuisine": "cantonese;western",
         "name": "大家樂 Café de Coral",
         "name:en": "Café de Coral",
         "name:zh": "大家樂",
@@ -8493,7 +8493,7 @@
         "brand:zh": "大快活",
         "brand:zh-Hans": "大快活",
         "brand:zh-Hant": "大快活",
-        "cuisine": "hong_kong",
+        "cuisine": "cantonese;western",
         "name": "大快活 Fairwood",
         "name:en": "Fairwood",
         "name:zh": "大快活",
@@ -8965,6 +8965,22 @@
       }
     },
     {
+      "displayName": "築地銀だこ Gindaco",
+      "locationSet": {"include": ["hk"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "築地銀だこ",
+        "brand:en": "Gindaco",
+        "brand:ja": "築地銀だこ",
+        "brand:wikidata": "Q11603490",
+        "cuisine": "takoyaki",
+        "name": "築地銀だこ Gindaco",
+        "name:en": "Gindaco",
+        "name:ja": "築地銀だこ",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "繼光香香雞",
       "id": "jandgfriedchicken-60a4d5",
       "locationSet": {"include": ["tw"]},
@@ -8992,7 +9008,7 @@
         "brand:en": "Maxim's MX",
         "brand:wikidata": "Q7213063",
         "brand:zh": "美心MX",
-        "cuisine": "hong_kong",
+        "cuisine": "cantonese;western",
         "name": "美心MX Maxim's MX",
         "name:en": "Maxim's MX",
         "name:zh": "美心MX",

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -8472,7 +8472,7 @@
         "brand:zh": "大家樂",
         "brand:zh-Hans": "大家乐",
         "brand:zh-Hant": "大家樂",
-        "cuisine": "chinese",
+        "cuisine": "hong_kong",
         "name": "大家樂 Café de Coral",
         "name:en": "Café de Coral",
         "name:zh": "大家樂",
@@ -8493,7 +8493,7 @@
         "brand:zh": "大快活",
         "brand:zh-Hans": "大快活",
         "brand:zh-Hant": "大快活",
-        "cuisine": "chinese",
+        "cuisine": "hong_kong",
         "name": "大快活 Fairwood",
         "name:en": "Fairwood",
         "name:zh": "大快活",
@@ -8776,12 +8776,11 @@
       "locationSet": {
         "include": [
           "cn",
-          "hk",
           "jp",
-          "mo",
           "sg",
           "tw"
-        ]
+        ],
+        "exclude": ["hk","mo"]
       },
       "tags": {
         "amenity": "fast_food",
@@ -8993,7 +8992,7 @@
         "brand:en": "Maxim's MX",
         "brand:wikidata": "Q7213063",
         "brand:zh": "美心MX",
-        "cuisine": "chinese",
+        "cuisine": "hong_kong",
         "name": "美心MX Maxim's MX",
         "name:en": "Maxim's MX",
         "name:zh": "美心MX",
@@ -9229,7 +9228,10 @@
     {
       "displayName": "食其家",
       "id": "sukiya-65b4e8",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {
+        "include": ["cn","tw"]
+      , "exclude": ["hk"]
+      },
       "tags": {
         "amenity": "fast_food",
         "brand": "すき家",
@@ -9240,8 +9242,25 @@
         "cuisine": "beef_bowl",
         "name": "食其家",
         "name:en": "Sukiya",
-        "name:ja": "食其家",
+        "name:ja": "すき家",
         "name:zh": "食其家",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "Sukiya",
+      "locationSet": {"include": ["hk"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "すき家 Sukiya",
+        "brand:en": "Sukiya",
+        "brand:ja": "すき家",
+        "brand:wikidata": "Q6137375",
+        "cuisine": "beef_bowl",
+        "name": "すき家 Sukiya",
+        "name:en": "Sukiya",
+        "name:ja": "すき家",
+        "int_name:zh": "食其家",
         "takeaway": "yes"
       }
     },

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -9326,6 +9326,45 @@
         "name:zh-Hans": "麦当劳",
         "takeaway": "yes"
       }
-    }
+    },
+        {
+      "displayName": "八方雲集",
+      "id": "eightway-e68d5b",
+      "locationSet": {
+        "include": ["cn", "tw"],
+        "exclude": ["hk"]
+      },
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "八方雲集",
+        "brand:en": "Eight Way",
+        "brand:wikidata": "Q28417381",
+        "brand:zh": "八方雲集",
+        "cuisine": "dumplings",
+        "name": "八方雲集",
+        "name:en": "Eight Way",
+        "name:zh": "八方雲集"
+      }
+    },
+    {
+      "displayName": "八方雲集 Bafang Dumpling",
+      "id": "bafangdumpling-8b6c9a",
+      "locationSet": {"include": ["hk"]},
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "八方雲集 Bafang Dumpling",
+        "brand:en": "Bafang Dumpling",
+        "brand:wikidata": "Q28417381",
+        "brand:zh": "八方雲集",
+        "brand:zh-Hans": "八方云集",
+        "brand:zh-Hant": "八方雲集",
+        "cuisine": "dumplings",
+        "name": "八方雲集",
+        "name:en": "Bafang Dumpling",
+        "name:zh": "八方雲集",
+        "name:zh-Hans": "八方云集",
+        "name:zh-Hant": "八方雲集"
+      }
+    },
   ]
 }

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -9276,7 +9276,7 @@
         "name": "すき家 Sukiya",
         "name:en": "Sukiya",
         "name:ja": "すき家",
-        "int_name:zh": "食其家",
+        "name:zh": "食其家",
         "takeaway": "yes"
       }
     },

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -5503,7 +5503,7 @@
         "brand:en": "Eight Way",
         "brand:wikidata": "Q28417381",
         "brand:zh": "八方雲集",
-        "cuisine": "dumpling",
+        "cuisine": "dumplings",
         "name": "八方雲集",
         "name:en": "Eight Way",
         "name:zh": "八方雲集"
@@ -5521,7 +5521,7 @@
         "brand:zh": "八方雲集",
         "brand:zh-Hans": "八方云集",
         "brand:zh-Hant": "八方雲集",
-        "cuisine": "dumpling",
+        "cuisine": "dumplings",
         "name": "八方雲集",
         "name:en": "Bafang Dumpling",
         "name:zh": "八方雲集",

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -5503,7 +5503,7 @@
         "brand:en": "Eight Way",
         "brand:wikidata": "Q28417381",
         "brand:zh": "八方雲集",
-        "cuisine": "chinese",
+        "cuisine": "dumpling",
         "name": "八方雲集",
         "name:en": "Eight Way",
         "name:zh": "八方雲集"
@@ -5521,7 +5521,7 @@
         "brand:zh": "八方雲集",
         "brand:zh-Hans": "八方云集",
         "brand:zh-Hant": "八方雲集",
-        "cuisine": "chinese",
+        "cuisine": "dumpling",
         "name": "八方雲集",
         "name:en": "Bafang Dumpling",
         "name:zh": "八方雲集",

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -5491,45 +5491,6 @@
       }
     },
     {
-      "displayName": "八方雲集",
-      "id": "eightway-e68d5b",
-      "locationSet": {
-        "include": ["cn", "tw"],
-        "exclude": ["hk"]
-      },
-      "tags": {
-        "amenity": "restaurant",
-        "brand": "八方雲集",
-        "brand:en": "Eight Way",
-        "brand:wikidata": "Q28417381",
-        "brand:zh": "八方雲集",
-        "cuisine": "dumplings",
-        "name": "八方雲集",
-        "name:en": "Eight Way",
-        "name:zh": "八方雲集"
-      }
-    },
-    {
-      "displayName": "八方雲集 Bafang Dumpling",
-      "id": "bafangdumpling-8b6c9a",
-      "locationSet": {"include": ["hk"]},
-      "tags": {
-        "amenity": "restaurant",
-        "brand": "八方雲集 Bafang Dumpling",
-        "brand:en": "Bafang Dumpling",
-        "brand:wikidata": "Q28417381",
-        "brand:zh": "八方雲集",
-        "brand:zh-Hans": "八方云集",
-        "brand:zh-Hant": "八方雲集",
-        "cuisine": "dumplings",
-        "name": "八方雲集",
-        "name:en": "Bafang Dumpling",
-        "name:zh": "八方雲集",
-        "name:zh-Hans": "八方云集",
-        "name:zh-Hant": "八方雲集"
-      }
-    },
-    {
       "displayName": "南京大牌档",
       "id": "njdapaidang-0a8e9b",
       "locationSet": {"include": ["cn"]},


### PR DESCRIPTION
Correct some self-service restaurants in Hong Kong and Taiwan.

Changes:
1. It looks misleading for cha chaan teng food style fast food (Fairwood, Cafe de Corel, Maxim)  to be `=chinese` when  at least  half the items are Western, other Asian (depending on how to define Hong Kong curry) and even Japanese (deep-fried pork cutlet). That's better reserved for Super Super Congee & Noodles. From Taginfo, there is 1 `=hong_kong;cha_chaan_teng;fast_food`, and 1 typo `cha_chan_teng` instances, but that might be too specific. There are 42 `=*hong_kong*` and `=*Hong_Kong*` being used now. This seems acceptable. https://en.wikipedia.org/wiki/Cha_chaan_teng refers similarly to https://en.wikipedia.org/wiki/Hong_Kong_cuisine as "Hong Kong style". Hong Kong style fast food has its separate article https://zh.wikipedia.org/zh-hk/港式快餐 and was recorded by the Tourism Board before https://web.archive.org/web/20170118150702/https://www.discoverhongkong.com/tc/dine-drink/what-to-eat/local-flavours/hk-style-fast-food.jsp (dead page). A secondary option could be `cuisine=cantonese;western` (`cuisine=cantonese` is documented), considering the dishes, and prominence of siu mei. 
2. Sukiya uses only English and Japanese name in Hong Kong. Can't find “食其家" here.  https://www.sukiya.com.hk/menu/ (other minor typos corrected)
3. Bafang Dumpling is a counter-served and significantly take-out `=fast_food`, not waiter-served `=restaurant`. For `cuisine=`, the singular `=dumpling` (657 instances) is actually more widespread in Taiwan than the documented `=dumplings` (187 instances), but the word is usually used plural (cf `=fish_and_chips`) and have multiple dumplings served (cf `=wings`).

Questions:
1. Should I split them up, or will you review them together? (sorry for noob question)
2. Is there a requirement for tags to be documented? 
