### PR TITLE
Correction of Urdu name+brand mislabeled as Arabic; added Punjabi name for PSO

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -5830,12 +5830,16 @@
       "tags": {
         "amenity": "fuel",
         "brand": "پاکستان اسٹیٹ آئل",
-        "brand:ar": "پاکستان اسٹیٹ آئل",
         "brand:en": "Pakistan State Oil",
+        "brand:pa": "ਪਾਕਸਤਾਨ ਸਟੇਟ ਆਇਲ",
+        "brand:pnb": "پاکستان سٹیٹ آئیل",
+        "brand:ur": "پاکستان اسٹیٹ آئل",
         "brand:wikidata": "Q2741455",
         "name": "پاکستان اسٹیٹ آئل",
-        "name:ar": "پاکستان اسٹیٹ آئل",
-        "name:en": "Pakistan State Oil",
+        "name:en": "Pakistan State Oil"
+        "brand:pa": "ਪਾਕਸਤਾਨ ਸਟੇਟ ਆਇਲ",
+        "brand:pnb": "پاکستان سٹیٹ آئیل",
+        "name:ur": "پاکستان اسٹیٹ آئل",
         "short_name:en": "PSO"
       }
     },

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -5837,8 +5837,8 @@
         "brand:wikidata": "Q2741455",
         "name": "پاکستان اسٹیٹ آئل",
         "name:en": "Pakistan State Oil",
-        "brand:pa": "ਪਾਕਸਤਾਨ ਸਟੇਟ ਆਇਲ",
-        "brand:pnb": "پاکستان سٹیٹ آئیل",
+        "name:pa": "ਪਾਕਸਤਾਨ ਸਟੇਟ ਆਇਲ",
+        "name:pnb": "پاکستان سٹیٹ آئیل",
         "name:ur": "پاکستان اسٹیٹ آئل",
         "short_name:en": "PSO"
       }

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -5836,7 +5836,7 @@
         "brand:ur": "پاکستان اسٹیٹ آئل",
         "brand:wikidata": "Q2741455",
         "name": "پاکستان اسٹیٹ آئل",
-        "name:en": "Pakistan State Oil"
+        "name:en": "Pakistan State Oil",
         "brand:pa": "ਪਾਕਸਤਾਨ ਸਟੇਟ ਆਇਲ",
         "brand:pnb": "پاکستان سٹیٹ آئیل",
         "name:ur": "پاکستان اسٹیٹ آئل",


### PR DESCRIPTION
This PR corrects the name and brand tag `name:ar` / `brand:ar` to `name:ur` / `brand:ur` as these tags in the preset currently contain Urdu names rather than Arabic ones, with letters like پ and ی which are not used for Arabic. Contrast with Shell, where the difference between the Urdu and Arabic names is correct and ی is excluded from the Arabic.

I also added the name in Punjabi (`pnb` and `pa` being the codes for the two scripts the language uses), as the pronunciation and spelling is slightly different.