### PR TITLE
Update street_cabinet.json

### DIFF
--- a/data/operators/man_made/street_cabinet.json
+++ b/data/operators/man_made/street_cabinet.json
@@ -19,7 +19,7 @@
         "man_made": "street_cabinet",
         "operator": "Openreach",
         "operator:wikidata": "Q7096543",
-        "street_cabinet": "telecom"
+        "utility": "telecom"
       }
     },
     {
@@ -31,7 +31,7 @@
         "man_made": "street_cabinet",
         "operator": "Proximus",
         "operator:wikidata": "Q2005282",
-        "street_cabinet": "telecom"
+        "utility": "telecom"
       }
     },
     {
@@ -45,6 +45,18 @@
       }
     },
     {
+      "displayName": "Virgin Media",
+      "id": "virginmedia-9ac957",
+      "locationSet": {"include": ["gb"]},
+      "matchNames": ["vm", "vmo2"],
+      "tags": {
+        "man_made": "street_cabinet",
+        "operator": "Virgin Media",
+        "operator:wikidata": "Q1199764",
+        "utility": "telecom"
+      }
+    },
+    {
       "displayName": "WightFibre",
       "id": "wightfibre-9ac957",
       "locationSet": {"include": ["gb"]},
@@ -52,7 +64,7 @@
         "man_made": "street_cabinet",
         "operator": "WightFibre",
         "operator:wikidata": "Q7999638",
-        "street_cabinet": "telecom"
+        "utility": "telecom"
       }
     }
   ]


### PR DESCRIPTION
Adds Virgin Media as a Street Cabinet operator

Changes `street_cabinet=telecom` to `utility=telecom` as the former has been deprecated in favour of the later - https://wiki.openstreetmap.org/wiki/Tag:man_made%3Dstreet_cabinet

I have ran `npm run build` to generate the id.