### PR TITLE
Delicious Pho

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -1324,6 +1324,19 @@
       }
     },
     {
+      "displayName": "Delicious Pho",
+      "locationSet": {
+        "include": ["ca", "gb-lon.geojson"]
+      },
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "Delicious Pho",
+        "brand:wikidata": "Q114794842",
+        "cuisine": "vietnamese",
+        "name": "Delicious Pho"
+      }
+    },
+    {
       "displayName": "Denny's",
       "id": "dennys-2fabb0",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
The Canadian chain has expanded to London https://www.bighospitality.co.uk/Article/2021/07/01/Canada-s-Delicious-Pho-to-make-London-debut