### PR TITLE
Delete "Kojima" and leave "Kojima × Bic Camera"

### DIFF
--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -1439,21 +1439,6 @@
       }
     },
     {
-      "displayName": "コジマ",
-      "id": "kojima-f86f5e",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "brand": "コジマ",
-        "brand:en": "Kojima",
-        "brand:ja": "コジマ",
-        "brand:wikidata": "Q11302052",
-        "name": "コジマ",
-        "name:en": "Kojima",
-        "name:ja": "コジマ",
-        "shop": "electronics"
-      }
-    },
-    {
       "displayName": "コジマ×ビックカメラ",
       "id": "3dc97a-f86f5e",
       "locationSet": {"include": ["jp"]},


### PR DESCRIPTION
The Kojima (コジマ) brand disappeared this month and was replaced by Kojima × Bic Camera (コジマ×ビックカメラ).