### PR TITLE
Add Forenom hostels

### DIFF
--- a/data/brands/tourism/hostel.json
+++ b/data/brands/tourism/hostel.json
@@ -44,6 +44,16 @@
       }
     },
     {
+      "displayName": "Forenom",
+      "locationSet": {"include": ["fi", "se"]},
+      "tags": {
+        "brand": "Forenom",
+        "brand:wikidata": "Q101142662",
+        "name": "Forenom Hostel",
+        "tourism": "hostel"
+      }
+    },
+    {
       "displayName": "Girls Hostel",
       "id": "girlshostel-840e3b",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
9 locations across Finland and Sweden according to https://www.forenom.com/hostels/

They also have [aparthotels](https://www.forenom.com/aparthotels/), but I don't know in which file I should put them if they are generally tagged by `tourism=apartment` ?