### PR TITLE
Alternate name for chibabank

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -13390,6 +13390,7 @@
       "displayName": "千葉銀行",
       "id": "chibabank-d7a9e7",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["ちばぎん"],
       "tags": {
         "amenity": "bank",
         "brand": "千葉銀行",


### PR DESCRIPTION
Branch offices of [Chiba Bank](https://www.chibabank.co.jp/) use the letters ちばぎん on their buildings. This PR adds this as an alternate name.