### PR TITLE
Fix タイムズカー (Times Car) of Japanese Car Sharing Brand

### DIFF
--- a/data/operators/amenity/car_sharing.json
+++ b/data/operators/amenity/car_sharing.json
@@ -665,35 +665,24 @@
       }
     },
     {
-      "displayName": "タイムズ",
-      "id": "15ecb5-4854ed",
+      "displayName": "タイムズカー",
+      "id": "timesmobility-4854ed",
       "locationSet": {"include": ["jp"]},
+      "matchNames": [
+        "タイムズカーシェア",
+        "タイムズ",
+        "タイムズ24"
+      ],
       "tags": {
         "amenity": "car_sharing",
-        "operator": "タイムズ",
-        "operator:ja": "タイムズ"
-      }
-    },
-    {
-      "displayName": "タイムズ24",
-      "id": "d1ffdb-4854ed",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "car_sharing",
-        "operator": "タイムズ24",
-        "operator:ja": "タイムズ24"
-      }
-    },
-    {
-      "displayName": "タイムズカーシェア",
-      "id": "timescarshare-4854ed",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "car_sharing",
-        "operator": "タイムズカーシェア",
-        "operator:en": "Times Car Share",
-        "operator:ja": "タイムズカーシェア",
-        "operator:wikidata": "Q17987881"
+        "brand": "タイムズカー",
+        "brand:en": "Times Car",
+        "brand:ja": "タイムズカー",
+        "brand:wikidata": "Q17987881",
+        "operator": "タイムズモビリティ",
+        "operator:en": "Times Mobility",
+        "operator:ja": "タイムズモビリティ",
+        "operator:wikidata": "Q115248773"
       }
     }
   ]


### PR DESCRIPTION
This may be able to close #7392.

As I wrote in Issue, Times Car is about the brand, so I clearly separated the brand from the management company.

However, since the brand is better known than the official name of the operating company, it might be better to move it to brands/amenity/car_sharing (but I don't know the criteria).

Also, running `npm run build` adds タイムズ(Times) and タイムズ24(Times 24), so I added those to matchNames. These are the names of the parking lots and their operators.

---
close #7392