### PR TITLE
Removed AEON Market as it does not exist and added Peacock Store

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -8540,21 +8540,6 @@
       }
     },
     {
-      "displayName": "イオンマーケット",
-      "id": "aeonmarket-fe0970",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "brand": "イオンマーケット",
-        "brand:en": "Aeon Market",
-        "brand:ja": "イオンマーケット",
-        "brand:wikidata": "Q11331715",
-        "name": "イオンマーケット",
-        "name:en": "Aeon Market",
-        "name:ja": "イオンマーケット",
-        "shop": "supermarket"
-      }
-    },
-    {
       "displayName": "イズミヤ",
       "id": "izumiya-fe0970",
       "locationSet": {"include": ["jp"]},
@@ -8967,6 +8952,21 @@
         "name": "バロー",
         "name:en": "Valor",
         "name:ja": "バロー",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "ピーコックストア",
+      "id": "peacockstore-fe0970",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "PEACOCK STORE",
+        "brand:en": "PEACOCK STORE",
+        "brand:ja": "ピーコックストア",
+        "brand:wikidata": "Q11331715",
+        "name": "ピーコックストア",
+        "name:en": "Peacock Store",
+        "name:ja": "ピーコックストア",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
AEON Market is the name of the company after the absorption merger, and its stores remain Peacock Store.