### PR TITLE
Additions, edits & suggestion of some Japanese brands

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6392,6 +6392,7 @@
         "brand": "apollostation",
         "brand:en": "apollostation",
         "brand:ja": "アポロステーション",
+        "brand:wikidata": "Q2216770",
         "name": "apollostation",
         "name:en": "apollostation",
         "name:ja": "アポロステーション"

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6383,6 +6383,19 @@
         "brand": "福懋加油站",
         "name": "福懋加油站"
       }
+    },
+    {
+      "displayName": "apollostation",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "fuel",
+        "brand": "apollostation",
+        "brand:en": "apollostation",
+        "brand:ja": "アポロステーション",
+        "name": "apollostation",
+        "name:en": "apollostation",
+        "name:ja": "アポロステーション"
+      }
     }
   ]
 }

--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -1337,6 +1337,18 @@
         "name:ja": "ナフコ",
         "shop": "doityourself"
       }
+    },
+    {
+      "displayName": "DCM",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "DCM",
+        "brand:en": "DCM",
+        "brand:ja": "ディーシーエム",
+        "name": "DCM",
+        "name:en": "DCM",
+        "name:ja": "ディーシーエム"
+      }
     }
   ]
 }

--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -1345,6 +1345,7 @@
         "brand": "DCM",
         "brand:en": "DCM",
         "brand:ja": "ディーシーエム",
+        "brand:wikidata": "Q11195603",
         "name": "DCM",
         "name:en": "DCM",
         "name:ja": "ディーシーエム"

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -9658,7 +9658,7 @@
       "displayName": "イオンスーパーセンター",
       "locationSet": {"include": ["jp"]},
       "tags": {
-        "brand": "AEON SUPERCENTER",
+        "brand": "イオンスーパーセンター",
         "brand:ja": "イオンスーパーセンター",
         "brand:en": "AEON SUPERCENTER",
         "brand:wikidata": "Q11285970",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -8694,8 +8694,11 @@
       "tags": {
         "brand": "ザ・ビッグ",
         "brand:ja": "ザ・ビッグ",
+        "brand:en": "THE BIG",
+        "brand:wikidata": "Q11306676",
         "name": "ザ・ビッグ",
         "name:ja": "ザ・ビッグ",
+        "name:en": "THE BIG",
         "shop": "supermarket"
       }
     },
@@ -9648,6 +9651,61 @@
         "brand:ja": "関西スーパー",
         "name": "関西スーパー",
         "name:ja": "関西スーパー",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "イオンスーパーセンター",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "AEON SUPERCENTER",
+        "brand:ja": "イオンスーパーセンター",
+        "brand:en": "AEON SUPERCENTER",
+        "brand:wikidata": "Q11285970",
+        "name": "イオンスーパーセンター",
+        "name:ja": "イオンスーパーセンター",
+        "name:en": "Aeon Supercenter",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "ザ・ビッグ エクスプレス",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "ザ・ビッグ エクスプレス",
+        "brand:ja": "ザ・ビッグ エクスプレス",
+        "brand:en": "THE BIG Express",
+        "name": "ザ・ビッグ エクスプレス",
+        "name:ja": "ザ・ビッグ エクスプレス",
+        "name:en": "THE BIG Express",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "東光ストア",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "東光ストア",
+        "brand:ja": "東光ストア",
+        "brand:en": "Tokou Store",
+        "brand:wikidata": "Q11526020",
+        "name": "東光ストア",
+        "name:ja": "東光ストア",
+        "name:en": "Tokou Store",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "コープさっぽろ",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "コープさっぽろ",
+        "brand:ja": "コープさっぽろ",
+        "brand:en": "Coop Sapporo",
+        "brand:wikidata": "Q11574624",
+        "name": "コープさっぽろ",
+        "name:ja": "コープさっぽろ",
+        "name:en": "Coop Sapporo",
         "shop": "supermarket"
       }
     }

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -9675,6 +9675,7 @@
         "brand": "ザ・ビッグ エクスプレス",
         "brand:ja": "ザ・ビッグ エクスプレス",
         "brand:en": "THE BIG Express",
+        "brand:wikidata": "Q11306676",
         "name": "ザ・ビッグ エクスプレス",
         "name:ja": "ザ・ビッグ エクスプレス",
         "name:en": "THE BIG Express",


### PR DESCRIPTION
Hello.
As the title says, I have added or edited the following Japanese brands.
If I have done something wrong, I apologize. I am still a newbie and unfamiliar with it.
Also, I left the id blank because I wasn't sure how to add it. My apologies.

・apollostation (fuel)
・DCM (doityourself)
・イオンスーパーセンター (AEON SUPERCENTER) (supermarket)
・ザ・ビッグ エクスプレス (THE BIG Express) (supermarket)
・東光ストア (Tokou Store) (supermarket)
・コープさっぽろ (Coop Sapporo) (supermarket)

Furthermore, the Japanese Naming sample has a standard: "**In the name tag, if the store's brand name (as written on the sign) and the name in Japanese are different, the name in Japanese is given priority**".


This is my personal feeling, but I feel uncomfortable when only Viva Home is written in English while the surrounding POIs are written in Japanese.

Therefore, I think that name tags in Japan should be written in Japanese as well as other brands in Japan (If it is common to use Japanese for brand names, even if the signage is in English, as is the standard of the OSM Wiki in Japan).

I apologize for the length of this post. If it is acceptable, I would appreciate it if you could merge, etc.