### PR TITLE
Use more specific brand:wikidata value for Martin's newsagents

### DIFF
--- a/data/brands/shop/newsagent.json
+++ b/data/brands/shop/newsagent.json
@@ -156,7 +156,7 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "Martin's",
-        "brand:wikidata": "Q16997477",
+        "brand:wikidata": "Q116779207",
         "name": "Martin's",
         "shop": "newsagent"
       }


### PR DESCRIPTION
The current wikidata entry https://www.wikidata.org/wiki/Q16997477 is actually for McColl's the owner of the chain. Martin's newsagents use a distinct fascia brand from other stores in the group. It would be better to use the more specific https://www.wikidata.org/wiki/Q116779207 .