### PR TITLE
Add BYD Auto to car brands as discussed in issue #7804

### DIFF
--- a/data/brands/shop/car.json
+++ b/data/brands/shop/car.json
@@ -127,12 +127,27 @@
     },
     {
       "displayName": "BYD",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["001"],"exclude":["cn"]},
       "matchNames": ["build your dreams"],
       "tags": {
         "brand": "BYD Auto",
         "brand:wikidata": "Q27423",
         "name": "BYD",
+        "shop": "car"
+      }
+    },
+        {
+      "displayName": "比亚迪",
+      "locationSet": {"include": ["cn"]},
+      "matchNames": ["比亚迪汽车"],
+      "tags": {
+        "brand": "比亚迪",
+        "brand:zh": "比亚迪",
+        "brand:en": "BYD",
+        "name:en": "BYD",
+        "brand:wikidata": "Q27423",
+        "name": "比亚迪",
+        "name:zh": "比亚迪",
         "shop": "car"
       }
     },

--- a/data/brands/shop/car.json
+++ b/data/brands/shop/car.json
@@ -126,6 +126,17 @@
       }
     },
     {
+      "displayName": "BYD",
+      "locationSet": {"include": ["001"]},
+      "matchNames": ["build your dreams"],
+      "tags": {
+        "brand": "BYD Auto",
+        "brand:wikidata": "Q27423",
+        "name": "BYD",
+        "shop": "car"
+      }
+    },
+    {
       "displayName": "Byrider",
       "id": "byrider-71ab24",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Since there was no further input besides the comment from UKChris-osm, nor any objections in issue #7804 , I added BYD Auto to the car brands.
Also included a matchname handle since they both use "Build your Dreams" as slogan and as the full name of the brands (with BYD being the abbreviation).