### PR TITLE
Add Chambre(シャンブル) and Birthday(バースデイ), Remove Shimamura(しまむら) duplicate

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -8832,14 +8832,32 @@
       }
     },
     {
-      "displayName": "ショッピングセンターしまむら",
-      "id": "dcb0d4-85f881",
+      "displayName": "シャンブル",
+      "id": "chambre-85f881",
       "locationSet": {"include": ["jp"]},
       "tags": {
-        "brand": "ショッピングセンターしまむら",
-        "brand:ja": "ショッピングセンターしまむら",
-        "name": "ショッピングセンターしまむら",
-        "name:ja": "ショッピングセンターしまむら",
+        "brand": "シャンブル",
+        "brand:en": "Chambre",
+        "brand:ja": "シャンブル",
+        "brand:wikidata": "Q113489480",
+        "name": "シャンブル",
+        "name:en": "Chambre",
+        "name:ja": "シャンブル",
+        "shop": "clothes"
+      }
+    },
+    {
+      "displayName": "バースデイ",
+      "id": "birthday-85f881",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "バースデイ",
+        "brand:en": "Birthday",
+        "brand:ja": "バースデイ",
+        "brand:wikidata": "Q113487317",
+        "name": "バースデイ",
+        "name:en": "Birthday",
+        "name:ja": "バースデイ",
         "shop": "clothes"
       }
     },


### PR DESCRIPTION
This is an addition of Shimamura Group brands (Chambre and Birthday).

As for Shimamura, I removed the one without wikidata, English name, and official_name, and left the one with detailed tags.