### PR TITLE
Fix ja-Hira and ja-Latn and Key

### DIFF
--- a/data/brands/amenity/language_school.json
+++ b/data/brands/amenity/language_school.json
@@ -145,7 +145,6 @@
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "language_school",
-        "alt_name:ja": "ガバ",
         "brand": "GABA",
         "brand:en": "Gaba",
         "brand:ja": "GABA",
@@ -165,9 +164,9 @@
       "id": "nova-411869",
       "locationSet": {"include": ["jp"]},
       "tags": {
-        "amenity": "language_school",
         "alt_name:ja": "ノヴァ",
         "alt_name:ja-Latn": "Nobua",
+        "amenity": "language_school",
         "brand": "NOVA",
         "brand:en": "Nova",
         "brand:ja": "NOVA",

--- a/data/brands/amenity/language_school.json
+++ b/data/brands/amenity/language_school.json
@@ -249,14 +249,14 @@
         "brand": "セイハ英語学院",
         "brand:en": "Seiha English Academy",
         "brand:ja": "セイハ英語学院",
-        "brand:ja-Hani": "せいはえいごがくいん",
+        "brand:ja-Hira": "せいはえいごがくいん",
         "brand:ja-Latn": "Seiha Eigo Gakuin",
         "brand:wikidata": "Q7446694",
         "language:en": "main",
         "name": "セイハ英語学院",
         "name:en": "Seiha English Academy",
         "name:ja": "セイハ英語学院",
-        "name:ja-Hani": "せいはえいごがくいん",
+        "name:ja-Hira": "せいはえいごがくいん",
         "name:ja-Latn": "Seiha Eigo Gakuin"
       }
     },

--- a/data/brands/amenity/language_school.json
+++ b/data/brands/amenity/language_school.json
@@ -12,15 +12,15 @@
       "tags": {
         "amenity": "language_school",
         "brand": "AEON",
-        "brand:en": "Aeon",
-        "brand:ja": "AEON",
+        "brand:en": "AEON",
+        "brand:ja": "イーオン",
         "brand:ja-Hira": "いーおん",
         "brand:ja-Latn": "Īon",
         "brand:wikidata": "Q4687898",
         "language:en": "main",
         "name": "AEON",
-        "name:en": "Aeon",
-        "name:ja": "AEON",
+        "name:en": "AEON",
+        "name:ja": "イーオン",
         "name:ja-Hira": "いーおん",
         "name:ja-Latn": "Īon"
       }

--- a/data/brands/amenity/language_school.json
+++ b/data/brands/amenity/language_school.json
@@ -14,15 +14,15 @@
         "brand": "AEON",
         "brand:en": "Aeon",
         "brand:ja": "AEON",
-        "brand:ja-Hira": "イーオン",
-        "brand:ja-Latn": "AEON",
+        "brand:ja-Hira": "いーおん",
+        "brand:ja-Latn": "Īon",
         "brand:wikidata": "Q4687898",
         "language:en": "main",
         "name": "AEON",
         "name:en": "Aeon",
         "name:ja": "AEON",
-        "name:ja-Hira": "イーオン",
-        "name:ja-Latn": "AEON"
+        "name:ja-Hira": "いーおん",
+        "name:ja-Latn": "Īon"
       }
     },
     {
@@ -83,20 +83,20 @@
         "brand": "ECC外語学院",
         "brand:en": "ECC Foreign Language Institute",
         "brand:ja": "ECC外語学院",
-        "brand:ja-Hira": "イーシーシーがいごがくいん",
-        "brand:ja-Latn": "ECC Gaigo Gakuin",
+        "brand:ja-Hira": "いーしーしーがいごがくいん",
+        "brand:ja-Latn": "Īshīshī Gaigo Gakuin",
         "brand:wikidata": "Q5322655",
         "language:en": "main",
         "name": "ECC外語学院",
         "name:en": "ECC Foreign Language Institute",
         "name:ja": "ECC外語学院",
-        "name:ja-Hira": "イーシーシーがいごがくいん",
-        "name:ja-Latn": "ECC Gaigo Gakuin",
+        "name:ja-Hira": "いーしーしーがいごがくいん",
+        "name:ja-Latn": "Īshīshī Gaigo Gakuin",
         "short_name": "ECC",
         "short_name:en": "ECC",
         "short_name:ja": "ECC",
-        "short_name:ja-Hira": "イーシーシー",
-        "short_name:ja-Latn": "ECC"
+        "short_name:ja-Hira": "いーしーしー",
+        "short_name:ja-Latn": "Īshīshī"
       }
     },
     {
@@ -145,17 +145,18 @@
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "language_school",
+        "alt_name:ja": "ガバ",
         "brand": "GABA",
         "brand:en": "Gaba",
         "brand:ja": "GABA",
-        "brand:ja-Kana": "ガバ",
+        "brand:ja-Hira": "がば",
         "brand:ja-Latn": "GABA",
         "brand:wikidata": "Q5515241",
         "language:en": "main",
         "name": "GABA",
         "name:en": "Gaba",
         "name:ja": "GABA",
-        "name:ja-Kana": "ガバ",
+        "name:ja-Hira": "がば",
         "name:ja-Latn": "GABA"
       }
     },
@@ -165,18 +166,20 @@
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "language_school",
+        "alt_name:ja": "ノヴァ",
+        "alt_name:ja-Latn": "Nobua",
         "brand": "NOVA",
         "brand:en": "Nova",
         "brand:ja": "NOVA",
-        "brand:ja-Hira": "ノヴァ",
-        "brand:ja-Latn": "NOVA",
+        "brand:ja-Hira": "のば",
+        "brand:ja-Latn": "Noba",
         "brand:wikidata": "Q7064000",
         "language:en": "main",
         "name": "NOVA",
         "name:en": "Nova",
         "name:ja": "NOVA",
-        "name:ja-Hira": "ノヴァ",
-        "name:ja-Latn": "NOVA"
+        "name:ja-Hira": "のば",
+        "name:ja-Latn": "Noba"
       }
     },
     {
@@ -247,14 +250,14 @@
         "brand": "セイハ英語学院",
         "brand:en": "Seiha English Academy",
         "brand:ja": "セイハ英語学院",
-        "brand:ja-Hani": "セイハえいごがくいん",
+        "brand:ja-Hani": "せいはえいごがくいん",
         "brand:ja-Latn": "Seiha Eigo Gakuin",
         "brand:wikidata": "Q7446694",
         "language:en": "main",
         "name": "セイハ英語学院",
         "name:en": "Seiha English Academy",
         "name:ja": "セイハ英語学院",
-        "name:ja-Hani": "セイハえいごがくいん",
+        "name:ja-Hani": "せいはえいごがくいん",
         "name:ja-Latn": "Seiha Eigo Gakuin"
       }
     },
@@ -285,12 +288,12 @@
         "brand": "ベルリッツ",
         "brand:en": "Berlitz",
         "brand:ja": "ベルリッツ",
-        "brand:ja-Hira": "ベルリッツ",
+        "brand:ja-Hira": "べるりっつ",
         "brand:wikidata": "Q4892545",
         "name": "ベルリッツ",
         "name:en": "Berlitz",
         "name:ja": "ベルリッツ",
-        "name:ja-Hira": "ベルリッツ"
+        "name:ja-Hira": "べるりっつ"
       }
     },
     {

--- a/data/brands/amenity/prep_school.json
+++ b/data/brands/amenity/prep_school.json
@@ -377,13 +377,13 @@
         "amenity": "prep_school",
         "brand": "栄光ゼミナール",
         "brand:ja": "栄光ゼミナール",
-        "brand:ja-Hira": "えいこうゼミナール",
+        "brand:ja-Hira": "えいこうぜみなーる",
         "brand:ja-Latn": "Eikō Zemināru",
         "brand:wikidata": "Q11535632",
         "name": "栄光ゼミナール",
         "name:en": "Eikoh Seminar",
         "name:ja": "栄光ゼミナール",
-        "name:ja-Hira": "えいこうゼミナール",
+        "name:ja-Hira": "えいこうぜみなーる",
         "name:ja-Latn": "Eikō Zemināru"
       }
     },


### PR DESCRIPTION
According to the OSM Wiki page for [name:ja-Hira](https://wiki.openstreetmap.org/wiki/JA:Key:name:ja-Hira) and [Multilingual names](https://wiki.openstreetmap.org/wiki/Multilingual_names#Japan), it is written that name:ja-Hira describes hiragana ([Wikipedia](https://en.wikipedia.org/wiki/Hiragana)), so I changed katakana ([Wikipedia](https://en.wikipedia.org/wiki/Katakana)) to hiragana.

Also, for name:ja-Latn ([OSM Wiki](https://wiki.openstreetmap.org/wiki/Key:name:ja-Latn)), there were parts that were in English instead of rōmaji([Wikipedia](https://en.wikipedia.org/wiki/Romanization_of_Japanese)), so I changed English to rōmaji.