### PR TITLE
Fix Kinder Morgan Texas

### DIFF
--- a/data/operators/man_made/pipeline.json
+++ b/data/operators/man_made/pipeline.json
@@ -2426,14 +2426,9 @@
       "displayName": "Kinder Morgan Texas Pipeline LLC",
       "id": "kindermorgantexaspipelinellc-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": [
-        "kinder morgan tejas pipeline",
-        "kinder morgan tejas pipeline llc"
-      ],
       "tags": {
         "man_made": "pipeline",
         "operator": "Kinder Morgan Texas Pipeline LLC",
-        "operator:wikidata": "Q110987354"
       }
     },
     {

--- a/data/operators/man_made/pipeline.json
+++ b/data/operators/man_made/pipeline.json
@@ -2426,6 +2426,9 @@
       "displayName": "Kinder Morgan Texas Pipeline LLC",
       "id": "kindermorgantexaspipelinellc-0a386a",
       "locationSet": {"include": ["us"]},
+      "matchNames": [
+        "kinder morgan texas pipeline",
+                    ],
       "tags": {
         "man_made": "pipeline",
         "operator": "Kinder Morgan Texas Pipeline LLC",

--- a/data/operators/man_made/pipeline.json
+++ b/data/operators/man_made/pipeline.json
@@ -2429,6 +2429,7 @@
       "tags": {
         "man_made": "pipeline",
         "operator": "Kinder Morgan Texas Pipeline LLC",
+        "operator:wikidata": "Q110987354"
       }
     },
     {


### PR DESCRIPTION
"Kinder Morgan Tejas Pipeline" is a seperate operating company, NOT a typo. So please remove it.

Also, before any more wikidata tags are added to pipelines, I want this (:wikidata on man_made=pipeline) to be properly discussed - not just silently added.