### PR TITLE
Remove matchNames from Inver

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -2479,6 +2479,7 @@
       "displayName": "Inver",
       "id": "inver-f499fc",
       "locationSet": {"include": ["ca", "ie"]},
+      "note": "don't need to add topaz as matchnames, see #7714",
       "tags": {
         "amenity": "fuel",
         "brand": "Inver",

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -2479,7 +2479,6 @@
       "displayName": "Inver",
       "id": "inver-f499fc",
       "locationSet": {"include": ["ca", "ie"]},
-      "matchNames": ["topaz"],
       "tags": {
         "amenity": "fuel",
         "brand": "Inver",


### PR DESCRIPTION
Setting the matchNames to Topaz in this situation is incorrect as Inver has not replaced Topaz it is its own separate brand. Topaz had been purchased by Circle K and they have rebranded old Topaz location to Circle K but I haven't added a matchName to Circle K as i'm not certain every location that was a Topaz is now a Circle K