### PR TITLE
Add Revolution Laundry

### DIFF
--- a/data/brands/shop/laundry.json
+++ b/data/brands/shop/laundry.json
@@ -64,6 +64,18 @@
       }
     },
     {
+      "displayName": "Revolution Laundry",
+      "id": "revolutionlaundry-ca17f3",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "Revolution Laundry",
+        "brand:wikidata": "Q113516904",
+        "name": "Revolution Laundry",
+        "self_service": "yes",
+        "shop": "laundry"
+      }
+    },
+    {
       "displayName": "Speed Queen",
       "id": "speedqueen-ca17f3",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Add Revolution Laundry (Q113516904)

I was not sure whether to use [shop=laundry](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dlaundry) or [amenity=washing_mashine](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dwashing_machine). The latter seems to be more appropriate, but is barely used.