### PR TITLE
Add SomiSomi soft serve & taiyaki chain

### DIFF
--- a/data/brands/amenity/ice_cream.json
+++ b/data/brands/amenity/ice_cream.json
@@ -673,6 +673,19 @@
       }
     },
     {
+      "displayName": "SomiSomi",
+      "id": "somisomi-8697a4",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "amenity": "ice_cream",
+        "brand": "SomiSomi",
+        "brand:wikidata": "Q104879354",
+        "cuisine": "soft_serve;taiyaki;bungeoppang",
+        "name": "SomiSomi",
+        "official_name": "SomiSomi Soft Serve & Taiyaki"
+      }
+    },
+    {
       "displayName": "Sub Zero",
       "id": "subzero-8697a4",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
All of the cuisine options are pretty uncommon, especially `soft_serve` and `bungeoppang`. However, they seem pretty relevant. Open to opinions.

Wikidata: [Q104879354](https://www.wikidata.org/wiki/Q104879354)
Website: https://www.somisomi.com