### PR TITLE
Add Ma'loa: Hawaiian poke bowl fast food chain

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -4287,6 +4287,19 @@
       }
     },
     {
+      "displayName": "Ma'loa",
+      "id": "maloa-accea8",
+      "locationSet": {"include": ["de", "fr"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Ma'loa",
+        "brand:wikidata": "Q116898012",
+        "cuisine": "poke",
+        "name": "Ma'loa",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Malvón",
       "id": "malvon-d3d66f",
       "locationSet": {


### PR DESCRIPTION
[Ma'loa](https://maloa.com/) is a Hawaiian poké bowl fast food chain from Germany