### PR TITLE
Update EG Australia

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -5208,14 +5208,22 @@
       }
     },
     {
-      "displayName": "Woolworths Petrol",
-      "id": "woolworthspetrol-9ed9c0",
+      "displayName": "EG Australia",
+      "id": "egaustralia-9ed9c0",
       "locationSet": {"include": ["au"]},
+      "matchNames": [
+        "woolworths petrol",
+        "caltex woolworths",
+        "woolworths caltex"
+      ],
       "tags": {
         "amenity": "fuel",
+        "fuel:discount": "Woolworths",
         "brand": "Ampol",
-        "brand:wikidata": "Q5023980",
-        "name": "Woolworths Petrol"
+        "brand:wikidata": "Q4748528",
+        "operator": "EG Australia",
+        "operator:wikidata": "Q5023980",
+        "name": "EG Australia"
       }
     },
     {


### PR DESCRIPTION
Try to clean up the EG mess now their long overdue branding is rolling out across Australia. 
EG operate the stations and have their brand on the site.   Ampol supplies the fuel and has their brand on the roof and pumps.   
Woolworths no longer has any connection except some old signage and their supermarket dockets are used for discounts.