### PR TITLE
fix network=Frimobil

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -5146,8 +5146,7 @@
       "locationSet": {"include": ["ch"]},
       "matchNames": ["tpf"],
       "tags": {
-        "network": "frimobil",
-        "network:short": "TVF",
+        "network": "Frimobil",
         "network:wikidata": "Q2394200",
         "route": "bus"
       }


### PR DESCRIPTION
TVF is not a shortname for network=Frimobil
Frimobil start with a uppercase letter, like any brand