### PR TITLE
fix wrong long name of public transport association VVM around Würzburg, Bavaria, Germany

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -17387,16 +17387,16 @@
       }
     },
     {
-      "displayName": "Verkehrsverbund Mainfranken",
-      "id": "verkehrsverbundmainfranken-bfc089",
+      "displayName": "Verkehrsunternehmens-Verbund Mainfranken",
+      "id": "verkehrsunternehmensverbundmainfranken-dbddaa",
       "locationSet": {
         "include": ["de-by.geojson"]
       },
       "matchNames": [
-        "verkehrsunternehmens-verbund mainfranken"
+        "verkehrsverbund mainfranken"
       ],
       "tags": {
-        "network": "Verkehrsverbund Mainfranken",
+        "network": "Verkehrsunternehmens-Verbund Mainfranken",
         "network:short": "VVM",
         "network:wikidata": "Q2516466",
         "route": "bus"

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -2223,14 +2223,14 @@
       }
     },
     {
-      "displayName": "Verkehrsverbund Mainfranken",
-      "id": "verkehrsverbundmainfranken-da20e0",
+      "displayName": "Verkehrsunternehmens-Verbund Mainfranken",
+      "id": "verkehrsunternehmensverbundmainfranken-dbddaa",
       "locationSet": {"include": ["de"]},
       "matchNames": [
-        "verkehrsunternehmens-verbund mainfranken"
+        "verkehrsverbund mainfranken"
       ],
       "tags": {
-        "network": "Verkehrsverbund Mainfranken",
+        "network": "Verkehrsunternehmens-Verbund Mainfranken",
         "network:short": "VVM",
         "network:wikidata": "Q2516466",
         "route": "train"

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -846,16 +846,16 @@
       }
     },
     {
-      "displayName": "Verkehrsverbund Mainfranken",
-      "id": "verkehrsverbundmainfranken-52e12a",
+      "displayName": "Verkehrsunternehmens-Verbund Mainfranken",
+      "id": "verkehrsunternehmensverbundmainfranken-dbddaa",
       "locationSet": {
         "include": ["de-by.geojson"]
       },
       "matchNames": [
-        "verkehrsunternehmens-verbund mainfranken"
+        "verkehrsverbund mainfranken"
       ],
       "tags": {
-        "network": "Verkehrsverbund Mainfranken",
+        "network": "Verkehrsunternehmens-Verbund Mainfranken",
         "network:short": "VVM",
         "network:wikidata": "Q2516466",
         "operator": "Würzburger Straßenbahn GmbH",


### PR DESCRIPTION
- Good: "Verkehrsunternehmens-Verbund Mainfranken"
- Wrong: "Verkehrsverbund Mainfranken"

N.B.: wikidata and wikipedia are wrong as well

Wikipedia at least know the good one but redirects to the wrong one