### PR TITLE
Correcting Serbian brands to latin script

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -10307,15 +10307,15 @@
       }
     },
     {
-      "displayName": "АИК банка",
+      "displayName": "AIK banka",
       "id": "aikbank-e9ea45",
       "locationSet": {"include": ["rs"]},
       "matchNames": ["aik banka", "аик банк"],
       "tags": {
         "amenity": "bank",
-        "brand": "АИК банка",
+        "brand": "AIK banka",
         "brand:wikidata": "Q293650",
-        "name": "АИК банка",
+        "name": "AIK banka",
         "name:en": "AIK bank",
         "name:sr": "АИК банка",
         "name:sr-Latn": "AIK banka"

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -5494,7 +5494,7 @@
     {
       "displayName": "ОМВ",
       "id": "637ba4-7131c1",
-      "locationSet": {"include": ["bg", "rs"]},
+      "locationSet": {"include": ["bg"]},
       "tags": {
         "amenity": "fuel",
         "brand": "ОМВ",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -6917,6 +6917,7 @@
       "displayName": "Univerexport",
       "id": "univerexport-b83687",
       "locationSet": {"include": ["rs"]},
+      "matchNames": ["универекспорт", "univereksport"],
       "tags": {
         "brand": "Univerexport",
         "brand:wikidata": "Q12747294",
@@ -7831,10 +7832,11 @@
       "displayName": "Лидл (Србија)",
       "id": "366fb7-b83687",
       "locationSet": {"include": ["rs"]},
+      "matchNames": ["лидл"],
       "tags": {
-        "brand": "Лидл",
+        "brand": "Lidl",
         "brand:wikidata": "Q114509929",
-        "name": "Лидл",
+        "name": "Lidl",
         "name:sr": "Лидл",
         "name:sr-Latn": "Lidl",
         "shop": "supermarket"
@@ -7905,15 +7907,18 @@
       }
     },
     {
-      "displayName": "Макси",
+      "displayName": "Maxi",
       "id": "maxi-b83687",
       "locationSet": {"include": ["rs"]},
+      "matchNames": ["макси", "maksi"],
       "tags": {
-        "brand": "Макси",
+        "brand": "Maxi",
         "brand:en": "Maxi",
         "brand:wikidata": "Q6795490",
-        "name": "Макси",
+        "name": "Maxi",
         "name:en": "Maxi",
+        "name:sr": "Макси",
+        "name:sr-Latn": "Maxi",
         "shop": "supermarket"
       }
     },
@@ -8076,15 +8081,16 @@
       }
     },
     {
-      "displayName": "Рода",
+      "displayName": "Roda",
       "id": "roda-b83687",
       "locationSet": {"include": ["rs"]},
+      "matchNames": ["рода"],
       "tags": {
-        "brand": "Рода",
+        "brand": "Roda",
         "brand:en": "Roda",
         "brand:sr": "Рода",
         "brand:wikidata": "Q21446192",
-        "name": "Рода",
+        "name": "Roda",
         "name:en": "Roda",
         "name:sr": "Рода",
         "name:sr-Latn": "Roda",
@@ -8199,15 +8205,16 @@
       }
     },
     {
-      "displayName": "Темпо",
+      "displayName": "Tempo",
       "id": "25c3ac-b83687",
       "locationSet": {"include": ["rs"]},
+      "matchNames": ["темпо"],
       "tags": {
-        "brand": "Темпо",
+        "brand": "Tempo",
         "brand:wikidata": "Q7698875",
-        "name": "Темпо",
+        "name": "Tempo",
         "name:sr": "Темпо",
-        "name:sr-Latn": "Темпо",
+        "name:sr-Latn": "Tempo",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
There were some Serbian brands that were imported/added with Cyrillic script, but they should be in Latin. We use both Cyrillic and Latin scripts, but some names (like "Maxi" => "Maksi"/"Макси" and other corrected in this PR) are never used in Cyrillic, never written as such, there are no signs on these shops that are written like this (ground truth), website do not use them and are just awkward to be read like that. This PR corrects those found and keeps "name:sr" in Cyrillic for those, but converts "name" and "brand" to Latin versions