### PR TITLE
Improving Brazilian Post Office

### DIFF
--- a/data/brands/amenity/post_office.json
+++ b/data/brands/amenity/post_office.json
@@ -15,7 +15,9 @@
         "amenity": "post_office",
         "brand": "Empresa Brasileira de Correios e Telégrafos",
         "brand:short": "Correios",
-        "brand:wikidata": "Q3375004"
+        "brand:wikidata": "Q3375004",
+        "brand:wikipedia=pt": "Empresa Brasileira de Correios e Telégrafos",
+        "name": "Correios"
       }
     },
     {

--- a/data/brands/amenity/post_office.json
+++ b/data/brands/amenity/post_office.json
@@ -16,7 +16,6 @@
         "brand": "Empresa Brasileira de Correios e Telégrafos",
         "brand:short": "Correios",
         "brand:wikidata": "Q3375004",
-        "brand:wikipedia": "pt:Empresa Brasileira de Correios e Telégrafos",
         "name": "Correios"
       }
     },

--- a/data/brands/amenity/post_office.json
+++ b/data/brands/amenity/post_office.json
@@ -16,7 +16,7 @@
         "brand": "Empresa Brasileira de Correios e Telégrafos",
         "brand:short": "Correios",
         "brand:wikidata": "Q3375004",
-        "brand:wikipedia=pt": "Empresa Brasileira de Correios e Telégrafos",
+        "brand:wikipedia": "pt:Empresa Brasileira de Correios e Telégrafos",
         "name": "Correios"
       }
     },

--- a/data/operators/amenity/post_box.json
+++ b/data/operators/amenity/post_box.json
@@ -54,10 +54,8 @@
       "locationSet": {"include": ["br"]},
       "tags": {
         "amenity": "post_box",
-        "brand": "Empresa Brasileira de Correios e Telégrafos",
-        "brand:short": "Correios",
-        "brand:wikidata": "Q3375004",
         "operator": "Empresa Brasileira de Correios e Telégrafos",
+        "operator:short": "Correios",
         "operator:type": "public",
         "operator:wikidata": "Q3375004"
       }

--- a/data/operators/amenity/post_box.json
+++ b/data/operators/amenity/post_box.json
@@ -15,6 +15,7 @@
     {
       "note": "Auto create post boxes for all brand post offices - a few exceptions",
       "templateExclude": [
+        "correios",
         "fedex",
         "orlen",
         "upsstore"
@@ -46,6 +47,19 @@
         "amenity": "post_box",
         "colour": "yellow",
         "name": ""
+      }
+    },
+    {
+      "displayName": "Caixa dos Correios",
+      "locationSet": {"include": ["br"]},
+      "tags": {
+        "amenity": "post_box",
+        "brand": "Empresa Brasileira de Correios e Telégrafos",
+        "brand:short": "Correios",
+        "brand:wikidata": "Q3375004",
+        "operator": "Empresa Brasileira de Correios e Telégrafos",
+        "operator:type": "public",
+        "operator:wikidata": "Q3375004"
       }
     },
     {

--- a/data/operators/amenity/post_depot.json
+++ b/data/operators/amenity/post_depot.json
@@ -38,10 +38,12 @@
       "matchNames": ["ebct", "ect"],
       "tags": {
         "amenity": "post_depot",
+        "name": "Centro de Distribuição dos Correios",
         "operator": "Empresa Brasileira de Correios e Telégrafos",
         "operator:short": "Correios",
         "operator:type": "public",
-        "operator:wikidata": "Q3375004"
+        "operator:wikidata": "Q3375004",
+        "operator:wikipedia": "pt:Empresa Brasileira de Correios e Telégrafos"
       }
     },
     {

--- a/data/operators/amenity/post_depot.json
+++ b/data/operators/amenity/post_depot.json
@@ -43,7 +43,6 @@
         "operator:short": "Correios",
         "operator:type": "public",
         "operator:wikidata": "Q3375004",
-        "operator:wikipedia": "pt:Empresa Brasileira de Correios e Telégrafos"
       }
     },
     {

--- a/data/operators/amenity/post_depot.json
+++ b/data/operators/amenity/post_depot.json
@@ -42,7 +42,7 @@
         "operator": "Empresa Brasileira de Correios e Telégrafos",
         "operator:short": "Correios",
         "operator:type": "public",
-        "operator:wikidata": "Q3375004",
+        "operator:wikidata": "Q3375004"
       }
     },
     {


### PR DESCRIPTION
Hey guys,

I didn't have time to make suggestions to #7154, but this PR attempts to improve that PR.

Basically, due to the change of display name, things were a bit weird when editing on OSM, so I did 3 things on this PR:

### Post Office

- Added name (tag `name=Correios`)

### Post Depot
- Added name (tag `name=Centro de Distribuição dos Correios`)

### Post Box
- I created a whole new entry, given the display name of post office does not make sense here. Not sure if this part is correct, though.

What do you think? CC @vgeorge @UKChris-osm @willemarcel @LaoshuBaby 