### PR TITLE
Add Japanese computer store, change 100 Man Volt and Kojima to one that seems appropriate

### DIFF
--- a/data/brands/shop/computer.json
+++ b/data/brands/shop/computer.json
@@ -201,6 +201,7 @@
     },
     {
       "displayName": "ドスパラ",
+      "id": "dospara-8cc09d",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "brand": "ドスパラ",
@@ -215,6 +216,7 @@
     },
     {
       "displayName": "パソコン工房",
+      "id": "6185e9-8cc09d",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "brand": "パソコン工房",

--- a/data/brands/shop/computer.json
+++ b/data/brands/shop/computer.json
@@ -198,6 +198,32 @@
         "name:zh-Hant": "偉倫電腦",
         "shop": "computer"
       }
+    },
+    {
+      "displayName": "ドスパラ",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "ドスパラ",
+        "brand:en": "Dospara",
+        "brand:ja": "ドスパラ",
+        "brand:wikidata": "Q11306200",
+        "name": "ドスパラ",
+        "name:en": "Dospara",
+        "name:ja": "ドスパラ",
+        "shop": "computer"
+      }
+    },
+    {
+      "displayName": "パソコン工房",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "パソコン工房",
+        "brand:ja": "パソコン工房",
+        "brand:wikidata": "Q11345680",
+        "name": "パソコン工房",
+        "name:ja": "パソコン工房",
+        "shop": "computer"
+      }
     }
   ]
 }

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -10,11 +10,11 @@
       "locationSet": {"include": ["jp"]},
       "tags": {
         "brand": "100満ボルト",
-        "brand:en": "100mv",
+        "brand:en": "100 Man Volt",
         "brand:ja": "100満ボルト",
         "brand:wikidata": "Q11305504",
         "name": "100満ボルト",
-        "name:en": "100mv",
+        "name:en": "100 Man Volt",
         "name:ja": "100満ボルト",
         "shop": "electronics"
       }
@@ -1676,6 +1676,23 @@
         "brand": "MediaWorld",
         "brand:wikidata": "Q76504823",
         "name": "MediaWorld",
+        "shop": "electronics"
+      }
+    },
+    {
+      "displayName": "コジマ×ビックカメラ",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "コジマ×ビックカメラ",
+        "brand:en": "Kojima × Bic Camera",
+        "brand:ja": "コジマ×ビックカメラ",
+        "brand:wikidata": "Q11302052",
+        "name": "コジマ×ビックカメラ",
+        "name:en": "Kojima × Bic Camera",
+        "name:ja": "コジマ×ビックカメラ",
+        "short_name": "コジマ",
+        "short_name:en": "Kojima",
+        "short_name:ja": "コジマ",
         "shop": "electronics"
       }
     }

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -6,7 +6,7 @@
   "items": [
     {
       "displayName": "100満ボルト",
-      "id": "100mv-f86f5e",
+      "id": "100manvolt-f86f5e",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "brand": "100満ボルト",
@@ -1387,6 +1387,24 @@
       }
     },
     {
+      "displayName": "コジマ×ビックカメラ",
+      "id": "3dc97a-f86f5e",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "コジマ×ビックカメラ",
+        "brand:en": "Kojima × Bic Camera",
+        "brand:ja": "コジマ×ビックカメラ",
+        "brand:wikidata": "Q11302052",
+        "name": "コジマ×ビックカメラ",
+        "name:en": "Kojima × Bic Camera",
+        "name:ja": "コジマ×ビックカメラ",
+        "shop": "electronics",
+        "short_name": "コジマ",
+        "short_name:en": "Kojima",
+        "short_name:ja": "コジマ"
+      }
+    },
+    {
       "displayName": "ソフマップ",
       "id": "sofmap-f86f5e",
       "locationSet": {"include": ["jp"]},
@@ -1678,22 +1696,6 @@
         "name": "MediaWorld",
         "shop": "electronics"
       }
-    },
-    {
-      "displayName": "コジマ×ビックカメラ",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "brand": "コジマ×ビックカメラ",
-        "brand:en": "Kojima × Bic Camera",
-        "brand:ja": "コジマ×ビックカメラ",
-        "brand:wikidata": "Q11302052",
-        "name": "コジマ×ビックカメラ",
-        "name:en": "Kojima × Bic Camera",
-        "name:ja": "コジマ×ビックカメラ",
-        "short_name": "コジマ",
-        "short_name:en": "Kojima",
-        "short_name:ja": "コジマ",
-        "shop": "electronics"
       }
     }
   ]

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -8,6 +8,7 @@
       "displayName": "100満ボルト",
       "id": "100manvolt-f86f5e",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["100mv"],
       "tags": {
         "brand": "100満ボルト",
         "brand:en": "100 Man Volt",

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -1696,7 +1696,6 @@
         "name": "MediaWorld",
         "shop": "electronics"
       }
-      }
     }
   ]
 }


### PR DESCRIPTION
As for 100 Man Volt, "100mv" is an abbreviation for a website or social networking account, and the English translation of the original name "100 Man Volt" would be more appropriate.

As for Kojima, it is now part of Bic Camera, and most "Kojima" brand stores are now branded "Kojima x Bic Camera", with only one "Kojima" brand store remaining.
However, I am not sure if the original "Kojima" should be removed, so I am leaving it as it is.