### PR TITLE
Add Belgian fashion chain e5 Mode

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -2601,6 +2601,17 @@
       }
     },
     {
+      "displayName": "e5 Mode",
+      "locationSet": {"include": ["be"]},
+      "matchNames": ["e5","E5","e5 mode"],
+      "tags": {
+        "brand": "E5 Mode",
+        "brand:wikidata": "Q85313633",
+        "name": "E5 Mode",
+        "shop": "clothes",
+      }
+    },
+    {
       "displayName": "Eddie Bauer",
       "id": "eddiebauer-6680bd",
       "locationSet": {


### PR DESCRIPTION
Please add the Belgian fashion chain e5 Mode. The Wikidata page has the name with capital "E", but it seems the company uses and prefers the lowercase version. Therefore also including a matchname handle (the "Mode" part is frequently omitted).