### PR TITLE
Fuel: Add Petrol in ba, hr, me, rs, si

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -3555,6 +3555,25 @@
       }
     },
     {
+      "displayName": "Petrol",
+      "id": "petrol-7302f5",
+      "locationSet": {
+        "include": ["ba", "hr", "me", "rs", "si"]
+      },
+      "matchNames": [
+        "bencinski servis petrol",
+        "bs petrol",
+        "petrol"
+      ],
+      "note": "https://github.com/osmlab/name-suggestion-index/issues/6552",
+      "tags": {
+        "amenity": "fuel",
+        "brand": "Petrol",
+        "brand:wikidata": "Q174824",
+        "name": "Petrol"
+      }
+    },
+    {
       "displayName": "Petrol Ofisi",
       "id": "petrolofisi-b3d110",
       "locationSet": {"include": ["001"]},
@@ -5724,6 +5743,7 @@
       "displayName": "Петрол",
       "id": "petrol-b450da",
       "locationSet": {"include": ["bg"]},
+      "note": "https://github.com/osmlab/name-suggestion-index/issues/6552",
       "tags": {
         "amenity": "fuel",
         "brand": "Петрол",


### PR DESCRIPTION
Website: https://www.petrol.eu/
Wikidata: https://wikidata.org/wiki/Q174824
Gas stations: https://www.petrol.eu/gas-stations/map?lng=19.073434719415555&lat=44.39337908980519&zoom=7#
Area: https://location-conflation.com/?locationSet=%7B%20include%3A%20%5B%22ba%22%2C%20%22hr%22%2C%20%22me%22%2C%20%22rs%22%2C%20%22si%22%5D%20%7D&referrer=nsi

It should work with `bs petrol` and `bencinski servis petrol`, but not matched by `petrol` because of
* #6552