### PR TITLE
Change formatting for "EVBOX" to "EVBox"

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -1447,12 +1447,12 @@
       }
     },
     {
-      "displayName": "EVBOX",
+      "displayName": "EVBox",
       "id": "evbox-7f623e",
       "locationSet": {"include": ["150"]},
       "tags": {
         "amenity": "charging_station",
-        "operator": "EVBOX",
+        "operator": "EVBox",
         "operator:wikidata": "Q28406392"
       }
     },


### PR DESCRIPTION
Changed name based on official website: https://evbox.com/