### PR TITLE
Update Japanese Electric Power Companies

### DIFF
--- a/data/operators/power/generator.json
+++ b/data/operators/power/generator.json
@@ -7930,12 +7930,12 @@
       "displayName": "中国電力",
       "id": "chugokuelectricpowercompany-11cc64",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["中国電力株式会社"],
       "note": "This 中国 don't means China",
       "tags": {
-        "operator": "中国電力株式会社",
+        "operator": "中国電力",
         "operator:en": "Chugoku Electric Power Company",
-        "operator:ja": "中国電力株式会社",
-        "operator:short": "中国電力",
+        "operator:ja": "中国電力",
         "operator:wikidata": "Q73171",
         "power": "generator"
       }
@@ -7944,11 +7944,12 @@
       "displayName": "中部電力",
       "id": "chubuelectricpowercompany-11cc64",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["中部電力株式会社"],
       "tags": {
-        "operator": "中部電力株式会社",
+        "operator": "中部電力",
         "operator:en": "Chubu Electric Power Company",
-        "operator:ja": "中部電力株式会社",
-        "operator:short": "中部電力",
+        "operator:ja": "中部電力",
+        "operator:short": "中電",
         "operator:wikidata": "Q1091203",
         "power": "generator"
       }
@@ -7957,11 +7958,12 @@
       "displayName": "九州電力",
       "id": "kyushuelectricpowercompany-11cc64",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["九州電力株式会社"],
       "tags": {
-        "operator": "九州電力株式会社",
+        "operator": "九州電力",
         "operator:en": "Kyushu Electric Power Company",
-        "operator:ja": "九州電力株式会社",
-        "operator:short": "九州電力",
+        "operator:ja": "九州電力",
+        "operator:short": "九電",
         "operator:wikidata": "Q694507",
         "power": "generator"
       }
@@ -7970,11 +7972,12 @@
       "displayName": "北海道電力",
       "id": "hokkaidoelectricpowercompany-11cc64",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["北海道電力株式会社"],
       "tags": {
-        "operator": "北海道電力株式会社",
+        "operator": "北海道電力",
         "operator:en": "Hokkaido Electric Power Company",
-        "operator:ja": "北海道電力株式会社",
-        "operator:short": "北海道電力",
+        "operator:ja": "北海道電力",
+        "operator:short": "ほくでん",
         "operator:wikidata": "Q742449",
         "power": "generator"
       }
@@ -7983,11 +7986,12 @@
       "displayName": "北陸電力",
       "id": "hokurikuelectricpowercompany-11cc64",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["北陸電力株式会社"],
       "tags": {
-        "operator": "北陸電力株式会社",
+        "operator": "北陸電力",
         "operator:en": "Hokuriku Electric Power Company",
-        "operator:ja": "北陸電力株式会社",
-        "operator:short": "北陸電力",
+        "operator:ja": "北陸電力",
+        "operator:short": "りくでん",
         "operator:wikidata": "Q742461",
         "power": "generator"
       }
@@ -8045,11 +8049,12 @@
       "displayName": "四国電力",
       "id": "shikokuelectricpowercompany-11cc64",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["四国電力株式会社"],
       "tags": {
-        "operator": "四国電力株式会社",
+        "operator": "四国電力",
         "operator:en": "Shikoku Electric Power Company",
-        "operator:ja": "四国電力株式会社",
-        "operator:short": "四国電力",
+        "operator:ja": "四国電力",
+        "operator:short": "よんでん",
         "operator:wikidata": "Q388455",
         "power": "generator"
       }
@@ -8129,11 +8134,12 @@
       "displayName": "東京電力",
       "id": "tokyoelectricpowercompany-11cc64",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["東京電力株式会社"],
       "tags": {
-        "operator": "東京電力株式会社",
+        "operator": "東京電力",
         "operator:en": "Tokyo Electric Power Company",
-        "operator:ja": "東京電力株式会社",
-        "operator:short": "東京電力",
+        "operator:ja": "東京電力",
+        "operator:short": "東電",
         "operator:wikidata": "Q333894",
         "power": "generator"
       }
@@ -8142,11 +8148,12 @@
       "displayName": "東北電力",
       "id": "tohokuelectricpowercompany-11cc64",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["東北電力株式会社"],
       "tags": {
-        "operator": "東北電力株式会社",
+        "operator": "東北電力",
         "operator:en": "Tohoku Electric Power Company",
-        "operator:ja": "東北電力株式会社",
-        "operator:short": "東北電力",
+        "operator:ja": "東北電力",
+        "operator:short": "東北電",
         "operator:wikidata": "Q592765",
         "power": "generator"
       }
@@ -8155,11 +8162,12 @@
       "displayName": "沖縄電力",
       "id": "okinawaelectricpowercompany-11cc64",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["沖縄電力株式会社"],
       "tags": {
-        "operator": "沖縄電力株式会社",
+        "operator": "沖縄電力",
         "operator:en": "Okinawa Electric Power Company",
-        "operator:ja": "沖縄電力株式会社",
-        "operator:short": "沖縄電力",
+        "operator:ja": "沖縄電力",
+        "operator:short": "おきでん",
         "operator:wikidata": "Q2017226",
         "power": "generator"
       }
@@ -8187,11 +8195,12 @@
       "displayName": "関西電力",
       "id": "kansaielectricpowercompany-11cc64",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["関西電力株式会社"],
       "tags": {
-        "operator": "関西電力株式会社",
+        "operator": "関西電力",
         "operator:en": "Kansai Electric Power Company",
-        "operator:ja": "関西電力株式会社",
-        "operator:short": "関西電力",
+        "operator:ja": "関西電力",
+        "operator:short": "かんでん",
         "operator:wikidata": "Q1365015",
         "power": "generator"
       }
@@ -8209,11 +8218,11 @@
       "displayName": "電源開発",
       "id": "electricpowerdevelopmentcompany-11cc64",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["電源開発株式会社"],
       "tags": {
-        "operator": "電源開発株式会社",
+        "operator": "電源開発",
         "operator:en": "Electric Power Development Company",
-        "operator:ja": "電源開発株式会社",
-        "operator:short": "電源開発",
+        "operator:ja": "電源開発",
         "operator:wikidata": "Q3805077",
         "power": "generator"
       }

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -3216,10 +3216,11 @@
       "displayName": "JR東日本",
       "id": "eastjapanrailwaycompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["東日本旅客鉄道株式会社"],
       "tags": {
-        "operator": "東日本旅客鉄道株式会社",
+        "operator": "東日本旅客鉄道",
         "operator:en": "East Japan Railway Company",
-        "operator:ja": "東日本旅客鉄道株式会社",
+        "operator:ja": "東日本旅客鉄道",
         "operator:short": "JR東日本",
         "operator:wikidata": "Q499071",
         "power": "line"
@@ -3229,10 +3230,11 @@
       "displayName": "JR東海",
       "id": "centraljapanrailwaycompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["東海旅客鉄道株式会社"],
       "tags": {
-        "operator": "東海旅客鉄道株式会社",
+        "operator": "東海旅客鉄道",
         "operator:en": "Central Japan Railway Company",
-        "operator:ja": "東海旅客鉄道株式会社",
+        "operator:ja": "東海旅客鉄道",
         "operator:short": "JR東海",
         "operator:wikidata": "Q513679",
         "power": "line"
@@ -6677,42 +6679,38 @@
       }
     },
     {
-      "displayName": "中国電力",
-      "id": "chugokuelectricpowercompany-e95322",
+      "displayName": "中国電力ネットワーク",
+      "id": "chugokuelectricpowertransmissionanddistributioncompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["中国電力", "中国電力株式会社"],
       "note": "This 中国 don't means China",
       "tags": {
-        "operator": "中国電力株式会社",
-        "operator:en": "Chugoku Electric Power Company",
-        "operator:ja": "中国電力株式会社",
-        "operator:short": "中国電力",
-        "operator:wikidata": "Q73171",
+        "operator": "中国電力ネットワーク",
+        "operator:en": "Chugoku Electric Power Transmission & Distribution Company",
+        "operator:ja": "中国電力ネットワーク",
+        "operator:wikidata": "Q65093799",
         "power": "line"
       }
     },
     {
       "displayName": "中部電力",
-      "id": "chubuelectricpowercompany-e95322",
-      "locationSet": {"include": ["jp"]},
+      "id": "e0ec69-116894",
+      "locationSet": {"include": ["001"]},
       "tags": {
-        "operator": "中部電力株式会社",
-        "operator:en": "Chubu Electric Power Company",
-        "operator:ja": "中部電力株式会社",
-        "operator:short": "中部電力",
-        "operator:wikidata": "Q1091203",
+        "operator": "中部電力",
         "power": "line"
       }
     },
     {
-      "displayName": "九州電力",
-      "id": "kyushuelectricpowercompany-e95322",
+      "displayName": "中部電力パワーグリッド",
+      "id": "chubuelectricpowergridcompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["中部電力株式会社"],
       "tags": {
-        "operator": "九州電力株式会社",
-        "operator:en": "Kyushu Electric Power Company",
-        "operator:ja": "九州電力株式会社",
-        "operator:short": "九州電力",
-        "operator:wikidata": "Q694507",
+        "operator": "中部電力パワーグリッド",
+        "operator:en": "Chubu Electric Power Grid Company",
+        "operator:ja": "中部電力パワーグリッド",
+        "operator:wikidata": "Q66119034",
         "power": "line"
       }
     },
@@ -6720,6 +6718,7 @@
       "displayName": "九州電力送配電",
       "id": "kyushuelectricpowertransmissionanddistributioncompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["九州電力", "九州電力株式会社"],
       "tags": {
         "operator": "九州電力送配電",
         "operator:en": "Kyushu Electric Power Transmission and Distribution Company",
@@ -6729,41 +6728,42 @@
       }
     },
     {
-      "displayName": "北海道電力",
-      "id": "hokkaidoelectricpowercompany-e95322",
+      "displayName": "北海道電力ネットワーク",
+      "id": "hokkaidoelectricpowernetwork-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["北海道電力", "北海道電力株式会社"],
       "tags": {
-        "operator": "北海道電力株式会社",
-        "operator:en": "Hokkaido Electric Power Company",
-        "operator:ja": "北海道電力株式会社",
-        "operator:short": "北海道電力",
-        "operator:wikidata": "Q742449",
+        "operator": "北海道電力ネットワーク",
+        "operator:en": "Hokkaido Electric Power Network",
+        "operator:ja": "北海道電力ネットワーク",
+        "operator:short": "ほくでんネットワーク",
+        "operator:wikidata": "Q64504223",
         "power": "line"
       }
     },
     {
-      "displayName": "北陸電力",
-      "id": "hokurikuelectricpowercompany-e95322",
+      "displayName": "北陸電力送配電",
+      "id": "hokurikuelectricpowertransmissionanddistributioncompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["北陸電力", "北陸電力株式会社"],
       "tags": {
-        "operator": "北陸電力株式会社",
-        "operator:en": "Hokuriku Electric Power Company",
-        "operator:ja": "北陸電力株式会社",
-        "operator:short": "北陸電力",
-        "operator:wikidata": "Q742461",
+        "operator": "北陸電力送配電",
+        "operator:en": "Hokuriku Electric Power Transmission & Distribution Company",
+        "operator:ja": "北陸電力送配電",
+        "operator:wikidata": "Q65142438",
         "power": "line"
       }
     },
     {
-      "displayName": "四国電力",
-      "id": "shikokuelectricpowercompany-e95322",
+      "displayName": "四国電力送配電",
+      "id": "shikokuelectricpowertransmissionanddistributioncompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["四国電力", "四国電力株式会社"],
       "tags": {
-        "operator": "四国電力株式会社",
-        "operator:en": "Shikoku Electric Power Company",
-        "operator:ja": "四国電力株式会社",
-        "operator:short": "四国電力",
-        "operator:wikidata": "Q388455",
+        "operator": "四国電力送配電",
+        "operator:en": "Shikoku Electric Power Transmission & Distribution Company",
+        "operator:ja": "四国電力送配電",
+        "operator:wikidata": "Q65096000",
         "power": "line"
       }
     },
@@ -6780,22 +6780,10 @@
       }
     },
     {
-      "displayName": "東京電力",
-      "id": "tokyoelectricpowercompany-e95322",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "operator": "東京電力株式会社",
-        "operator:en": "Tokyo Electric Power Company",
-        "operator:ja": "東京電力株式会社",
-        "operator:short": "東京電力",
-        "operator:wikidata": "Q333894",
-        "power": "line"
-      }
-    },
-    {
       "displayName": "東京電力パワーグリッド",
       "id": "tepcopowergrid-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["tepco", "東京電力", "東京電力株式会社"],
       "tags": {
         "operator": "東京電力パワーグリッド",
         "operator:en": "TEPCO Power Grid",
@@ -6805,16 +6793,15 @@
       }
     },
     {
-      "displayName": "東北電力",
-      "id": "tohokuelectricpowercompany-e95322",
+      "displayName": "東北電力ネットワーク",
+      "id": "tohokuelectricpowernetworkcompany-e95322",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["tepco"],
+      "matchNames": ["東北電力", "東北電力株式会社"],
       "tags": {
-        "operator": "東北電力株式会社",
-        "operator:en": "Tohoku Electric Power Company",
-        "operator:ja": "東北電力株式会社",
-        "operator:short": "東北電力",
-        "operator:wikidata": "Q592765",
+        "operator": "東北電力ネットワーク",
+        "operator:en": "Tohoku Electric Power Network Company",
+        "operator:ja": "東北電力ネットワーク",
+        "operator:wikidata": "Q65040183",
         "power": "line"
       }
     },
@@ -6822,38 +6809,39 @@
       "displayName": "沖縄電力",
       "id": "okinawaelectricpowercompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["沖縄電力株式会社"],
       "tags": {
-        "operator": "沖縄電力株式会社",
+        "operator": "沖縄電力",
         "operator:en": "Okinawa Electric Power Company",
-        "operator:ja": "沖縄電力株式会社",
-        "operator:short": "沖縄電力",
+        "operator:ja": "沖縄電力",
+        "operator:short": "おきでん",
         "operator:wikidata": "Q2017226",
         "power": "line"
       }
     },
     {
-      "displayName": "関西電力",
-      "id": "kansaielectricpowercompany-e95322",
+      "displayName": "関西電力送配電",
+      "id": "kansaitransmissionanddistribution-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["関西電力", "関西電力株式会社"],
       "tags": {
-        "operator": "関西電力株式会社",
-        "operator:en": "Kansai Electric Power Company",
-        "operator:ja": "関西電力株式会社",
-        "operator:short": "関西電力",
-        "operator:wikidata": "Q1365015",
+        "operator": "関西電力送配電",
+        "operator:en": "Kansai Transmission and Distribution",
+        "operator:ja": "関西電力送配電",
+        "operator:wikidata": "Q65556946",
         "power": "line"
       }
     },
     {
-      "displayName": "電源開発",
-      "id": "electricpowerdevelopmentcompany-e95322",
+      "displayName": "電源開発送変電ネットワーク",
+      "id": "jpowertransmissionnetwork-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["電源開発", "電源開発株式会社"],
       "tags": {
-        "operator": "電源開発株式会社",
-        "operator:en": "Electric Power Development Company",
-        "operator:ja": "電源開発株式会社",
-        "operator:short": "電源開発",
-        "operator:wikidata": "Q3805077",
+        "operator": "電源開発送変電ネットワーク",
+        "operator:en": "J-Power Transmission Network",
+        "operator:ja": "電源開発送変電ネットワーク",
+        "operator:wikidata": "Q71543179",
         "power": "line"
       }
     }

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -6693,19 +6693,10 @@
       }
     },
     {
-      "displayName": "中部電力",
-      "id": "e0ec69-116894",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "operator": "中部電力",
-        "power": "line"
-      }
-    },
-    {
       "displayName": "中部電力パワーグリッド",
       "id": "chubuelectricpowergridcompany-e95322",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["中部電力株式会社"],
+      "matchNames": ["中部電力", "中部電力株式会社"],
       "tags": {
         "operator": "中部電力パワーグリッド",
         "operator:en": "Chubu Electric Power Grid Company",


### PR DESCRIPTION
Basically, Japanese electric power companies separate companies between generation and transmission lines, so I changed it accordingly.
FYI:
https://www.enecho.meti.go.jp/category/electricity_and_gas/electric/summary/electric_transmission_list/
https://www.enecho.meti.go.jp/category/electricity_and_gas/electricity_measures/004/list/

In addition, since the Japanese operator tag basically does not include "株式会社" and there are some short names that are actually commonly used, I changed it so that it does not include it.