### PR TITLE
Add Rosauers Supermarkets and Fort Vancouver Regional Libraries

### DIFF
--- a/data/brands/amenity/library.json
+++ b/data/brands/amenity/library.json
@@ -25,6 +25,16 @@
       }
     },
     {
+      "displayName": "FVRL",
+      "locationSet": {"include": ["us-wa.geojson"]},
+      "tags": {
+        "amenity": "library",
+        "brand": "Fort Vancouver Regional Libraries",
+        "brand:short": "FVRL",
+        "brand:wikidata": "Q5472215"
+      }
+    },
+    {
       "displayName": "LEO",
       "id": "librariesofeasternoregon-0b187f",
       "locationSet": {

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -5496,6 +5496,16 @@
       }
     },
     {
+      "displayName": "Rosauers Supermarkets",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "brand": "Rosauers Supermarkets",
+        "brand:wikidata": "Q7367458",
+        "name": "Rosauers Supermarkets",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Rouses",
       "id": "rouses-dde59d",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Hi,
I tried adding two brands under the same pull request (both need ID). This PR should solve #6916 and #6917.

For FVRL I set the `locationSet` to `["us-wa.geojson"]`, since they will probably not expand to other states, while for Rosauers Supermarkets I chose `["us"]`, as they already expanded to multiple states and will probably continue to do so.

---

Close #6916 , #6917 
