### PR TITLE
Update Japanese mobile stores

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -1424,15 +1424,15 @@
       "id": "softbank-0a8be9",
       "locationSet": {"include": ["jp"]},
       "tags": {
-        "brand": "ソフトバンクショップ",
-        "brand:en": "SoftBankShop",
-        "brand:ja": "ソフトバンクショップ",
-        "brand:wikidata": "Q11315281",
+        "brand": "ソフトバンク",
+        "brand:en": "SoftBank",
+        "brand:ja": "ソフトバンク",
+        "brand:wikidata": "Q2214105",
         "name": "ソフトバンク",
         "name:en": "SoftBank",
         "name:ja": "ソフトバンク",
         "official_name": "ソフトバンクショップ",
-        "official_name:en": "SoftBankShop",
+        "official_name:en": "SoftBank Shop",
         "official_name:ja": "ソフトバンクショップ",
         "shop": "mobile_phone"
       }
@@ -1456,18 +1456,14 @@
       "displayName": "ドコモショップ",
       "id": "docomoshop-0a8be9",
       "locationSet": {"include": ["jp"]},
-      "matchNames": [
-        "ｄｏｃｏｍｏ",
-        "ntt docomo",
-        "nttドコモ"
-      ],
+      "matchNames": ["ｄｏｃｏｍｏ"],
       "tags": {
-        "brand": "ドコモショップ",
-        "brand:en": "DoCoMo Shop",
-        "brand:ja": "ドコモショップ",
+        "brand": "NTT docomo",
+        "brand:en": "NTT docomo",
+        "brand:ja": "NTTドコモ",
         "brand:wikidata": "Q853958",
         "name": "ドコモショップ",
-        "name:en": "DoCoMo Shop",
+        "name:en": "docomo Shop",
         "name:ja": "ドコモショップ",
         "shop": "mobile_phone"
       }
@@ -1478,7 +1474,7 @@
       "locationSet": {"include": ["jp"]},
       "matchNames": ["yahooモバイル"],
       "tags": {
-        "brand": "ワイモバイル",
+        "brand": "Y!mobile",
         "brand:en": "Y!mobile",
         "brand:ja": "ワイモバイル",
         "brand:wikidata": "Q18455742",

--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -1424,7 +1424,7 @@
       "id": "softbank-0a8be9",
       "locationSet": {"include": ["jp"]},
       "tags": {
-        "brand": "ソフトバンク",
+        "brand": "SoftBank",
         "brand:en": "SoftBank",
         "brand:ja": "ソフトバンク",
         "brand:wikidata": "Q2214105",

--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -86,15 +86,16 @@
     },
     {
       "displayName": "auショップ",
-      "id": "au-0a8be9",
+      "id": "aushop-0a8be9",
       "locationSet": {"include": ["jp"]},
       "matchNames": ["エーユー"],
       "tags": {
         "brand": "au",
+        "brand:en": "au",
         "brand:ja": "au",
         "brand:wikidata": "Q307110",
         "name": "auショップ",
-        "name:en": "au",
+        "name:en": "au Shop",
         "name:ja": "auショップ",
         "shop": "mobile_phone"
       }
@@ -1017,7 +1018,7 @@
       "locationSet": {"include": ["jp"]},
       "matchNames": ["ユーキュースポット", "ユーキューモバイル"],
       "tags": {
-        "brand": "UQモバイル",
+        "brand": "UQ mobile",
         "brand:en": "UQ mobile",
         "brand:ja": "UQモバイル",
         "brand:wikidata": "Q11252091",
@@ -1421,19 +1422,16 @@
     },
     {
       "displayName": "ソフトバンクショップ",
-      "id": "softbank-0a8be9",
+      "id": "softbankshop-0a8be9",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "brand": "SoftBank",
         "brand:en": "SoftBank",
         "brand:ja": "ソフトバンク",
         "brand:wikidata": "Q2214105",
-        "name": "ソフトバンク",
-        "name:en": "SoftBank",
-        "name:ja": "ソフトバンク",
-        "official_name": "ソフトバンクショップ",
-        "official_name:en": "SoftBank Shop",
-        "official_name:ja": "ソフトバンクショップ",
+        "name": "ソフトバンクショップ",
+        "name:en": "SoftBank Shop",
+        "name:ja": "ソフトバンクショップ",
         "shop": "mobile_phone"
       }
     },


### PR DESCRIPTION
Revised the Japanese mobile store brand tag to what is actually recognized as the brand and changed the English name to the one used in the official description.
The names of some stores were also changed to their official names as stores instead of brands.