### PR TITLE
Fix Renge Shokudo

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -5888,19 +5888,19 @@
       }
     },
     {
-      "displayName": "れんげ食堂",
-      "id": "rengeshokudo-36ca8e",
+      "displayName": "れんげ食堂Toshu",
+      "id": "rengeshokudotoshu-36ca8e",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "restaurant",
-        "brand": "れんげ食堂",
-        "brand:en": "Renge Shokudo",
-        "brand:ja": "れんげ食堂",
+        "brand": "れんげ食堂Toshu",
+        "brand:en": "Renge Shokudo Toshu",
+        "brand:ja": "れんげ食堂Toshu",
         "brand:wikidata": "Q92662226",
-        "cuisine": "japanese",
-        "name": "れんげ食堂",
-        "name:en": "Renge Shokudo",
-        "name:ja": "れんげ食堂"
+        "cuisine": "chinese",
+        "name": "れんげ食堂Toshu",
+        "name:en": "Renge Shokudo Toshu",
+        "name:ja": "れんげ食堂Toshu"
       }
     },
     {


### PR DESCRIPTION
The store name is "れんげ食堂Toshu (Renge Shokudo Toshu)" on the signboards, Covid-19 notices, and official website.

As for food, the main dishes are what is called Chinese food in Japan, such as Mapo tofu, Chahan, and Jiaozi. It is also listed as Chinese food on the official website.

https://www.toshu.co.jp/renge_toshu/about.html

![IMG_1620](https://user-images.githubusercontent.com/72978935/209803599-0d9d6ba0-cd0f-4a00-a3df-9947b38a90cc.jpg)
![IMG_1621](https://user-images.githubusercontent.com/72978935/209803608-1f94c2b3-5406-4efb-8962-322369720ec8.jpg)
