### PR TITLE
Correcting error in bookmaker.json

### DIFF
--- a/data/brands/shop/bookmaker.json
+++ b/data/brands/shop/bookmaker.json
@@ -27,9 +27,9 @@
     {
       "displayName": "Bar One Racing",
       "id": "baroneracing-15bf4d",
+      "matchNames": ["bar one"],
       "locationSet": {
         "include": ["gb-nir", "ie"],
-        "matchNames": ["bar one"]
       },
       "tags": {
         "brand": "Bar One Racing",

--- a/data/brands/shop/bookmaker.json
+++ b/data/brands/shop/bookmaker.json
@@ -28,7 +28,8 @@
       "displayName": "Bar One Racing",
       "id": "baroneracing-15bf4d",
       "locationSet": {
-        "include": ["gb-nir", "ie"]
+        "include": ["gb-nir", "ie"],
+        "matchNames": ["bar one"]
       },
       "tags": {
         "brand": "Bar One Racing",
@@ -41,7 +42,6 @@
       "displayName": "Betfred",
       "id": "betfred-58d00b",
       "locationSet": {"include": ["gb"]},
-      "matchNames": ["bar one"],
       "tags": {
         "brand": "Betfred",
         "brand:wikidata": "Q4897425",


### PR DESCRIPTION
Fixed error created in #6779 where the matchNames for Bar One Racing was accidently added to Betfred