### PR TITLE
Add America Today as new clothing chain

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -366,6 +366,16 @@
       }
     },
     {
+      "displayName": "America Today",
+      "locationSet": {"include": ["nl","be","de"]},
+      "tags": {
+        "brand": "America Today",
+        "brand:wikidata": "Q97011125",
+        "name": "America Today",
+        "shop": "clothes"
+      }
+    },
+    {
       "displayName": "American Eagle Outfitters",
       "id": "americaneagleoutfitters-0615dc",
       "locationSet": {"include": ["ca", "us"]},


### PR DESCRIPTION
Please add the Dutch clothing chain America Today (it had already a Wikidata item, but was not very complete. So I added more information used in NSI).