### PR TITLE
Updates to SEE power operator

### DIFF
--- a/data/operators/power/generator.json
+++ b/data/operators/power/generator.json
@@ -5191,16 +5191,6 @@
       }
     },
     {
-      "displayName": "SSE (Ireland and Great Britain)",
-      "id": "sse-8d3bcf",
-      "locationSet": {"include": ["gb", "ie"]},
-      "tags": {
-        "operator": "SSE",
-        "operator:wikidata": "Q493854",
-        "power": "generator"
-      }
-    },
-    {
       "displayName": "SSE (Slovakia)",
       "id": "sse-300ba3",
       "locationSet": {"include": ["sk"]},
@@ -5211,22 +5201,22 @@
       }
     },
     {
-      "displayName": "SSE Airtricity",
-      "id": "sseairtricity-8d3bcf",
-      "locationSet": {"include": ["gb", "ie"]},
-      "tags": {
-        "operator": "SSE Airtricity",
-        "operator:wikidata": "Q409271",
-        "power": "generator"
-      }
-    },
-    {
       "displayName": "SSE Renewables",
       "id": "sserenewables-8d3bcf",
       "locationSet": {"include": ["gb", "ie"]},
       "tags": {
         "operator": "SSE Renewables",
         "operator:wikidata": "Q7392992",
+        "power": "generator"
+      }
+    },
+    {
+      "displayName": "SSE Thermal",
+      "id": "",
+      "locationSet": {"include": ["gb", "ie"]},
+      "tags": {
+        "operator": "SSE Thermal",
+        "operator:wikidata": "Q105078879",
         "power": "generator"
       }
     },

--- a/data/operators/power/plant.json
+++ b/data/operators/power/plant.json
@@ -1725,15 +1725,22 @@
       }
     },
     {
-      "displayName": "SSE (UK and Ireland)",
-      "id": "sse-6adf37",
+      "displayName": "SSE Renewables",
+      "id": "",
       "locationSet": {"include": ["gb", "ie"]},
-      "matchNames": [
-        "scottish & southern energy"
-      ],
       "tags": {
-        "operator": "SSE",
-        "operator:wikidata": "Q493854",
+        "operator": "SSE Renewables",
+        "operator:wikidata": "Q7392992",
+        "power": "plant"
+      }
+    },
+    {
+      "displayName": "SSE Thermal",
+      "id": "",
+      "locationSet": {"include": ["gb", "ie"]},
+      "tags": {
+        "operator": "SSE Thermal",
+        "operator:wikidata": "Q105078879",
         "power": "plant"
       }
     },


### PR DESCRIPTION
Removed SSE Airtricity from power/generator as it is a retailer that sells electricity and does not operate any generators.
Removed SSE plc as it operates plants / generators under the SSE Renewables and SSE Thermal subsidiaries