### PR TITLE
Update UQ mobile

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -1031,7 +1031,7 @@
         "brand": "UQ mobile",
         "brand:en": "UQ mobile",
         "brand:ja": "UQモバイル",
-        "brand:wikidata": "Q11252091",
+        "brand:wikidata": "Q86726664",
         "name": "UQスポット",
         "name:en": "UQ Spot",
         "name:ja": "UQスポット",


### PR DESCRIPTION
I changed to the wikipedia/wikidata page of UQ mobile as a brand (the operating company has also changed from UQ Communications to KDDI now).