### PR TITLE
Addition of Japanese cram (prep) schools

### DIFF
--- a/data/brands/amenity/prep_school.json
+++ b/data/brands/amenity/prep_school.json
@@ -131,6 +131,244 @@
       }
     },
     {
+      "displayName": "九大進学会",
+      "id": "kyudaishingakukai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "進学会",
+        "brand:en": "SHINGAKUKAI",
+        "brand:ja": "進学会",
+        "brand:wikidata": "Q11640144",
+        "name": "九大進学会",
+        "name:en": "Kyudai Shingakukai",
+        "name:ja": "九大進学会"
+      }
+    },
+    {
+      "displayName": "京大進学会",
+      "id": "kyodaishingakukai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "進学会",
+        "brand:en": "SHINGAKUKAI",
+        "brand:ja": "進学会",
+        "brand:wikidata": "Q11640144",
+        "name": "京大進学会",
+        "name:en": "Kyodai Shingakukai",
+        "name:ja": "京大進学会"
+      }
+    },
+    {
+      "displayName": "仙台練成会",
+      "id": "sendairenseikai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "練成会",
+        "brand:en": "RENSEIKAI",
+        "brand:ja": "練成会",
+        "brand:wikidata": "Q11608020",
+        "name": "仙台練成会",
+        "name:en": "Sendai Renseikai",
+        "name:ja": "仙台練成会"
+      }
+    },
+    {
+      "displayName": "個別教室のトライ",
+      "id": "02f231-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "個別教室のトライ",
+        "brand:ja": "個別教室のトライ",
+        "brand:wikidata": "Q11455435",
+        "name": "個別教室のトライ",
+        "name:ja": "個別教室のトライ"
+      }
+    },
+    {
+      "displayName": "函館練成会",
+      "id": "hakodaterenseikai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "練成会",
+        "brand:en": "RENSEIKAI",
+        "brand:ja": "練成会",
+        "brand:wikidata": "Q11608020",
+        "name": "函館練成会",
+        "name:en": "Hakodate Renseikai",
+        "name:ja": "函館練成会"
+      }
+    },
+    {
+      "displayName": "北大学力増進会",
+      "id": "hokudaigakuryokuzoshinkai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "進学会",
+        "brand:en": "SHINGAKUKAI",
+        "brand:ja": "進学会",
+        "brand:wikidata": "Q11640144",
+        "name": "北大学力増進会",
+        "name:en": "Hokudai Gakuryoku Zoshinkai",
+        "name:ja": "北大学力増進会"
+      }
+    },
+    {
+      "displayName": "北見練成会",
+      "id": "kitamirenseikai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "練成会",
+        "brand:en": "RENSEIKAI",
+        "brand:ja": "練成会",
+        "brand:wikidata": "Q11608020",
+        "name": "北見練成会",
+        "name:en": "Kitami Renseikai",
+        "name:ja": "北見練成会"
+      }
+    },
+    {
+      "displayName": "名大進学会",
+      "id": "meidaishingakukai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "進学会",
+        "brand:en": "SHINGAKUKAI",
+        "brand:ja": "進学会",
+        "brand:wikidata": "Q11640144",
+        "name": "名大進学会",
+        "name:en": "Meidai Shingakukai",
+        "name:ja": "名大進学会"
+      }
+    },
+    {
+      "displayName": "小樽練成会",
+      "id": "otarurenseikai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "練成会",
+        "brand:en": "RENSEIKAI",
+        "brand:ja": "練成会",
+        "brand:wikidata": "Q11608020",
+        "name": "小樽練成会",
+        "name:en": "Otaru Renseikai",
+        "name:ja": "小樽練成会"
+      }
+    },
+    {
+      "displayName": "山形練成会",
+      "id": "yamagatarenseikai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "練成会",
+        "brand:en": "RENSEIKAI",
+        "brand:ja": "練成会",
+        "brand:wikidata": "Q11608020",
+        "name": "山形練成会",
+        "name:en": "Yamagata Renseikai",
+        "name:ja": "山形練成会"
+      }
+    },
+    {
+      "displayName": "岩見沢練成会",
+      "id": "iwamizawarenseikai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "練成会",
+        "brand:en": "RENSEIKAI",
+        "brand:ja": "練成会",
+        "brand:wikidata": "Q11608020",
+        "name": "岩見沢練成会",
+        "name:en": "Iwamizawa Renseikai",
+        "name:ja": "岩見沢練成会"
+      }
+    },
+    {
+      "displayName": "旭川練成会",
+      "id": "asahikawarenseikai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "練成会",
+        "brand:en": "RENSEIKAI",
+        "brand:ja": "練成会",
+        "brand:wikidata": "Q11608020",
+        "name": "旭川練成会",
+        "name:en": "Asahikawa Renseikai",
+        "name:ja": "旭川練成会"
+      }
+    },
+    {
+      "displayName": "札幌練成会",
+      "id": "sappororenseikai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "練成会",
+        "brand:en": "RENSEIKAI",
+        "brand:ja": "練成会",
+        "brand:wikidata": "Q11608020",
+        "name": "札幌練成会",
+        "name:en": "Sapporo Renseikai",
+        "name:ja": "札幌練成会"
+      }
+    },
+    {
+      "displayName": "東北大進学会",
+      "id": "tohokudaishingakukai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "進学会",
+        "brand:en": "SHINGAKUKAI",
+        "brand:ja": "進学会",
+        "brand:wikidata": "Q11640144",
+        "name": "東北大進学会",
+        "name:en": "Tohokudai Shingakukai",
+        "name:ja": "東北大進学会"
+      }
+    },
+    {
+      "displayName": "東大進学会",
+      "id": "todaishingakukai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "進学会",
+        "brand:en": "SHINGAKUKAI",
+        "brand:ja": "進学会",
+        "brand:wikidata": "Q11640144",
+        "name": "東大進学会",
+        "name:en": "Todai Shingakukai",
+        "name:ja": "東大進学会"
+      }
+    },
+    {
+      "displayName": "東進衛星予備校",
+      "id": "toshineiseiyobiko-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "東進衛星予備校",
+        "brand:en": "Toshin Eisei Yobiko",
+        "brand:ja": "東進衛星予備校",
+        "brand:wikidata": "Q11528409",
+        "name": "東進衛星予備校",
+        "name:en": "Toshin Eisei Yobiko",
+        "name:ja": "東進衛星予備校"
+      }
+    },
+    {
       "displayName": "栄光ゼミナール",
       "id": "eikohseminar-cae330",
       "locationSet": {"include": ["jp"]},
@@ -147,6 +385,96 @@
         "name:ja": "栄光ゼミナール",
         "name:ja-Hira": "えいこうゼミナール",
         "name:ja-Latn": "Eikō Zemināru"
+      }
+    },
+    {
+      "displayName": "滝川練成会",
+      "id": "takikawarenseikai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "練成会",
+        "brand:en": "RENSEIKAI",
+        "brand:ja": "練成会",
+        "brand:wikidata": "Q11608020",
+        "name": "滝川練成会",
+        "name:en": "Takikawa Renseikai",
+        "name:ja": "滝川練成会"
+      }
+    },
+    {
+      "displayName": "畜大練成会",
+      "id": "chikudairenseikai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "練成会",
+        "brand:en": "RENSEIKAI",
+        "brand:ja": "練成会",
+        "brand:wikidata": "Q11608020",
+        "name": "畜大練成会",
+        "name:en": "Chikudai Renseikai",
+        "name:ja": "畜大練成会"
+      }
+    },
+    {
+      "displayName": "秀英予備校",
+      "id": "shueiyobiko-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "秀英予備校",
+        "brand:en": "Shuei-Yobiko",
+        "brand:ja": "秀英予備校",
+        "brand:wikidata": "Q11594557",
+        "name": "秀英予備校",
+        "name:en": "Shuei Yobiko",
+        "name:ja": "秀英予備校"
+      }
+    },
+    {
+      "displayName": "苫小牧練成会",
+      "id": "tomakomairenseikai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "練成会",
+        "brand:en": "RENSEIKAI",
+        "brand:ja": "練成会",
+        "brand:wikidata": "Q11608020",
+        "name": "苫小牧練成会",
+        "name:en": "Tomakomai Renseikai",
+        "name:ja": "苫小牧練成会"
+      }
+    },
+    {
+      "displayName": "釧路練成会",
+      "id": "kushirorenseikai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "練成会",
+        "brand:en": "RENSEIKAI",
+        "brand:ja": "練成会",
+        "brand:wikidata": "Q11608020",
+        "name": "釧路練成会",
+        "name:en": "Kushiro Renseikai",
+        "name:ja": "釧路練成会"
+      }
+    },
+    {
+      "displayName": "青森練成会",
+      "id": "aomorirenseikai-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "練成会",
+        "brand:en": "RENSEIKAI",
+        "brand:ja": "練成会",
+        "brand:wikidata": "Q11608020",
+        "name": "青森練成会",
+        "name:en": "Aomori Renseikai",
+        "name:ja": "青森練成会"
       }
     }
   ]


### PR DESCRIPTION
The additions are as follows:

- 進学会ホールディングス（Shingakukai, and its Affiliates）
- 練成会グループ（Renseikai Group）
- 秀英予備校 (Shuei-Yobiko)
- 東進衛星予備校 (Toshin Eisei Yobiko)
- 個別教室のトライ (Kobetsu Kyoshitsu no Try (?) )