### PR TITLE
Split German and Dutch “Cigo” newsagents

### DIFF
--- a/data/brands/shop/newsagent.json
+++ b/data/brands/shop/newsagent.json
@@ -23,7 +23,7 @@
       }
     },
     {
-      "displayName": "Cigo",
+      "displayName": "Cigo (Germany)",
       "id": "cigo-dbf769",
       "locationSet": {"include": ["de"]},
       "tags": {
@@ -34,7 +34,7 @@
       }
     },
     {
-      "displayName": "Cigo",
+      "displayName": "Cigo (Netherlands)",
       "id": "cigo-401e3d",
       "locationSet": {"include": ["nl"]},
       "tags": {

--- a/data/brands/shop/newsagent.json
+++ b/data/brands/shop/newsagent.json
@@ -24,8 +24,19 @@
     },
     {
       "displayName": "Cigo",
+      "id": "cigo-dbf769",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "brand": "Cigo",
+        "brand:wikidata": "Q113290782",
+        "name": "Cigo",
+        "shop": "newsagent"
+      }
+    },
+    {
+      "displayName": "Cigo",
       "id": "cigo-401e3d",
-      "locationSet": {"include": ["de", "nl"]},
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "brand": "Cigo",
         "brand:wikidata": "Q62391977",

--- a/data/brands/shop/newsagent.json
+++ b/data/brands/shop/newsagent.json
@@ -30,7 +30,8 @@
         "brand": "Cigo",
         "brand:wikidata": "Q113290782",
         "name": "Cigo",
-        "shop": "newsagent"
+        "shop": "newsagent",
+        "tobacco": "yes"
       }
     },
     {


### PR DESCRIPTION
They are separate companies with different owners and different
brand identities. Not sure if they’ve been related at some point
in the past (possibly before 2010); as of 2022, they’re separate.