### PR TITLE
Fix apollostation, Shell in Japan

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -360,7 +360,7 @@
         "brand": "apollostation",
         "brand:en": "apollostation",
         "brand:ja": "アポロステーション",
-        "brand:wikidata": "Q2216770",
+        "brand:wikidata": "Q114731101",
         "name": "apollostation",
         "name:en": "apollostation",
         "name:ja": "アポロステーション"
@@ -6196,6 +6196,26 @@
       }
     },
     {
+      "displayName": "シェル",
+      "id": "shell-fbe2e4",
+      "locationSet": {"include": ["jp"]},
+      "matchNames": [
+        "ロイヤル・ダッチ・シェル",
+        "昭和シェル",
+        "昭和シェル石油"
+      ],
+      "tags": {
+        "amenity": "fuel",
+        "brand": "シェル",
+        "brand:en": "Shell",
+        "brand:ja": "シェル",
+        "brand:wikidata": "Q110716465",
+        "name": "シェル",
+        "name:en": "Shell",
+        "name:ja": "シェル"
+      }
+    },
+    {
       "displayName": "中国国际能源",
       "id": "chinainternationalenergy-e4b6c0",
       "locationSet": {"include": ["cn"]},
@@ -6400,26 +6420,6 @@
         "name:zh": "广西交投",
         "operator": "广西交通投资集团有限公司",
         "operator:type": "public"
-      }
-    },
-    {
-      "displayName": "昭和シェル",
-      "id": "showashellsekiyu-fbe2e4",
-      "locationSet": {"include": ["jp"]},
-      "matchNames": ["ロイヤル・ダッチ・シェル", "昭和シェル石油"],
-      "note": "Showa Shell Sekiyu was a subsidiary of Royal Dutch Shell but now operates as its own entity in japan with qid Q277115",
-      "tags": {
-        "amenity": "fuel",
-        "brand": "昭和シェル",
-        "brand:en": "Showa Shell Sekiyu",
-        "brand:ja": "昭和シェル",
-        "brand:wikidata": "Q277115",
-        "name": "昭和シェル",
-        "name:en": "Showa Shell Sekiyu",
-        "name:ja": "昭和シェル",
-        "short_name": "シェル",
-        "short_name:en": "Shell",
-        "short_name:ja": "シェル"
       }
     },
     {

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6196,26 +6196,6 @@
       }
     },
     {
-      "displayName": "シェル",
-      "id": "shell-fbe2e4",
-      "locationSet": {"include": ["jp"]},
-      "matchNames": [
-        "ロイヤル・ダッチ・シェル",
-        "昭和シェル",
-        "昭和シェル石油"
-      ],
-      "tags": {
-        "amenity": "fuel",
-        "brand": "シェル",
-        "brand:en": "Shell",
-        "brand:ja": "シェル",
-        "brand:wikidata": "Q110716465",
-        "name": "シェル",
-        "name:en": "Shell",
-        "name:ja": "シェル"
-      }
-    },
-    {
       "displayName": "中国国际能源",
       "id": "chinainternationalenergy-e4b6c0",
       "locationSet": {"include": ["cn"]},
@@ -6420,6 +6400,22 @@
         "name:zh": "广西交投",
         "operator": "广西交通投资集团有限公司",
         "operator:type": "public"
+      }
+    },
+    {
+      "displayName": "昭和シェル",
+      "id": "showashell-fbe2e4",
+      "locationSet": {"include": ["jp"]},
+      "matchNames": ["ロイヤル・ダッチ・シェル", "昭和シェル石油"],
+      "tags": {
+        "amenity": "fuel",
+        "brand": "シェル",
+        "brand:en": "Shell",
+        "brand:ja": "シェル",
+        "brand:wikidata": "Q110716465",
+        "name": "昭和シェル",
+        "name:en": "Showa Shell",
+        "name:ja": "昭和シェル"
       }
     },
     {


### PR DESCRIPTION
Showa Shell Sekiyu used to operate Shell-branded gas stations, but it was not itself a brand. It was however a good reason why Wikidata needs a separate item for the Shell brand versus Shell plc: Royal Dutch Shell hasn’t owned or operated any of the Shell stations in Japan for a few years now.

Anyhow, Idemitsu Kosan renamed its Showa Shell Sekiyu subsidiary to RS Energy, then shut it down, and now it’s in the process of [phasing out](https://response.jp/article/2020/11/25/340639.html) the Shell and Idemitsu brands in favor of apollostation by next year, when it loses the Shell franchise. This PR also distinguishes between apollostation and Idemitsu Kosan, which currently owns or operates three different gas station brands and many other things besides.

/ref #4109 #7077 #7216