### PR TITLE
Rename VinMart to WinMart; merge VinMart+ with WinMart+

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -3489,17 +3489,6 @@
       }
     },
     {
-      "displayName": "VinMart+",
-      "id": "vinmart-61b913",
-      "locationSet": {"include": ["vn"]},
-      "tags": {
-        "brand": "VinMart",
-        "brand:wikidata": "Q60245505",
-        "name": "VinMart+",
-        "shop": "convenience"
-      }
-    },
-    {
       "displayName": "Viva",
       "id": "viva-856fe1",
       "locationSet": {"include": ["150"]},
@@ -3587,10 +3576,12 @@
     },
     {
       "displayName": "WinMart+",
-      "id": "winmart-4d6b4b",
-      "locationSet": {"include": ["001"]},
+      "id": "winmart-61b913",
+      "locationSet": {"include": ["vn"]},
+      "matchNames": ["vinmart+"],
       "tags": {
         "brand": "WinMart+",
+        "brand:wikidata": "Q60245505",
         "name": "WinMart+",
         "shop": "convenience"
       }

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -6670,17 +6670,6 @@
       }
     },
     {
-      "displayName": "VinMart",
-      "id": "vinmart-45db57",
-      "locationSet": {"include": ["vn"]},
-      "tags": {
-        "brand": "VinMart",
-        "brand:wikidata": "Q60245505",
-        "name": "VinMart",
-        "shop": "supermarket"
-      }
-    },
-    {
       "displayName": "VOI",
       "id": "voi-36e991",
       "locationSet": {"include": ["ch"]},
@@ -6872,6 +6861,18 @@
         "brand": "WinCo Foods",
         "brand:wikidata": "Q8023592",
         "name": "WinCo Foods",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "WinMart",
+      "id": "winmart-45db57",
+      "locationSet": {"include": ["vn"]},
+      "matchNames": ["vinmart"],
+      "tags": {
+        "brand": "WinMart",
+        "brand:wikidata": "Q60245505",
+        "name": "WinMart",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
Renamed VinMart to WinMart, reflecting a rebranding that took place earlier this year. The rebranding also affected the supermarket chain’s VinMart+ convenience stores, which are now WinMart+. 919f4d0bbdca40ca4a2ab495d2d78383d757683a added a WinMart+ entry but left the VinMart+ entry in place. This PR merges the two entries.

When Grab went to systematically map the entire WinMart+ chain as part of GRABOSM/Grab-Data#117, they clicked the “Not the same VinMart+” button on each one to preserve `name=WinMart+`. Unfortunately, that has resulted in the entire chain being tagged `not:wikidata:brand=Q60245505` instead of `wikidata:brand=Q60245505`. `not:wikidata:brand=Q60245505` is currently the top value of [`not:wikidata:brand`](https://taginfo.openstreetmap.org/keys/not:brand:wikidata#values) globally by far. Each of these locations will need to be retagged manually.

/ref #2656