### PR TITLE
Move VLOTTE from operator to brand

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -116,6 +116,15 @@
       }
     },
     {
+      "displayName": "VLOTTE",
+      "id": "vlotte-3f60da",
+      "locationSet": {"include": ["at"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "VLOTTE"
+      }
+    },
+    {
       "displayName": "Tesla Destination Charger",
       "id": "tesladestinationcharger-67e574",
       "locationSet": {

--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -116,12 +116,12 @@
       }
     },
     {
-      "displayName": "VLOTTE",
+      "displayName": "vkw vlotte",
       "id": "vlotte-3f60da",
       "locationSet": {"include": ["at"]},
       "tags": {
         "amenity": "charging_station",
-        "operator": "VLOTTE"
+        "operator": "vkw vlotte"
       }
     },
     {

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -4294,15 +4294,6 @@
       }
     },
     {
-      "displayName": "VLOTTE",
-      "id": "vlotte-3f60da",
-      "locationSet": {"include": ["at"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "VLOTTE"
-      }
-    },
-    {
       "displayName": "Volkswagen Group Charging GmbH",
       "id": "volkswagengroupcharginggmbh-1299a8",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
VLOTTE is only the brand for their charging stations. The operator is the "illwerke vkw AG". Check their website ([footer](https://www.vlotte.at/)):
![image](https://user-images.githubusercontent.com/3351668/196660420-1ce7a410-dc55-49c5-b348-a01b10a9d6df.png)
