### PR TITLE
Updated Pepco locationSet

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -6252,7 +6252,11 @@
           "ro",
           "rs",
           "si",
-          "sk"
+          "sk",
+          "es",
+          "de",
+          "el",
+          "at"
         ]
       },
       "matchTags": ["shop/variety_store"],


### PR DESCRIPTION
Pepco is also available in Spain, Germany, Greece and Austria