### PR TITLE
Mark Auntie Anne's brand as worldwide

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -307,7 +307,7 @@
     {
       "displayName": "Auntie Anne's",
       "id": "auntieannes-e5e868",
-      "locationSet": {"include": ["th", "us"]},
+      "locationSet": {"include": ["001"]},
       "matchNames": ["auntie annes pretzels"],
       "tags": {
         "amenity": "fast_food",


### PR DESCRIPTION
Per [Wikipedia](https://en.wikipedia.org/wiki/Auntie_Anne%27s#International_locations),  

> Auntie Anne's now has over 600 international locations, including many across Europe, namely the United Kingdom.[10] Locations in Asia include Brunei, Cambodia, India, Indonesia, Malaysia,[11] Philippines, Saudi Arabia,[12] South Korea, Singapore, Taiwan, Thailand and Vietnam, while in the Americas there are sites in Costa Rica and Trinidad and Tobago.