### PR TITLE
Update names of Hamasushi (はま寿司) in Japan

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -8984,17 +8984,18 @@
     },
     {
       "displayName": "はま寿司",
-      "id": "hamazushi-3e7699",
+      "id": "hamasushi-3e7699",
       "locationSet": {"include": ["jp"]},
       "tags": {
+        "alt_name:en": "Hamazushi",
         "amenity": "fast_food",
         "brand": "はま寿司",
-        "brand:en": "Hamazushi",
+        "brand:en": "HAMA-SUSHI",
         "brand:ja": "はま寿司",
         "brand:wikidata": "Q17220385",
         "cuisine": "sushi",
         "name": "はま寿司",
-        "name:en": "Hamazushi",
+        "name:en": "Hamasushi",
         "name:ja": "はま寿司",
         "takeaway": "yes"
       }


### PR DESCRIPTION
I updated the English name of the brand, as it seems changed from "HAMAZUSHi" to "HAMA-SUSHI" in 2021.

However, "Hamasushi" is used in the description of English website (https://en.hama-sushi.co.jp/) and IDs of various official accounts, so I changed brand:en to written in the logo and name:en to used in the descriptions and IDs.

Because I wasn't sure, I capitalized brand:en as written in the logo, but will change if there are any problems.

Also, the Japanese pronunciation of the name is the same as the old name, and in some cases it is used, so I left that in the alt_name:en just in case.