### PR TITLE
Remove Create(クリエイト)

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -3833,25 +3833,10 @@
       }
     },
     {
-      "displayName": "クリエイト",
-      "id": "create-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "クリエイト",
-        "brand:en": "Create",
-        "brand:ja": "クリエイト",
-        "brand:wikidata": "Q17215731",
-        "healthcare": "pharmacy",
-        "name": "クリエイト",
-        "name:en": "Create",
-        "name:ja": "クリエイト"
-      }
-    },
-    {
       "displayName": "クリエイトSD",
       "id": "createsd-650eee",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["クリエイト"],
       "tags": {
         "alt_name": "薬CREATE",
         "alt_name:ja": "薬クリエイト",


### PR DESCRIPTION
Wikidata item for Create(クリエイト) (Q17215731) is an ad agency, not a pharmacy. As far as I know/researched, the only pharmacies with the name "Create" are Create SD(クリエイトSD) (Q11299163) and Create Pharmacy(クリエイト薬局) (Q115682176) operated by Create SD Co., Ltd.

Based on the above, I think it is appropriate to remove it.