### PR TITLE
Tag GB recycling containers more appropriately

### DIFF
--- a/data/brands/amenity/recycling.json
+++ b/data/brands/amenity/recycling.json
@@ -258,13 +258,27 @@
     },
     {
       "displayName": "The Salvation Army",
-      "id": "thesalvationarmy-417047",
-      "locationSet": {"include": ["gb", "us"]},
+      "id": "thesalvationarmy-a9e339",
+      "locationSet": {"include": ["gb"]},
       "matchNames": ["salvation army"],
       "tags": {
         "amenity": "recycling",
         "brand": "The Salvation Army",
         "brand:wikidata": "Q188307",
+        "recycling_type": "container",
+        "recycling:clothes": "yes"
+      }
+    },
+    {
+      "displayName": "The Salvation Army (US)",
+      "id": "thesalvationarmy-f8d7ba",
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["salvation army"],
+      "tags": {
+        "amenity": "recycling",
+        "brand": "The Salvation Army",
+        "brand:wikidata": "Q188307",
+        "name": "The Salvation Army",
         "recycling_type": "container",
         "recycling:clothes": "yes"
       }

--- a/data/brands/amenity/recycling.json
+++ b/data/brands/amenity/recycling.json
@@ -205,7 +205,6 @@
         "amenity": "recycling",
         "brand": "Oxfam",
         "brand:wikidata": "Q267941",
-        "name": "Oxfam",
         "operator": "Oxfam",
         "operator:wikidata": "Q267941",
         "recycling_type": "container",
@@ -266,7 +265,7 @@
         "amenity": "recycling",
         "brand": "The Salvation Army",
         "brand:wikidata": "Q188307",
-        "name": "The Salvation Army",
+        "recycling_type": "container",
         "recycling:clothes": "yes"
       }
     },


### PR DESCRIPTION
This change tags Salvation Army recycling points as containers and
removes names for containers.

People don't generally assign names to recycling containers.  If someone
says "I'm going to Oxfam" you assume they mean a shop, not a container:
https://wiki.openstreetmap.org/wiki/Names#Name_is_the_name_only