### PR TITLE
Corrected category of MUJI(無印良品) in Japan

### DIFF
--- a/data/brands/shop/department_store.json
+++ b/data/brands/shop/department_store.json
@@ -1562,9 +1562,9 @@
     },
     {
       "displayName": "無印良品",
-      "id": "muji-c72ec8",
+      "id": "muji-ed1ceb",
       "locationSet": {
-        "include": ["jp", "mo", "my", "sg", "tw"]
+        "include": ["mo", "my", "sg", "tw"]
       },
       "matchNames": ["良品計画"],
       "tags": {

--- a/data/brands/shop/variety_store.json
+++ b/data/brands/shop/variety_store.json
@@ -975,6 +975,24 @@
         "name:zh-Hant": "名創優品",
         "shop": "variety_store"
       }
+    },
+    {
+      "displayName": "無印良品",
+      "id": "muji-e1b193",
+      "locationSet": {"include": ["jp"]},
+      "matchNames": ["良品計画"],
+      "matchTags": ["shop/department_store"],
+      "tags": {
+        "brand": "無印良品",
+        "brand:en": "MUJI",
+        "brand:ja": "無印良品",
+        "brand:wikidata": "Q708789",
+        "name": "無印良品",
+        "name:en": "MUJI",
+        "name:ja": "無印良品",
+        "official_name:en": "Ryohin Keikaku",
+        "shop": "variety_store"
+      }
     }
   ]
 }


### PR DESCRIPTION
According to [JA:Naming sample](https://wiki.openstreetmap.org/wiki/JA:Naming_sample#shop=variety_store), shop=variety_store is more correct for MUJI.
My feeling is also that it is not a department store at least.

In this PR, I don't know how it is perceived in other countries, so I fixed it only for Japan.