### PR TITLE
UA updates

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -7496,7 +7496,7 @@
       "displayName": "Домино'c",
       "id": "dominos-873380",
       "locationSet": {
-        "include": ["by", "kz", "ru", "ua"]
+        "include": ["by", "kz", "ru"]
       },
       "matchNames": ["доминоc пицца"],
       "tags": {

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -1015,6 +1015,7 @@
       "tags": {
         "amenity": "fuel",
         "brand": "Chipo",
+        "brand:wikidata": "Q112082302",
         "name": "Chipo"
       }
     },

--- a/data/brands/office/telecommunication.json
+++ b/data/brands/office/telecommunication.json
@@ -78,7 +78,6 @@
           "kz",
           "la",
           "ru",
-          "ua",
           "vn"
         ]
       },
@@ -280,7 +279,7 @@
       "displayName": "Билайн",
       "id": "beeline-212d09",
       "locationSet": {
-        "include": ["ge", "kg", "kz", "ru", "ua"]
+        "include": ["ge", "kg", "kz", "ru"]
       },
       "tags": {
         "brand": "Билайн",

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -318,6 +318,17 @@
       }
     },
     {
+      "displayName": "Eldorado (Україна)",
+      "locationSet": {"include": ["ua"]},
+      "matchNames": ["ельдорадо"],
+      "tags": {
+        "brand": "Eldorado",
+        "brand:wikidata": "Q60851865",
+        "name": "Eldorado",
+        "shop": "electronics"
+      }
+    },
+    {
       "displayName": "Elektra",
       "id": "elektra-10d776",
       "locationSet": {
@@ -1293,7 +1304,7 @@
     {
       "displayName": "Эльдорадо",
       "id": "d6f3ca-10b077",
-      "locationSet": {"include": ["ru", "ua"]},
+      "locationSet": {"include": ["ru"]},
       "tags": {
         "brand": "Эльдорадо",
         "brand:wikidata": "Q4531492",

--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -1135,6 +1135,7 @@
       "displayName": "Київстар",
       "id": "kyivstar-985251",
       "locationSet": {"include": ["ua"]},
+      "matchNames": ["beeline", "білайн"],
       "tags": {
         "brand": "Київстар",
         "brand:en": "Kyivstar",


### PR DESCRIPTION
 - Moved Domino's to a common scheme. In Ukraine, the Dominos chain uses only the original name without transliteration
 - Sorted cuisine according to relevance (matches the lexicographic order) for Eurasia
 - Beeline was bought by Kyivstar in 2010. The brand has not survived. There are no entries in the OSM DB
 - Added Eldorado chain of electronics shops