### PR TITLE
change location of "Nord-Ostsee Sparkasse"

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -7390,7 +7390,7 @@
     {
       "displayName": "Nord-Ostsee Sparkasse",
       "id": "nordostseesparkasse-1180cf",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {"include": ["de-sh"]},
       "tags": {
         "amenity": "bank",
         "brand": "Nord-Ostsee Sparkasse",


### PR DESCRIPTION
This bank is only present in the German state Schleswig-Holstein