### PR TITLE
Update welcia(ウエルシア薬局)

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -4125,7 +4125,7 @@
       "matchNames": ["ウェルシア", "ウエルシア", "ハックドラッグ"],
       "tags": {
         "amenity": "pharmacy",
-        "brand": "ウエルシア薬局",
+        "brand": "welcia",
         "brand:en": "welcia",
         "brand:ja": "ウエルシア薬局",
         "brand:wikidata": "Q11288687",

--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -4119,33 +4119,19 @@
       }
     },
     {
-      "displayName": "ウェルシア",
-      "id": "2939ba-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "ウェルシア",
-        "brand:ja": "ウェルシア",
-        "brand:wikidata": "Q11288687",
-        "healthcare": "pharmacy",
-        "name": "ウェルシア",
-        "name:ja": "ウェルシア"
-      }
-    },
-    {
       "displayName": "ウエルシア薬局",
-      "id": "welciayakkyoku-650eee",
+      "id": "welcia-650eee",
       "locationSet": {"include": ["jp"]},
-      "matchNames": ["ウエルシア", "ハックドラッグ"],
+      "matchNames": ["ウェルシア", "ウエルシア", "ハックドラッグ"],
       "tags": {
         "amenity": "pharmacy",
         "brand": "ウエルシア薬局",
-        "brand:en": "Welcia Yakkyoku",
+        "brand:en": "welcia",
         "brand:ja": "ウエルシア薬局",
         "brand:wikidata": "Q11288687",
         "healthcare": "pharmacy",
         "name": "ウエルシア薬局",
-        "name:en": "Welcia Yakkyoku",
+        "name:en": "Welcia",
         "name:ja": "ウエルシア薬局"
       }
     },


### PR DESCRIPTION
I changed *:en with reference to [JA:Naming sample](https://wiki.openstreetmap.org/wiki/JA:Naming_sample#amenity=pharmacy), and typo added to matchNames.