### PR TITLE
Add pipeline operator entries for UK gas distribution companies

### DIFF
--- a/data/operators/man_made/pipeline.json
+++ b/data/operators/man_made/pipeline.json
@@ -576,6 +576,16 @@
       }
     },
     {
+      "displayName": "Cadent",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "man_made": "pipeline",
+        "operator": "Cadent",
+        "operator:wikidata": "Q30688985",
+        "substance": "gas"
+      }
+    },
+    {
       "displayName": "CAGEPA",
       "id": "cagepa-143312",
       "locationSet": {"include": ["001"]},
@@ -3714,6 +3724,16 @@
       }
     },
     {
+      "displayName": "Northern Gas Networks",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "man_made": "pipeline",
+        "operator": "Northern Gas Networks",
+        "operator:wikidata": "Q7058365",
+        "substance": "gas"
+      }
+    },
+    {
       "displayName": "Northern Ireland Water",
       "id": "northernirelandwater-143312",
       "locationSet": {"include": ["001"]},
@@ -4638,15 +4658,6 @@
       }
     },
     {
-      "displayName": "Scotland Gas Networks",
-      "id": "scotlandgasnetworks-143312",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "man_made": "pipeline",
-        "operator": "Scotland Gas Networks"
-      }
-    },
-    {
       "displayName": "Scottish & Southern Energy",
       "id": "scottishandsouthernenergy-143312",
       "locationSet": {"include": ["001"]},
@@ -4755,12 +4766,25 @@
       }
     },
     {
-      "displayName": "SGN Natural Gas",
-      "id": "sgnnaturalgas-143312",
-      "locationSet": {"include": ["001"]},
+      "displayName": "SGN",
+      "locationSet": {"include": ["gb-eng", "gb-sct"]},
+      "matchNames": ["scotland gas networks", "scotia gas networks"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "SGN Natural Gas"
+        "operator": "SGN",
+        "operator:wikidata": "Q7435584",
+        "substance": "gas"
+      }
+    },
+    {
+      "displayName": "SGN Natural Gas",
+      "id": "sgnnaturalgas-143312",
+      "locationSet": {"include": ["gb-nir"]},
+      "tags": {
+        "man_made": "pipeline",
+        "operator": "SGN Natural Gas",
+        "operator:wikidata": "Q116562155",
+        "substance": "gas"
       }
     },
     {
@@ -6031,10 +6055,12 @@
     {
       "displayName": "Wales & West Utilities",
       "id": "walesandwestutilities-143312",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["gb-eng", "gb-wls"]},
       "tags": {
         "man_made": "pipeline",
-        "operator": "Wales & West Utilities"
+        "operator": "Wales & West Utilities",
+        "operator:wikidata": "Q7961745",
+        "substance": "gas"
       }
     },
     {


### PR DESCRIPTION
This updates the five UK gas distribution operators with wikidata entries and correct locationSets.