### PR TITLE
Remove Vorarlberger Kraftwerke AG

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -4317,16 +4317,6 @@
       }
     },
     {
-      "displayName": "Vorarlberger Kraftwerke",
-      "id": "vorarlbergerkraftwerke-3f60da",
-      "locationSet": {"include": ["at"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Vorarlberger Kraftwerke",
-        "operator:wikidata": "Q1267084"
-      }
-    },
-    {
       "displayName": "wallbe",
       "id": "wallbe-1299a8",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
[Vorarlberger Kraftwerke AG](https://de.wikipedia.org/wiki/Vorarlberger_Kraftwerke ) was merged into [illwerke vkw AG](https://de.wikipedia.org/wiki/Illwerke_vkw) in 2019 and is no longer a legal entity.