### PR TITLE
Add reading cinemas

### DIFF
--- a/data/brands/amenity/cinema.json
+++ b/data/brands/amenity/cinema.json
@@ -971,6 +971,21 @@
       }
     },
     {
+      "displayName": "Wallis Cinemas",
+      "id": "wallis-1a8a27",
+      "locationSet": {"include": ["au"]},
+      "matchNames": [
+        "wallis cinema",
+        "wallis theatres"
+      ],
+      "tags": {
+        "amenity": "cinema",
+        "brand": "Wallis Cinemas",
+        "brand:wikidata": "Q7963128",
+        "name": "Wallis"
+      }
+    },
+    {
       "displayName": "Yelmo",
       "id": "yelmo-408f25",
       "locationSet": {"include": ["es"]},

--- a/data/brands/amenity/cinema.json
+++ b/data/brands/amenity/cinema.json
@@ -822,6 +822,19 @@
       }
     },
     {
+      "displayName": "Reading Cinemas",
+      "id": "reading-49d471",
+      "locationSet": {
+        "include": ["au", "nz", "us"]
+      },
+      "tags": {
+        "amenity": "cinema",
+        "brand": "Reading Cinemas",
+        "brand:wikidata": "Q43898773",
+        "name": "Reading"
+      }
+    },
+    {
       "displayName": "Regal Cinemas",
       "id": "regalcinemas-a7c63e",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Added Australian and New Zealand cinema chain, Reading Cinemas

https://en.wikipedia.org/wiki/Reading_Cinemas
https://www.wikidata.org/wiki/Q43898773