### PR TITLE
Modify locationSet of Glendale Beeline

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -5155,7 +5155,7 @@
     {
       "displayName": "Glendale Beeline",
       "id": "beeline-cf3ede",
-      "locationSet": {"include": [[-118, 34]]},
+      "locationSet": {"include": [[-118.25,34.1]]},
       "tags": {
         "network": "Beeline",
         "network:wikidata": "Q5568346",


### PR DESCRIPTION
Previous coordinates were too imprecise, and excluded the city of Glendale where the service actually is. Modified coordinates to be roughly centered on Glendale