### PR TITLE
Fixed duplication

### DIFF
--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -657,22 +657,12 @@
       "displayName": "Meest",
       "id": "meest-970b0c",
       "locationSet": {"include": ["ua"]},
+      "matchNames": ["meest express", "міст експрес"],
       "tags": {
         "amenity": "post_office",
         "operator": "Meest",
         "operator:en": "Meest",
-        "operator:uk": "Міст"
-      }
-    },
-    {
-      "displayName": "Meest Express",
-      "id": "meestexpress-970b0c",
-      "locationSet": {"include": ["ua"]},
-      "tags": {
-        "amenity": "post_office",
-        "operator": "Meest Express",
-        "operator:en": "Meest Express",
-        "operator:uk": "Міст Експрес",
+        "operator:uk": "Міст",
         "operator:wikidata": "Q25432124"
       }
     },


### PR DESCRIPTION
The company shortened its name and no longer uses the word "Express"