### PR TITLE
Add Pharmacy Tsuruha (調剤薬局ツルハドラッグ)

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -4187,6 +4187,22 @@
       }
     },
     {
+      "displayName": "調剤薬局ツルハドラッグ",
+      "id": "pharmacytsuruha-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "ツルハドラッグ",
+        "brand:en": "Tsuruha",
+        "brand:ja": "ツルハドラッグ",
+        "brand:wikidata": "Q114891238",
+        "healthcare": "pharmacy",
+        "name": "調剤薬局ツルハドラッグ",
+        "name:en": "Pharmacy Tsuruha",
+        "name:ja": "調剤薬局ツルハドラッグ"
+      }
+    },
+    {
       "displayName": "高济",
       "id": "cowell-f38123",
       "locationSet": {"include": ["cn"]},


### PR DESCRIPTION
I added the dispensary portion because it seems to be treated as a separate store brand.
<hr>
Not directly related to this PR, but how can I prevent dispensing=yes from being automatically added in the amenity=pharmacy and healthcare=pharmacy presets?<br>
In Japan, drug stores are added with this preset (tags), but not all stores have dispensing available, like the brand I have just added.

I didn't see it in the NSI json, so is it necessary to change the code of the iD preset?