### PR TITLE
Blank Street Coffee has locations across the US

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -384,7 +384,7 @@
       "locationSet": {
         "include": [
           "gb-lon.geojson",
-          "us-ny.geojson"
+          "us"
         ]
       },
       "matchNames": ["blank street"],


### PR DESCRIPTION
The brand has locations in New York, Boston and Washington as well as London

 https://dc.eater.com/2022/10/17/23402834/blank-street-coffee-nyc-dc-stores-openings