### PR TITLE
[nz] Add brand:wikidata to a liquor shop

### DIFF
--- a/data/brands/shop/alcohol.json
+++ b/data/brands/shop/alcohol.json
@@ -494,6 +494,7 @@
       "locationSet": {"include": ["nz"]},
       "tags": {
         "brand": "Super Liquor",
+        "brand:wikidata": "Q112038718",
         "name": "Super Liquor",
         "shop": "alcohol"
       }


### PR DESCRIPTION
Looking at [the history of the wikidata item](https://www.wikidata.org/w/index.php?title=Q112038718&action=history), I can't tell why it was removed from NSI days after it was originally added...