### PR TITLE
updated and additions to brands in Ireland

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -1802,7 +1802,7 @@
     {
       "displayName": "Eddie Rocket's",
       "id": "eddierockets-5cf996",
-      "locationSet": {"include": ["ir"]},
+      "locationSet": {"include": ["ie"]},
       "tags": {
         "amenity": "fast_food",
         "brand": "Eddie Rocket's",

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -73,6 +73,19 @@
       }
     },
     {
+      "displayName": "Boojum",
+      "id": "",
+      "locationSet": {"include": ["ie", "gb-nir"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Boojum",
+        "brand:wikidata": "Q111973095",
+        "cuisine": "mexican",
+        "name": "Boojum",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "A&W (USA)",
       "id": "aandw-4d2ff4",
       "locationSet": {"include": ["us"]},

--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -2260,7 +2260,7 @@
     {
       "displayName": "Superdrug",
       "id": "superdrug-b98d4f",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {"include": ["gb", "ie"]},
       "tags": {
         "amenity": "pharmacy",
         "brand": "Superdrug",

--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -356,7 +356,7 @@
     {
       "displayName": "Boots",
       "id": "boots-9fb23d",
-      "locationSet": {"include": ["gb", "th"]},
+      "locationSet": {"include": ["gb", "th", "ie"]},
       "matchNames": ["boots pharmacy"],
       "tags": {
         "amenity": "pharmacy",

--- a/data/brands/shop/chemist.json
+++ b/data/brands/shop/chemist.json
@@ -67,7 +67,7 @@
     {
       "displayName": "Boots",
       "id": "boots-b82430",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {"include": ["gb", "ie"]},
       "tags": {
         "brand": "Boots",
         "brand:wikidata": "Q6123139",
@@ -388,7 +388,7 @@
     {
       "displayName": "Superdrug",
       "id": "superdrug-b82430",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {"include": ["gb", "ie"]},
       "tags": {
         "brand": "Superdrug",
         "brand:wikidata": "Q7643261",

--- a/data/brands/shop/pet.json
+++ b/data/brands/shop/pet.json
@@ -435,6 +435,17 @@
       }
     },
     {
+      "displayName": "Petmania",
+      "id": "",
+      "locationSet": {"include": ["ie"]},
+      "tags": {
+        "brand": "Petmania",
+        "brand:wikidata": "Q113281278",
+        "name": "Petmania",
+        "shop": "pet"
+      }
+    },
+    {
       "displayName": "Petz",
       "id": "petz-df7a1d",
       "locationSet": {"include": ["br"]},


### PR DESCRIPTION
- Adds Boojum (`amenity/fast_food`) & Petmania (`shop/pet`).
- Corrects `locationSet` for Eddie Rocket's which was set to `ir` not `ie`.
- Add the Irish `locationSet` for Boots & Superdrug.