### PR TITLE
Remove GoBus

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -4993,16 +4993,6 @@
       }
     },
     {
-      "displayName": "GoBus",
-      "id": "gobus-23677d",
-      "locationSet": {"include": ["ie"]},
-      "tags": {
-        "network": "GoBus",
-        "network:wikidata": "Q111372529",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "GoCary",
       "id": "gocary-5fe206",
       "locationSet": {


### PR DESCRIPTION
GoBus has recently been [purchased ](https://www.galwaydaily.com/news/transport/irish-citylink-takes-over-galway-based-gobus/) by Irish Citylink. 