### PR TITLE
Change Shake Shack from us/gb to global

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -5705,7 +5705,7 @@
     {
       "displayName": "Shake Shack",
       "id": "shakeshack-56a2ff",
-      "locationSet": {"include": ["gb", "us"]},
+      "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "fast_food",
         "brand": "Shake Shack",


### PR DESCRIPTION
Countries detected on their website:

1 "Oman"
3 "Philippines"
3 "Qatar"
4 "Hong Kong"
5 "Saudi Arabia"
6 "Singapore"
6 "Turkey"
7 "Mexico"
10 "United Kingdom"
10 "United Arab Emirates"
11 "Japan"
11 "Kuwait"
13 "South Korea"
15 "China"
17 null
253 "United States of America"