### PR TITLE
Add Mondial Relay parcel lockers

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -229,6 +229,17 @@
       }
     },
     {
+      "displayName": "Mondial Relay",
+      "id": "mondialrelay",
+      "locationSet": {"include": ["be", "fr"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "Mondial Relay",
+        "brand:wikidata": "Q3320547",
+        "parcel_mail_in": "yes"
+      }
+    },
+    {
       "displayName": "My Post 24",
       "id": "mypost24-237d95",
       "locationSet": {"include": ["ch"]},


### PR DESCRIPTION
Add Mondial Relay parcel lockers in France, e.g. [like that one](https://commons.wikimedia.org/wiki/File:Centre_commercial_Portes_de_Lyon_-_Retrait_colis_libre-service_(août_2018).jpg).