### PR TITLE
Add superstore to Tesco match names

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -6504,7 +6504,7 @@
       "displayName": "Tesco",
       "id": "tesco-986a24",
       "locationSet": {"include": ["001"]},
-      "matchNames": ["jacks", "tesco metro"],
+      "matchNames": ["jacks", "tesco metro", "tesco superstore"],
       "tags": {
         "brand": "Tesco",
         "brand:wikidata": "Q487494",


### PR DESCRIPTION
Digitally these are "Superstore" but in person the fascia is usually just "Tesco"