### PR TITLE
Adding Agglobus (Rodez) and disambiguation

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -127,9 +127,11 @@
       }
     },
     {
-      "displayName": "AggloBus",
-      "id": "agglobus-ed7458",
-      "locationSet": {"include": ["fr"]},
+      "displayName": "AggloBus (Bourges)",
+      "id": "agglobus-792c11",
+      "locationSet": {
+        "include": ["fr-cvl.geojson"]
+      },
       "tags": {
         "network": "AggloBus",
         "network:wikidata": "Q3537943",
@@ -137,9 +139,23 @@
       }
     },
     {
+      "displayName": "Agglobus (Rodez)",
+      "id": "agglobus-3755d1",
+      "locationSet": {
+        "include": ["fr-occ.geojson"]
+      },
+      "tags": {
+        "network": "Agglobus",
+        "network:wikidata": "Q2826802",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "Agglobus Cavem",
-      "id": "agglobuscavem-ed7458",
-      "locationSet": {"include": ["fr"]},
+      "id": "agglobuscavem-cbddab",
+      "locationSet": {
+        "include": ["fr-pac.geojson"]
+      },
       "tags": {
         "network": "Agglobus Cavem",
         "network:wikidata": "Q86664442",


### PR DESCRIPTION
Purpose is to fix iD wrong suggestions due to homonyms.

![OSM ID wrong suggestion](https://user-images.githubusercontent.com/1572964/184683763-ad517dff-accb-46f9-b758-1e27ba2301e1.jpg)

