### PR TITLE
Add T-Mobile US

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -703,12 +703,22 @@
       }
     },
     {
-      "displayName": "T-Mobile",
+      "displayName": "T-Mobile International",
       "id": "tmobile-ee5434",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["001"], "exclude": ["us"]},
       "tags": {
         "brand": "T-Mobile",
         "brand:wikidata": "Q327634",
+        "name": "T-Mobile",
+        "shop": "mobile_phone"
+      }
+    },
+    {
+      "displayName": "T-Mobile US",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "brand": "T-Mobile",
+        "brand:wikidata": "Q3511885",
         "name": "T-Mobile",
         "shop": "mobile_phone"
       }


### PR DESCRIPTION
[T-Mobile US](https://www.wikidata.org/wiki/Q3511885) has a different QID to [T-Mobile International](https://www.wikidata.org/wiki/Q327634), so this introduces some complexity.

I don't have the drive to push for a OSM bulk edit of `brand:wikidata=Q327634` -> `brand:wikidata=Q3511885` in the US. What do we have to do to encourage iD users to update the tag?