### PR TITLE
Correction of Urdu bank brand name mislabeled as Arabic

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -328,17 +328,15 @@
     {
       "displayName": "Allied Bank (Pakistan)",
       "id": "alliedbank-da5806",
-      "locationSet": {"include": ["pk"]},
+      "locationSet": {"include": ["bh", "pk"]},
       "matchNames": ["allied bank limited"],
       "tags": {
         "amenity": "bank",
-        "brand": "Allied Bank",
-        "brand:ar": "الائیڈ بینک لمیٹڈ",
-        "brand:en": "Allied Bank",
-        "brand:ur": "الائیڈ بینک",
+        "brand": "Allied Bank Limited",
+        "brand:en": "Allied Bank Limited",
+        "brand:ur": "الائیڈ بینک لمیٹڈ",
         "brand:wikidata": "Q4732553",
         "name": "Allied Bank",
-        "name:ar": "الائیڈ بینک لمیٹڈ",
         "name:en": "Allied Bank",
         "name:ur": "الائیڈ بینک"
       }


### PR DESCRIPTION
This PR removes the `name:ar` and `brand:ar` tags for the preset for Allied Bank (Pakistan), because these have Urdu strings in them instead of Arabic, including multiple letters which do not exist in the Arabic alphabet like ڈ, ٹ, ی, and ک. The current `name:ar` and `brand:ar` values just say "Allied Bank Limited" in Urdu, which is the full brand name, so I just put that as the tag from `brand:ur`. Contrast with Faysal Bank for example, a bank with correct names in both Arabic and Urdu and you can see that they are using different alphabets and spellings.

I could not find anything that mentioned an official Arabic name for Allied Bank so I did not add one. They apparently have one location in Bahrain, where Arabic is used, but Urdu is also widely spoken there and that branch is also signed in Urdu anyway. I added "bh" to the country list.