### PR TITLE
updating the wikidata for Metro d'Alger

### DIFF
--- a/data/transit/route/subway.json
+++ b/data/transit/route/subway.json
@@ -201,7 +201,7 @@
       "matchNames": ["ratp"],
       "tags": {
         "network": "Métro d'Alger",
-        "network:wikidata": "Q50716",
+        "network:wikidata": "Q728045",
         "operator": "RATP El Djazaïr",
         "route": "subway"
       }


### PR DESCRIPTION
The Wikidata for the Algiers Metro was the code for the Paris Metro. I have added the correct wikidata entry