### PR TITLE
Editing Central Banks Brand name and adding wikidata

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -3737,13 +3737,13 @@
     },
     {
       "displayName": "Central Bank",
-      "id": "centralbank-b7a026",
-      "locationSet": {"include": ["001"]},
+      "id": "centralbank-ea2e2d",
+      "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "bank",
-        "brand": "Central Bancompany",
+        "brand": "Central Bank",
         "brand:wikidata": "Q113482320",
-        "name": "Central Bancompany"
+        "name": "Central Bank"
       }
     },
     {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -3741,8 +3741,9 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "bank",
-        "brand": "Central Bank",
-        "name": "Central Bank"
+        "brand": "Central Bancompany",
+        "brand:wikidata": "Q113482320",
+        "name": "Central Bancompany"
       }
     },
     {


### PR DESCRIPTION
I updated the Central Bank info (data/brands/amenity/bank.json) file.

Since it didn't have a Wikipedia page, I created a new item in Wikidata. I used its official website, Youtube channel, and Linkedin as identifiers.
Note that its display name is Central Bank but its brand is Central Bancompany according to its website: 

- https://www.centralbank.net/
- https://www.youtube.com/user/CentralBankMO
- https://www.linkedin.com/company/central-bancompany/