### PR TITLE
Netto pulled out of SE

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -4854,7 +4854,7 @@
       "displayName": "Netto (Salling)",
       "id": "netto-e5945f",
       "locationSet": {
-        "include": ["de", "dk", "pl", "se"]
+        "include": ["de", "dk", "pl"]
       },
       "tags": {
         "brand": "Netto",


### PR DESCRIPTION
[Sold to "Swedish Coop Butiker & Stormarknader AB"](https://en.wikipedia.org/wiki/Netto_(store)#Geographic_coverage)