### PR TITLE
Removed name tag for IGA (Australia)

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -3175,7 +3175,6 @@
       "tags": {
         "brand": "IGA",
         "brand:wikidata": "Q5970945",
-        "name": "IGA",
         "shop": "supermarket"
       }
     },

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -3172,9 +3172,11 @@
       "displayName": "IGA (Australia)",
       "id": "iga-c254c9",
       "locationSet": {"include": ["au"]},
+      "preserveTags": ["^name"],
       "tags": {
         "brand": "IGA",
         "brand:wikidata": "Q5970945",
+        "name": "IGA",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
IGA stores across Australia trade under many different names however they are all part of IGA (Australia).