### PR TITLE
Add English name and Wikidata for Board of Education in Japan

### DIFF
--- a/data/operators/amenity/school.json
+++ b/data/operators/amenity/school.json
@@ -29391,9 +29391,9 @@
     },
     {
       "displayName": "世田谷区教育委員会",
-      "id": "366cb3-557cea",
-      "note": "It is a ward in Japanese, but the (official) English translation is City as it is a special ward.",
+      "id": "setagayacityboardofeducation-557cea",
       "locationSet": {"include": ["jp"]},
+      "note": "It is a ward in Japanese, but the (official) English translation is City as it is a special ward.",
       "tags": {
         "amenity": "school",
         "operator": "世田谷区教育委員会",
@@ -29505,9 +29505,9 @@
     },
     {
       "displayName": "北海道教育委員会",
-      "matchNames": ["北海道"],
-      "id": "4af3d8-557cea",
+      "id": "hokkaidoboardofeducation-557cea",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["北海道"],
       "tags": {
         "amenity": "school",
         "operator": "北海道教育委員会",
@@ -29545,7 +29545,7 @@
     },
     {
       "displayName": "名古屋市教育委員会",
-      "id": "5318ee-557cea",
+      "id": "nagoyacityboardofeducation-557cea",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "school",
@@ -29593,13 +29593,13 @@
     },
     {
       "displayName": "大分県教育委員会",
-      "id": "f03f4b-557cea",
+      "id": "oitaprefecturalboardofeducation-557cea",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "school",
         "operator": "大分県教育委員会",
         "operator:en": "Oita Prefectural Board of Education",
-        "operator:ja": "大分県教育委員会", 
+        "operator:ja": "大分県教育委員会",
         "operator:wikidata": "Q11432814"
       }
     },
@@ -29614,9 +29614,9 @@
     },
     {
       "displayName": "大田区教育委員会",
-      "id": "cc829e-557cea",
-      "note": "It is a ward in Japanese, but the (official) English translation is City as it is a special ward.",
+      "id": "otacityboardofeducation-557cea",
       "locationSet": {"include": ["jp"]},
+      "note": "It is a ward in Japanese, but the (official) English translation is City as it is a special ward.",
       "tags": {
         "amenity": "school",
         "operator": "大田区教育委員会",
@@ -29746,7 +29746,7 @@
     },
     {
       "displayName": "愛知県教育委員会",
-      "id": "a06abd-557cea",
+      "id": "aichiprefecturalboardofeducation-557cea",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "school",
@@ -29776,9 +29776,9 @@
     },
     {
       "displayName": "札幌市教育委員会",
-      "matchNames": ["札幌市"],
-      "id": "9fd1b8-557cea",
+      "id": "sapporocityboardofeducation-557cea",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["札幌市"],
       "tags": {
         "amenity": "school",
         "operator": "札幌市教育委員会",
@@ -29798,7 +29798,7 @@
     },
     {
       "displayName": "東京都教育委員会",
-      "id": "7549ca-557cea",
+      "id": "tokyometropolitangovernmentboardofeducation-557cea",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "school",
@@ -29955,9 +29955,9 @@
     },
     {
       "displayName": "苫小牧市教育委員会",
-      "id": "448be1-557cea",
-      "matchNames": ["苫小牧市"],
+      "id": "tomakomaicityboardofeducation-557cea",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["苫小牧市"],
       "tags": {
         "amenity": "school",
         "operator": "苫小牧市教育委員会",

--- a/data/operators/amenity/school.json
+++ b/data/operators/amenity/school.json
@@ -29392,10 +29392,13 @@
     {
       "displayName": "世田谷区教育委員会",
       "id": "366cb3-557cea",
+      "note": "It is a ward in Japanese, but the (official) English translation is City as it is a special ward.",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "school",
-        "operator": "世田谷区教育委員会"
+        "operator": "世田谷区教育委員会",
+        "operator:en": "Setagaya City Board of Education",
+        "operator:wikidata": "Q11362065"
       }
     },
     {
@@ -29501,21 +29504,16 @@
       }
     },
     {
-      "displayName": "北海道",
-      "id": "b92efc-557cea",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "school",
-        "operator": "北海道"
-      }
-    },
-    {
       "displayName": "北海道教育委員会",
+      "matchNames": ["北海道"],
       "id": "4af3d8-557cea",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "school",
-        "operator": "北海道教育委員会"
+        "operator": "北海道教育委員会",
+        "operator:en": "Hokkaido Board of Education",
+        "operator:ja": "北海道教育委員会",
+        "operator:wikidata": "Q11402768"
       }
     },
     {
@@ -29551,7 +29549,10 @@
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "school",
-        "operator": "名古屋市教育委員会"
+        "operator": "名古屋市教育委員会",
+        "operator:en": "Nagoya City Board of Education",
+        "operator:ja": "名古屋市教育委員会",
+        "operator:wikidata": "Q11415003"
       }
     },
     {
@@ -29596,7 +29597,10 @@
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "school",
-        "operator": "大分県教育委員会"
+        "operator": "大分県教育委員会",
+        "operator:en": "Oita Prefectural Board of Education",
+        "operator:ja": "大分県教育委員会", 
+        "operator:wikidata": "Q11432814"
       }
     },
     {
@@ -29611,10 +29615,14 @@
     {
       "displayName": "大田区教育委員会",
       "id": "cc829e-557cea",
+      "note": "It is a ward in Japanese, but the (official) English translation is City as it is a special ward.",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "school",
-        "operator": "大田区教育委員会"
+        "operator": "大田区教育委員会",
+        "operator:en": "Ota City Board of Education",
+        "operator:ja": "大田区教育委員会",
+        "operator:wikidata": "Q11437839"
       }
     },
     {
@@ -29742,7 +29750,10 @@
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "school",
-        "operator": "愛知県教育委員会"
+        "operator": "愛知県教育委員会",
+        "operator:en": "Aichi Prefectural Board of Education",
+        "operator:ja": "愛知県教育委員会",
+        "operator:wikidata": "Q11494131"
       }
     },
     {
@@ -29764,21 +29775,16 @@
       }
     },
     {
-      "displayName": "札幌市",
-      "id": "e1715c-557cea",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "school",
-        "operator": "札幌市"
-      }
-    },
-    {
       "displayName": "札幌市教育委員会",
+      "matchNames": ["札幌市"],
       "id": "9fd1b8-557cea",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "school",
-        "operator": "札幌市教育委員会"
+        "operator": "札幌市教育委員会",
+        "operator:en": "Sapporo City Board of Education",
+        "operator:ja": "札幌市教育委員会",
+        "operator:wikidata": "Q11521270"
       }
     },
     {
@@ -29796,7 +29802,10 @@
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "school",
-        "operator": "東京都教育委員会"
+        "operator": "東京都教育委員会",
+        "operator:en": "Tokyo Metropolitan Government Board of Education",
+        "operator:ja": "東京都教育委員会",
+        "operator:wikidata": "Q6131931"
       }
     },
     {
@@ -29945,12 +29954,16 @@
       }
     },
     {
-      "displayName": "苫小牧市",
+      "displayName": "苫小牧市教育委員会",
       "id": "448be1-557cea",
+      "matchNames": ["苫小牧市"],
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "school",
-        "operator": "苫小牧市"
+        "operator": "苫小牧市教育委員会",
+        "operator:en": "Tomakomai City Board of Education",
+        "operator:ja": "苫小牧市教育委員会",
+        "operator:wikidata": "Q106967121"
       }
     },
     {

--- a/data/operators/amenity/school.json
+++ b/data/operators/amenity/school.json
@@ -29398,6 +29398,7 @@
         "amenity": "school",
         "operator": "世田谷区教育委員会",
         "operator:en": "Setagaya City Board of Education",
+        "operator:ja": "世田谷区教育委員会",
         "operator:wikidata": "Q11362065"
       }
     },


### PR DESCRIPTION
Added English names of Japanese school governing boards and Wikidata.

The duplicated operators such as "xx city" and "xx city board of education" are merged into "xx city board of education" and added to matchNames, since the number of operators already registered was larger for the "xx city board of education" type.