### PR TITLE
Remove Sガスト (S Gusto)

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -6925,23 +6925,6 @@
       }
     },
     {
-      "displayName": "Sガスト",
-      "id": "sgusto-3e7699",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "fast_food",
-        "brand": "ガスト",
-        "brand:en": "Gusto",
-        "brand:ja": "ガスト",
-        "brand:wikidata": "Q87724117",
-        "cuisine": "western;japanese",
-        "name": "Sガスト",
-        "name:en": "S-Gusto",
-        "name:ja": "Sガスト",
-        "takeaway": "yes"
-      }
-    },
-    {
       "displayName": "Taco Bell",
       "id": "tacobell-658eea",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
All S Gusto are closed by 2020 and have been removed from the official website.