### PR TITLE
Soul Origin is fast food

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -2627,19 +2627,6 @@
       }
     },
     {
-      "displayName": "Soul Origin",
-      "id": "soulorigin-70e4e4",
-      "locationSet": {"include": ["au"]},
-      "tags": {
-        "amenity": "cafe",
-        "brand": "Soul Origin",
-        "brand:wikidata": "Q110473093",
-        "cuisine": "coffee_shop",
-        "name": "Soul Origin",
-        "takeaway": "yes"
-      }
-    },
-    {
       "displayName": "Starbucks",
       "id": "starbucks-e1ef51",
       "locationSet": {"include": ["001"]},

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -6714,6 +6714,19 @@
       }
     },
     {
+      "displayName": "Soul Origin",
+      "id": "soulorigin-70e4e4",
+      "locationSet": {"include": ["au"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Soul Origin",
+        "brand:wikidata": "Q110473093",
+        "cuisine": "coffee_shop;salad;sandwich",
+        "name": "Soul Origin",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Southern Fried Chicken",
       "id": "southernfriedchicken-a6761c",
       "locationSet": {"include": ["in", "uk"]},


### PR DESCRIPTION
It is more appropriate to tag Soul Origin as fast food serving salad, sandwiches and coffee, as they market themselves as "healthy fast food"