### PR TITLE
Add 'Türkiye Petrolleri' brand

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -4678,6 +4678,17 @@
       }
     },
     {
+      "displayName": "Türkiye Petrolleri",
+      "matchNames":["TP","TPPD"],
+      "locationSet": {"include": ["tr"]},
+      "tags": {
+        "amenity": "fuel",
+        "brand": "Türkiye Petrolleri",
+        "brand:wikidata": "Q15946806",
+        "name": "Türkiye Petrolleri"
+      }
+    },
+    {
       "displayName": "Turmöl",
       "id": "turmol-565075",
       "locationSet": {"include": ["at"]},


### PR DESCRIPTION
This PR adds the 'Türkiye Petrolleri' brand of fuel stations in Turkey. There are currently 48 nodes with this name occurring in Turkey.

I have not been able to run `npm build` yet; hope to be able to figure this out soon.

Some stations have been labelled as "TP" and wikidata also has "TPPD"; hence, I am adding these two as matchNames. Not sure whether such short matchNames make sense -- I am looking for guidance on this.
