### PR TITLE
Remove name from WIlson Parking

### DIFF
--- a/data/operators/amenity/parking.json
+++ b/data/operators/amenity/parking.json
@@ -824,24 +824,5 @@
         "operator:wikidata": "Q11415765"
       }
     },
-    {
-      "displayName": "威信停車場",
-      "id": "wilsonparking-1f7225",
-      "locationSet": {"include": ["hk"]},
-      "matchNames": ["威信"],
-      "tags": {
-        "amenity": "parking",
-        "brand": "威信停車場",
-        "brand:en": "Wilson Parking",
-        "brand:wikidata": "Q28448427",
-        "brand:zh": "威信停車場",
-        "fee": "yes",
-        "name": "威信停車場 Wilson Parking",
-        "operator": "威信停車場",
-        "operator:en": "Wilson Parking",
-        "operator:wikidata": "Q28448427",
-        "operator:zh": "威信停車場"
-      }
-    }
   ]
 }

--- a/data/operators/amenity/parking.json
+++ b/data/operators/amenity/parking.json
@@ -824,5 +824,24 @@
         "operator:wikidata": "Q11415765"
       }
     },
+    
+    {
+      "displayName": "威信停車場 Wilson Parking",
+      "id": "wilsonparking-1f7225",
+      "locationSet": {"include": ["hk"]},
+      "matchNames": ["威信", "Wilson"],
+      "tags": {
+        "amenity": "parking",
+        "brand": "威信停車場 Wilson Parking",
+        "brand:en": "Wilson Parking",
+        "brand:wikidata": "Q28448427",
+        "brand:zh": "威信停車場",
+        "fee": "yes", 
+        "operator": "威信停車場 Wilson Parking",
+        "operator:en": "Wilson Parking",
+        "operator:wikidata": "Q28448427",
+        "operator:zh": "威信停車場"
+      }
+    }
   ]
 }


### PR DESCRIPTION
 It is only a contractor for outsourced parking management, not having any dedicated carparks. Users have added useless `name=Wilson Parking`  to `=parking`, when the correct name is the carpark of the building (mall, hotel, etc) it is in.  