### PR TITLE
The Source Bulk Foods

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -6534,6 +6534,19 @@
       }
     },
     {
+      "displayName": "The Source Bulk Foods",
+      "locationSet": {
+        "include": ["au", "ca", "gb-eng"]
+      },
+      "tags": {
+        "brand": "The Source Bulk Foods",
+        "brand:wikidata": "Q113771168",
+        "name": "The Source Bulk Foods",
+        "shop": "supermarket",
+        "zero_waste": "only"
+      }
+    },
+    {
       "displayName": "The Store",
       "id": "thestore-80e9ee",
       "locationSet": {"include": ["my"]},


### PR DESCRIPTION
The Source Bulk Foods has plastic free stores in Australia, Canada and the UK