### PR TITLE
Add German Decathlon bicycle tube machines

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -1149,6 +1149,17 @@
         "name:ja": "明治",
         "vending": "food"
       }
+    },
+    {
+      "displayName": "Decathlon Radtour-Retter",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "amenity": "vending_machine",
+        "brand": "Decathlon",
+        "brand:wikidata": "Q509349",
+        "name": "Decathlon Radtour-Retter",
+        "vending": "bicycle_tube"
+      }
     }
   ]
 }


### PR DESCRIPTION
At some German stores, Decathlon operates these bicycle tube vending machines. They all look the same, are functionally the same and are named the same. 

![image](https://user-images.githubusercontent.com/77762440/180571405-8ecd7282-865c-4bbd-9e83-6adea4c403f5.png)
