### PR TITLE
Adding M&M Food Market to shop/frozen_food

### DIFF
--- a/data/brands/shop/frozen_food.json
+++ b/data/brands/shop/frozen_food.json
@@ -113,6 +113,19 @@
         "name": "Галя Балувана",
         "shop": "frozen_food"
       }
+    },
+    {
+      "displayName": "M&M Food Market",
+      "id": "mandmfoodmarket-479c86",
+      "locationSet": {"include": ["ca"]},
+      "matchNames": ["M&M Meats"],
+      "matchTags": ["shop/butcher"], 
+      "tags": {
+        "brand": "M&M Food Market",
+        "brand:wikidata": "Q6711827",
+        "name": "M&M Food Market",
+        "shop": "frozen_food"
+      }
     }
   ]
 }


### PR DESCRIPTION
Removed M&M Food Market from shop/butcher, to be added to shop/frozen_food. Included matchNames and matchTags for outdated branding