### PR TITLE
Updated locationSet of Santander US

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -8604,7 +8604,7 @@
     {
       "displayName": "Santander",
       "id": "santander-b7a026",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us"]},
       "matchNames": ["santander consumer bank"],
       "tags": {
         "amenity": "bank",


### PR DESCRIPTION
Santander with wikidata Q5835668 is exclusively from USA https://www.santanderbank.com/ and I also wanted to update the ATM (santander-2f6feb) but I didn't find where is it