### PR TITLE
Rename Western Power Distribution -> National Grid Electricity Distribution

### DIFF
--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -3686,6 +3686,19 @@
       }
     },
     {
+      "displayName": "National Grid Electricity Distribution",
+      "locationSet": {"include": ["gb-eng"]},
+      "matchNames": [
+        "western power",
+        "western power distribution"
+      ],
+      "tags": {
+        "operator": "National Grid Electricity Distribution",
+        "operator:wikidata": "Q7988183",
+        "power": "line"
+      }
+    },
+    {
       "displayName": "National Grid Corporation of the Philippines",
       "id": "nationalgridcorporationofthephilippines-53cceb",
       "locationSet": {"include": ["ph"]},
@@ -5799,17 +5812,6 @@
         "operator": "Western Area Power Administration",
         "operator:short": "WAPA",
         "operator:wikidata": "Q7987459",
-        "power": "line"
-      }
-    },
-    {
-      "displayName": "Western Power Distribution",
-      "id": "westernpowerdistribution-2a61eb",
-      "locationSet": {"include": ["gb"]},
-      "matchNames": ["western power"],
-      "tags": {
-        "operator": "Western Power Distribution",
-        "operator:wikidata": "Q7988183",
         "power": "line"
       }
     },

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -4648,6 +4648,19 @@
       }
     },
     {
+      "displayName": "National Grid Electricity Distribution",
+      "locationSet": {"include": ["gb-eng"]},
+      "matchNames": [
+        "western power",
+        "western power distribution"
+      ],
+      "tags": {
+        "operator": "National Grid Electricity Distribution",
+        "operator:wikidata": "Q7988183",
+        "power": "substation"
+      }
+    },
+    {
       "displayName": "National Grid Corporation of the Philippines",
       "id": "nationalgridcorporationofthephilippines-851165",
       "locationSet": {"include": ["ph"]},
@@ -8234,15 +8247,6 @@
       }
     },
     {
-      "displayName": "Western Power (United Kingdom)",
-      "id": "westernpower-3f58d2",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "operator": "Western Power",
-        "power": "substation"
-      }
-    },
-    {
       "displayName": "Western Power (Western Australia)",
       "id": "westernpower-ba34d7",
       "locationSet": {
@@ -8251,25 +8255,6 @@
       "tags": {
         "operator": "Western Power",
         "operator:wikidata": "Q7988180",
-        "power": "substation"
-      }
-    },
-    {
-      "displayName": "Western Power Distribution (South West) plc (United Kingdom)",
-      "id": "westernpowerdistributionsouthwestplc-3f58d2",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "operator": "Western Power Distribution (South West) plc",
-        "power": "substation"
-      }
-    },
-    {
-      "displayName": "Western Power Distribution (United Kingdom)",
-      "id": "westernpowerdistribution-3f58d2",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "operator": "Western Power Distribution",
-        "operator:wikidata": "Q7988183",
         "power": "substation"
       }
     },


### PR DESCRIPTION
Western Power Distribution (which is a power distribution network operator in England) has been acquired by National Grid and recently rebranded to "National Grid Electricity Distribution". This changeset removes the old operator and adds the new one.

The OSM-GB community has decided that it's best to keep this separate from "National Grid" as a whole (which also operates a different part of the electricity network in the UK).

This changeset also removes "Western Power" (which I believe was an error/duplicate) and "Western Power Distribution (South West) plc" (which was/is an internal division of WPD/NGED - we've decided to put this distinction in the `owner` tag).