### PR TITLE
Fix UQ mobile

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -901,9 +901,9 @@
     },
     {
       "displayName": "UQモバイル",
-      "id": "uqmobile-0a8be9",
+      "id": "uqspot-0a8be9",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["ユーキューモバイル", "ユーキュースポット"],
+      "matchNames": ["ユーキュースポット", "ユーキューモバイル"],
       "tags": {
         "brand": "UQモバイル",
         "brand:en": "UQ mobile",

--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -903,15 +903,15 @@
       "displayName": "UQモバイル",
       "id": "uqmobile-0a8be9",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["ユーキューモバイル"],
+      "matchNames": ["ユーキューモバイル", "ユーキュースポット"],
       "tags": {
         "brand": "UQモバイル",
         "brand:en": "UQ mobile",
         "brand:ja": "UQモバイル",
         "brand:wikidata": "Q11252091",
-        "name": "UQモバイル",
-        "name:en": "UQ mobile",
-        "name:ja": "UQモバイル",
+        "name": "UQスポット",
+        "name:en": "UQ Spot",
+        "name:ja": "UQスポット",
         "shop": "mobile_phone"
       }
     },


### PR DESCRIPTION
When I checked the shop name of UQ mobile on field survey/website, it was "UQ spot(UQスポット)".

https://www.uqwimax.jp/mobile/shoplist/
![IMG_1565](https://user-images.githubusercontent.com/72978935/209462480-a3ce681e-d196-45fb-9dcf-6163bf47cc17.jpg)
