### PR TITLE
Added tag 'government=public_safety' for PSP in pl

### DIFF
--- a/data/operators/office/government.json
+++ b/data/operators/office/government.json
@@ -888,6 +888,7 @@
       "locationSet": {"include": ["pl"]},
       "tags": {
         "office": "government",
+        "government": "public_safety",
         "operator": "Państwowa Straż Pożarna",
         "operator:wikidata": "Q11815208"
       }


### PR DESCRIPTION
An additional tag completes the function of this type of unit.