### PR TITLE
Shoe retail chains Snipes and Courir are also present in Belgium

### DIFF
--- a/data/brands/shop/shoes.json
+++ b/data/brands/shop/shoes.json
@@ -369,7 +369,7 @@
     {
       "displayName": "Courir",
       "id": "courir-c57706",
-      "locationSet": {"include": ["fr"]},
+      "locationSet": {"include": ["fr", "be"]},
       "tags": {
         "brand": "Courir",
         "brand:wikidata": "Q3001258",
@@ -1584,6 +1584,7 @@
       "locationSet": {
         "include": [
           "at",
+	  "be",
           "ch",
           "de",
           "es",


### PR DESCRIPTION
Shoe retail chains Snipes and Courir are also present in Belgium. I've adjusted the locationset to match.