### PR TITLE
MaxValu (supermarket) correction

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -9077,15 +9077,15 @@
     },
     {
       "displayName": "マックスバリュ",
-      "id": "maxvalutokai-fe0970",
+      "id": "maxvalu-fe0970",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "brand": "マックスバリュ",
-        "brand:en": "Maxvalu Tokai",
+        "brand:en": "MaxValu",
         "brand:ja": "マックスバリュ",
-        "brand:wikidata": "Q1960109",
+        "brand:wikidata": "Q11340427",
         "name": "マックスバリュ",
-        "name:en": "Maxvalu Tokai",
+        "name:en": "MaxValu",
         "name:ja": "マックスバリュ",
         "shop": "supermarket"
       }


### PR DESCRIPTION
English names and Wikidata were limited to Tokai region, so they were corrected to common ones.