### PR TITLE
Kwantum is also active in Belgium, adding locationSet

### DIFF
--- a/data/brands/shop/furniture.json
+++ b/data/brands/shop/furniture.json
@@ -922,7 +922,7 @@
     {
       "displayName": "Kwantum",
       "id": "kwantum-e8ade6",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {"include": ["nl", "be"]},
       "tags": {
         "brand": "Kwantum",
         "brand:wikidata": "Q2262591",


### PR DESCRIPTION
The Dutch furniture/house decoration chain Kwantum has also shops in Belgium (Flanders). Therefore also adding Belgium to its locationset.