### PR TITLE
Removing Dominion from line and substation files

### DIFF
--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -1323,20 +1323,6 @@
       }
     },
     {
-      "displayName": "Dominion",
-      "id": "dominion-b654b4",
-      "locationSet": {"include": ["us"]},
-      "matchNames": [
-        "dominion power",
-        "dominion virginia power"
-      ],
-      "tags": {
-        "operator": "Dominion",
-        "operator:wikidata": "Q677464",
-        "power": "line"
-      }
-    },
-    {
       "displayName": "Dominion Energy",
       "id": "dominionenergy-b654b4",
       "locationSet": {"include": ["us"]},

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -1488,20 +1488,6 @@
       }
     },
     {
-      "displayName": "Dominion",
-      "id": "dominion-301545",
-      "locationSet": {"include": ["us"]},
-      "matchNames": [
-        "dominion power",
-        "dominion virginia power"
-      ],
-      "tags": {
-        "operator": "Dominion",
-        "operator:wikidata": "Q677464",
-        "power": "substation"
-      }
-    },
-    {
       "displayName": "Dominion Energy",
       "id": "dominionenergy-301545",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
It has been replaced by Dominion Energy. Confirmed it is no longer listed in operators_keep.json