### PR TITLE
Add Cluck-U Chicken

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -1357,6 +1357,19 @@
       }
     },
     {
+      "displayName": "Cluck-U Chicken",
+      "id": "cluckuchicken-4d2ff4",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Cluck-U Chicken",
+        "brand:wikidata": "Q5136557",
+        "cuisine": "chicken",
+        "name": "Cluck-U Chicken",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "CoCo壱番屋",
       "id": "cocoichibanya-3e7699",
       "locationSet": {"include": ["jp"]},


### PR DESCRIPTION
Cluck-U Chicken is a New Jersey / Maryland based fast food chain with 20 locations