### PR TITLE
Fix typo in Lewis Stores brand name

### DIFF
--- a/data/brands/shop/furniture.json
+++ b/data/brands/shop/furniture.json
@@ -980,7 +980,7 @@
         "include": ["bw", "ls", "na", "sz", "za"]
       },
       "tags": {
-        "brand": "Lewsi Stores",
+        "brand": "Lewis Stores",
         "brand:wikidata": "Q116474928",
         "name": "Lewis",
         "shop": "furniture"


### PR DESCRIPTION
The lack of wikidata tag for this brand has been successfully fixed after the release. But I also noticed a typo in the brand tag.