### PR TITLE
Update Translink tagging for Queensland

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -15501,7 +15501,7 @@
       }
     },
     {
-      "displayName": "TransLink (Queensland)",
+      "displayName": "Translink (Queensland)",
       "id": "translink-322d6c",
       "locationSet": {
         "include": ["au-qld.geojson"]
@@ -15513,34 +15513,12 @@
       }
     },
     {
-      "displayName": "Translink Cairns",
-      "id": "translinkcairns-322d6c",
-      "locationSet": {
-        "include": ["au-qld.geojson"]
-      },
-      "tags": {
-        "network": "Translink Cairns",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "Translink Metro",
       "id": "translinkmetro-36d7b1",
       "locationSet": {"include": ["gb-nir"]},
       "tags": {
         "network": "Translink Metro",
         "network:wikidata": "Q6824449",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "Translink SEQ",
-      "id": "translinkseq-322d6c",
-      "locationSet": {
-        "include": ["au-qld.geojson"]
-      },
-      "tags": {
-        "network": "Translink SEQ",
         "route": "bus"
       }
     },


### PR DESCRIPTION
Translink (Queensland) is the only Translink network in Queensland.