### PR TITLE
Update operator for Network Citéa

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -2943,7 +2943,7 @@
       "tags": {
         "network": "Citéa",
         "network:wikidata": "Q2990053",
-        "operator": "Transdev Valence",
+        "operator": "Transdev Valence Mobilité",
         "route": "bus"
       }
     },


### PR DESCRIPTION
Update the operator for the bus network Citéa (France)
old name : Transdev Valence
new name : Transdev Valence Mobilité