### PR TITLE
Removed M&M Food Market from shop/butcher

### DIFF
--- a/data/brands/shop/butcher.json
+++ b/data/brands/shop/butcher.json
@@ -94,17 +94,6 @@
       }
     },
     {
-      "displayName": "M&M Food Market",
-      "id": "mandmfoodmarket-479c86",
-      "locationSet": {"include": ["ca"]},
-      "tags": {
-        "brand": "M&M Food Market",
-        "brand:wikidata": "Q6711827",
-        "name": "M&M Food Market",
-        "shop": "butcher"
-      }
-    },
-    {
       "displayName": "Mad Butcher",
       "id": "madbutcher-79ce66",
       "locationSet": {"include": ["nz"]},


### PR DESCRIPTION
Removed M&M Food Market from shop/butcher, to be added to shop/frozen_food in https://github.com/osmlab/name-suggestion-index/pull/8004