### PR TITLE
Update notation of ヤマダ電機 (Yamada Denki) to ヤマダデンキ

### DIFF
--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -1652,18 +1652,19 @@
       }
     },
     {
-      "displayName": "ヤマダ電機",
+      "displayName": "ヤマダデンキ",
       "id": "yamadadenki-f86f5e",
       "locationSet": {"include": ["jp"]},
       "matchNames": ["yamada"],
       "tags": {
-        "brand": "ヤマダ電機",
+        "brand": "ヤマダデンキ",
         "brand:en": "Yamada Denki",
-        "brand:ja": "ヤマダ電機",
+        "brand:ja": "ヤマダデンキ",
         "brand:wikidata": "Q1096390",
-        "name": "ヤマダ電機",
+        "name": "ヤマダデンキ",
         "name:en": "Yamada Denki",
-        "name:ja": "ヤマダ電機",
+        "name:ja": "ヤマダデンキ",
+        "alt_name": "ヤマダ電機",
         "shop": "electronics"
       }
     },

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -1657,6 +1657,7 @@
       "locationSet": {"include": ["jp"]},
       "matchNames": ["yamada"],
       "tags": {
+        "alt_name": "ヤマダ電機",
         "brand": "ヤマダデンキ",
         "brand:en": "Yamada Denki",
         "brand:ja": "ヤマダデンキ",
@@ -1664,7 +1665,6 @@
         "name": "ヤマダデンキ",
         "name:en": "Yamada Denki",
         "name:ja": "ヤマダデンキ",
-        "alt_name": "ヤマダ電機",
         "shop": "electronics"
       }
     },


### PR DESCRIPTION
Around 2020, the "Denki" part of the Japanese trade name was changed from kanji to katakana.
However, it is also true that kanji notation continues to be commonly used, so I have described it in alt_name.