### PR TITLE
Use Cyrillic alfabet for Serbian Starbucks

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -3502,7 +3502,7 @@
     {
       "displayName": "Старбакс",
       "id": "starbucks-1c12ef",
-      "locationSet": {"include": ["ru"]},
+      "locationSet": {"include": ["ru", "rs"]},
       "tags": {
         "amenity": "cafe",
         "brand": "Старбакс",


### PR DESCRIPTION
Starbucks has its logo in Cyrillic in Serbia it also has one on English but Cyrillic script is the "main" one.
![6a9ktriab3i71](https://user-images.githubusercontent.com/54671367/229517134-6473a790-552c-4415-b182-20b08530daf7.jpg)