### PR TITLE
Add alt_name and recycling types to Лѣпта

### DIFF
--- a/data/brands/amenity/recycling.json
+++ b/data/brands/amenity/recycling.json
@@ -326,12 +326,15 @@
         "amenity": "recycling",
         "brand": "Лѣпта",
         "brand:wikidata": "Q110234180",
+        "alt_name": "Лепта",
         "name": "Лѣпта",
         "operator": "Лѣпта",
         "operator:wikidata": "Q110234180",
         "recycling_type": "container",
+        "recycling:bags": "yes",
         "recycling:clothes": "yes",
-        "recycling:shoes": "yes"
+        "recycling:shoes": "yes",
+        "recycling:toys": "yes"
       }
     },
     {


### PR DESCRIPTION
Source for recycling types: https://lepta.info/give-things/#what-give
Alt name: there is no "ѣ" on the Russian keyboard, so it would be nice to tag alt_name