### PR TITLE
Add and modify doityourself (Komeri, Homac nicot)

### DIFF
--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -1402,6 +1402,7 @@
       "displayName": "ホーマックニコット",
       "id": "homacnicot-dd401d",
       "locationSet": {"include": ["jp"]},
+      "note": "According to the company announcement, this will be renamed \"DCMニコット(DCM nicot)\" in the future.",
       "tags": {
         "brand": "ホーマックニコット",
         "brand:en": "Homac nicot",

--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -1322,17 +1322,32 @@
       }
     },
     {
-      "displayName": "コメリ",
-      "id": "komeri-dd401d",
+      "displayName": "コメリハード&グリーン",
+      "id": "komerihardandgreen-dd401d",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "brand": "コメリ",
-        "brand:en": "Komeri",
+        "brand:en": "KOMERI",
         "brand:ja": "コメリ",
         "brand:wikidata": "Q11302690",
-        "name": "コメリ",
-        "name:en": "Komeri",
-        "name:ja": "コメリ",
+        "name": "コメリハード&グリーン",
+        "name:en": "Komeri Hard & Green",
+        "name:ja": "コメリハード&グリーン",
+        "shop": "doityourself"
+      }
+    },
+    {
+      "displayName": "コメリパワー",
+      "id": "komeripower-dd401d",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "コメリ",
+        "brand:en": "KOMERI",
+        "brand:ja": "コメリ",
+        "brand:wikidata": "Q11302690",
+        "name": "コメリパワー",
+        "name:en": "Komeri Power",
+        "name:ja": "コメリパワー",
         "shop": "doityourself"
       }
     },
@@ -1385,8 +1400,8 @@
     },
     {
       "displayName": "ホーマックニコット",
-      "id": "homacnicot-092aaf",
-      "locationSet": {"include": ["001"]},
+      "id": "homacnicot-dd401d",
+      "locationSet": {"include": ["jp"]},
       "tags": {
         "brand": "ホーマックニコット",
         "brand:en": "Homac nicot",

--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -1406,6 +1406,7 @@
         "brand": "ホーマックニコット",
         "brand:en": "Homac nicot",
         "brand:ja": "ホーマックニコット",
+        "brand:wikidata": "Q11318834",
         "name": "ホーマックニコット",
         "name:en": "Homac nicot",
         "name:ja": "ホーマックニコット",

--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -1322,6 +1322,21 @@
       }
     },
     {
+      "displayName": "コメリPRO",
+      "id": "komeripro-dd401d",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "コメリ",
+        "brand:en": "KOMERI",
+        "brand:ja": "コメリ",
+        "brand:wikidata": "Q11302690",
+        "name": "コメリPRO",
+        "name:en": "Komeri PRO",
+        "name:ja": "コメリPRO",
+        "shop": "doityourself"
+      }
+    },
+    {
       "displayName": "コメリハード&グリーン",
       "id": "komerihardandgreen-dd401d",
       "locationSet": {"include": ["jp"]},


### PR DESCRIPTION
I added because there is no store named "Komeri" in Komeri, and while other brands are distinguished but not by Komeri.

As for Homac nicot, it is only available in Japan and I have corrected it.