### PR TITLE
Add Belgian chain of electronics stores Eldi

### DIFF
--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -374,6 +374,16 @@
       }
     },
     {
+      "displayName": "Eldi",
+      "locationSet": {"include": ["be"]},
+      "tags": {
+        "brand": "Eldi",
+        "brand:wikidata": "Q3050500",
+        "name": "Eldi",
+        "shop": "electronics"
+      }
+    },
+    {
       "displayName": "Eldorado (Україна)",
       "id": "eldorado-f31684",
       "locationSet": {"include": ["ua"]},


### PR DESCRIPTION
I've revised the Wikidata entry for the Belgian chain of electronics stores named Eldi, so it is usable for NSI (links to social media accounts/logos). Also added an entry in NSI itself.