### PR TITLE
Improve tags for CoCo Fresh Tea & Juice

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -827,7 +827,8 @@
         "brand": "CoCo",
         "brand:wikidata": "Q65084369",
         "cuisine": "bubble_tea",
-        "name": "Coco",
+        "name": "CoCo Fresh Tea & Juice",
+        "short_name": "CoCo",
         "takeaway": "yes"
       }
     },


### PR DESCRIPTION
Also fixes the capitalization from "Coco" to "CoCo".