### PR TITLE
match metro against Metro Petroleum in Australia and exclude METRO

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -2952,7 +2952,10 @@
     {
       "displayName": "METRO",
       "id": "metro-b3d110",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": ["001"],
+        "exclude": ["au"]
+      },
       "tags": {
         "amenity": "fuel",
         "brand": "METRO",
@@ -2964,6 +2967,7 @@
       "displayName": "Metro Petroleum",
       "id": "metropetroleum-9ed9c0",
       "locationSet": {"include": ["au"]},
+      "matchNames": ["metro"],
       "tags": {
         "amenity": "fuel",
         "brand": "Metro Petroleum",


### PR DESCRIPTION
In Australia we have https://www.wikidata.org/wiki/Q111970125 and brand/name=Metro should match this.

We don't have METRO https://www.wikidata.org/wiki/Q13610282 and so it should not match.