### PR TITLE
Update Matsuya(松屋)

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -10378,14 +10378,14 @@
         "brand:ja": "松屋",
         "brand:wikidata": "Q848773",
         "brand:zh": "松屋",
-        "cuisine": "japanese",
+        "cuisine": "beef_bowl",
         "name": "松屋",
         "name:en": "Matsuya",
         "name:ja": "松屋",
         "name:zh": "松屋",
-        "official_name": "松屋フーズ",
-        "official_name:en": "Matsuya Foods",
-        "official_name:ja": "松屋フーズ",
+        "operator": "松屋フーズ",
+        "operator:en": "Matsuya Foods",
+        "operator:ja": "松屋フーズ",
         "takeaway": "yes"
       }
     },


### PR DESCRIPTION
Regarding `cuisine`, at least in Japan, it is known as a beef bowl shop, similar to [Yoshinoya(吉野家)](https://nsi.guide/index.html?t=brands&k=amenity&v=fast_food&tt=yoshinoya) and [Sukiya(すき家)](https://nsi.guide/index.html?t=brands&k=amenity&v=fast_food&tt=sukiya), and sells mainly beef bowls.

Matsuya Foods is the name of the operating company rather than the official name, so I changed the name from `official_name` to `operator`.