### PR TITLE
Change operator key to network for OSP in Poland

### DIFF
--- a/data/operators/amenity/fire_station.json
+++ b/data/operators/amenity/fire_station.json
@@ -1315,8 +1315,8 @@
       "matchNames": ["osp"],
       "tags": {
         "amenity": "fire_station",
-        "operator": "Ochotnicza Straż Pożarna",
-        "operator:wikidata": "Q55289175"
+        "network": "Ochotnicza Straż Pożarna",
+        "network:wikidata": "Q55289175"
       }
     },
     {

--- a/data/operators/amenity/fire_station.json
+++ b/data/operators/amenity/fire_station.json
@@ -1309,17 +1309,6 @@
       }
     },
     {
-      "displayName": "Ochotnicza Straż Pożarna",
-      "id": "ochotniczastrazpozarna-a9e71c",
-      "locationSet": {"include": ["pl"]},
-      "matchNames": ["osp"],
-      "tags": {
-        "amenity": "fire_station",
-        "network": "Ochotnicza Straż Pożarna",
-        "network:wikidata": "Q55289175"
-      }
-    },
-    {
       "displayName": "Orange County Fire Authority",
       "id": "orangecountyfireauthority-8a59ad",
       "locationSet": {


### PR DESCRIPTION
After arrangements with the Polish OSM community, OSP is a generally accepted collective name for independent organizations with the same task. This is not an organization that has central management and therefore instead of the key 'operator' a more appropriate key is 'network'