### PR TITLE
Add some South Africa shops

### DIFF
--- a/data/brands/shop/alcohol.json
+++ b/data/brands/shop/alcohol.json
@@ -915,6 +915,26 @@
       }
     },
     {
+      "displayName": "Liquor Shop Checkers",
+      "locationSet": {"include": ["za"]},
+      "tags": {
+        "brand": "Checkers",
+        "brand:wikidata": "Q5089126",
+        "name": "Liquor Shop Checkers",
+        "shop": "alcohol"
+      }
+    },
+    {
+      "displayName": "Pick n Pay Liquor",
+      "locationSet": {"include": ["za"]},
+      "tags": {
+        "brand": "Pick n Pay",
+        "brand:wikidata": "Q7190735",
+        "name": "Pick n Pay Liquor",
+        "shop": "alcohol"
+      }
+    },
+    {
       "displayName": "リカーマウンテン",
       "id": "liquormountain-42f62c",
       "locationSet": {"include": ["jp"]},

--- a/data/brands/shop/houseware.json
+++ b/data/brands/shop/houseware.json
@@ -637,6 +637,16 @@
       }
     },
     {
+      "displayName": "Pep Home",
+      "locationSet": {"include": ["za"]},
+      "tags": {
+        "brand": "Pep",
+        "brand:wikidata": "Q7166182",
+        "name": "Pep Home",
+        "shop": "houseware"
+      }
+    },
+    {
       "displayName": "日本城 JHC",
       "id": "jhc-9791f5",
       "locationSet": {"include": ["hk"]},

--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -1545,6 +1545,36 @@
       }
     },
     {
+      "displayName": "Vodacom",
+      "locationSet": {"include": ["za"]},
+      "tags": {
+        "brand": "Vodacom",
+        "brand:wikidata": "Q1856518",
+        "name": "Vodacom",
+        "shop": "mobile_phone"
+      }
+    },
+    {
+      "displayName": "Telkom",
+      "locationSet": {"include": ["za"]},
+      "tags": {
+        "brand": "Telkom",
+        "brand:wikidata": "Q1818970",
+        "name": "Telkom",
+        "shop": "mobile_phone"
+      }
+    },
+    {
+      "displayName": "Pep Cell",
+      "locationSet": {"include": ["za"]},
+      "tags": {
+        "brand": "Pep",
+        "brand:wikidata": "Q7166182",
+        "name": "Pep Cell",
+        "shop": "mobile_phone"
+      }
+    },
+    {
       "displayName": "領域 CityLink",
       "id": "citylink-55ee4b",
       "locationSet": {"include": ["hk"]},


### PR DESCRIPTION
A number of these are subsidiary shops, where the main one (e.g. supermarket) is already included in NSI.