### PR TITLE
Adding bicycle_rental=docking_station to Citi Bike

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -1016,6 +1016,7 @@
       ],
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Citi Bike",
         "brand:wikidata": "Q2974438",
         "fee": "yes",


### PR DESCRIPTION
Adding because all Citi Bike stations are docking stations. Not experienced with Github so please let me know if I did anything wrong.