### PR TITLE
Add Irish brands

### DIFF
--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -127,6 +127,19 @@
         "shop": "electronics"
       }
     },
+     {
+      "displayName": "DID Electrical",
+      "id": "",
+      "locationSet": {
+        "include": ["ie""]
+      },
+      "tags": {
+        "brand": "DID Electrical",
+        "brand:wikidata": "Q113471741",
+        "name": "DID Electrical",
+        "shop": "electronics"
+      }
+    },
     {
       "displayName": "Bing Lee",
       "id": "binglee-026a7a",

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -130,9 +130,7 @@
      {
       "displayName": "DID Electrical",
       "id": "",
-      "locationSet": {
-        "include": ["ie""]
-      },
+      "locationSet": {"include": ["ie"]},
       "tags": {
         "brand": "DID Electrical",
         "brand:wikidata": "Q113471741",

--- a/data/brands/shop/furniture.json
+++ b/data/brands/shop/furniture.json
@@ -96,6 +96,17 @@
       }
     },
     {
+      "displayName": "EZ Living Furniture",
+      "id": "",
+      "locationSet": {"include": ["ie"]},
+      "tags": {
+        "brand": "EZ Living Furniture",
+        "brand:wikidata": "Q113472646",
+        "name": "EZ Living Furniture",
+        "shop": "furniture"
+      }
+    },
+    {
       "displayName": "Ashley HomeStore",
       "id": "ashleyhomestore-a694b9",
       "locationSet": {"include": ["ca", "us"]},

--- a/data/brands/shop/houseware.json
+++ b/data/brands/shop/houseware.json
@@ -189,6 +189,17 @@
       }
     },
     {
+      "displayName": "Home Store + More",
+      "id": "",
+      "locationSet": {"include": ["ie"]},
+      "tags": {
+        "brand": "Home Store + More",
+        "brand:wikidata": "Q113471802",
+        "name": "Home Store + More",
+        "shop": "houseware"
+      }
+    },
+    {
       "displayName": "Howards Storage World",
       "id": "howardsstorageworld-9d9c4b",
       "locationSet": {"include": ["au"]},

--- a/data/brands/shop/interior_decoration.json
+++ b/data/brands/shop/interior_decoration.json
@@ -115,6 +115,17 @@
       }
     },
     {
+      "displayName": "Harry Corry",
+      "id": "",
+      "locationSet": {"include": ["ie", "gb"]},
+      "tags": {
+        "brand": "Harry Corry",
+        "brand:wikidata": "Q5668069",
+        "name": "Harry Corry",
+        "shop": "interior_decoration"
+      }
+    },
+    {
       "displayName": "H&M HOME",
       "id": "handmhome-0f41f2",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Added:
- [Harry Corry](https://www.harrycorry.com/) ([Q5668069](https://www.wikidata.org/wiki/Q5668069))
- [DID Electrical](https://www.did.ie/) ([Q113471741](https://www.wikidata.org/wiki/Q113471741))
- [Home Store + More](https://www.homestoreandmore.ie/) ([Q113471802](https://www.wikidata.org/wiki/Q113471802))
- [EZ Living Furniture](https://www.ezlivingfurniture.ie/) ([Q113472646](https://www.wikidata.org/wiki/Q113472646))
