### PR TITLE
Add Wahlburgers and more Wingstop locations

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -7318,7 +7318,7 @@
     {
       "displayName": "Wingstop",
       "id": "wingstop-bca76b",
-      "locationSet": {"include": ["mx", "us"]},
+      "locationSet": {"include": ["ae", "ca", "es", "fx", "gb", "id", "mx", "sg", "us"]},
       "tags": {
         "amenity": "fast_food",
         "brand": "Wingstop",

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -7166,6 +7166,20 @@
       }
     },
     {
+      "displayName": "Wahlburgers",
+      "locationSet": {
+        "include": ["au", "ca", "de", "us"],
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Wahlburgers",
+        "brand:wikidata": "Q17032457",
+        "cuisine": "burger",
+        "name": "Wahlburgers",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Wayback Burgers",
       "id": "waybackburgers-658eea",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
As per https://www.wingstop.com/international-development and https://www.wingstop.co.uk/about-us Left out Colombia, Malaysia and Panama as only listed on the UK site Triggered by https://www.theguardian.com/food/2022/nov/08/how-americas-fast-food-giants-are-eating-up-britains-high-streets