### PR TITLE
Expand BreadTalk brand listing to Asia and Europe

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -417,7 +417,7 @@
     {
       "displayName": "BreadTalk",
       "id": "breadtalk-96a6b3",
-      "locationSet": {"include": ["sg"]},
+      "locationSet": {"include": ["142", "150"]},
       "tags": {
         "brand": "BreadTalk",
         "brand:wikidata": "Q1106640",


### PR DESCRIPTION
The Singaporean brand operates in certain other Southeast Asian countries (Malaysia and Thailand), and then has franchises "all over Asia and Europe" as per [WP](https://en.wikipedia.org/wiki/BreadTalk#History).

> The Group has a network of owned bakery outlets in Singapore, PRC, Malaysia, Hong Kong and Thailand as well as franchised bakery outlets across Asia, Europe and the Middle East. 