### PR TITLE
Add operator social_facility : Club Alpino Italiano [resolves #6971]

### DIFF
--- a/data/operators/amenity/social_facility.json
+++ b/data/operators/amenity/social_facility.json
@@ -1080,7 +1080,6 @@
         "operator": "Club Alpino Italiano",
         "operator:short": "CAI",
         "operator:wikidata": "Q795273",
-        "operator:wikipedia": "it:Club Alpino Italiano"
       }
     }
   ]

--- a/data/operators/amenity/social_facility.json
+++ b/data/operators/amenity/social_facility.json
@@ -1079,7 +1079,7 @@
         "amenity": "social_facility",
         "operator": "Club Alpino Italiano",
         "operator:short": "CAI",
-        "operator:wikidata": "Q795273",
+        "operator:wikidata": "Q795273"
       }
     }
   ]

--- a/data/operators/amenity/social_facility.json
+++ b/data/operators/amenity/social_facility.json
@@ -1070,6 +1070,18 @@
         "operator": "公益財団法人ドナルド・マクドナルド・ハウス・チャリティーズ・ジャパン",
         "operator:ja": "公益財団法人ドナルド・マクドナルド・ハウス・チャリティーズ・ジャパン"
       }
+    },
+    {
+      "displayName": "Club Alpino Italiano",
+      "id": "clupalpinoitaliano-6d6198",
+      "locationSet": {"include": ["it"]},
+      "tags": {
+        "amenity": "social_facility",
+        "operator": "Club Alpino Italiano",
+        "operator:short": "CAI",
+        "operator:wikidata": "Q795273",
+        "operator:wikipedia": "it:Club Alpino Italiano"
+      }
     }
   ]
 }


### PR DESCRIPTION
The Club Alpino Italiano is the senior Italian alpine club which stages climbing competitions, operates alpine huts, marks and maintains paths, and is active in protecting the Alpine environment. https://en.wikipedia.org/wiki/Club_Alpino_Italiano