### PR TITLE
Add railway=station suggestion

### DIFF
--- a/data/transit/railway/station.json
+++ b/data/transit/railway/station.json
@@ -1,0 +1,26 @@
+{
+    "properties": {
+      "path": "transit/railway/station",
+      "skipCollection": true,
+      "exclude": {
+        "generic": ["^railway\\s?(station)?$"]
+      }
+    },
+    "items": [
+        {
+            "displayName": "LIRR",
+            "id": "lirr-94d192",
+            "locationSet": {
+              "include": ["us-ny.geojson"]
+            },
+            "tags": {
+              "network": "LIRR",
+              "network:wikidata": "Q125943",
+              "operator": "Long Island Rail Road",
+              "operator:wikidata": "Q125943",
+              "route": "train"
+            }
+          }
+    ]
+  }
+  

--- a/data/transit/railway/station.json
+++ b/data/transit/railway/station.json
@@ -18,7 +18,7 @@
               "network:wikidata": "Q125943",
               "operator": "Long Island Rail Road",
               "operator:wikidata": "Q125943",
-              "route": "train"
+              "railway": "station"
             }
           }
     ]


### PR DESCRIPTION
Hello, I would like to add [`railway=station`](https://wiki.openstreetmap.org/wiki/Tag:railway%3Dstation) suggestions. 

I'm working through stations in New York like this one: https://www.openstreetmap.org/node/7092423541

It would be helpful to have network & operator information fill out once one of the tags is set.