### PR TITLE
Clean up UK power operators

### DIFF
--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -563,17 +563,6 @@
       }
     },
     {
-      "displayName": "BritNed",
-      "id": "britned-822cd8",
-      "locationSet": {
-        "include": ["gb-eng", "nl"]
-      },
-      "tags": {
-        "operator": "BritNed",
-        "power": "line"
-      }
-    },
-    {
       "displayName": "Brookings Muncipal Utilities",
       "id": "brookingsmuncipalutilities-b654b4",
       "locationSet": {"include": ["us"]},
@@ -1485,12 +1474,6 @@
       }
     },
     {
-      "displayName": "EEB",
-      "id": "eeb-2a61eb",
-      "locationSet": {"include": ["gb"]},
-      "tags": {"operator": "EEB", "power": "line"}
-    },
-    {
       "displayName": "EED",
       "id": "eed-74d56c",
       "locationSet": {"include": ["hu"]},
@@ -1576,7 +1559,8 @@
     {
       "displayName": "Electricity North West",
       "id": "electricitynorthwest-2a61eb",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {"include": ["gb-eng"]},
+      "matchNames": ["enwl"],
       "tags": {
         "operator": "Electricity North West",
         "operator:wikidata": "Q5357804",
@@ -3427,6 +3411,15 @@
       }
     },
     {
+      "displayName": "Manx Utilities",
+      "locationSet": {"include": ["im"]},
+      "tags": {
+        "operator": "Manx Utilities",
+        "operator:wikidata": "Q96391881",
+        "power": "line"
+      }
+    },
+    {
       "displayName": "Maritime Electric",
       "id": "maritimeelectric-6c988f",
       "locationSet": {"include": ["ca"]},
@@ -3630,6 +3623,7 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "operator": "Mutual Energy",
+        "operator:wikidata": "Q112882722",
         "power": "line"
       }
     },
@@ -3673,7 +3667,7 @@
     {
       "displayName": "National Grid",
       "id": "nationalgrid-2a61eb",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {"include": ["au", "gb-eng", "us"]},
       "matchNames": [
         "national grid et",
         "national grid plc",
@@ -3720,15 +3714,6 @@
         "operator:en": "NB Power",
         "operator:fr": "Énergie NB",
         "operator:wikidata": "Q749716",
-        "power": "line"
-      }
-    },
-    {
-      "displayName": "NEDL",
-      "id": "nedl-2a61eb",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "operator": "NEDL",
         "power": "line"
       }
     },
@@ -3889,6 +3874,10 @@
       "displayName": "Northern Powergrid",
       "id": "northernpowergrid-11f3a5",
       "locationSet": {"include": ["gb-eng"]},
+      "matchNames": [
+        "yedl",
+        "nedl"
+      ],
       "tags": {
         "operator": "Northern Powergrid",
         "operator:wikidata": "Q7058871",
@@ -4672,25 +4661,28 @@
       }
     },
     {
-      "displayName": "Scottish Hydro Electric Transmission",
-      "id": "scottishhydroelectrictransmission-2a61eb",
+      "displayName": "Scottish and Southern Energy (SSE)",
       "locationSet": {"include": ["gb"]},
+      "matchNames": [
+        "scottish hydro electric power distribution",
+        "southern electric"
+      ],
       "tags": {
-        "operator": "Scottish Hydro Electric Transmission",
+        "operator": "Scottish and Southern Energy",
+        "operator:wikidata": "Q493854",
         "power": "line"
       }
     },
     {
-      "displayName": "Scottish Power",
-      "id": "scottishpower-2a61eb",
-      "locationSet": {"include": ["gb"]},
+      "displayName": "SSEN Transmission",
+      "locationSet": {"include": ["gb-sct"]},
       "matchNames": [
-        "sp distribution",
-        "sp energy networks"
+        "scottish hydro electric transmission"
       ],
+      "note": "Operates the electricity transmission network in northern Scotland.",
       "tags": {
-        "operator": "Scottish Power",
-        "operator:wikidata": "Q1778417",
+        "operator": "SSEN Transmission",
+        "operator:wikidata": "Q114423668",
         "power": "line"
       }
     },
@@ -4874,11 +4866,30 @@
       }
     },
     {
+      "displayName": "SP Energy Networks",
+      "locationSet": {"include": ["gb"]},
+      "matchNames": [
+        "scottish power energy networks",
+        "sp distribution",
+        "sp manweb"
+      ],
+      "tags": {
+        "operator": "SP Energy Networks",
+        "operator:wikidata": "Q1778417",
+        "power": "line"
+      }
+    },
+    {
       "displayName": "SP Transmission",
       "id": "sptransmission-2a61eb",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {"include": ["gb-sct"]},
+      "matchNames": [
+        "scottish power transmission"
+      ],
+      "note": "Operates the electricity transmission network in southern Scotland.",
       "tags": {
         "operator": "SP Transmission",
+        "operator:wikidata": "Q114436108",
         "power": "line"
       }
     },
@@ -5891,15 +5902,6 @@
       "tags": {
         "operator": "Xcel Energy",
         "operator:wikidata": "Q1486956",
-        "power": "line"
-      }
-    },
-    {
-      "displayName": "YEDL",
-      "id": "yedl-2a61eb",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "operator": "YEDL",
         "power": "line"
       }
     },

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -4,11 +4,12 @@
     "exclude": {
       "generic": ["^line$"],
       "named": [
-        "badenwerk",
-        "badenwerk ag",
-        "enbw",
-        "enbw ag",
-        "national grid et"
+        "^badenwerk ag$",
+        "^badenwerk$",
+        "^britned$",
+        "^enbw ag$",
+        "^enbw$",
+        "^national grid et$"
       ]
     }
   },
@@ -1474,6 +1475,12 @@
       }
     },
     {
+      "displayName": "EEB",
+      "id": "eeb-ddc6a3",
+      "locationSet": {"include": ["br"]},
+      "tags": {"operator": "EEB", "power": "line"}
+    },
+    {
       "displayName": "EED",
       "id": "eed-74d56c",
       "locationSet": {"include": ["hu"]},
@@ -1558,7 +1565,7 @@
     },
     {
       "displayName": "Electricity North West",
-      "id": "electricitynorthwest-2a61eb",
+      "id": "electricitynorthwest-11f3a5",
       "locationSet": {"include": ["gb-eng"]},
       "matchNames": ["enwl"],
       "tags": {
@@ -3412,6 +3419,7 @@
     },
     {
       "displayName": "Manx Utilities",
+      "id": "manxutilities-be061e",
       "locationSet": {"include": ["im"]},
       "tags": {
         "operator": "Manx Utilities",
@@ -3666,8 +3674,10 @@
     },
     {
       "displayName": "National Grid",
-      "id": "nationalgrid-2a61eb",
-      "locationSet": {"include": ["au", "gb-eng", "us"]},
+      "id": "nationalgrid-036c1a",
+      "locationSet": {
+        "include": ["au", "gb-eng", "us"]
+      },
       "matchNames": [
         "national grid et",
         "national grid plc",
@@ -3680,7 +3690,19 @@
       }
     },
     {
+      "displayName": "National Grid Corporation of the Philippines",
+      "id": "nationalgridcorporationofthephilippines-53cceb",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "operator": "National Grid Corporation of the Philippines",
+        "operator:short": "NGCP",
+        "operator:wikidata": "Q28197109",
+        "power": "line"
+      }
+    },
+    {
       "displayName": "National Grid Electricity Distribution",
+      "id": "nationalgridelectricitydistribution-11f3a5",
       "locationSet": {"include": ["gb-eng"]},
       "matchNames": [
         "western power",
@@ -3689,17 +3711,6 @@
       "tags": {
         "operator": "National Grid Electricity Distribution",
         "operator:wikidata": "Q7988183",
-        "power": "line"
-      }
-    },
-    {
-      "displayName": "National Grid Corporation of the Philippines",
-      "id": "nationalgridcorporationofthephilippines-53cceb",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "operator": "National Grid Corporation of the Philippines",
-        "operator:short": "NGCP",
-        "operator:wikidata": "Q28197109",
         "power": "line"
       }
     },
@@ -3874,10 +3885,7 @@
       "displayName": "Northern Powergrid",
       "id": "northernpowergrid-11f3a5",
       "locationSet": {"include": ["gb-eng"]},
-      "matchNames": [
-        "yedl",
-        "nedl"
-      ],
+      "matchNames": ["nedl", "yedl"],
       "tags": {
         "operator": "Northern Powergrid",
         "operator:wikidata": "Q7058871",
@@ -4662,6 +4670,7 @@
     },
     {
       "displayName": "Scottish and Southern Energy (SSE)",
+      "id": "scottishandsouthernenergy-2a61eb",
       "locationSet": {"include": ["gb"]},
       "matchNames": [
         "scottish hydro electric power distribution",
@@ -4674,15 +4683,11 @@
       }
     },
     {
-      "displayName": "SSEN Transmission",
-      "locationSet": {"include": ["gb-sct"]},
-      "matchNames": [
-        "scottish hydro electric transmission"
-      ],
-      "note": "Operates the electricity transmission network in northern Scotland.",
+      "displayName": "Scottish Power",
+      "id": "scottishpower-116894",
+      "locationSet": {"include": ["001"]},
       "tags": {
-        "operator": "SSEN Transmission",
-        "operator:wikidata": "Q114423668",
+        "operator": "Scottish Power",
         "power": "line"
       }
     },
@@ -4867,6 +4872,7 @@
     },
     {
       "displayName": "SP Energy Networks",
+      "id": "spenergynetworks-2a61eb",
       "locationSet": {"include": ["gb"]},
       "matchNames": [
         "scottish power energy networks",
@@ -4881,7 +4887,7 @@
     },
     {
       "displayName": "SP Transmission",
-      "id": "sptransmission-2a61eb",
+      "id": "sptransmission-cd3045",
       "locationSet": {"include": ["gb-sct"]},
       "matchNames": [
         "scottish power transmission"
@@ -4939,6 +4945,20 @@
       "tags": {
         "operator": "SSE",
         "operator:wikidata": "Q493854",
+        "power": "line"
+      }
+    },
+    {
+      "displayName": "SSEN Transmission",
+      "id": "ssentransmission-cd3045",
+      "locationSet": {"include": ["gb-sct"]},
+      "matchNames": [
+        "scottish hydro electric transmission"
+      ],
+      "note": "Operates the electricity transmission network in northern Scotland.",
+      "tags": {
+        "operator": "SSEN Transmission",
+        "operator:wikidata": "Q114423668",
         "power": "line"
       }
     },

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -1950,7 +1950,8 @@
     {
       "displayName": "Electricity North West",
       "id": "electricitynorthwest-3f58d2",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {"include": ["gb-eng"]},
+      "matchNames": ["enwl"],
       "tags": {
         "operator": "Electricity North West",
         "operator:wikidata": "Q5357804",
@@ -4402,6 +4403,15 @@
       }
     },
     {
+      "displayName": "Manx Utilities",
+      "locationSet": {"include": ["im"]},
+      "tags": {
+        "operator": "Manx Utilities",
+        "operator:wikidata": "Q96391881",
+        "power": "substation"
+      }
+    },
+    {
       "displayName": "Maquoketa Valley REC",
       "id": "maquoketavalleyrec-301545",
       "locationSet": {"include": ["us"]},
@@ -4634,7 +4644,7 @@
       "displayName": "National Grid",
       "id": "nationalgrid-aaa8bf",
       "locationSet": {
-        "include": ["au", "gb", "us"]
+        "include": ["au", "gb-eng", "us"]
       },
       "matchNames": [
         "national grid et",
@@ -4949,7 +4959,7 @@
       "displayName": "Northern Powergrid",
       "id": "northernpowergrid-a368ae",
       "locationSet": {"include": ["gb-eng"]},
-      "matchNames": ["nedl"],
+      "matchNames": ["nedl", "yedl"],
       "tags": {
         "operator": "Northern Powergrid",
         "operator:wikidata": "Q7058871",
@@ -5982,25 +5992,28 @@
       }
     },
     {
-      "displayName": "Scottish Hydro-Electric",
-      "id": "scottishhydroelectric-fc3a87",
-      "locationSet": {"include": ["001"]},
+      "displayName": "Scottish and Southern Energy (SSE)",
+      "locationSet": {"include": ["gb"]},
+      "matchNames": [
+        "scottish hydro electric power distribution",
+        "southern electric"
+      ],
       "tags": {
-        "operator": "Scottish Hydro-Electric",
+        "operator": "Scottish and Southern Energy",
+        "operator:wikidata": "Q493854",
         "power": "substation"
       }
     },
     {
-      "displayName": "Scottish Power",
-      "id": "scottishpower-3f58d2",
-      "locationSet": {"include": ["gb"]},
+      "displayName": "SSEN Transmission",
+      "locationSet": {"include": ["gb-sct"]},
       "matchNames": [
-        "sp distribution",
-        "sp energy networks"
+        "scottish hydro electric transmission"
       ],
+      "note": "Operates the electricity transmission network in northern Scotland.",
       "tags": {
-        "operator": "Scottish Power",
-        "operator:wikidata": "Q1778417",
+        "operator": "SSEN Transmission",
+        "operator:wikidata": "Q114423668",
         "power": "substation"
       }
     },
@@ -6192,6 +6205,33 @@
         "operator": "Southern California Edison",
         "operator:short": "SCE",
         "operator:wikidata": "Q1706317",
+        "power": "substation"
+      }
+    },
+    {
+      "displayName": "SP Energy Networks",
+      "locationSet": {"include": ["gb"]},
+      "matchNames": [
+        "scottish power energy networks",
+        "sp distribution",
+        "sp manweb"
+      ],
+      "tags": {
+        "operator": "SP Energy Networks",
+        "operator:wikidata": "Q1778417",
+        "power": "substation"
+      }
+    },
+    {
+      "displayName": "SP Transmission",
+      "locationSet": {"include": ["gb-sct"]},
+      "matchNames": [
+        "scottish power transmission"
+      ],
+      "note": "Operates the electricity transmission network in southern Scotland.",
+      "tags": {
+        "operator": "SP Transmission",
+        "operator:wikidata": "Q114436108",
         "power": "substation"
       }
     },
@@ -8393,15 +8433,6 @@
       "tags": {
         "operator": "Xcel Energy",
         "operator:wikidata": "Q1486956",
-        "power": "substation"
-      }
-    },
-    {
-      "displayName": "YEDL",
-      "id": "yedl-a368ae",
-      "locationSet": {"include": ["gb-eng"]},
-      "tags": {
-        "operator": "YEDL",
         "power": "substation"
       }
     },

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -1949,7 +1949,7 @@
     },
     {
       "displayName": "Electricity North West",
-      "id": "electricitynorthwest-3f58d2",
+      "id": "electricitynorthwest-a368ae",
       "locationSet": {"include": ["gb-eng"]},
       "matchNames": ["enwl"],
       "tags": {
@@ -4404,6 +4404,7 @@
     },
     {
       "displayName": "Manx Utilities",
+      "id": "manxutilities-831ba8",
       "locationSet": {"include": ["im"]},
       "tags": {
         "operator": "Manx Utilities",
@@ -4642,7 +4643,7 @@
     },
     {
       "displayName": "National Grid",
-      "id": "nationalgrid-aaa8bf",
+      "id": "nationalgrid-b3ac2d",
       "locationSet": {
         "include": ["au", "gb-eng", "us"]
       },
@@ -4658,7 +4659,19 @@
       }
     },
     {
+      "displayName": "National Grid Corporation of the Philippines",
+      "id": "nationalgridcorporationofthephilippines-851165",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "operator": "National Grid Corporation of the Philippines",
+        "operator:short": "NGCP",
+        "operator:wikidata": "Q28197109",
+        "power": "substation"
+      }
+    },
+    {
       "displayName": "National Grid Electricity Distribution",
+      "id": "nationalgridelectricitydistribution-a368ae",
       "locationSet": {"include": ["gb-eng"]},
       "matchNames": [
         "western power",
@@ -4667,17 +4680,6 @@
       "tags": {
         "operator": "National Grid Electricity Distribution",
         "operator:wikidata": "Q7988183",
-        "power": "substation"
-      }
-    },
-    {
-      "displayName": "National Grid Corporation of the Philippines",
-      "id": "nationalgridcorporationofthephilippines-851165",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "operator": "National Grid Corporation of the Philippines",
-        "operator:short": "NGCP",
-        "operator:wikidata": "Q28197109",
         "power": "substation"
       }
     },
@@ -5993,6 +5995,7 @@
     },
     {
       "displayName": "Scottish and Southern Energy (SSE)",
+      "id": "scottishandsouthernenergy-3f58d2",
       "locationSet": {"include": ["gb"]},
       "matchNames": [
         "scottish hydro electric power distribution",
@@ -6005,15 +6008,20 @@
       }
     },
     {
-      "displayName": "SSEN Transmission",
-      "locationSet": {"include": ["gb-sct"]},
-      "matchNames": [
-        "scottish hydro electric transmission"
-      ],
-      "note": "Operates the electricity transmission network in northern Scotland.",
+      "displayName": "Scottish Hydro-Electric",
+      "id": "scottishhydroelectric-fc3a87",
+      "locationSet": {"include": ["001"]},
       "tags": {
-        "operator": "SSEN Transmission",
-        "operator:wikidata": "Q114423668",
+        "operator": "Scottish Hydro-Electric",
+        "power": "substation"
+      }
+    },
+    {
+      "displayName": "Scottish Power",
+      "id": "scottishpower-fc3a87",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "operator": "Scottish Power",
         "power": "substation"
       }
     },
@@ -6210,6 +6218,7 @@
     },
     {
       "displayName": "SP Energy Networks",
+      "id": "spenergynetworks-3f58d2",
       "locationSet": {"include": ["gb"]},
       "matchNames": [
         "scottish power energy networks",
@@ -6224,6 +6233,7 @@
     },
     {
       "displayName": "SP Transmission",
+      "id": "sptransmission-6ff402",
       "locationSet": {"include": ["gb-sct"]},
       "matchNames": [
         "scottish power transmission"
@@ -6274,6 +6284,20 @@
       "tags": {
         "operator": "SSE",
         "operator:wikidata": "Q493854",
+        "power": "substation"
+      }
+    },
+    {
+      "displayName": "SSEN Transmission",
+      "id": "ssentransmission-6ff402",
+      "locationSet": {"include": ["gb-sct"]},
+      "matchNames": [
+        "scottish hydro electric transmission"
+      ],
+      "note": "Operates the electricity transmission network in northern Scotland.",
+      "tags": {
+        "operator": "SSEN Transmission",
+        "operator:wikidata": "Q114423668",
         "power": "substation"
       }
     },
@@ -8295,6 +8319,15 @@
       "tags": {
         "operator": "Western Power",
         "operator:wikidata": "Q7988180",
+        "power": "substation"
+      }
+    },
+    {
+      "displayName": "Western Power Distribution (South West) plc",
+      "id": "westernpowerdistributionsouthwestplc-fc3a87",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "operator": "Western Power Distribution (South West) plc",
         "power": "substation"
       }
     },


### PR DESCRIPTION
This changeset cleans up the list of UK power network operators, adding wikidata and more specific country codes where possible. This should now (hopefully) line up with the list of operators here:

https://www.energynetworks.org/customers/find-my-network-operator

"BritNed" has been removed as it only operates one interconnector and is probably not worth having in the NSI.

"EEB", "NEDL", and "YEDL" have been removed as they are historic region names which are now part of other operators.

Manx Utilities is also added for the Isle of Man.