### PR TITLE
Add LUCKY and CITY supermarkets, edit some Japanese pharmacies

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -3862,7 +3862,7 @@
         "brand:wikidata": "Q11299163",
         "healthcare": "pharmacy",
         "name": "クリエイトSD",
-        "name:en": "CreateSD",
+        "name:en": "Create SD",
         "name:ja": "クリエイトSD"
       }
     },
@@ -3936,9 +3936,10 @@
       "displayName": "サツドラ",
       "id": "sapporodrugstore-650eee",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["サッポロドラッグストアー"],
       "tags": {
+        "alt_name": "サッポロドラッグストアー",
         "alt_name:en": "Satsudora",
+        "alt_name:ja": "サッポロドラッグストアー",
         "amenity": "pharmacy",
         "brand": "サツドラ",
         "brand:en": "Sapporo Drug Store",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -9135,6 +9135,36 @@
       }
     },
     {
+      "displayName": "シティ",
+      "id": "city-fe0970",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "シティ",
+        "brand:en": "CITY",
+        "brand:ja": "シティ",
+        "brand:wikidata": "Q115865410",
+        "name": "シティ",
+        "name:en": "CITY",
+        "name:ja": "シティ",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "シティマート",
+      "id": "citymart-fe0970",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "シティ",
+        "brand:en": "CITY",
+        "brand:ja": "シティ",
+        "brand:wikidata": "Q115865410",
+        "name": "シティマート",
+        "name:en": "CITY mart",
+        "name:ja": "シティマート",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "スーパーアークス",
       "id": "superarcs-fe0970",
       "locationSet": {"include": ["jp"]},
@@ -9537,6 +9567,38 @@
         "name": "ライフ",
         "name:en": "Life",
         "name:ja": "ライフ",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "ラッキー",
+      "id": "lucky-fe0970",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "ラッキー",
+        "brand:en": "LUCKY",
+        "brand:ja": "ラッキー",
+        "brand:wikidata": "Q115865306",
+        "name": "ラッキー",
+        "name:en": "LUCKY",
+        "name:ja": "ラッキー",
+        "official_name": "北雄ラッキー",
+        "official_name:ja": "北雄ラッキー",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "ラッキーマート",
+      "id": "luckymart-fe0970",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "ラッキー",
+        "brand:en": "LUCKY",
+        "brand:ja": "ラッキー",
+        "brand:wikidata": "Q115865306",
+        "name": "ラッキーマート",
+        "name:en": "LUCKY mart",
+        "name:ja": "ラッキーマート",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
Added [LUCKY (ラッキー) and CITY (シティ)](https://www.hokuyu-lucky.co.jp/), modified the English name of Create SD (クリエイトSD), and added Japanese alt_name for Satudora (サツドラ, サッポロドラッグストアー).