### PR TITLE
Add Shurgard Self-Storage to storage rental

### DIFF
--- a/data/brands/shop/storage_rental.json
+++ b/data/brands/shop/storage_rental.json
@@ -214,6 +214,16 @@
       }
     },
     {
+      "displayName": "Shurgard Self-Storage",
+      "locationSet": {"include": ["be", "de", "fr", "nl"]},
+      "tags": {
+        "brand": "Shurgard Storage Centers",
+        "brand:wikidata": "Q3482670",
+        "name": "Shurgard Self-Storage",
+        "shop": "storage_rental"
+      }
+    },
+    {
       "displayName": "Storage King",
       "id": "storageking-e49450",
       "locationSet": {"include": ["au", "nz"]},


### PR DESCRIPTION
In some European countries there is a chain of storage rental shops branded Shurgard. The Wikidata page lists Shurgard Storage Centers as the brand, but they are mostly known as Shurgard Self-Storage (hence the different display name and name from the brand/wikidata entry).