### PR TITLE
Remove Things Remembered

### DIFF
--- a/data/brands/shop/gift.json
+++ b/data/brands/shop/gift.json
@@ -6,7 +6,10 @@
         "^(gift|souvenirs?)( shop)?$",
         "^(подарки|сувениры)$"
       ],
-      "named": ["^(papyrus)$"]
+      "named": [
+        "^(papyrus)$",
+        "^(things remembered)$"
+      ]
     }
   },
   "items": [
@@ -310,17 +313,6 @@
         "brand:wikidata": "Q7576055",
         "name": "Spencer's",
         "official_name": "Spencer Gifts",
-        "shop": "gift"
-      }
-    },
-    {
-      "displayName": "Things Remembered",
-      "id": "thingsremembered-26efb0",
-      "locationSet": {"include": ["ca", "us"]},
-      "tags": {
-        "brand": "Things Remembered",
-        "brand:wikidata": "Q54958287",
-        "name": "Things Remembered",
         "shop": "gift"
       }
     },


### PR DESCRIPTION
https://www.newsday.com/business/things-remembered-closing-stores-bankruptcy-gift-ad-populum-enesco-yedfu5ey
https://www.thingsremembered.com/

"moving into an exciting new chapter" == Firing all the staff and selling the brand to an online only retailer.

But the real reason for the PR: is adding the name to the excludes enough, or do we also have to flag the QID?

Bonus question, I only use JSOM, so I'm not that familiar with iD, but do dead brands make it to iD and the warn user? In GB we have a QA tool to [highlight](https://osm.mathmos.net/ghosts/) them, but obviously getting that into the editors is better.