### PR TITLE
remove Entergy local subsidiary replacement

### DIFF
--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -151,7 +151,7 @@
       }
     },
     {
-      "displayName": "Alliant f",
+      "displayName": "Alliant Energy",
       "id": "alliantenergy-b654b4",
       "locationSet": {"include": ["us"]},
       "tags": {

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -151,7 +151,7 @@
       }
     },
     {
-      "displayName": "Alliant Energy",
+      "displayName": "Alliant f",
       "id": "alliantenergy-b654b4",
       "locationSet": {"include": ["us"]},
       "tags": {
@@ -2283,10 +2283,7 @@
       "displayName": "Entergy",
       "id": "entergy-b654b4",
       "locationSet": {"include": ["us"]},
-      "matchNames": [
-        "entergy gulf states louisiana",
-        "entergy mississippi"
-      ],
+      "matchNames": [],
       "tags": {
         "operator": "Entergy",
         "operator:wikidata": "Q1344587",

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -2283,7 +2283,6 @@
       "displayName": "Entergy",
       "id": "entergy-b654b4",
       "locationSet": {"include": ["us"]},
-      "matchNames": [],
       "tags": {
         "operator": "Entergy",
         "operator:wikidata": "Q1344587",


### PR DESCRIPTION
Local subsidiaries shouldn't be replaced with the parent company, as this reduces accuracy.