### PR TITLE
add Turkish fuel station brands Sunpet and termo

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -4302,6 +4302,7 @@
     },
     {
       "displayName": "Sunpet",
+      "id": "sunpet-ec7588",
       "locationSet": {"include": ["tr"]},
       "tags": {
         "amenity": "fuel",
@@ -4452,11 +4453,8 @@
     },
     {
       "displayName": "termo",
-      "locationSet": {
-        "include": [
-          "tr"
-        ]
-      },
+      "id": "termo-ec7588",
+      "locationSet": {"include": ["tr"]},
       "tags": {
         "amenity": "fuel",
         "brand": "termo",
@@ -4703,8 +4701,9 @@
     },
     {
       "displayName": "Türkiye Petrolleri",
-      "matchNames":["TP","TPPD"],
+      "id": "turkiyepetrolleri-ec7588",
       "locationSet": {"include": ["tr"]},
+      "matchNames": ["tp", "tppd"],
       "tags": {
         "amenity": "fuel",
         "brand": "Türkiye Petrolleri",

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -4441,6 +4441,20 @@
       }
     },
     {
+      "displayName": "termo",
+      "locationSet": {
+        "include": [
+          "tr"
+        ]
+      },
+      "tags": {
+        "amenity": "fuel",
+        "brand": "termo",
+        "brand:wikidata": "Q113565581",
+        "name": "termo"
+      }
+    },
+    {
       "displayName": "Terpel",
       "id": "terpel-23f925",
       "locationSet": {

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -4301,6 +4301,16 @@
       }
     },
     {
+      "displayName": "Sunpet",
+      "locationSet": {"include": ["tr"]},
+      "tags": {
+        "amenity": "fuel",
+        "brand": "Sunpet",
+        "brand:wikidata": "Q113579553",
+        "name": "Sunpet"
+      }
+    },
+    {
       "displayName": "Super U",
       "id": "superu-3772a0",
       "locationSet": {"include": ["fr"]},


### PR DESCRIPTION
With this addition, all Turkish fuel station brands that had more than 40 mentions in OSM nodes in Turkey are mentioned in nsi.

I chose 40 as cut-off (rather than the informal 50 threshold) because there is good evidence that there are plenty more stations of each brand; fuzzy searching flags up more than 50 stations for each (and many have either not been mapped or not tagged with a name).

Sunpet is a brand of OPET. I edited this into wikidata as a separate entity, so it goes under a different identifier than OPET.

The PR also includes the output of `npm run build` though only for fuel.json (disregarding any changes to other files). `npm run build` throws a few warnings but nothing connected to these changes, as far as I can see.