### PR TITLE
Add Belgian water utility company Pidpa

### DIFF
--- a/data/operators/office/water_utility.json
+++ b/data/operators/office/water_utility.json
@@ -29,6 +29,16 @@
       }
     },
     {
+      "displayName": "Pidpa",
+      "locationSet": {"include": ["be"]},
+      "tags": {
+        "name": "Pidpa",
+        "office": "water_utility",
+        "operator": "Pidpa",
+        "operator:wikidata": "Q1902675"
+      }
+    },
+    {
       "displayName": "Watercare",
       "id": "watercare-7cc3eb",
       "locationSet": {


### PR DESCRIPTION
Please add the Belgian water utility company Pidpa, which operates in the Belgian province of Antwerp.