### PR TITLE
Add Playa Bowls

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -5212,6 +5212,19 @@
       }
     },
     {
+      "displayName": "Playa Bowls",
+      "id": "playabowls-4d2ff4",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Playa Bowls",
+        "brand:wikidata": "Q114618507",
+        "cuisine": "açaí",
+        "name": "Playa Bowls",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Poke Bros.",
       "id": "pokebros-eebea8",
       "locationSet": {


### PR DESCRIPTION
Playa Bowls is a New Jersey based fast food chain with >100 locations