### PR TITLE
Rename the English name of 出光(Idemitsu)

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6378,17 +6378,16 @@
     },
     {
       "displayName": "出光",
-      "id": "idemitsukosan-fbe2e4",
+      "id": "idemitsu-fbe2e4",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["idemitsu"],
       "tags": {
         "amenity": "fuel",
         "brand": "出光",
-        "brand:en": "Idemitsu Kosan",
+        "brand:en": "Idemitsu",
         "brand:ja": "出光",
         "brand:wikidata": "Q2216770",
         "name": "出光",
-        "name:en": "Idemitsu Kosan",
+        "name:en": "Idemitsu",
         "name:ja": "出光"
       }
     },

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6380,6 +6380,7 @@
       "displayName": "出光",
       "id": "idemitsu-fbe2e4",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["idemitsu kosan"],
       "tags": {
         "amenity": "fuel",
         "brand": "出光",


### PR DESCRIPTION
I revised the name to one that seemed appropriate, referring to the way the brand name is written in Japanese, the English name on the signboard, and JA:Naming sample.