### PR TITLE
Add Bangsamoro and some Native American flags

### DIFF
--- a/data/flags/man_made/flagpole.json
+++ b/data/flags/man_made/flagpole.json
@@ -218,10 +218,9 @@
     },
     {
       "displayName": "AU - Australian Aboriginal",
-      "id": "australianaboriginal-e5dc93",
-      "locationSet": {"include": ["001"]},
+      "id": "australianaboriginal-aec753",
+      "locationSet": {"include": ["au"]},
       "tags": {
-        "country": "AU",
         "flag:name": "Australian Aboriginal",
         "flag:type": "indigenous",
         "flag:wikidata": "Q1285625",
@@ -310,10 +309,9 @@
     },
     {
       "displayName": "AU - Torres Strait Islander",
-      "id": "torresstraitislander-e5dc93",
-      "locationSet": {"include": ["001"]},
+      "id": "torresstraitislander-aec753",
+      "locationSet": {"include": ["au"]},
       "tags": {
-        "country": "AU",
         "flag:name": "Torres Strait Islander",
         "flag:type": "indigenous",
         "flag:wikidata": "Q462621",
@@ -3495,7 +3493,7 @@
       }
     },
     {
-      "displayName": "NZ - United Tribes",
+      "displayName": "NZ - United Tribes of New Zealand",
       "id": "unitedtribesofnewzealand-f1c036",
       "locationSet": {"include": ["nz"]},
       "tags": {
@@ -3585,6 +3583,19 @@
         "man_made": "flagpole",
         "subject": "Papua New Guinea",
         "subject:wikidata": "Q691"
+      }
+    },
+    {
+      "displayName": "PH - Bangsamoro",
+      "id": "bangsamoro-54d211",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "flag:name": "Bangsamoro",
+        "flag:type": "regional",
+        "flag:wikidata": "Q74484535",
+        "man_made": "flagpole",
+        "subject": "Bangsamoro",
+        "subject:wikidata": "Q24869612"
       }
     },
     {
@@ -4520,6 +4531,50 @@
       }
     },
     {
+      "displayName": "US - Cherokee Nation",
+      "id": "cherokeenation-85bb3f",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "flag:colour": "orange",
+        "flag:name": "Cherokee Nation",
+        "flag:type": "indigenous",
+        "flag:wikidata": "Q5456858",
+        "man_made": "flagpole",
+        "subject": "Cherokee Nation",
+        "subject:wikidata": "Q14708404"
+      }
+    },
+    {
+      "displayName": "US - Chickasaw Nation",
+      "id": "chickasawnation-85bb3f",
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["chicasaw"],
+      "tags": {
+        "flag:colour": "indigo",
+        "flag:name": "Chickasaw Nation",
+        "flag:type": "indigenous",
+        "flag:wikidata": "Q114643306",
+        "man_made": "flagpole",
+        "subject": "Chickasaw Nation",
+        "subject:wikidata": "Q3336808"
+      }
+    },
+    {
+      "displayName": "US - Choctaw Nation of Oklahoma",
+      "id": "choctawnationofoklahoma-85bb3f",
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["choctaw", "choctaw nation"],
+      "tags": {
+        "flag:colour": "purple",
+        "flag:name": "Choctaw Nation of Oklahoma",
+        "flag:type": "indigenous",
+        "flag:wikidata": "Q114642869",
+        "man_made": "flagpole",
+        "subject": "Choctaw Nation of Oklahoma",
+        "subject:wikidata": "Q5103726"
+      }
+    },
+    {
       "displayName": "US - Colorado",
       "id": "colorado-85bb3f",
       "locationSet": {"include": ["us"]},
@@ -4825,6 +4880,25 @@
       }
     },
     {
+      "displayName": "US - Muscogee (Creek) Nation",
+      "id": "muscogeenation-85bb3f",
+      "locationSet": {"include": ["us"]},
+      "matchNames": [
+        "creek",
+        "creek nation",
+        "muscogee"
+      ],
+      "tags": {
+        "flag:colour": "white",
+        "flag:name": "Muscogee Nation",
+        "flag:type": "indigenous",
+        "flag:wikidata": "Q114554335",
+        "man_made": "flagpole",
+        "subject": "Muscogee Nation",
+        "subject:wikidata": "Q6940348"
+      }
+    },
+    {
       "displayName": "US - Nebraska",
       "id": "nebraska-85bb3f",
       "locationSet": {"include": ["us"]},
@@ -4977,6 +5051,21 @@
       }
     },
     {
+      "displayName": "US - Pawnee Nation of Oklahoma",
+      "id": "pawneenationofoklahoma-85bb3f",
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["pawnee", "pawnee nation"],
+      "tags": {
+        "flag:colour": "blue",
+        "flag:name": "Pawnee Nation of Oklahoma",
+        "flag:type": "indigenous",
+        "flag:wikidata": "Q114643616",
+        "man_made": "flagpole",
+        "subject": "Pawnee Nation of Oklahoma",
+        "subject:wikidata": "Q750947"
+      }
+    },
+    {
       "displayName": "US - Pennsylvania",
       "id": "pennsylvania-85bb3f",
       "locationSet": {"include": ["us"]},
@@ -5002,6 +5091,33 @@
         "man_made": "flagpole",
         "subject": "Rhode Island",
         "subject:wikidata": "Q1387"
+      }
+    },
+    {
+      "displayName": "US - Seminole Nation of Oklahoma",
+      "id": "seminolenationofoklahoma-85bb3f",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "flag:colour": "white",
+        "flag:name": "Seminole Nation of Oklahoma",
+        "flag:type": "indigenous",
+        "flag:wikidata": "Q114642332",
+        "man_made": "flagpole",
+        "subject": "Seminole Nation of Oklahoma",
+        "subject:wikidata": "Q7449528"
+      }
+    },
+    {
+      "displayName": "US - Seminole Tribe of Florda",
+      "id": "seminoletribeofflorida-85bb3f",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "flag:name": "Seminole Tribe of Florida",
+        "flag:type": "indigenous",
+        "flag:wikidata": "Q108837351",
+        "man_made": "flagpole",
+        "subject": "Seminole Tribe of Florida",
+        "subject:wikidata": "Q7449545"
       }
     },
     {
@@ -5490,7 +5606,7 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "flag:name": "Wiphala",
-        "flag:type": "cultural",
+        "flag:type": "indigenous",
         "flag:wikidata": "Q1193967",
         "man_made": "flagpole"
       }


### PR DESCRIPTION
This adds the flags requested in #7188.  
I did make a small change though..

@ianlopez1115 said:
> I've tagged flags representing Native American nations and similar entities as `flag:type=national` following the precedent set in https://github.com/osmlab/name-suggestion-index/issues/5786

I looked through the current list of flags and - since we've started adding these - a few other people (e9b17fe78, 89661e68, maybe others) have added indigenous flags for Australia and New Zealand and tagged them as `flag:type=indigenous`.  I think this is a better descriptive value for the flag type, and since other people are using it, it seems ok..  I updated the Wiphala flag (#4892) to use this value too.

I notice that `flag:type=cultural` and `flag:type=indigenous` are not documented yet on https://wiki.openstreetmap.org/wiki/Key:flag:type so it would be great if someone would add these values.

Anyway happy (belated) [Indigenous People's Day](https://en.wikipedia.org/wiki/Indigenous_Peoples%27_Day)!

