### PR TITLE
Update ferry tagging for Queensland

### DIFF
--- a/data/transit/route/ferry.json
+++ b/data/transit/route/ferry.json
@@ -306,8 +306,10 @@
         "include": ["au-qld.geojson"]
       },
       "tags": {
-        "network": "RiverCity Ferries",
-        "network:wikidata": "Q97194713",
+        "network": "Translink",
+        "network:wikidata": "Q7833625",
+        "operator": "RiverCity Ferries",
+        "operator:wikidata": "Q97194713",
         "route": "ferry"
       }
     },


### PR DESCRIPTION
Network is Translink, operator is RiverCity Ferries.