### PR TITLE
Correct Intermarché wikidata and add Intermarché Hyper

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1682,7 +1682,7 @@
       "matchTags": ["shop/supermarket"],
       "tags": {
         "brand": "Intermarché Contact",
-        "brand:wikidata": "Q3153200",
+        "brand:wikidata": "Q98278049",
         "name": "Intermarché Contact",
         "shop": "convenience"
       }

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -3210,8 +3210,20 @@
       },
       "tags": {
         "brand": "Intermarché Super",
-        "brand:wikidata": "Q3153200",
+        "brand:wikidata": "Q98278038",
         "name": "Intermarché Super",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "Intermarché Hyper",
+      "locationSet": {
+        "include": ["fr"]
+      },
+      "tags": {
+        "brand": "Intermarché Hyper",
+        "brand:wikidata": "Q98278022",
+        "name": "Intermarché Hyper",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
Use specific QIDs since they are available.

Looking at [Wikipedia](https://en.wikipedia.org/wiki/Intermarch%C3%A9) Intermarché Express may be closer to `shop=convenience` than `shop=supermarket`, but then again, maybe it'd have been fixed by now if that was true.