### PR TITLE
fix Create SD(クリエイトSD)

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -3843,9 +3843,9 @@
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "pharmacy",
-        "brand": "クリエイトSD",
-        "brand:en": "CreateSD",
-        "brand:ja": "クリエイトSD",
+        "brand": "薬CREATE",
+        "brand:en": "CREATE",
+        "brand:ja": "薬クリエイト",
         "brand:wikidata": "Q11299163",
         "healthcare": "pharmacy",
         "name": "クリエイトSD",


### PR DESCRIPTION
The name of the store is "クリエイトSD", but the sign of the store says "薬CREATE", so I think it is appropriate to make the brand "薬CREATE".
![IMG_1534](https://user-images.githubusercontent.com/72978935/208305840-0b89c54a-90cd-48bf-a9d3-27803e7755d8.jpg)
![IMG_1551](https://user-images.githubusercontent.com/72978935/208305866-9507567d-889f-44eb-8230-2eb475393db5.jpg)
