### PR TITLE
Remove some brands from UA

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -3374,7 +3374,7 @@
     {
       "displayName": "Кофе Хауз",
       "id": "14d894-e2c355",
-      "locationSet": {"include": ["ru", "ua"]},
+      "locationSet": {"include": ["ru"]},
       "tags": {
         "amenity": "cafe",
         "brand": "Кофе Хауз",
@@ -3613,7 +3613,7 @@
       "displayName": "Штолле",
       "id": "stolle-80fe8b",
       "locationSet": {
-        "include": ["by", "ru", "ua"]
+        "include": ["by", "ru"]
       },
       "tags": {
         "amenity": "cafe",

--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -2830,7 +2830,7 @@
     {
       "displayName": "Апрель",
       "id": "d13b83-571ebe",
-      "locationSet": {"include": ["ru", "ua"]},
+      "locationSet": {"include": ["ru"]},
       "tags": {
         "amenity": "pharmacy",
         "brand": "Апрель",

--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -3460,7 +3460,7 @@
     {
       "displayName": "Gloria Jeans",
       "id": "gloriajeans-7876f3",
-      "locationSet": {"include": ["ru", "ua"]},
+      "locationSet": {"include": ["ru"]},
       "tags": {
         "brand": "Gloria Jeans",
         "brand:wikidata": "Q4139985",

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -4592,7 +4592,7 @@
     {
       "displayName": "Ермолино",
       "id": "yermolino-c491ec",
-      "locationSet": {"include": ["ru", "ua"]},
+      "locationSet": {"include": ["ru"]},
       "matchNames": ["продукты ермолино"],
       "tags": {
         "brand": "Ермолино",

--- a/data/brands/shop/cosmetics.json
+++ b/data/brands/shop/cosmetics.json
@@ -707,7 +707,7 @@
     {
       "displayName": "Подружка",
       "id": "95c47a-b8d09c",
-      "locationSet": {"include": ["ru", "ua"]},
+      "locationSet": {"include": ["ru"]},
       "tags": {
         "brand": "Подружка",
         "brand:wikidata": "Q101646588",

--- a/data/brands/shop/hardware.json
+++ b/data/brands/shop/hardware.json
@@ -19,7 +19,7 @@
       "displayName": "220 вольт",
       "id": "220volt-41db75",
       "locationSet": {
-        "include": ["by", "ru", "ua"]
+        "include": ["by", "ru"]
       },
       "tags": {
         "brand": "220 вольт",

--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -1310,7 +1310,7 @@
       "displayName": "Евросеть",
       "id": "euroset-4d9972",
       "locationSet": {
-        "include": ["by", "kz", "ru", "ua"]
+        "include": ["by", "kz", "ru"]
       },
       "tags": {
         "brand": "Евросеть",

--- a/data/brands/shop/shoes.json
+++ b/data/brands/shop/shoes.json
@@ -2135,7 +2135,7 @@
       "displayName": "ЦентрОбувь",
       "id": "6c57c6-ea44e5",
       "locationSet": {
-        "include": ["by", "ru", "ua"]
+        "include": ["by", "ru"]
       },
       "tags": {
         "brand": "ЦентрОбувь",

--- a/data/brands/shop/tyres.json
+++ b/data/brands/shop/tyres.json
@@ -396,7 +396,7 @@
       "displayName": "Колесо",
       "id": "koleso-0a95f9",
       "locationSet": {
-        "include": ["by", "ru", "ua"]
+        "include": ["by", "ru"]
       },
       "tags": {
         "brand": "Колесо",


### PR DESCRIPTION
All removed entries have no more than 9 POIs in DB

"220 вольт" & "Колесо" are general terms, In Ukraine aren't related to any chains

About all this chains there are mentions that they left Ukraine or there are no mentions on the websites that they operates in Ukraine