### PR TITLE
Update OpenLoop Charging stations 

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -95,6 +95,15 @@
       }
     },
     {
+      "displayName": "OpenLoop",
+      "locationSet": { "include": [ "nz" ] },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "OpenLoop",
+        "brand:wikidata": "Q113289213"
+      }
+    },
+    {
       "displayName": "Recharge",
       "id": "recharge-508422",
       "locationSet": {

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -2652,17 +2652,6 @@
       }
     },
     {
-      "displayName": "OpenLoop",
-      "locationSet": {"include": ["nz"]},
-      "tags": {
-        "amenity": "charging_station",
-        "network": "OpenLoop",
-        "network:wikidata": "Q113289213",
-        "brand": "OpenLoop",
-        "brand:wikidata": "Q113289213"
-      }
-    },
-    {
       "displayName": "WEL Networks",
       "locationSet": {"include": ["nz"]},
       "tags": {
@@ -2671,8 +2660,6 @@
         "operator:wikidata": "Q7948949",
         "network": "OpenLoop",
         "network:wikidata": "Q113289213",
-        "brand": "OpenLoop",
-        "brand:wikidata": "Q113289213"
       }
     },
     {
@@ -2682,10 +2669,8 @@
         "amenity": "charging_station",
         "operator": "Z Energy",
         "operator:wikidata": "Q8063337",
-        "network": "OpenLoop",
-        "network:wikidata": "Q113289213",
-        "brand": "OpenLoop",
-        "brand:wikidata": "Q113289213"
+        "network": "Z Energy",
+        "network:wikidata": "Q8063337",
       }
     },
     {
@@ -2697,8 +2682,6 @@
         "operator:wikidata": "Q108450092",
         "network": "OpenLoop",
         "network:wikidata": "Q113289213",
-        "brand": "OpenLoop",
-        "brand:wikidata": "Q113289213"
       }
     },
     {

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -2659,7 +2659,7 @@
         "operator": "OpenLoop",
         "operator:wikidata": "Q113289213",
         "network": "OpenLoop",
-        "network:wikidata": "Q113289213"
+        "network:wikidata": "Q113289213",
         "brand": "OpenLoop",
         "brand:wikidata": "Q113289213"
       }
@@ -2673,7 +2673,7 @@
         "operator": "WEL Networks",
         "operator:wikidata": "Q7948949",
         "network": "OpenLoop",
-        "network:wikidata": "Q113289213"
+        "network:wikidata": "Q113289213",
         "brand": "OpenLoop",
         "brand:wikidata": "Q113289213"
       }
@@ -2686,7 +2686,7 @@
         "operator": "Z Energy",
         "operator:wikidata": "Q8063337",
         "network": "OpenLoop",
-        "network:wikidata": "Q113289213"
+        "network:wikidata": "Q113289213",
         "brand": "OpenLoop",
         "brand:wikidata": "Q113289213"
       }
@@ -2699,7 +2699,7 @@
         "operator": "Counties Energy",
         "operator:wikidata": "Q108450092",
         "network": "OpenLoop",
-        "network:wikidata": "Q113289213"
+        "network:wikidata": "Q113289213",
         "brand": "OpenLoop",
         "brand:wikidata": "Q113289213"
       }

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -2656,8 +2656,6 @@
       "locationSet": {"include": ["nz"]},
       "tags": {
         "amenity": "charging_station",
-        "operator": "OpenLoop",
-        "operator:wikidata": "Q113289213",
         "network": "OpenLoop",
         "network:wikidata": "Q113289213",
         "brand": "OpenLoop",
@@ -2666,7 +2664,6 @@
     },
     {
       "displayName": "WEL Networks",
-      "id": "openloop-9850e1",
       "locationSet": {"include": ["nz"]},
       "tags": {
         "amenity": "charging_station",

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -2653,34 +2653,53 @@
     },
     {
       "displayName": "OpenLoop",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "OpenLoop",
+        "operator:wikidata": "Q113289213",
+        "network": "OpenLoop",
+        "network:wikidata": "Q113289213"
+        "brand": "OpenLoop",
+        "brand:wikidata": "Q113289213"
+      }
+    },
+    {
+      "displayName": "WEL Networks",
       "id": "openloop-9850e1",
       "locationSet": {"include": ["nz"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "WEL Networks",
         "operator:wikidata": "Q7948949",
+        "network": "OpenLoop",
+        "network:wikidata": "Q113289213"
         "brand": "OpenLoop",
         "brand:wikidata": "Q113289213"
       }
     },
     {
-      "displayName": "OpenLoop",
+      "displayName": "Z Energy",
       "locationSet": {"include": ["nz"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Z Energy",
         "operator:wikidata": "Q8063337",
+        "network": "OpenLoop",
+        "network:wikidata": "Q113289213"
         "brand": "OpenLoop",
         "brand:wikidata": "Q113289213"
       }
     },
     {
-      "displayName": "OpenLoop",
+      "displayName": "Counties Energy",
       "locationSet": {"include": ["nz"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Counties Energy",
         "operator:wikidata": "Q108450092",
+        "network": "OpenLoop",
+        "network:wikidata": "Q113289213"
         "brand": "OpenLoop",
         "brand:wikidata": "Q113289213"
       }

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -2657,8 +2657,32 @@
       "locationSet": {"include": ["nz"]},
       "tags": {
         "amenity": "charging_station",
-        "operator": "OpenLoop",
-        "operator:wikidata": "Q113289213"
+        "operator": "WEL Networks",
+        "operator:wikidata": "Q7948949",
+        "brand": "OpenLoop",
+        "brand:wikidata": "Q113289213"
+      }
+    },
+    {
+      "displayName": "OpenLoop",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Z Energy",
+        "operator:wikidata": "Q8063337",
+        "brand": "OpenLoop",
+        "brand:wikidata": "Q113289213"
+      }
+    },
+    {
+      "displayName": "OpenLoop",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Counties Energy",
+        "operator:wikidata": "Q108450092",
+        "brand": "OpenLoop",
+        "brand:wikidata": "Q113289213"
       }
     },
     {


### PR DESCRIPTION
Moved Openloop from operators to brands, to reflect that OpenLoop doesn't actually own or physically operate any EV Chargers, they just provide the app and the software for the stations - so all the chargers appear in the openloop app with status, authentication and billing. 
The Physical stations themselves are owned by other companies, and usually painted with their respective branding.

Please check that this is the correct way to implement this.