### PR TITLE
Add TfL's Legible London maps

### DIFF
--- a/data/brands/tourism/information.json
+++ b/data/brands/tourism/information.json
@@ -54,7 +54,6 @@
         "information": "map",
         "map_size": "local",
         "map_type": "street",
-        "network": "legible_london",
         "operator": "Transport for London",
         "operator:type": "government",
         "operator:wikidata": "Q682520",

--- a/data/brands/tourism/information.json
+++ b/data/brands/tourism/information.json
@@ -44,6 +44,23 @@
         "name": "i-SITE",
         "tourism": "information"
       }
+    },
+    {
+      "displayName": "Legible London map",
+      "locationSet": {"include": ["gb-lon.geojson"]},
+      "tags": {
+        "brand": "Legible London",
+        "brand:wikidata": "Q6518074",
+        "information": "map",
+        "map_size": "local",
+        "map_type": "street",
+        "network": "legible_london",
+        "operator": "Transport for London",
+        "operator:type": "government",
+        "operator:wikidata": "Q682520",
+        "tourism": "information"
+      }
     }
+
   ]
 }


### PR DESCRIPTION
Street maps present at hundreds of locations throughout Greater London. 100 of these are already mapped with network=legible_london