### PR TITLE
Category fixes related to variety_store for Japanese stores

### DIFF
--- a/data/brands/shop/department_store.json
+++ b/data/brands/shop/department_store.json
@@ -1477,22 +1477,6 @@
       }
     },
     {
-      "displayName": "ロフト",
-      "id": "loft-96cf7b",
-      "locationSet": {"include": ["jp"]},
-      "matchTags": ["shop/hardware"],
-      "tags": {
-        "brand": "ロフト",
-        "brand:en": "Loft",
-        "brand:ja": "ロフト",
-        "brand:wikidata": "Q5358428",
-        "name": "ロフト",
-        "name:en": "Loft",
-        "name:ja": "ロフト",
-        "shop": "department_store"
-      }
-    },
-    {
       "displayName": "名创优品",
       "id": "miniso-85e4e5",
       "locationSet": {
@@ -1542,21 +1526,6 @@
         "name": "无印良品",
         "name:en": "Muji",
         "name:zh": "无印良品",
-        "shop": "department_store"
-      }
-    },
-    {
-      "displayName": "東急ハンズ",
-      "id": "tokyuhands-96cf7b",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "brand": "東急ハンズ",
-        "brand:en": "Tokyu Hands",
-        "brand:ja": "東急ハンズ",
-        "brand:wikidata": "Q859212",
-        "name": "東急ハンズ",
-        "name:en": "Tokyu Hands",
-        "name:ja": "東急ハンズ",
         "shop": "department_store"
       }
     },

--- a/data/brands/shop/variety_store.json
+++ b/data/brands/shop/variety_store.json
@@ -992,17 +992,18 @@
       }
     },
     {
-      "displayName": "東急ハンズ",
+      "displayName": "ハンズ",
       "id": "tokyuhands-e1b193",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["東急ハンズ"],
       "tags": {
-        "brand": "東急ハンズ",
-        "brand:en": "Tokyu Hands",
-        "brand:ja": "東急ハンズ",
+        "brand": "ハンズ",
+        "brand:en": "Hands",
+        "brand:ja": "ハンズ",
         "brand:wikidata": "Q859212",
-        "name": "東急ハンズ",
-        "name:en": "Tokyu Hands",
-        "name:ja": "東急ハンズ",
+        "name": "ハンズ",
+        "name:en": "Hands",
+        "name:ja": "ハンズ",
         "shop": "variety_store"
       }
     },

--- a/data/brands/shop/variety_store.json
+++ b/data/brands/shop/variety_store.json
@@ -905,17 +905,33 @@
       }
     },
     {
+      "displayName": "ハンズ",
+      "id": "hands-e1b193",
+      "locationSet": {"include": ["jp"]},
+      "matchNames": ["東急ハンズ"],
+      "tags": {
+        "brand": "ハンズ",
+        "brand:en": "Hands",
+        "brand:ja": "ハンズ",
+        "brand:wikidata": "Q859212",
+        "name": "ハンズ",
+        "name:en": "Hands",
+        "name:ja": "ハンズ",
+        "shop": "variety_store"
+      }
+    },
+    {
       "displayName": "ロフト",
       "id": "loft-e1b193",
       "locationSet": {"include": ["jp"]},
       "matchTags": ["shop/department_store"],
       "tags": {
         "brand": "ロフト",
-        "brand:en": "LOFT",
+        "brand:en": "Loft",
         "brand:ja": "ロフト",
         "brand:wikidata": "Q5358428",
         "name": "ロフト",
-        "name:en": "LOFT",
+        "name:en": "Loft",
         "name:ja": "ロフト",
         "shop": "variety_store"
       }
@@ -988,22 +1004,6 @@
         "name:zh": "名創優品",
         "name:zh-Hans": "名创优品",
         "name:zh-Hant": "名創優品",
-        "shop": "variety_store"
-      }
-    },
-    {
-      "displayName": "ハンズ",
-      "id": "tokyuhands-e1b193",
-      "locationSet": {"include": ["jp"]},
-      "matchNames": ["東急ハンズ"],
-      "tags": {
-        "brand": "ハンズ",
-        "brand:en": "Hands",
-        "brand:ja": "ハンズ",
-        "brand:wikidata": "Q859212",
-        "name": "ハンズ",
-        "name:en": "Hands",
-        "name:ja": "ハンズ",
         "shop": "variety_store"
       }
     },

--- a/data/brands/shop/variety_store.json
+++ b/data/brands/shop/variety_store.json
@@ -909,6 +909,7 @@
       "id": "hands-e1b193",
       "locationSet": {"include": ["jp"]},
       "matchNames": ["東急ハンズ"],
+      "matchTags": ["shop/department_store"],
       "tags": {
         "brand": "ハンズ",
         "brand:en": "Hands",

--- a/data/brands/shop/variety_store.json
+++ b/data/brands/shop/variety_store.json
@@ -831,11 +831,11 @@
       "locationSet": {"include": ["jp"]},
       "tags": {
         "brand": "キャンドゥ",
-        "brand:en": "CAN DO",
+        "brand:en": "Can Do",
         "brand:ja": "キャンドゥ",
         "brand:wikidata": "Q11297367",
         "name": "キャンドゥ",
-        "name:en": "CAN DO",
+        "name:en": "Can Do",
         "name:ja": "キャンドゥ",
         "shop": "variety_store"
       }

--- a/data/brands/shop/variety_store.json
+++ b/data/brands/shop/variety_store.json
@@ -898,11 +898,26 @@
         "name": "ドン・キホーテ",
         "name:en": "Don Quijote",
         "name:ja": "ドン・キホーテ",
-        "opening_hours": "24/7",
         "shop": "variety_store",
         "short_name": "ドンキ",
         "short_name:en": "Donki",
         "short_name:ja": "ドンキ"
+      }
+    },
+    {
+      "displayName": "ロフト",
+      "id": "loft-e1b193",
+      "locationSet": {"include": ["jp"]},
+      "matchTags": ["shop/department_store"],
+      "tags": {
+        "brand": "ロフト",
+        "brand:en": "LOFT",
+        "brand:ja": "ロフト",
+        "brand:wikidata": "Q5358428",
+        "name": "ロフト",
+        "name:en": "LOFT",
+        "name:ja": "ロフト",
+        "shop": "variety_store"
       }
     },
     {
@@ -973,6 +988,21 @@
         "name:zh": "名創優品",
         "name:zh-Hans": "名创优品",
         "name:zh-Hant": "名創優品",
+        "shop": "variety_store"
+      }
+    },
+    {
+      "displayName": "東急ハンズ",
+      "id": "tokyuhands-e1b193",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "東急ハンズ",
+        "brand:en": "Tokyu Hands",
+        "brand:ja": "東急ハンズ",
+        "brand:wikidata": "Q859212",
+        "name": "東急ハンズ",
+        "name:en": "Tokyu Hands",
+        "name:ja": "東急ハンズ",
         "shop": "variety_store"
       }
     },


### PR DESCRIPTION
FYI, The corrected details are as follows:
|name|description|
|---|---|
|ドン・キホーテ(Don Quixote)|Stores that are not open 24/7 naturally exist and should not register opening_hours as 24/7 in NSI
|ロフト(Loft)|It should be considered a variety store, as officially calls itself a variety store|
|ハンズ(Hands)<br>(旧 東急ハンズ, Former Tokyu Hands)|Above and trade name and store name changes|
|キャンドゥ(Can Do)|Since the official website and logo refer to "Can★Do", the entire text should not be capitalized|
