### PR TITLE
Rename National Grid to National Gas

### DIFF
--- a/data/operators/man_made/pipeline.json
+++ b/data/operators/man_made/pipeline.json
@@ -3512,12 +3512,17 @@
       }
     },
     {
-      "displayName": "National Grid",
-      "id": "nationalgrid-143312",
-      "locationSet": {"include": ["001"]},
+      "displayName": "National Gas",
+      "locationSet": {"include": ["gb"]},
+      "matchNames": [
+        "national grid",
+        "transco"
+      ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "National Grid"
+        "substance": "gas",
+        "operator": "National Gas",
+        "operator:wikidata": "Q116544806"
       }
     },
     {


### PR DESCRIPTION
National Grid's UK gas transmission business has been spun off into National Gas. Update the operator for `man_made=pipeline` and add wikidata.

https://www.energylivenews.com/2023/01/31/national-gas-leaves-national-grid/