### PR TITLE
Add Ario (アリオ) and preserveTags for AEON MALL (イオンモール) name tag

### DIFF
--- a/data/brands/shop/mall.json
+++ b/data/brands/shop/mall.json
@@ -153,16 +153,33 @@
       }
     },
     {
+      "displayName": "アリオ",
+      "id": "ario-ee1aa0",
+      "locationSet": {"include": ["jp"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "アリオ",
+        "brand:en": "Ario",
+        "brand:ja": "アリオ",
+        "brand:wikidata": "Q16143182",
+        "name": "アリオ",
+        "name:en": "Ario",
+        "name:ja": "アリオ",
+        "shop": "mall"
+      }
+    },
+    {
       "displayName": "イオンモール",
       "id": "aeonmall-ee1aa0",
       "locationSet": {"include": ["jp"]},
+      "preserveTags": ["^name"],
       "tags": {
         "brand": "イオンモール",
-        "brand:en": "AEON Mall",
+        "brand:en": "AEON MALL",
         "brand:ja": "イオンモール",
         "brand:wikidata": "Q11286068",
         "name": "イオンモール",
-        "name:en": "AEON Mall",
+        "name:en": "AEON MALL",
         "name:ja": "イオンモール",
         "shop": "mall"
       }


### PR DESCRIPTION
All of these brands have whole branch names attached to their names, and I think they are better known by their names, so I tried to preserve the name tag.

As for Aeon Mall, the official English name is basically capitalized, so I matched it.