### PR TITLE
Update EG Australia

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -4071,15 +4071,16 @@
       }
     },
     {
-      "displayName": "Woolworths Petrol",
-      "id": "woolworthspetrol-0b0ae9",
+      "displayName": "EG Australia",
+      "id": "egaustralia-0b0ae9",
       "locationSet": {"include": ["au"]},
+      "matchNames": [
+        "woolworths petrol"
+      ],
       "tags": {
-        "brand": "Caltex",
+        "brand": "EG Australia",
         "brand:wikidata": "Q5023980",
-        "name": "Woolworths Petrol",
-        "operator": "Woolworths Group",
-        "operator:wikidata": "Q607272",
+        "name": "EG Australia",
         "shop": "convenience"
       }
     },


### PR DESCRIPTION
Woolworths sold their fuel and convenience sites to EG, branding has now changed to EG.