### PR TITLE
Add Colombia as location for pharmacy: Cruz Verde

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -617,7 +617,7 @@
     {
       "displayName": "Cruz Verde",
       "id": "cruzverde-af67e0",
-      "locationSet": {"include": ["cl"]},
+      "locationSet": {"include": ["cl", "co"]},
       "matchNames": ["farmacias cruz verde"],
       "tags": {
         "amenity": "pharmacy",


### PR DESCRIPTION
As can be seen [here](https://www.cruzverde.com.co/) this brand also exists in Colombia