### PR TITLE
Correction of name of Dubai Islamic Bank from Arabic to Urdu; added added actual Arabic name

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -4665,8 +4665,8 @@
         "brand:wikidata": "Q5310570",
         "name": "Dubai Islamic Bank",
         "name:ar": "بنك دبي الإسلامي",
-        "brand:en": "Dubai Islamic Bank",
-        "brand:ur": "دبئی اسلامی بینک"
+        "name:en": "Dubai Islamic Bank",
+        "name:ur": "دبئی اسلامی بینک"
       }
     },
     {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -4659,10 +4659,14 @@
       "tags": {
         "amenity": "bank",
         "brand": "Dubai Islamic Bank",
-        "brand:ar": "دبئی اسلامی بینک",
+        "brand:ar": "بنك دبي الإسلامي",
         "brand:en": "Dubai Islamic Bank",
+        "brand:ur": "دبئی اسلامی بینک",
         "brand:wikidata": "Q5310570",
-        "name": "Dubai Islamic Bank"
+        "name": "Dubai Islamic Bank",
+        "name:ar": "بنك دبي الإسلامي",
+        "brand:en": "Dubai Islamic Bank",
+        "brand:ur": "دبئی اسلامی بینک"
       }
     },
     {


### PR DESCRIPTION
More of these have come up than I expected when searching NSI for Urdu letters outside of `name:ur`. Urdu is more widely understood than Arabic in Dubai so it is not surprising it only had the Urdu name even though the official language there is Arabic. This does have an official Arabic name so I added this