### PR TITLE
Remove dead code for one brand and improve one preset with adding a "…

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -18,7 +18,6 @@
         "^zigarettenautomat$",
         "^自販機$"
       ],
-      "named": ["^tobaccoland$"]
     }
   },
   "items": [
@@ -862,6 +861,8 @@
         "min_age": "18",
         "operator": "Tobaccoland Automatengesellschaft",
         "operator:wikidata": "Q1439872"
+        "vending": "cigarettes"
+        "preserveTags": "vending"
       }
     },
     {

--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -854,15 +854,15 @@
       "id": "tobaccoland-a242c5",
       "locationSet": {"include": ["de"]},
       "matchNames": ["tobaccoland"],
+      "preserveTags": ["vending"],
       "tags": {
         "amenity": "vending_machine",
         "brand": "tobaccoland",
         "brand:wikidata": "Q1439872",
         "min_age": "18",
         "operator": "Tobaccoland Automatengesellschaft",
-        "operator:wikidata": "Q1439872"
+        "operator:wikidata": "Q1439872",
         "vending": "cigarettes"
-        "preserveTags": "vending"
       }
     },
     {


### PR DESCRIPTION
…vending" value

Hi,
here I removed dead code for the brand "Tobaccoland", because the code line isn't needed anymore, and I added the key "vending", so that the preset is more complete. I also added "preserveTags", because sometimes the vending key may differ from vending=cigarettes (e. g. vending=cigarettes;condoms). See also https://github.com/osmlab/name-suggestion-index/pull/6301