### PR TITLE
Change ENEOS(エネオス) notation and merge (remove) EneJet(エネジェット)

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6179,23 +6179,8 @@
       }
     },
     {
-      "displayName": "エネオス",
+      "displayName": "ENEOS",
       "id": "eneos-fbe2e4",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "fuel",
-        "brand": "エネオス",
-        "brand:en": "ENEOS",
-        "brand:ja": "エネオス",
-        "brand:wikidata": "Q1640290",
-        "name": "エネオス",
-        "name:en": "ENEOS",
-        "name:ja": "エネオス"
-      }
-    },
-    {
-      "displayName": "エネオス エネジェット",
-      "id": "enejet-fbe2e4",
       "locationSet": {"include": ["jp"]},
       "matchNames": [
         "esso",
@@ -6208,13 +6193,13 @@
       ],
       "tags": {
         "amenity": "fuel",
-        "brand": "エネオス エネジェット",
-        "brand:en": "ENEOS Enejet",
-        "brand:ja": "エネオス エネジェット",
-        "brand:wikidata": "Q11289795",
-        "name": "エネジェット",
-        "name:en": "EneJet",
-        "name:ja": "エネジェット"
+        "brand": "ENEOS",
+        "brand:en": "ENEOS",
+        "brand:ja": "エネオス",
+        "brand:wikidata": "Q1640290",
+        "name": "ENEOS",
+        "name:en": "ENEOS",
+        "name:ja": "エネオス"
       }
     },
     {

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -1502,6 +1502,31 @@
       }
     },
     {
+      "displayName": "ENEOS",
+      "id": "eneos-fbe2e4",
+      "locationSet": {"include": ["jp"]},
+      "matchNames": [
+        "esso",
+        "mobil",
+        "tonen general",
+        "エッソ",
+        "エッソ石油",
+        "エネオス エネジェット",
+        "ゼネラル",
+        "モービル"
+      ],
+      "tags": {
+        "amenity": "fuel",
+        "brand": "ENEOS",
+        "brand:en": "ENEOS",
+        "brand:ja": "エネオス",
+        "brand:wikidata": "Q1640290",
+        "name": "ENEOS",
+        "name:en": "ENEOS",
+        "name:ja": "エネオス"
+      }
+    },
+    {
       "displayName": "Enercoop",
       "id": "enercoop-e8f712",
       "locationSet": {"include": ["it"]},
@@ -6176,30 +6201,6 @@
         "brand:ko": "현대오일뱅크",
         "name": "현대오일뱅크",
         "name:ko": "현대오일뱅크"
-      }
-    },
-    {
-      "displayName": "ENEOS",
-      "id": "eneos-fbe2e4",
-      "locationSet": {"include": ["jp"]},
-      "matchNames": [
-        "esso",
-        "mobil",
-        "tonen general",
-        "エッソ",
-        "エッソ石油",
-        "ゼネラル",
-        "モービル"
-      ],
-      "tags": {
-        "amenity": "fuel",
-        "brand": "ENEOS",
-        "brand:en": "ENEOS",
-        "brand:ja": "エネオス",
-        "brand:wikidata": "Q1640290",
-        "name": "ENEOS",
-        "name:en": "ENEOS",
-        "name:ja": "エネオス"
       }
     },
     {

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -7806,6 +7806,19 @@
       }
     },
     {
+      "displayName": "ДИС",
+      "id": "981fe7-b83687",
+      "locationSet": {"include": ["rs"]},
+      "tags": {
+        "brand": "ДИС",
+        "brand:wikidata": "Q115091348",
+        "name": "ДИС",
+        "name:sr": "ДИС",
+        "name:sr-Latn": "DIS",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Дэлгүүр",
       "id": "45c849-387d64",
       "locationSet": {"include": ["mn"]},
@@ -9970,18 +9983,6 @@
         "brand:ja": "関西スーパー",
         "name": "関西スーパー",
         "name:ja": "関西スーパー",
-        "shop": "supermarket"
-      }
-    },
-    {
-      "displayName": "ДИС",
-      "locationSet": {"include": ["rs"]},
-      "tags": {
-        "brand": "ДИС",
-        "brand:wikidata": "Q115091348",
-        "name": "ДИС",
-        "name:sr": "ДИС",
-        "name:sr-Latn": "DIS",
         "shop": "supermarket"
       }
     }


### PR DESCRIPTION
For ENEOS, I adapted the notation used on the official website, etc., and originally commonly used in OSM.
I think it is a similar case to apollostation as to whether Japanese or English notation should be used.

As for EneJet, according to the official store locator service, the name of the store itself is "ENEOS" and instead the name of the branch begins with "EneJet" (i.e., attributional, like whether it is self-service or not), so I think there is no need to separate them by brand or name tags.