### PR TITLE
Add "the niu" hotel chain

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -2746,6 +2746,20 @@
       }
     },
     {
+      "displayName": "the niu",
+      "id": "theniu-3dd84b",
+      "locationSet": {
+        "include": ["at", "de", "nl", "uk"]
+      },
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "the niu",
+        "brand:wikidata": "Q116486979",
+        "name": "the niu",
+        "tourism": "hotel"
+      }
+    },
+    {
       "displayName": "The Ritz-Carlton",
       "id": "theritzcarlton-779ccb",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Add hotel chain “the niu” present in mainly DE, and also AT, NL, UK with ~26 locations.