### PR TITLE
Update& Add LAWSON's

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5493,7 +5493,7 @@
       "locationSet": {"include": ["jp"]},
       "matchNames": ["ﾛｰｿﾝ"],
       "tags": {
-        "brand": "ローソン",
+        "brand": "LAWSON",
         "brand:en": "LAWSON",
         "brand:ja": "ローソン",
         "brand:wikidata": "Q1557223",
@@ -5507,17 +5507,14 @@
       "displayName": "ローソン・スリーエフ",
       "id": "lawsonthreef-652b3e",
       "locationSet": {"include": ["jp"]},
-      "matchNames": [
-        "lawson+スリーエフ",
-        "ﾛｰｿﾝ・スリーエフ"
-      ],
+      "matchNames": ["ﾛｰｿﾝ・スリーエフ"],
       "tags": {
-        "brand": "ローソン・スリーエフ",
-        "brand:en": "LAWSON･Three F",
-        "brand:ja": "ローソン・スリーエフ",
+        "brand": "LAWSON+スリーエフ",
+        "brand:en": "LAWSON+Three F",
+        "brand:ja": "ローソン+スリーエフ",
         "brand:wikidata": "Q24866804",
         "name": "ローソン・スリーエフ",
-        "name:en": "Lawson･Three F",
+        "name:en": "Lawson-Three F",
         "name:ja": "ローソン・スリーエフ",
         "shop": "convenience"
       }
@@ -5527,7 +5524,7 @@
       "id": "lawsonstore100-652b3e",
       "locationSet": {"include": ["jp"]},
       "tags": {
-        "brand": "ローソンストア100",
+        "brand": "LAWSON STORE 100",
         "brand:en": "LAWSON STORE 100",
         "brand:ja": "ローソンストア100",
         "brand:wikidata": "Q11350960",

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5514,7 +5514,7 @@
         "brand:ja": "ローソン+スリーエフ",
         "brand:wikidata": "Q24866804",
         "name": "ローソン・スリーエフ",
-        "name:en": "Lawson-Three F",
+        "name:en": "Lawson Three F",
         "name:ja": "ローソン・スリーエフ",
         "shop": "convenience"
       }
@@ -5529,7 +5529,7 @@
         "brand:ja": "ローソン+ポプラ",
         "brand:wikidata": "Q116957010",
         "name": "ローソン・ポプラ",
-        "name:en": "Lawson-Poplar",
+        "name:en": "Lawson Poplar",
         "name:ja": "ローソン・ポプラ",
         "shop": "convenience"
       }

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5520,6 +5520,21 @@
       }
     },
     {
+      "displayName": "ローソン・ポプラ",
+      "id": "lawsonpoplar-652b3e",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "LAWSON+ポプラ",
+        "brand:en": "LAWSON+Poplar",
+        "brand:ja": "ローソン+ポプラ",
+        "brand:wikidata": "Q116957010",
+        "name": "ローソン・ポプラ",
+        "name:en": "Lawson-Poplar",
+        "name:ja": "ローソン・ポプラ",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "ローソンストア100",
       "id": "lawsonstore100-652b3e",
       "locationSet": {"include": ["jp"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5535,6 +5535,22 @@
       }
     },
     {
+      "displayName": "ローソン+トークス",
+      "id": "lawsontoks-652b3e",
+      "locationSet": {"include": ["jp"]},
+      "note": "LAWSON+toks has two types of stores: convenience store and kiosk.",
+      "tags": {
+        "brand": "LAWSON+toks",
+        "brand:en": "LAWSON+toks",
+        "brand:ja": "ローソン+トークス",
+        "brand:wikidata": "Q115868119",
+        "name": "ローソン+トークス",
+        "name:en": "Lawson+toks",
+        "name:ja": "ローソン+トークス",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "ローソンストア100",
       "id": "lawsonstore100-652b3e",
       "locationSet": {"include": ["jp"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -2120,10 +2120,10 @@
     },
     {
       "displayName": "Lawson",
-      "id": "lawson-04f01c",
+      "id": "lawson-e7e121",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["cn"]
+        "exclude": ["cn", "jp"]
       },
       "tags": {
         "brand": "Lawson",

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5553,14 +5553,13 @@
       "displayName": "ローソンプラストークス",
       "id": "lawsontoks-652b3e",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["ローソン+トークス"],
       "note": "LAWSON+toks has two types of stores: convenience store and kiosk.",
       "tags": {
         "brand": "LAWSON+toks",
         "brand:en": "LAWSON+toks",
         "brand:ja": "ローソンプラストークス",
         "brand:wikidata": "Q115868119",
-        "name": "ローソンプラストークス",
+        "name": "ローソン+トークス",
         "name:en": "Lawson+toks",
         "name:ja": "ローソンプラストークス",
         "shop": "convenience"

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5535,23 +5535,6 @@
       }
     },
     {
-      "displayName": "ローソン+トークス",
-      "id": "lawsontoks-652b3e",
-      "locationSet": {"include": ["jp"]},
-      "matchNames": ["ローソンプラストークス"],
-      "note": "LAWSON+toks has two types of stores: convenience store and kiosk.",
-      "tags": {
-        "brand": "LAWSON+toks",
-        "brand:en": "LAWSON+toks",
-        "brand:ja": "ローソン+トークス",
-        "brand:wikidata": "Q115868119",
-        "name": "ローソン+トークス",
-        "name:en": "Lawson+toks",
-        "name:ja": "ローソン+トークス",
-        "shop": "convenience"
-      }
-    },
-    {
       "displayName": "ローソンストア100",
       "id": "lawsonstore100-652b3e",
       "locationSet": {"include": ["jp"]},
@@ -5563,6 +5546,23 @@
         "name": "ローソンストア100",
         "name:en": "Lawson Store 100",
         "name:ja": "ローソンストア100",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "ローソンプラストークス",
+      "id": "lawsontoks-652b3e",
+      "locationSet": {"include": ["jp"]},
+      "matchNames": ["ローソン+トークス"],
+      "note": "LAWSON+toks has two types of stores: convenience store and kiosk.",
+      "tags": {
+        "brand": "LAWSON+toks",
+        "brand:en": "LAWSON+toks",
+        "brand:ja": "ローソンプラストークス",
+        "brand:wikidata": "Q115868119",
+        "name": "ローソンプラストークス",
+        "name:en": "Lawson+toks",
+        "name:ja": "ローソンプラストークス",
         "shop": "convenience"
       }
     },

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5538,6 +5538,7 @@
       "displayName": "ローソン+トークス",
       "id": "lawsontoks-652b3e",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["ローソンプラストークス"],
       "note": "LAWSON+toks has two types of stores: convenience store and kiosk.",
       "tags": {
         "brand": "LAWSON+toks",

--- a/data/brands/shop/kiosk.json
+++ b/data/brands/shop/kiosk.json
@@ -237,14 +237,13 @@
       "displayName": "ローソンプラストークス",
       "id": "lawsontoks-84165a",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["ローソン+トークス"],
       "note": "LAWSON+toks has two types of stores: convenience store and kiosk.",
       "tags": {
         "brand": "LAWSON+toks",
         "brand:en": "LAWSON+toks",
         "brand:ja": "ローソンプラストークス",
         "brand:wikidata": "Q115868119",
-        "name": "ローソンプラストークス",
+        "name": "ローソン+トークス",
         "name:en": "Lawson+toks",
         "name:ja": "ローソンプラストークス",
         "shop": "kiosk"

--- a/data/brands/shop/kiosk.json
+++ b/data/brands/shop/kiosk.json
@@ -234,19 +234,19 @@
       }
     },
     {
-      "displayName": "ローソン+トークス",
+      "displayName": "ローソンプラストークス",
       "id": "lawsontoks-84165a",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["ローソンプラストークス"],
+      "matchNames": ["ローソン+トークス"],
       "note": "LAWSON+toks has two types of stores: convenience store and kiosk.",
       "tags": {
         "brand": "LAWSON+toks",
         "brand:en": "LAWSON+toks",
-        "brand:ja": "ローソン+トークス",
+        "brand:ja": "ローソンプラストークス",
         "brand:wikidata": "Q115868119",
-        "name": "ローソン+トークス",
+        "name": "ローソンプラストークス",
         "name:en": "Lawson+toks",
-        "name:ja": "ローソン+トークス",
+        "name:ja": "ローソンプラストークス",
         "shop": "kiosk"
       }
     }

--- a/data/brands/shop/kiosk.json
+++ b/data/brands/shop/kiosk.json
@@ -232,6 +232,22 @@
         "name:ja": "キヨスク",
         "shop": "kiosk"
       }
+    },
+    {
+      "displayName": "ローソン+トークス",
+      "id": "lawsontoks-84165a",
+      "locationSet": {"include": ["jp"]},
+      "note": "LAWSON+toks has two types of stores: convenience store and kiosk.",
+      "tags": {
+        "brand": "LAWSON+toks",
+        "brand:en": "LAWSON+toks",
+        "brand:ja": "ローソン+トークス",
+        "brand:wikidata": "Q115868119",
+        "name": "ローソン+トークス",
+        "name:en": "Lawson+toks",
+        "name:ja": "ローソン+トークス",
+        "shop": "kiosk"
+      }
     }
   ]
 }

--- a/data/brands/shop/kiosk.json
+++ b/data/brands/shop/kiosk.json
@@ -237,6 +237,7 @@
       "displayName": "ローソン+トークス",
       "id": "lawsontoks-84165a",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["ローソンプラストークス"],
       "note": "LAWSON+toks has two types of stores: convenience store and kiosk.",
       "tags": {
         "brand": "LAWSON+toks",


### PR DESCRIPTION
Updated LAWSON's tag with reference to [JA:Naming sample](https://wiki.openstreetmap.org/wiki/JA:Naming_sample#shop=convenience).

For LAWSON+toks, '+' is also used for name because '+' is also used on the [website](http://www.e-toks.co.jp/business/convenience).

[LAWSON+Three F (Mapillary)](https://www.mapillary.com/app/?pKey=411364724039138)
[LAWSON+Poplar(Mapillary)](https://www.mapillary.com/app/?pKey=490777225316624)