### PR TITLE
Added Romania to Enel X charging_station (enelx-7667bf)

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -1254,7 +1254,7 @@
     {
       "displayName": "Enel X",
       "id": "enelx-7667bf",
-      "locationSet": {"include": ["cl", "it"]},
+      "locationSet": {"include": ["cl", "it", "ro"]},
       "matchNames": ["enel x metbus"],
       "tags": {
         "amenity": "charging_station",


### PR DESCRIPTION
See here: https://www.enelx.com/ro/en/harta-statiilor-de-incarcare

There are probably more countries to add.