### PR TITLE
Add Joyful AK (ジョイフルエーケー), DCM nicot (DCMニコット)

### DIFF
--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -379,6 +379,21 @@
       }
     },
     {
+      "displayName": "DCMニコット",
+      "id": "dcmnicot-dd401d",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "DCMニコット",
+        "brand:en": "DCM nicot",
+        "brand:ja": "DCMニコット",
+        "brand:wikidata": "Q11318834",
+        "name": "DCMニコット",
+        "name:en": "DCM nicot",
+        "name:ja": "DCMニコット",
+        "shop": "doityourself"
+      }
+    },
+    {
       "displayName": "Dnipro-M",
       "id": "dniprom-2dbcce",
       "locationSet": {"include": ["ua"]},
@@ -1433,6 +1448,22 @@
         "name": "コメリパワー",
         "name:en": "Komeri Power",
         "name:ja": "コメリパワー",
+        "shop": "doityourself"
+      }
+    },
+    {
+      "displayName": "ジョイフルエーケー",
+      "id": "joyfulak-dd401d",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "alt_name": "ジョイフルAK",
+        "brand": "ジョイフルエーケー",
+        "brand:en": "Joyful AK",
+        "brand:ja": "ジョイフルエーケー",
+        "brand:wikidata": "Q11310519",
+        "name": "ジョイフルエーケー",
+        "name:en": "Joyful AK",
+        "name:ja": "ジョイフルエーケー",
         "shop": "doityourself"
       }
     },


### PR DESCRIPTION
For reference, the website is as follows:
https://joyful-ak.com/
https://www.homac-nicot.co.jp/

Note: A new store named (branded) DCM nicot has been established, but Homac nicot has not yet been integrated.