### PR TITLE
Update Japanese car rental shops

### DIFF
--- a/data/brands/amenity/car_rental.json
+++ b/data/brands/amenity/car_rental.json
@@ -268,59 +268,62 @@
     },
     {
       "displayName": "オリックスレンタカー",
-      "id": "orixcarrental-f05847",
+      "id": "orixrentacar-f05847",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "car_rental",
         "brand": "オリックスレンタカー",
-        "brand:en": "ORIX Car Rental",
+        "brand:en": "ORIX Rent-A-Car",
         "brand:ja": "オリックスレンタカー",
         "brand:wikidata": "Q11123021",
         "name": "オリックスレンタカー",
-        "name:en": "ORIX Car Rental",
+        "name:en": "ORIX Rent a Car",
         "name:ja": "オリックスレンタカー"
       }
     },
     {
       "displayName": "トヨタレンタカー",
-      "id": "toyotarentalcar-f05847",
+      "id": "toyotarentacar-f05847",
       "locationSet": {"include": ["jp"]},
       "matchNames": ["トヨタレンタリース"],
       "tags": {
         "amenity": "car_rental",
         "brand": "トヨタレンタカー",
-        "brand:en": "Toyota Rental Car",
+        "brand:en": "TOYOTA Rent a Car",
         "brand:ja": "トヨタレンタカー",
         "brand:wikidata": "Q11321580",
         "name": "トヨタレンタカー",
-        "name:en": "Toyota Rental Car",
+        "name:en": "Toyota Rent a Car",
         "name:ja": "トヨタレンタカー"
       }
     },
     {
       "displayName": "ニコニコレンタカー",
-      "id": "e9bf90-d9531a",
-      "locationSet": {"include": ["001"]},
+      "id": "niconicorentacar-f05847",
+      "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "car_rental",
         "brand": "ニコニコレンタカー",
+        "brand:en": "NICONICO RENTACAR",
         "brand:ja": "ニコニコレンタカー",
+        "brand:wikidata": "Q11324230",
         "name": "ニコニコレンタカー",
+        "name:en": "Niconico Rentacar",
         "name:ja": "ニコニコレンタカー"
       }
     },
     {
       "displayName": "ニッポンレンタカー",
-      "id": "nipponcarrental-f05847",
+      "id": "nipponrentacar-f05847",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "car_rental",
         "brand": "ニッポンレンタカー",
-        "brand:en": "Nippon Car Rental",
+        "brand:en": "NIPPON Rent-A-Car",
         "brand:ja": "ニッポンレンタカー",
         "brand:wikidata": "Q11086533",
         "name": "ニッポンレンタカー",
-        "name:en": "Nippon Car Rental",
+        "name:en": "Nippon Rent-A-Car",
         "name:ja": "ニッポンレンタカー"
       }
     },
@@ -341,16 +344,16 @@
     },
     {
       "displayName": "日産レンタカー",
-      "id": "nissancarrental-f05847",
+      "id": "nissanrentacar-f05847",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "car_rental",
         "brand": "日産レンタカー",
-        "brand:en": "Nissan Car Rental",
+        "brand:en": "NISSAN RENT A CAR",
         "brand:ja": "日産レンタカー",
         "brand:wikidata": "Q11086838",
         "name": "日産レンタカー",
-        "name:en": "Nissan Car Rental",
+        "name:en": "Nissan Rent a Car",
         "name:ja": "日産レンタカー"
       }
     },


### PR DESCRIPTION
Mainly changed the English name to the correct one.

ORIX Rent-A-Car
https://www.mapillary.com/app/?pKey=1495276107608196
https://car.orix.co.jp/eng/

TOYOTA Rent a Car
https://www.mapillary.com/app/?pKey=3231474703762653
https://rent.toyota.co.jp/eng/

NICONICO RENTACAR
https://www.mapillary.com/app/?pKey=1176712102780462
https://www.2525r.com

NIPPON Rent-A-Car
https://www.mapillary.com/app/?pKey=460445035027547
https://www.nrgroup-global.com/en/

NISSAN RENT A CAR
https://www.mapillary.com/app/?pKey=998491940936526
https://nissan-rentacar.com/english/