### PR TITLE
Remove operator:short

### DIFF
--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -3213,11 +3213,12 @@
       "displayName": "JR東日本",
       "id": "eastjapanrailwaycompany-e95322",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["JR東日本"],
+      "matchNames": ["東日本旅客鉄道株式会社"],
       "tags": {
-        "operator": "東日本旅客鉄道株式会社",
+        "operator": "東日本旅客鉄道",
         "operator:en": "East Japan Railway Company",
-        "operator:ja": "東日本旅客鉄道株式会社",
+        "operator:ja": "東日本旅客鉄道",
+        "operator:short": "JR東日本",
         "operator:wikidata": "Q499071",
         "power": "line"
       }
@@ -3226,11 +3227,12 @@
       "displayName": "JR東海",
       "id": "centraljapanrailwaycompany-e95322",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["JR東海"],
+      "matchNames": ["東海旅客鉄道株式会社"],
       "tags": {
-        "operator": "東海旅客鉄道株式会社",
+        "operator": "東海旅客鉄道",
         "operator:en": "Central Japan Railway Company",
-        "operator:ja": "東海旅客鉄道株式会社",
+        "operator:ja": "東海旅客鉄道",
+        "operator:short": "JR東海",
         "operator:wikidata": "Q513679",
         "power": "line"
       }
@@ -6733,9 +6735,37 @@
       }
     },
     {
+      "displayName": "中国電力ネットワーク",
+      "id": "chugokuelectricpowertransmissionanddistributioncompany-e95322",
+      "locationSet": {"include": ["jp"]},
+      "matchNames": ["中国電力", "中国電力株式会社"],
+      "note": "This 中国 don't means China",
+      "tags": {
+        "operator": "中国電力ネットワーク",
+        "operator:en": "Chugoku Electric Power Transmission & Distribution Company",
+        "operator:ja": "中国電力ネットワーク",
+        "operator:wikidata": "Q65093799",
+        "power": "line"
+      }
+    },
+    {
+      "displayName": "中部電力パワーグリッド",
+      "id": "chubuelectricpowergridcompany-e95322",
+      "locationSet": {"include": ["jp"]},
+      "matchNames": ["中部電力", "中部電力株式会社"],
+      "tags": {
+        "operator": "中部電力パワーグリッド",
+        "operator:en": "Chubu Electric Power Grid Company",
+        "operator:ja": "中部電力パワーグリッド",
+        "operator:wikidata": "Q66119034",
+        "power": "line"
+      }
+    },
+    {
       "displayName": "九州電力送配電",
       "id": "kyushuelectricpowertransmissionanddistributioncompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["九州電力", "九州電力株式会社"],
       "tags": {
         "operator": "九州電力送配電",
         "operator:en": "Kyushu Electric Power Transmission and Distribution Company",
@@ -6745,41 +6775,42 @@
       }
     },
     {
-      "displayName": "北海道電力",
-      "id": "hokkaidoelectricpowercompany-e95322",
+      "displayName": "北海道電力ネットワーク",
+      "id": "hokkaidoelectricpowernetwork-e95322",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["北海道電力"],
+      "matchNames": ["北海道電力", "北海道電力株式会社"],
       "tags": {
-        "operator": "北海道電力株式会社",
-        "operator:en": "Hokkaido Electric Power Company",
-        "operator:ja": "北海道電力株式会社",
-        "operator:wikidata": "Q742449",
+        "operator": "北海道電力ネットワーク",
+        "operator:en": "Hokkaido Electric Power Network",
+        "operator:ja": "北海道電力ネットワーク",
+        "operator:short": "ほくでんネットワーク",
+        "operator:wikidata": "Q64504223",
         "power": "line"
       }
     },
     {
-      "displayName": "北陸電力",
-      "id": "hokurikuelectricpowercompany-e95322",
+      "displayName": "北陸電力送配電",
+      "id": "hokurikuelectricpowertransmissionanddistributioncompany-e95322",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["北陸電力"],
+      "matchNames": ["北陸電力", "北陸電力株式会社"],
       "tags": {
-        "operator": "北陸電力株式会社",
-        "operator:en": "Hokuriku Electric Power Company",
-        "operator:ja": "北陸電力株式会社",
-        "operator:wikidata": "Q742461",
+        "operator": "北陸電力送配電",
+        "operator:en": "Hokuriku Electric Power Transmission & Distribution Company",
+        "operator:ja": "北陸電力送配電",
+        "operator:wikidata": "Q65142438",
         "power": "line"
       }
     },
     {
-      "displayName": "四国電力",
-      "id": "shikokuelectricpowercompany-e95322",
+      "displayName": "四国電力送配電",
+      "id": "shikokuelectricpowertransmissionanddistributioncompany-e95322",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["四国電力"],
+      "matchNames": ["四国電力", "四国電力株式会社"],
       "tags": {
-        "operator": "四国電力株式会社",
-        "operator:en": "Shikoku Electric Power Company",
-        "operator:ja": "四国電力株式会社",
-        "operator:wikidata": "Q388455",
+        "operator": "四国電力送配電",
+        "operator:en": "Shikoku Electric Power Transmission & Distribution Company",
+        "operator:ja": "四国電力送配電",
+        "operator:wikidata": "Q65096000",
         "power": "line"
       }
     },
@@ -6796,22 +6827,10 @@
       }
     },
     {
-      "displayName": "東京電力",
-      "id": "tokyoelectricpowercompany-e95322",
-      "locationSet": {"include": ["jp"]},
-      "matchNames": ["東京電力"],
-      "tags": {
-        "operator": "東京電力株式会社",
-        "operator:en": "Tokyo Electric Power Company",
-        "operator:ja": "東京電力株式会社",
-        "operator:wikidata": "Q333894",
-        "power": "line"
-      }
-    },
-    {
       "displayName": "東京電力パワーグリッド",
       "id": "tepcopowergrid-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["tepco", "東京電力", "東京電力株式会社"],
       "tags": {
         "operator": "東京電力パワーグリッド",
         "operator:en": "TEPCO Power Grid",
@@ -6821,15 +6840,15 @@
       }
     },
     {
-      "displayName": "東北電力",
-      "id": "tohokuelectricpowercompany-e95322",
+      "displayName": "東北電力ネットワーク",
+      "id": "tohokuelectricpowernetworkcompany-e95322",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["tepco","東北電力"],
+      "matchNames": ["東北電力", "東北電力株式会社"],
       "tags": {
-        "operator": "東北電力株式会社",
-        "operator:en": "Tohoku Electric Power Company",
-        "operator:ja": "東北電力株式会社",
-        "operator:wikidata": "Q592765",
+        "operator": "東北電力ネットワーク",
+        "operator:en": "Tohoku Electric Power Network Company",
+        "operator:ja": "東北電力ネットワーク",
+        "operator:wikidata": "Q65040183",
         "power": "line"
       }
     },
@@ -6837,38 +6856,39 @@
       "displayName": "沖縄電力",
       "id": "okinawaelectricpowercompany-e95322",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["沖縄電力"],
+      "matchNames": ["沖縄電力株式会社"],
       "tags": {
-        "operator": "沖縄電力株式会社",
+        "operator": "沖縄電力",
         "operator:en": "Okinawa Electric Power Company",
-        "operator:ja": "沖縄電力株式会社",
+        "operator:ja": "沖縄電力",
+        "operator:short": "おきでん",
         "operator:wikidata": "Q2017226",
         "power": "line"
       }
     },
     {
-      "displayName": "関西電力",
-      "id": "kansaielectricpowercompany-e95322",
+      "displayName": "関西電力送配電",
+      "id": "kansaitransmissionanddistribution-e95322",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["関西電力"],
+      "matchNames": ["関西電力", "関西電力株式会社"],
       "tags": {
-        "operator": "関西電力株式会社",
-        "operator:en": "Kansai Electric Power Company",
-        "operator:ja": "関西電力株式会社",
-        "operator:wikidata": "Q1365015",
+        "operator": "関西電力送配電",
+        "operator:en": "Kansai Transmission and Distribution",
+        "operator:ja": "関西電力送配電",
+        "operator:wikidata": "Q65556946",
         "power": "line"
       }
     },
     {
-      "displayName": "電源開発",
-      "id": "electricpowerdevelopmentcompany-e95322",
+      "displayName": "電源開発送変電ネットワーク",
+      "id": "jpowertransmissionnetwork-e95322",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["電源開発"],
+      "matchNames": ["電源開発", "電源開発株式会社"],
       "tags": {
-        "operator": "電源開発株式会社",
-        "operator:en": "Electric Power Development Company",
-        "operator:ja": "電源開発株式会社",
-        "operator:wikidata": "Q3805077",
+        "operator": "電源開発送変電ネットワーク",
+        "operator:en": "J-Power Transmission Network",
+        "operator:ja": "電源開発送変電ネットワーク",
+        "operator:wikidata": "Q71543179",
         "power": "line"
       }
     }

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -39,9 +39,10 @@
       }
     },
     {
-      "displayName": "AEP",
+      "displayName": "American Electric Power",
       "id": "americanelectricpower-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["AEP"],
       "tags": {
         "operator": "American Electric Power",
         "operator:wikidata": "Q464092",
@@ -126,6 +127,7 @@
     {
       "displayName": "Aktiengesellschaft für Versorgungsunternehmen",
       "id": "aktiengesellschaftfurversorgungsunternehmen-fe2846",
+      "matchNames": ["AVU"],
       "locationSet": {
         "include": ["de-nw.geojson"]
       },
@@ -264,6 +266,7 @@
     {
       "displayName": "APCO",
       "id": "appalachianpower-33137a",
+      "matchNames": ["APCO"],
       "locationSet": {
         "include": [
           "us-tn.geojson",
@@ -536,6 +539,7 @@
     {
       "displayName": "Bonneville Power Administration",
       "id": "bonnevillepoweradministration-b654b4",
+      "matchNames": ["BPA"],
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Bonneville Power Administration",
@@ -546,6 +550,7 @@
     {
       "displayName": "Botswana Power Corporation",
       "id": "botswanapower-fb59b6",
+      "matchNames": ["BPC"],
       "locationSet": {"include": ["bw"]},
       "tags": {
         "operator": "Botswana Power",
@@ -556,6 +561,7 @@
     {
       "displayName": "BPU",
       "id": "kansascityboardofpublicutilities-beff6d",
+      "matchNames": ["BPU"],
       "locationSet": {
         "include": ["us-ks.geojson"]
       },
@@ -818,6 +824,7 @@
     {
       "displayName": "Ceylon Electricity Board",
       "id": "ceylonelectricityboard-5c8a2f",
+      "matchNames": ["CEB"],
       "locationSet": {"include": ["lk"]},
       "tags": {
         "operator": "Ceylon Electricity Board",
@@ -1126,6 +1133,7 @@
       "locationSet": {"include": ["br"]},
       "matchNames": [
         "chesf - companhia hidro elétrica do são francisco"
+        "CHESF"
       ],
       "tags": {
         "operator": "Companhia Hidro Elétrica do São Francisco",
@@ -1644,6 +1652,7 @@
       "displayName": "Electricidade de Moçambique",
       "id": "electricidadedemocambique-8757c0",
       "locationSet": {"include": ["mz"]},
+      "matchNames": ["EDM"],
       "tags": {
         "operator": "Electricidade de Moçambique",
         "operator:wikidata": "Q5357771",
@@ -1654,6 +1663,7 @@
       "displayName": "Électricité de Mayotte",
       "id": "electricitedemayotte-6390c7",
       "locationSet": {"include": ["yt"]},
+      "matchNames": ["EDM"],
       "tags": {
         "operator": "Électricité de Mayotte",
         "operator:wikidata": "Q60849817",
@@ -2099,7 +2109,7 @@
       "locationSet": {
         "include": ["de-rp.geojson"]
       },
-      "matchNames": ["kevag"],
+      "matchNames": ["kevag","evm"],
       "tags": {
         "operator": "Energieversorgung Mittelrhein",
         "operator:wikidata": "Q1341466",
@@ -2410,6 +2420,7 @@
       "id": "eswatinielectricitycompany-60a7a1",
       "locationSet": {"include": ["sz"]},
       "matchNames": [
+        "EEC",
         "sec",
         "swaziland electricity board",
         "swaziland electricity company"
@@ -2433,6 +2444,7 @@
       "displayName": "Eugene Water & Electric Board",
       "id": "eugenewaterandelectricboard-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["EWEB"],
       "tags": {
         "operator": "Eugene Water & Electric Board",
         "operator:wikidata": "Q5407841",
@@ -2608,6 +2620,7 @@
       "displayName": "Florida Keys Electric Coorerative",
       "id": "floridakeyselectriccoorerative-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["FCEK"],
       "tags": {
         "operator": "Florida Keys Electric Coorerative",
         "power": "line"
@@ -2712,6 +2725,7 @@
       "displayName": "Gainesville Regional Utilities",
       "id": "gainesvilleregionalutilities-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["GRU"],
       "tags": {
         "operator": "Gainesville Regional Utilities",
         "operator:wikidata": "Q115691445",
@@ -2722,6 +2736,7 @@
       "displayName": "Garland Power & Light",
       "id": "garlandpowerandlight-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["GP&L"],
       "tags": {
         "operator": "Garland Power & Light",
         "operator:wikidata": "Q115691475",
@@ -2801,6 +2816,7 @@
       "displayName": "Grand River Dam Authority",
       "id": "grandriverdamauthority-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["GRDA"],
       "tags": {
         "operator": "Grand River Dam Authority",
         "operator:wikidata": "Q5595045",
@@ -3043,6 +3059,7 @@
     {
       "displayName": "Imperial Irrigation District",
       "id": "imperialirrigationdistrict-eefbc4",
+      "matchNames": ["IID"],
       "locationSet": {
         "include": ["us-ca.geojson"]
       },
@@ -3072,7 +3089,8 @@
         ]
       },
       "matchNames": [
-        "indiana michigan power company"
+        "indiana michigan power company",
+        "I&M"
       ],
       "tags": {
         "operator": "Indiana Michigan Power",
@@ -3084,6 +3102,7 @@
       "displayName": "Indianapolis Power & Light",
       "id": "indianapolispowerandlight-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["IPL"],
       "tags": {
         "operator": "Indianapolis Power & Light",
         "operator:wikidata": "Q6023919",
@@ -3114,7 +3133,8 @@
       "id": "interligacaoeletricadomadeirasa-ddc6a3",
       "locationSet": {"include": ["br"]},
       "matchNames": [
-        "iem - interligação elétrica do madeira s.a"
+        "iem - interligação elétrica do madeira s.a",
+        "IEM"
       ],
       "tags": {
         "operator": "Interligação Elétrica do Madeira S.A",
@@ -3173,6 +3193,7 @@
       "locationSet": {
         "include": [[-81.66, 30.34, 40]]
       },
+      "matchNames": ["JEA"],
       "tags": {
         "operator": "Jacksonville Electric Authority",
         "operator:wikidata": "Q17068270",
@@ -3192,6 +3213,7 @@
       "displayName": "JR東日本",
       "id": "eastjapanrailwaycompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["JR東日本"],
       "tags": {
         "operator": "東日本旅客鉄道株式会社",
         "operator:en": "East Japan Railway Company",
@@ -3204,6 +3226,7 @@
       "displayName": "JR東海",
       "id": "centraljapanrailwaycompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["JR東海"],
       "tags": {
         "operator": "東海旅客鉄道株式会社",
         "operator:en": "Central Japan Railway Company",
@@ -3325,6 +3348,7 @@
       "displayName": "KUB",
       "id": "knoxvilleutilitiesboard-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["KUB"],
       "tags": {
         "operator": "Knoxville Utilities Board",
         "operator:wikidata": "Q109923505",
@@ -3346,6 +3370,7 @@
       "locationSet": {
         "include": ["us-ca.geojson"]
       },
+      "matchNames": ["LADWP"],
       "tags": {
         "operator": "Los Angeles Department of Water and Power",
         "operator:wikidata": "Q3259704",
@@ -3366,6 +3391,7 @@
       "displayName": "LCEC",
       "id": "leecountyelectriccooperative-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["LCEC"],
       "tags": {
         "operator": "Lee County Electric Cooperative",
         "operator:wikidata": "Q115691632",
@@ -3392,7 +3418,8 @@
         "lech elektrizitätswerke augsburg",
         "lechwerke ag",
         "lechwerke ag augsburg",
-        "lechwerke augsburg"
+        "lechwerke augsburg",
+        "LEW"
       ],
       "tags": {
         "operator": "Lechwerke",
@@ -3525,6 +3552,7 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
+      "matchNames": ["LCRA"],
       "tags": {
         "operator": "Lower Colorado River Authority",
         "operator:wikidata": "Q16155608",
@@ -3551,6 +3579,7 @@
       "displayName": "Lubbock Power & Light",
       "id": "lubbockpowerandlight-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["LP&L"],
       "tags": {
         "operator": "Lubbock Power & Light",
         "operator:wikidata": "Q21188399",
@@ -3852,6 +3881,7 @@
       "displayName": "Nashville Electric Service",
       "id": "nashvilleelectricservice-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["NES"],
       "tags": {
         "operator": "Nashville Electric Service",
         "operator:wikidata": "Q6966967",
@@ -3876,6 +3906,7 @@
       "displayName": "National Grid Corporation of the Philippines",
       "id": "nationalgridcorporationofthephilippines-53cceb",
       "locationSet": {"include": ["ph"]},
+      "matchNames": ["NGCP"],
       "tags": {
         "operator": "National Grid Corporation of the Philippines",
         "operator:wikidata": "Q28197109",
@@ -4160,6 +4191,7 @@
       "displayName": "ÖBB-Infrastruktur AG",
       "id": "obbinfrastrukturag-7a29cb",
       "locationSet": {"include": ["at"]},
+      "matchNames": ["ÖBB Infra"],
       "tags": {
         "operator": "ÖBB-Infrastruktur AG",
         "operator:wikidata": "Q56425426",
@@ -4178,6 +4210,7 @@
     {
       "displayName": "Oklahoma Gas & Electric",
       "id": "oklahomagasandelectric-67f39c",
+      "matchNames": ["OG+E"],
       "locationSet": {
         "include": [
           "us-ar.geojson",
@@ -4232,6 +4265,7 @@
       "displayName": "Orlando Utilities Commission",
       "id": "orlandoutilitiescommission-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["OUC"],
       "tags": {
         "operator": "Orlando Utilities Commission",
         "operator:wikidata": "Q7103200",
@@ -4330,7 +4364,8 @@
       "locationSet": {"include": ["id"]},
       "matchNames": [
         "pt perusahaan listrik negara",
-        "pt pln (persero)"
+        "pt pln (persero)",
+        "PLN"
       ],
       "tags": {
         "operator": "Perusahaan Listrik Negara",
@@ -4415,6 +4450,7 @@
           "us-nm.geojson"
         ]
       },
+      "matchNames": ["PNM"],
       "tags": {
         "operator": "Public Service Company of New Mexico",
         "operator:wikidata": "Q112271592",
@@ -4435,6 +4471,7 @@
       "displayName": "Portland General Electric",
       "id": "portlandgeneralelectric-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["PGE"],
       "tags": {
         "operator": "Portland General Electric",
         "operator:wikidata": "Q7231939",
@@ -4456,6 +4493,7 @@
       "locationSet": {
         "include": ["baltimore_and_dc.geojson"]
       },
+      "matchNames": ["PEPCO"],
       "tags": {
         "operator": "Potomac Electric Power Company",
         "operator:wikidata": "Q7166207",
@@ -4601,6 +4639,7 @@
       "locationSet": {
         "include": ["us-ok.geojson"]
       },
+      "matchNames": ["PSO"],
       "tags": {
         "operator": "Public Service Company of Oklahoma",
         "operator:wikidata": "Q109016015",
@@ -4630,7 +4669,7 @@
       "displayName": "Red Eléctrica de España",
       "id": "redelectricadeespana-769454",
       "locationSet": {"include": ["es"]},
-      "matchNames": ["red electrica española"],
+      "matchNames": ["red electrica española","REE"],
       "tags": {
         "operator": "Red Eléctrica de España",
         "operator:wikidata": "Q1551220",
@@ -4857,6 +4896,7 @@
       "displayName": "San Diego Gas & Electric",
       "id": "sandiegogasandelectric-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["SDGE"],
       "tags": {
         "operator": "San Diego Gas & Electric",
         "operator:wikidata": "Q7413674",
@@ -5104,7 +5144,8 @@
         "include": ["us-ca.geojson"]
       },
       "matchNames": [
-        "southern california edison company"
+        "southern california edison company",
+        "SCE"
       ],
       "tags": {
         "operator": "Southern California Edison",
@@ -5160,6 +5201,7 @@
       "locationSet": {
         "include": ["us-or.geojson"]
       },
+      "matchNames": ["SUB"],
       "tags": {
         "operator": "Springfield Utility Board",
         "operator:wikidata": "Q114835124",
@@ -5435,6 +5477,7 @@
           "us-tx.geojson"
         ]
       },
+      "matchNames": ["SWEPCO"],
       "tags": {
         "operator": "Southwestern Electric Power Company",
         "operator:wikidata": "Q109016018",
@@ -5526,6 +5569,7 @@
       "displayName": "Tennessee Valley Authority",
       "id": "tennesseevalleyauthority-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["TVA"],
       "tags": {
         "operator": "Tennessee Valley Authority",
         "operator:wikidata": "Q1367577",
@@ -5632,6 +5676,7 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
+      "matchNames": ["TNMP"],
       "tags": {
         "operator": "Texas-New Mexico Power",
         "operator:wikidata": "Q112271571",
@@ -5917,6 +5962,7 @@
       "displayName": "UPCL",
       "id": "uttarakhandpowercorporationlimited-5c9c82",
       "locationSet": {"include": ["in"]},
+      "matchNames": ["UPCL"],
       "tags": {
         "operator": "Uttarakhand Power Corporation Limited",
         "operator:wikidata": "Q112623951",
@@ -6173,6 +6219,7 @@
       "displayName": "Western Area Power Administration",
       "id": "westernareapoweradministration-b654b4",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["WAPA"],
       "tags": {
         "operator": "Western Area Power Administration",
         "operator:wikidata": "Q7987459",
@@ -6650,6 +6697,7 @@
       "id": "chugokuelectricpowercompany-e95322",
       "locationSet": {"include": ["jp"]},
       "note": "This 中国 don't means China",
+      "matchNames": ["中国電力"],
       "tags": {
         "operator": "中国電力株式会社",
         "operator:en": "Chugoku Electric Power Company",
@@ -6662,6 +6710,7 @@
       "displayName": "中部電力",
       "id": "chubuelectricpowercompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["中部電力"],
       "tags": {
         "operator": "中部電力株式会社",
         "operator:en": "Chubu Electric Power Company",
@@ -6674,6 +6723,7 @@
       "displayName": "九州電力",
       "id": "kyushuelectricpowercompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["九州電力"],
       "tags": {
         "operator": "九州電力株式会社",
         "operator:en": "Kyushu Electric Power Company",
@@ -6698,6 +6748,7 @@
       "displayName": "北海道電力",
       "id": "hokkaidoelectricpowercompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["北海道電力"],
       "tags": {
         "operator": "北海道電力株式会社",
         "operator:en": "Hokkaido Electric Power Company",
@@ -6710,6 +6761,7 @@
       "displayName": "北陸電力",
       "id": "hokurikuelectricpowercompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["北陸電力"],
       "tags": {
         "operator": "北陸電力株式会社",
         "operator:en": "Hokuriku Electric Power Company",
@@ -6722,6 +6774,7 @@
       "displayName": "四国電力",
       "id": "shikokuelectricpowercompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["四国電力"],
       "tags": {
         "operator": "四国電力株式会社",
         "operator:en": "Shikoku Electric Power Company",
@@ -6746,6 +6799,7 @@
       "displayName": "東京電力",
       "id": "tokyoelectricpowercompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["東京電力"],
       "tags": {
         "operator": "東京電力株式会社",
         "operator:en": "Tokyo Electric Power Company",
@@ -6770,7 +6824,7 @@
       "displayName": "東北電力",
       "id": "tohokuelectricpowercompany-e95322",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["tepco"],
+      "matchNames": ["tepco","東北電力"],
       "tags": {
         "operator": "東北電力株式会社",
         "operator:en": "Tohoku Electric Power Company",
@@ -6783,6 +6837,7 @@
       "displayName": "沖縄電力",
       "id": "okinawaelectricpowercompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["沖縄電力"],
       "tags": {
         "operator": "沖縄電力株式会社",
         "operator:en": "Okinawa Electric Power Company",
@@ -6795,6 +6850,7 @@
       "displayName": "関西電力",
       "id": "kansaielectricpowercompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["関西電力"],
       "tags": {
         "operator": "関西電力株式会社",
         "operator:en": "Kansai Electric Power Company",
@@ -6807,6 +6863,7 @@
       "displayName": "電源開発",
       "id": "electricpowerdevelopmentcompany-e95322",
       "locationSet": {"include": ["jp"]},
+      "matchNames": ["電源開発"],
       "tags": {
         "operator": "電源開発株式会社",
         "operator:en": "Electric Power Development Company",

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -44,7 +44,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "American Electric Power",
-        "operator:short": "AEP",
         "operator:wikidata": "Q464092",
         "power": "line"
       }
@@ -132,7 +131,6 @@
       },
       "tags": {
         "operator": "Aktiengesellschaft für Versorgungsunternehmen",
-        "operator:short": "AVU",
         "operator:wikidata": "Q422118",
         "power": "line"
       }
@@ -276,7 +274,6 @@
       "matchNames": ["appalachian power company"],
       "tags": {
         "operator": "Appalachian Power",
-        "operator:short": "APCO",
         "operator:wikidata": "Q109013941",
         "power": "line"
       }
@@ -542,7 +539,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Bonneville Power Administration",
-        "operator:short": "BPA",
         "operator:wikidata": "Q2910288",
         "power": "line"
       }
@@ -553,7 +549,6 @@
       "locationSet": {"include": ["bw"]},
       "tags": {
         "operator": "Botswana Power",
-        "operator:short": "BPC",
         "operator:wikidata": "Q4948910",
         "power": "line"
       }
@@ -566,7 +561,6 @@
       },
       "tags": {
         "operator": "Kansas City Board of Public Utilities",
-        "operator:short": "BPU",
         "operator:wikidata": "Q29641882",
         "power": "line"
       }
@@ -827,7 +821,6 @@
       "locationSet": {"include": ["lk"]},
       "tags": {
         "operator": "Ceylon Electricity Board",
-        "operator:short": "CEB",
         "operator:wikidata": "Q5065789",
         "power": "line"
       }
@@ -1136,7 +1129,6 @@
       ],
       "tags": {
         "operator": "Companhia Hidro Elétrica do São Francisco",
-        "operator:short": "CHESF",
         "operator:wikidata": "Q5011113",
         "power": "line"
       }
@@ -1654,7 +1646,6 @@
       "locationSet": {"include": ["mz"]},
       "tags": {
         "operator": "Electricidade de Moçambique",
-        "operator:short": "EDM",
         "operator:wikidata": "Q5357771",
         "power": "line"
       }
@@ -1665,7 +1656,6 @@
       "locationSet": {"include": ["yt"]},
       "tags": {
         "operator": "Électricité de Mayotte",
-        "operator:short": "EDM",
         "operator:wikidata": "Q60849817",
         "power": "line"
       }
@@ -2112,7 +2102,6 @@
       "matchNames": ["kevag"],
       "tags": {
         "operator": "Energieversorgung Mittelrhein",
-        "operator:short": "evm",
         "operator:wikidata": "Q1341466",
         "power": "line"
       }
@@ -2427,7 +2416,6 @@
       ],
       "tags": {
         "operator": "Eswatini Electricity Company",
-        "operator:short": "EEC",
         "operator:wikidata": "Q56294552",
         "power": "line"
       }
@@ -2447,7 +2435,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Eugene Water & Electric Board",
-        "operator:short": "EWEB",
         "operator:wikidata": "Q5407841",
         "power": "line"
       }
@@ -2623,7 +2610,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Florida Keys Electric Coorerative",
-        "operator:short": "FKEC",
         "power": "line"
       }
     },
@@ -2728,7 +2714,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Gainesville Regional Utilities",
-        "operator:short": "GRU",
         "operator:wikidata": "Q115691445",
         "power": "line"
       }
@@ -2739,7 +2724,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Garland Power & Light",
-        "operator:short": "GP&L",
         "operator:wikidata": "Q115691475",
         "power": "line"
       }
@@ -2819,7 +2803,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Grand River Dam Authority",
-        "operator:short": "GRDA",
         "operator:wikidata": "Q5595045",
         "power": "line"
       }
@@ -2861,17 +2844,6 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "operator": "Gudbrandsdal Energi",
-        "power": "line"
-      }
-    },
-    {
-      "displayName": "Gulf Power",
-      "id": "gulfpower-b654b4",
-      "locationSet": {"include": ["us"]},
-      "tags": {
-        "operator": "Gulf Power",
-        "operator:short": "GPC",
-        "operator:wikidata": "Q5617509",
         "power": "line"
       }
     },
@@ -3076,7 +3048,6 @@
       },
       "tags": {
         "operator": "Imperial Irrigation District",
-        "operator:short": "IID",
         "operator:wikidata": "Q16985775",
         "power": "line"
       }
@@ -3105,7 +3076,6 @@
       ],
       "tags": {
         "operator": "Indiana Michigan Power",
-        "operator:short": "I&M",
         "operator:wikidata": "Q109016008",
         "power": "line"
       }
@@ -3116,7 +3086,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Indianapolis Power & Light",
-        "operator:short": "IPL",
         "operator:wikidata": "Q6023919",
         "power": "line"
       }
@@ -3149,7 +3118,6 @@
       ],
       "tags": {
         "operator": "Interligação Elétrica do Madeira S.A",
-        "operator:short": "IEM",
         "power": "line"
       }
     },
@@ -3207,7 +3175,6 @@
       },
       "tags": {
         "operator": "Jacksonville Electric Authority",
-        "operator:short": "JEA",
         "operator:wikidata": "Q17068270",
         "power": "line"
       }
@@ -3229,7 +3196,6 @@
         "operator": "東日本旅客鉄道株式会社",
         "operator:en": "East Japan Railway Company",
         "operator:ja": "東日本旅客鉄道株式会社",
-        "operator:short": "JR東日本",
         "operator:wikidata": "Q499071",
         "power": "line"
       }
@@ -3242,7 +3208,6 @@
         "operator": "東海旅客鉄道株式会社",
         "operator:en": "Central Japan Railway Company",
         "operator:ja": "東海旅客鉄道株式会社",
-        "operator:short": "JR東海",
         "operator:wikidata": "Q513679",
         "power": "line"
       }
@@ -3362,7 +3327,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Knoxville Utilities Board",
-        "operator:short": "KUB",
         "operator:wikidata": "Q109923505",
         "power": "line"
       }
@@ -3384,7 +3348,6 @@
       },
       "tags": {
         "operator": "Los Angeles Department of Water and Power",
-        "operator:short": "LADWP",
         "operator:wikidata": "Q3259704",
         "power": "line"
       }
@@ -3405,7 +3368,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Lee County Electric Cooperative",
-        "operator:short": "LCEC",
         "operator:wikidata": "Q115691632",
         "power": "line"
       }
@@ -3434,7 +3396,6 @@
       ],
       "tags": {
         "operator": "Lechwerke",
-        "operator:short": "LEW",
         "operator:wikidata": "Q1811384",
         "power": "line"
       }
@@ -3566,7 +3527,6 @@
       },
       "tags": {
         "operator": "Lower Colorado River Authority",
-        "operator:short": "LCRA",
         "operator:wikidata": "Q16155608",
         "power": "line"
       }
@@ -3593,7 +3553,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Lubbock Power & Light",
-        "operator:short": "LP&L",
         "operator:wikidata": "Q21188399",
         "power": "line"
       }
@@ -3895,7 +3854,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Nashville Electric Service",
-        "operator:short": "NES",
         "operator:wikidata": "Q6966967",
         "power": "line"
       }
@@ -3920,7 +3878,6 @@
       "locationSet": {"include": ["ph"]},
       "tags": {
         "operator": "National Grid Corporation of the Philippines",
-        "operator:short": "NGCP",
         "operator:wikidata": "Q28197109",
         "power": "line"
       }
@@ -4205,7 +4162,6 @@
       "locationSet": {"include": ["at"]},
       "tags": {
         "operator": "ÖBB-Infrastruktur AG",
-        "operator:short": "ÖBB Infra",
         "operator:wikidata": "Q56425426",
         "power": "line"
       }
@@ -4230,7 +4186,6 @@
       },
       "tags": {
         "operator": "Oklahoma Gas & Electric",
-        "operator:short": "OG+E",
         "operator:wikidata": "Q2007484",
         "power": "line"
       }
@@ -4279,7 +4234,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Orlando Utilities Commission",
-        "operator:short": "OUC",
         "operator:wikidata": "Q7103200",
         "power": "line"
       }
@@ -4380,7 +4334,6 @@
       ],
       "tags": {
         "operator": "Perusahaan Listrik Negara",
-        "operator:short": "PLN",
         "operator:wikidata": "Q4201636",
         "power": "line"
       }
@@ -4464,7 +4417,6 @@
       },
       "tags": {
         "operator": "Public Service Company of New Mexico",
-        "operator:short": "PNM",
         "operator:wikidata": "Q112271592",
         "power": "line"
       }
@@ -4485,7 +4437,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Portland General Electric",
-        "operator:short": "PGE",
         "operator:wikidata": "Q7231939",
         "power": "line"
       }
@@ -4507,7 +4458,6 @@
       },
       "tags": {
         "operator": "Potomac Electric Power Company",
-        "operator:short": "PEPCO",
         "operator:wikidata": "Q7166207",
         "power": "line"
       }
@@ -4653,7 +4603,6 @@
       },
       "tags": {
         "operator": "Public Service Company of Oklahoma",
-        "operator:short": "PSO",
         "operator:wikidata": "Q109016015",
         "power": "line"
       }
@@ -4684,7 +4633,6 @@
       "matchNames": ["red electrica española"],
       "tags": {
         "operator": "Red Eléctrica de España",
-        "operator:short": "REE",
         "operator:wikidata": "Q1551220",
         "power": "line"
       }
@@ -4911,7 +4859,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "San Diego Gas & Electric",
-        "operator:short": "SDGE",
         "operator:wikidata": "Q7413674",
         "power": "line"
       }
@@ -5161,7 +5108,6 @@
       ],
       "tags": {
         "operator": "Southern California Edison",
-        "operator:short": "SCE",
         "operator:wikidata": "Q1706317",
         "power": "line"
       }
@@ -5216,7 +5162,6 @@
       },
       "tags": {
         "operator": "Springfield Utility Board",
-        "operator:short": "SUB",
         "operator:wikidata": "Q114835124",
         "power": "line"
       }
@@ -5492,7 +5437,6 @@
       },
       "tags": {
         "operator": "Southwestern Electric Power Company",
-        "operator:short": "SWEPCO",
         "operator:wikidata": "Q109016018",
         "power": "line"
       }
@@ -5584,7 +5528,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Tennessee Valley Authority",
-        "operator:short": "TVA",
         "operator:wikidata": "Q1367577",
         "power": "line"
       }
@@ -5691,7 +5634,6 @@
       },
       "tags": {
         "operator": "Texas-New Mexico Power",
-        "operator:short": "TNMP",
         "operator:wikidata": "Q112271571",
         "power": "line"
       }
@@ -5977,7 +5919,6 @@
       "locationSet": {"include": ["in"]},
       "tags": {
         "operator": "Uttarakhand Power Corporation Limited",
-        "operator:short": "UPCL",
         "operator:wikidata": "Q112623951",
         "power": "line"
       }
@@ -6234,7 +6175,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Western Area Power Administration",
-        "operator:short": "WAPA",
         "operator:wikidata": "Q7987459",
         "power": "line"
       }
@@ -6714,7 +6654,6 @@
         "operator": "中国電力株式会社",
         "operator:en": "Chugoku Electric Power Company",
         "operator:ja": "中国電力株式会社",
-        "operator:short": "中国電力",
         "operator:wikidata": "Q73171",
         "power": "line"
       }
@@ -6727,7 +6666,6 @@
         "operator": "中部電力株式会社",
         "operator:en": "Chubu Electric Power Company",
         "operator:ja": "中部電力株式会社",
-        "operator:short": "中部電力",
         "operator:wikidata": "Q1091203",
         "power": "line"
       }
@@ -6740,7 +6678,6 @@
         "operator": "九州電力株式会社",
         "operator:en": "Kyushu Electric Power Company",
         "operator:ja": "九州電力株式会社",
-        "operator:short": "九州電力",
         "operator:wikidata": "Q694507",
         "power": "line"
       }
@@ -6765,7 +6702,6 @@
         "operator": "北海道電力株式会社",
         "operator:en": "Hokkaido Electric Power Company",
         "operator:ja": "北海道電力株式会社",
-        "operator:short": "北海道電力",
         "operator:wikidata": "Q742449",
         "power": "line"
       }
@@ -6778,7 +6714,6 @@
         "operator": "北陸電力株式会社",
         "operator:en": "Hokuriku Electric Power Company",
         "operator:ja": "北陸電力株式会社",
-        "operator:short": "北陸電力",
         "operator:wikidata": "Q742461",
         "power": "line"
       }
@@ -6791,7 +6726,6 @@
         "operator": "四国電力株式会社",
         "operator:en": "Shikoku Electric Power Company",
         "operator:ja": "四国電力株式会社",
-        "operator:short": "四国電力",
         "operator:wikidata": "Q388455",
         "power": "line"
       }
@@ -6816,7 +6750,6 @@
         "operator": "東京電力株式会社",
         "operator:en": "Tokyo Electric Power Company",
         "operator:ja": "東京電力株式会社",
-        "operator:short": "東京電力",
         "operator:wikidata": "Q333894",
         "power": "line"
       }
@@ -6842,7 +6775,6 @@
         "operator": "東北電力株式会社",
         "operator:en": "Tohoku Electric Power Company",
         "operator:ja": "東北電力株式会社",
-        "operator:short": "東北電力",
         "operator:wikidata": "Q592765",
         "power": "line"
       }
@@ -6855,7 +6787,6 @@
         "operator": "沖縄電力株式会社",
         "operator:en": "Okinawa Electric Power Company",
         "operator:ja": "沖縄電力株式会社",
-        "operator:short": "沖縄電力",
         "operator:wikidata": "Q2017226",
         "power": "line"
       }
@@ -6868,7 +6799,6 @@
         "operator": "関西電力株式会社",
         "operator:en": "Kansai Electric Power Company",
         "operator:ja": "関西電力株式会社",
-        "operator:short": "関西電力",
         "operator:wikidata": "Q1365015",
         "power": "line"
       }
@@ -6881,7 +6811,6 @@
         "operator": "電源開発株式会社",
         "operator:en": "Electric Power Development Company",
         "operator:ja": "電源開発株式会社",
-        "operator:short": "電源開発",
         "operator:wikidata": "Q3805077",
         "power": "line"
       }


### PR DESCRIPTION
operator:short tags should be removed. Such short variants are stored at wikidata, and such broad operator information is exactly why the operator's wikidata item is linked.  Additionally, I removed Gulf Power because they merged; their assets are now operated by Florida Power & Light (someone retagged already every OSM object).

Greetings