### PR TITLE
network:short=Coast -> COAST for Cooperative Alliance for Seacoast Transportation

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -3422,7 +3422,7 @@
       "matchNames": ["coastbus"],
       "tags": {
         "network": "Cooperative Alliance for Seacoast Transportation",
-        "network:short": "Coast",
+        "network:short": "COAST",
         "network:wikidata": "Q5167873",
         "route": "bus"
       }


### PR DESCRIPTION
The acronym is always capitalized in common usage (see https://coastbus.org/, for example).