### PR TITLE
remove defunct school districts in Quebec

### DIFF
--- a/data/operators/amenity/school.json
+++ b/data/operators/amenity/school.json
@@ -5527,6 +5527,9 @@
       "locationSet": {
         "include": ["ca-qc.geojson"]
       },
+      "matchNames": [
+        "commission scolaire de la capitale"
+      ],
       "tags": {
         "amenity": "school",
         "operator": "Centre de services scolaire de la Capitale",
@@ -5540,6 +5543,9 @@
       "locationSet": {
         "include": ["ca-qc.geojson"]
       },
+      "matchNames": [
+        "commission scolaire de la région-de-sherbrooke"
+      ],
       "tags": {
         "amenity": "school",
         "operator": "Centre de services scolaire de la Région-de-Sherbrooke",
@@ -5553,6 +5559,9 @@
       "locationSet": {
         "include": ["ca-qc.geojson"]
       },
+      "matchNames": [
+        "commission scolaire de montréal"
+      ],
       "tags": {
         "amenity": "school",
         "operator": "Centre de services scolaire de Montréal",
@@ -5566,6 +5575,9 @@
       "locationSet": {
         "include": ["ca-qc.geojson"]
       },
+      "matchNames": [
+        "commission scolaire des draveurs"
+      ],
       "tags": {
         "amenity": "school",
         "operator": "Centre de services scolaire des Draveurs",
@@ -6076,62 +6088,6 @@
         "amenity": "school",
         "operator": "Comhairle nan Eilean Siar",
         "operator:wikidata": "Q3778400"
-      }
-    },
-    {
-      "displayName": "Commission scolaire de la Capitale",
-      "id": "commissionscolairedelacapitale-d1e97c",
-      "locationSet": {
-        "include": ["ca-qc.geojson"]
-      },
-      "note": "Defunct since 2020 - Succeeded by Centre de services scolaire de la Capitale in 2020.",
-      "tags": {
-        "amenity": "school",
-        "operator": "Commission scolaire de la Capitale",
-        "operator:type": "public",
-        "operator:wikidata": "Q2986747"
-      }
-    },
-    {
-      "displayName": "Commission scolaire de la Région-de-Sherbrooke",
-      "id": "commissionscolairedelaregiondesherbrooke-d1e97c",
-      "locationSet": {
-        "include": ["ca-qc.geojson"]
-      },
-      "note": "Defunct since 2020 - Succeeded by Centre de services scolaire de la Région-de-Sherbrooke",
-      "tags": {
-        "amenity": "school",
-        "operator": "Commission scolaire de la Région-de-Sherbrooke",
-        "operator:type": "public",
-        "operator:wikidata": "Q5152771"
-      }
-    },
-    {
-      "displayName": "Commission scolaire de Montréal",
-      "id": "commissionscolairedemontreal-d1e97c",
-      "locationSet": {
-        "include": ["ca-qc.geojson"]
-      },
-      "note": "Defunct since 2020 - Succeeded by Centre de services scolaire de Montréal",
-      "tags": {
-        "amenity": "school",
-        "operator": "Commission scolaire de Montréal",
-        "operator:type": "public",
-        "operator:wikidata": "Q970756"
-      }
-    },
-    {
-      "displayName": "Commission scolaire des Draveurs",
-      "id": "commissionscolairedesdraveurs-d1e97c",
-      "locationSet": {
-        "include": ["ca-qc.geojson"]
-      },
-      "note": "Defunct since 2020 - Succeeded by Centre de services scolaire des Draveurs",
-      "tags": {
-        "amenity": "school",
-        "operator": "Commission scolaire des Draveurs",
-        "operator:type": "public",
-        "operator:wikidata": "Q5152629"
       }
     },
     {


### PR DESCRIPTION
Instead of having them as separate entries, instead add them in `matchNames`, and remove the defunct

They were replaced 1:1, the new organizations took over after the defunct ones