### PR TITLE
Modify "easybox" parcel lockers

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -170,12 +170,12 @@
     {
       "displayName": "easybox",
       "id": "easybox-ba4d23",
-      "locationSet": {"include": ["ro"]},
+      "locationSet": {"include": ["ro", "hu"]},
       "tags": {
         "amenity": "parcel_locker",
         "brand": "easybox",
-        "operator": "eMag",
-        "operator:wikidata": "Q23827008"
+        "operator": "Sameday",
+        "operator:wikidata": "Q114417096",
       }
     },
     {


### PR DESCRIPTION
Those "easybox" parcel lockers, are owned and operated by Sameday, a courier company based in Romania and Hungary. Only some of them are just branded by eMAG for sponsoring reasons but other couriers can drop parcels there.