### PR TITLE
Adding bar: Vino Volo

### DIFF
--- a/data/brands/amenity/bar.json
+++ b/data/brands/amenity/bar.json
@@ -152,6 +152,17 @@
         "brand:wikidata": "Q115139492",
         "name": "Vagabond"
       }
+    },
+    {
+      "displayName": "Vino Volo",
+      "locationSet": {"include": ["ca","us"]},
+      "matchTags": ["amenity/restaurant"],
+      "tags": {
+        "amenity": "bar",
+        "brand": "Vino Volo",
+        "brand:wikidata": "Q7932710",
+        "name": "Vino Volo"
+      }
     }
   ]
 }


### PR DESCRIPTION
Adding Vino Volo, a bar found in several American and Canadian airports. Most Vino Volo locations are mapped as bars, and the Wikipedia description identifies the business as bars, so I have used this tag.