### PR TITLE
Added general pants co to clothes.json

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -2991,6 +2991,17 @@
       }
     },
     {
+      "displayName": "General Pants Co.",
+      "id": "generalpantsco-392c8b",
+      "locationSet": {"include": ["au"]},
+      "tags": {
+        "brand": "General Pants Co.",
+        "brand:wikidata": "Q5532086",
+        "name": "General Pants Co.",
+        "shop": "clothes"
+      }
+    },
+    {
       "displayName": "George Richards Big & Tall Menswear",
       "id": "georgerichards-9e1367",
       "locationSet": {"include": ["ca"]},
@@ -3152,6 +3163,18 @@
         "brand": "Guess",
         "brand:wikidata": "Q2470307",
         "name": "Guess",
+        "shop": "clothes"
+      }
+    },
+    {
+      "displayName": "Gutteridge",
+      "id": "gutteridge-d72191",
+      "locationSet": {"include": ["it"]},
+      "tags": {
+        "brand": "Gutteridge",
+        "brand:wikidata": "Q114399516",
+        "clothes": "men",
+        "name": "Gutteridge",
         "shop": "clothes"
       }
     },
@@ -5683,21 +5706,9 @@
       "locationSet": {"include": ["it"]},
       "tags": {
         "brand": "Original Marines",
-        "brand:wikidata":"Q114399255",
-        "clothes":"babies;children",
+        "brand:wikidata": "Q114399255",
+        "clothes": "babies;children",
         "name": "Original Marines",
-        "shop": "clothes"
-      }
-    },
-        {
-      "displayName": "Gutteridge",
-      "id": "originalmarines-d72191",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "brand": "Gutteridge",
-        "brand:wikidata":"Q114399516",
-        "clothes":"men",
-        "name": "Gutteridge",
         "shop": "clothes"
       }
     },


### PR DESCRIPTION
Added Australian clothing retailer General Pants Co. to clothing brands

https://en.wikipedia.org/wiki/General_Pants_Co.

https://www.wikidata.org/wiki/Q5532086