### PR TITLE
Change brand tag for ステーキガスト (Steak Gusto) to ガスト (Gusto)

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -5785,11 +5785,11 @@
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "restaurant",
-        "brand": "ステーキガスト",
-        "brand:en": "Steak Gusto",
-        "brand:ja": "ステーキガスト",
-        "brand:wikidata": "Q92599119",
-        "cuisine": "steak",
+        "brand": "ガスト",
+        "brand:en": "Gusto",
+        "brand:ja": "ガスト",
+        "brand:wikidata": "Q87724117",
+        "cuisine": "steak;western;japanese",
         "name": "ステーキガスト",
         "name:en": "Steak Gusto",
         "name:ja": "ステーキガスト"


### PR DESCRIPTION
Steak Gusto is a variant brand of Gusto, and has many of the same menu items as Gusto, although there are some differences, such as specializing in griddle cuisine.
FYI:
Steak Gusto https://www.skylark.co.jp/en/steak_gusto/
Gusto https://www.skylark.co.jp/en/gusto/

Gusto is also used in the brand tag of Steak Gusto in JA:Naming sample.
https://wiki.openstreetmap.org/wiki/JA:Naming_sample#amenity=restaurant

But even if it were to be corrected, I don't know how to prevent adding the so called wrong one.

See also: #7765 