### PR TITLE
Add/Fix Japanese restaurants and fast food brands

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -1386,6 +1386,26 @@
       }
     },
     {
+      "displayName": "CoCo壱番屋",
+      "id": "cocoichibanya-3e7699",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "CoCo壱番屋",
+        "brand:en": "CoCo ICHIBANYA",
+        "brand:ja": "CoCo壱番屋",
+        "brand:wikidata": "Q5986105",
+        "cuisine": "japanese",
+        "name": "CoCo壱番屋",
+        "name:en": "CoCo ICHIBANYA",
+        "name:ja": "CoCo壱番屋",
+        "short_name": "ココイチ",
+        "short_name:en": "CoCoICHI",
+        "short_name:ja": "ココイチ",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Cœur de Blé",
       "id": "coeurdeble-e4dee6",
       "locationSet": {"include": ["fr"]},
@@ -8367,6 +8387,23 @@
       }
     },
     {
+      "displayName": "クリスピー・クリーム・ドーナツ",
+      "id": "krispykremedoughnuts-3e7699",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "クリスピー・クリーム・ドーナツ",
+        "brand:en": "Krispy Kreme Doughnuts",
+        "brand:ja": "クリスピー・クリーム・ドーナツ",
+        "brand:wikidata": "Q1192805",
+        "name": "クリスピー・クリーム・ドーナツ",
+        "name:en": "Krispy Kreme Doughnuts",
+        "name:ja": "クリスピー・クリーム・ドーナツ",
+        "short_name:en": "Krispy Kreme",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "ケンタッキーフライドチキン",
       "id": "kfc-3e7699",
       "locationSet": {"include": ["jp"]},
@@ -8537,10 +8574,9 @@
       }
     },
     {
-      "displayName": "ドミノ",
-      "id": "dominos-3e7699",
+      "displayName": "ドミノ・ピザ",
+      "id": "dominospizza-3e7699",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["ドミノ・ピザ"],
       "tags": {
         "amenity": "fast_food",
         "brand": "ドミノ",
@@ -8548,9 +8584,12 @@
         "brand:ja": "ドミノ",
         "brand:wikidata": "Q839466",
         "cuisine": "pizza",
-        "name": "ドミノ",
-        "name:en": "Domino's",
-        "name:ja": "ドミノ",
+        "name": "ドミノ・ピザ",
+        "name:en": "Domino's Pizza",
+        "name:ja": "ドミノ・ピザ",
+        "short_name": "ドミノ",
+        "short_name:en": "Domino's",
+        "short_name:ja": "ドミノ",
         "takeaway": "yes"
       }
     },
@@ -8929,6 +8968,23 @@
         "name:nan-TL": "Tan-tan Hàn-pó",
         "name:zh": "丹丹漢堡",
         "name:zh-Hant": "丹丹漢堡",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "元気寿司",
+      "id": "genkisushi-3e7699",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "元気寿司",
+        "brand:en": "Genki Sushi",
+        "brand:ja": "元気寿司",
+        "brand:wikidata": "Q5533323",
+        "cuisine": "sushi",
+        "name": "元気寿司",
+        "name:en": "Genki Sushi",
+        "name:ja": "元気寿司",
         "takeaway": "yes"
       }
     },
@@ -9557,6 +9613,8 @@
         "name": "築地銀だこ",
         "name:en": "Gindaco",
         "name:ja": "築地銀だこ",
+        "short_name": "銀だこ",
+        "short_name:ja": "銀だこ",
         "takeaway": "yes"
       }
     },
@@ -9871,6 +9929,23 @@
         "name:en": "Sukiya",
         "name:ja": "すき家",
         "name:zh": "食其家",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "魚べい",
+      "id": "uobei-3e7699",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "魚べい",
+        "brand:en": "Uobei",
+        "brand:ja": "魚べい",
+        "brand:wikidata": "Q115008809",
+        "cuisine": "sushi",
+        "name": "魚べい",
+        "name:en": "Uobei",
+        "name:ja": "魚べい",
         "takeaway": "yes"
       }
     },

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -1101,14 +1101,13 @@
     },
     {
       "displayName": "CoCo Ichibanya",
-      "id": "cocoichibanya-ee7d86",
+      "id": "cocoichibanya-365649",
       "locationSet": {
         "include": [
           "cn",
           "hk",
           "id",
           "in",
-          "jp",
           "kr",
           "ph",
           "sg",
@@ -1142,23 +1141,6 @@
         "brand:wikidata": "Q5139723",
         "cuisine": "american",
         "name": "Coco's Bakery"
-      }
-    },
-    {
-      "displayName": "CoCo壱番屋",
-      "id": "cocoichibanya-36ca8e",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "restaurant",
-        "brand": "CoCo壱番屋",
-        "brand:en": "CoCo Ichibanya",
-        "brand:ja": "CoCo壱番屋",
-        "brand:wikidata": "Q5986105",
-        "cuisine": "japanese",
-        "name": "CoCo壱番屋",
-        "name:en": "CoCo Ichibanya",
-        "name:ja": "CoCo壱番屋",
-        "takeaway": "yes"
       }
     },
     {
@@ -5356,6 +5338,21 @@
         "name": "からやま",
         "name:en": "Karayama",
         "name:ja": "からやま"
+      }
+    },
+    {
+      "displayName": "から好し",
+      "id": "karayoshi-36ca8e",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "から好し",
+        "brand:en": "Karayoshi",
+        "brand:ja": "から好し",
+        "brand:wikidata": "Q115008407",
+        "name": "から好し",
+        "name:en": "Karayoshi",
+        "name:ja": "から好し"
       }
     },
     {


### PR DESCRIPTION
The additions and fixes are as follows:
(Sorry for the length.)
|name|description|
|---|---|
|CoCo Ichibanya (CoCo壱番屋)|As described in Japanese Wikipedia and other sources, it is recognized as a fast food chain in Japan.<br>Also removed Japan from the global version due to duplication.|
|Krispy Kreme Doughnuts (クリスピー・クリーム・ドーナツ)|It seems to be recognized as "Krispy Kreme" in other countries, but I added Krispy Kreme to short_name instead, to match the name on the Japanese version of the website.|
|Domino's Pizza (ドミノ・ピザ)|In Japan, "Domino's Pizza" seems to be the official name rather than "Domino's", so I fixed it there and moved "Domino's" to short_name instead.|
|Gindaco (築地銀だこ)|As "銀だこ" is used in general sentences and conversations rather than "築地銀だこ", I added short_name so that it will also be found in searches.<br>English name seems to be "Gindaco" from the origin as far as signboards, so I didn't change the name to "Tsukiji Gindaco".|
|Karayoshi (から好し)|This is a Japanese fried chicken (Karaage, から揚げ) store chain.<br>Added as a restaurant, but could be fast food.|
|Genki Sushi (元気寿司)|This is a brand of the Genki Sushi Group.<br>By the way, although easily mistaken, the appropriate reading in Japanese is "Genki Zushi". <br>The official English name is fine for Genki Sushi.|
|Uobei (魚べい)|This is a brand of the Genki Sushi Group.|