### PR TITLE
Remove Papyrus

### DIFF
--- a/data/brands/shop/gift.json
+++ b/data/brands/shop/gift.json
@@ -268,17 +268,6 @@
       }
     },
     {
-      "displayName": "Papyrus",
-      "id": "papyrus-43d507",
-      "locationSet": {"include": ["us"]},
-      "tags": {
-        "brand": "Papyrus",
-        "brand:wikidata": "Q28222692",
-        "name": "Papyrus",
-        "shop": "gift"
-      }
-    },
-    {
       "displayName": "Scribbler",
       "id": "scribbler-da52c2",
       "locationSet": {"include": ["gb"]},


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Papyrus_(company)

Closed in early 2020, the branded products are still sold through other shops like Kroger and RiteAid.

I've never removed anything from NSI before, it this all we do?