### PR TITLE
Add free.fr as shop to the nsi

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -326,6 +326,17 @@
       }
     },
     {
+      "displayName": "Free",
+      "id": "free-7734a6",
+      "locationSet": {"include": ["fr"]},
+      "tags": {
+        "brand": "Free",
+        "brand:wikidata": "Q2467627",
+        "name": "Free",
+        "shop": "mobile_phone"
+      }
+    },
+    {
       "displayName": "Freedom Mobile",
       "id": "freedommobile-947b24",
       "locationSet": {"include": ["ca"]},


### PR DESCRIPTION
Adds https://www.free.fr/boutiques/ to the NSI.

Personally I just tagged it as `shop=telecommunication`, but since It's similar to SFR or Orange (which are tagged as `shop=mobile_phone`) I'd suggest to tag it similar to already existing brands.