### PR TITLE
Correct BART operator name

### DIFF
--- a/data/transit/route/light_rail.json
+++ b/data/transit/route/light_rail.json
@@ -95,7 +95,7 @@
       "tags": {
         "network": "BART",
         "network:wikidata": "Q610120",
-        "operator": "Bay Area Rapid Transit District",
+        "operator": "San Francisco Bay Area Rapid Transit District",
         "operator:wikidata": "Q4873922",
         "route": "light_rail"
       }

--- a/data/transit/route/subway.json
+++ b/data/transit/route/subway.json
@@ -44,7 +44,7 @@
       "tags": {
         "network": "BART",
         "network:wikidata": "Q610120",
-        "operator": "Bay Area Rapid Transit District",
+        "operator": "San Francisco Bay Area Rapid Transit District",
         "operator:wikidata": "Q4873922",
         "route": "subway"
       }


### PR DESCRIPTION
The operator name should be "San Francisco Bay Area Rapid Transit District" - the first part of the name was missing.  See https://www.bart.gov/about for example.