### PR TITLE
Limit location of Kołobrzeski Rower Miejski

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -1783,7 +1783,7 @@
     },
     {
       "displayName": "Kołobrzeski Rower Miejski",
-      "id": "kolobrzeskirowermiejski-4d145c",
+      "id": "kolobrzeskirowermiejski-499603",
       "locationSet": {
         "include": [[15.5764209, 54.1759614]]
       },

--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -1787,6 +1787,7 @@
       "locationSet": {
         "include": [[15.5764209, 54.1759614]]
       },
+      "note": "Kołobrzeg in Poland",
       "tags": {
         "amenity": "bicycle_rental",
         "brand": "Kołobrzeski Rower Miejski",

--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -1784,7 +1784,9 @@
     {
       "displayName": "Kołobrzeski Rower Miejski",
       "id": "kolobrzeskirowermiejski-4d145c",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": {
+        "include": [[15.5764209, 54.1759614]]
+      },
       "tags": {
         "amenity": "bicycle_rental",
         "brand": "Kołobrzeski Rower Miejski",


### PR DESCRIPTION
Users of iD apply Kołobrzeski Rower Miejski brand sugestion for bicycle rental station outside of Kołobrzeg.
Many bicycle rentals systems are operated by Nextbike. Not sure why this particular network is suggested, perhaps Polish letter `ł` causes issues with text comparison?
I decided to limit area where Kołobrzeski Rower Miejski is applicable.
According to https://github.com/ideditor/location-conflation/blob/main/README.md#location-conflation default radius is 25km.