### PR TITLE
Improve names and tags for Correios depots and post offices

### DIFF
--- a/data/brands/amenity/post_office.json
+++ b/data/brands/amenity/post_office.json
@@ -370,6 +370,22 @@
         "name:zh": "顺丰速运",
         "short_name": "顺丰"
       }
+    },
+    {
+      "displayName": "Agência dos Correios",
+      "id": "correios-e82118",
+      "locationSet": {"include": ["br"]},
+      "matchNames": [
+        "ebct",
+        "ect",
+        "empresa brasileira de correios e telégrafos"
+      ],
+      "tags": {
+        "amenity": "post_office",
+        "brand": "Empresa Brasileira de Correios e Telégrafos",
+        "brand:short": "Correios",
+        "brand:wikidata": "Q3375004"
+      }
     }
   ]
 }

--- a/data/operators/amenity/post_depot.json
+++ b/data/operators/amenity/post_depot.json
@@ -32,7 +32,7 @@
       }
     },
     {
-      "displayName": "Correios",
+      "displayName": "Centro de Distribuição dos Correios",
       "id": "correios-28fd5c",
       "locationSet": {"include": ["br"]},
       "matchNames": [
@@ -42,7 +42,8 @@
       ],
       "tags": {
         "amenity": "post_depot",
-        "operator": "Correios",
+        "operator": "Empresa Brasileira de Correios e Telégrafos",
+        "operator:short": "Correios",
         "operator:type": "public",
         "operator:wikidata": "Q3375004"
       }

--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -203,7 +203,7 @@
       }
     },
     {
-      "displayName": "Correios",
+      "displayName": "Agência dos Correios",
       "id": "correios-e82118",
       "locationSet": {"include": ["br"]},
       "matchNames": [
@@ -213,8 +213,9 @@
       ],
       "tags": {
         "amenity": "post_office",
-        "operator": "Correios",
-        "operator:wikidata": "Q3375004"
+        "brand": "Empresa Brasileira de Correios e Telégrafos",
+        "brand:short": "Correios",
+        "brand:wikidata": "Q3375004"
       }
     },
     {

--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -203,22 +203,6 @@
       }
     },
     {
-      "displayName": "Agência dos Correios",
-      "id": "correios-e82118",
-      "locationSet": {"include": ["br"]},
-      "matchNames": [
-        "ebct",
-        "ect",
-        "empresa brasileira de correios e telégrafos"
-      ],
-      "tags": {
-        "amenity": "post_office",
-        "brand": "Empresa Brasileira de Correios e Telégrafos",
-        "brand:short": "Correios",
-        "brand:wikidata": "Q3375004"
-      }
-    },
-    {
       "displayName": "Correo Argentino",
       "id": "correoargentino-debce4",
       "locationSet": {"include": ["ar"]},


### PR DESCRIPTION
This should address the issues discussed in #7100. Changes:

- Use extended names to differentiate post offices from depots
- Use `brand:*` instead of `operator:*` in post offices

cc @matheusgomesms @UKChris-osm @willemarcel  

---

Fix #7100