### PR TITLE
Soul Pattinson Chemist

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -2462,6 +2462,17 @@
       }
     },
     {
+      "displayName": "Soul Pattinson Chemist",
+      "locationSet": {"include": ["au"]},
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "Soul Pattinson Chemist",
+        "brand:wikidata": "Q117225301",
+        "healthcare": "pharmacy",
+        "name": "Soul Pattinson Chemist"
+      }
+    },
+    {
       "displayName": "South Star Drug",
       "id": "southstardrug-2ddb76",
       "locationSet": {"include": ["ph"]},


### PR DESCRIPTION
Despite the name, these stores are pharmacies not chemists https://soulpattinson.com.au/health-services/