### PR TITLE
Add more Irish brands

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -66,6 +66,18 @@
       }
     },
     {
+      "displayName": "O'Briens Café",
+      "id": "",
+      "locationSet": {"include":["ie", "ae", "cn", "th", "sg", "my", "au", "nz", "gb-nir"]},
+      "tags": {
+        "amenity": "cafe",
+        "brand": "O'Briens",
+        "brand:wikidata": "Q7071686",
+        "cusine": "sandwich",
+        "name": "O'Briens"
+      }
+    },
+    {
       "displayName": "50嵐",
       "id": "50lan-7d270d",
       "locationSet": {"include": ["tw"]},

--- a/data/brands/office/estate_agent.json
+++ b/data/brands/office/estate_agent.json
@@ -56,6 +56,28 @@
       }
     },
     {
+      "displayName": "Sherry FitzGerald",
+      "id": "",
+      "locationSet": {"include": ["ie"]},
+      "tags": {
+        "brand": "Sherry FitzGerald",
+        "brand:wikidata": "Q116646140",
+        "name": "Sherry FitzGerald",
+        "office": "estate_agent"
+      }
+    },
+    {
+      "displayName": "DNG",
+      "id": "",
+      "locationSet": {"include": ["ie"]},
+      "tags": {
+        "brand": "DNG",
+        "brand:wikidata": "Q116646713",
+        "name": "DNG",
+        "office": "estate_agent"
+      }
+    },
+    {
       "displayName": "Bairstow Eves",
       "id": "bairstoweves-aa448d",
       "locationSet": {"include": ["gb"]},

--- a/data/brands/shop/alcohol.json
+++ b/data/brands/shop/alcohol.json
@@ -50,6 +50,28 @@
       }
     },
     {
+      "displayName": "Carry Out",
+      "id": "",
+      "locationSet": {"include": ["ie"]},
+      "tags": {
+        "brand": "Carry Out",
+        "brand:wikidata": "Q116645699",
+        "name": "Carry Out",
+        "shop": "alcohol"
+      }
+    },
+    {
+      "displayName": "O'Briens Wine",
+      "id": "",
+      "locationSet": {"include": ["ie"]},
+      "tags": {
+        "brand": "O'Briens",
+        "brand:wikidata": "Q113151266",
+        "name": "O'Briens",
+        "shop": "alcohol"
+      }
+    },
+    {
       "displayName": "Alko",
       "id": "alko-d1a8a4",
       "locationSet": {"include": ["fi"]},


### PR DESCRIPTION
Added the following brands:
- O'Briens (Cafe)
- Carry Out (Alcohol)
- O'Briens Wine (Alcohol)
- DNG (Estate Agent)
- Sherry FitzGerald (Estate Agent)