### PR TITLE
Update clothes.json

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -1836,7 +1836,7 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "Cotton On",
-        "brand:wikidata": "Q5175717",
+        "brand:wikidata": "Q113961498",
         "clothes": "children",
         "name": "Cotton On Kids",
         "shop": "clothes"


### PR DESCRIPTION
Cotton On Kids has [it's own wikidata entry](https://www.wikidata.org/wiki/Q113961498) and is a separate brand from Cotton On.