### PR TITLE
Change "Deutsche Telekom" charging station operator to the consistent…

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -789,12 +789,12 @@
       }
     },
     {
-      "displayName": "Deutsche Telekom",
+      "displayName": "Deutsche Telekom AG",
       "id": "deutschetelekom-1299a8",
       "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
-        "operator": "Deutsche Telekom",
+        "operator": "Deutsche Telekom AG",
         "operator:wikidata": "Q9396"
       }
     },


### PR DESCRIPTION
… value "Deutsche Telekom AG"

For the operator "Deutsche Telekom [AG]" in Germany, we should use a consistent value. We do have "operator=Deutsche Telekom AG" (+ operator:wikidata=Q9396) already in the NSI for amenity=telephone and telecom=exchange. So we should use the value "Deutsche Telekom AG" for charging stations, too, to make it consistent. Especially because the operator for the telephones, the telephone exchanges and the charging stations is one adn the same, here.