### PR TITLE
Krefel is a Belgian chain, not active in France or NL

### DIFF
--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -682,7 +682,7 @@
     {
       "displayName": "Krëfel",
       "id": "krefel-86b1a0",
-      "locationSet": {"include": ["fr", "nl"]},
+      "locationSet": {"include": ["be"]},
       "tags": {
         "brand": "Krëfel",
         "brand:wikidata": "Q3200093",


### PR DESCRIPTION
Krefel is a Belgian electronics chain, and not active in France nor the Netherlands. I guess the creator of this brand somehow confused the languages in which it operates (which are indeed Dutch and French) for the countries.

Correcting this by this patch.