### PR TITLE
Adding and modifying banks in Cuba 

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -1123,7 +1123,6 @@
     },
       {
       "displayName": "Banco de Crédito y Comercio",
-      "id": "",
       "locationSet": {"include": ["cu"]},
       "matchNames": ["bandec"],
       "tags": {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -1121,6 +1121,18 @@
         "short_name": "Bancor"
       }
     },
+      {
+      "displayName": "Banco de Crédito y Comercio",
+      "id": "",
+      "locationSet": {"include": ["cu"]},
+      "matchNames": ["bandec"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "Banco de Crédito y Comercio",
+        "brand:wikidata": "Q113137945",
+        "name": "Banco de Crédito y Comercio"
+      }
+    },
     {
       "displayName": "Banco de Desarrollo Banrural",
       "id": "bancodedesarrollobanrural-2713d7",

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -1439,6 +1439,7 @@
       "displayName": "Banco Metropolitano",
       "id": "bancometropolitano-23df77",
       "locationSet": {"include": ["cu"]},
+      "matchNames": ["banmet"],
       "tags": {
         "amenity": "bank",
         "brand": "Banco Metropolitano",


### PR DESCRIPTION
Modifying Banco Metropolitano and adding Banco de Crédito y  Comercio 