### PR TITLE
Remove “k kiosk” from brands/shop/kiosk

### DIFF
--- a/data/brands/shop/kiosk.json
+++ b/data/brands/shop/kiosk.json
@@ -40,19 +40,6 @@
       }
     },
     {
-      "displayName": "k kiosk",
-      "id": "kkiosk-93f8c4",
-      "locationSet": {
-        "include": ["ch", "de", "li", "lu"]
-      },
-      "tags": {
-        "brand": "k kiosk",
-        "brand:wikidata": "Q60381703",
-        "name": "k kiosk",
-        "shop": "kiosk"
-      }
-    },
-    {
       "displayName": "Kiosk",
       "id": "kiosk-c47323",
       "locationSet": {"include": ["nl"]},


### PR DESCRIPTION
NSI already has [another rule](https://nsi.guide/?t=brands&k=shop&v=newsagent#kkiosk-3673ad) for the same brand which suggest tagging `shop=newsagent`.

The [OpenStreetMap wiki](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dkiosk#Similar_tags) mentions “k kiosk” as an explicit counter-example for tagging as `shop=kiosk`. According to the OSM wiki, `shop=kiosk` is inappropriate for this chain despite its name, since these are full-sized stores and not informal kiosks. Instead of `shop=kiosk`, the OSM wiki recommends `shop=newsagent`, which is what NSI already does in its other rule.