### PR TITLE
Add IGA and Friendly Grocer convenience version

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1405,6 +1405,17 @@
       }
     },
     {
+      "displayName": "Friendly Grocer",
+      "locationSet": {"include": ["au"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Friendly Grocer",
+        "brand:wikidata": "Q24190419",
+        "name": "Friendly Grocer",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "Fresh",
       "id": "fresh-2496a5",
       "locationSet": {"include": ["sk"]},
@@ -1696,6 +1707,17 @@
         "name:sr": "Идеа органик",
         "name:sr-Latn": "Idea organik",
         "organic": "only",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "IGA (Australia)",
+      "locationSet": {"include": ["au"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "IGA",
+        "brand:wikidata": "Q5970945",
+        "name": "IGA",
         "shop": "convenience"
       }
     },


### PR DESCRIPTION
IGA can both be a supermarket or a convenience shop due to their size. Friendly Grocer is a convenience sized shop in Australia.