### PR TITLE
Correct brand name of Norli book stores

### DIFF
--- a/data/brands/shop/books.json
+++ b/data/brands/shop/books.json
@@ -656,7 +656,7 @@
       "note": "https://github.com/osmlab/name-suggestion-index/issues/5500",
       "preserveTags": ["^name"],
       "tags": {
-        "brand": "National Book Store",
+        "brand": "Norli",
         "brand:wikidata": "Q1999199",
         "name": "Norli",
         "shop": "books"


### PR DESCRIPTION
National Book Store is not the correct brand name, unclear where it came from