### PR TITLE
Corrected details for TIC bus network in Compiègne, France

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -15670,6 +15670,7 @@
         "network": "Transports Intercommunaux du Compiégnois",
         "network:wikidata": "Q60846198",
         "operator": "Acary",
+        "operator:wikidata": "Q118108069",
         "route": "bus",
         "fee": "no"
       }

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -15665,7 +15665,7 @@
     {
       "displayName": "TIC",
       "id": "tic-add5eb",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {"include": ["fr-hdf.geojson"]},
       "tags": {
         "network": "Transports Intercommunaux du Compiégnois",
         "network:wikidata": "Q60846198",

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -15667,10 +15667,11 @@
       "id": "tic-add5eb",
       "locationSet": {"include": ["fx"]},
       "tags": {
-        "network": "TIC",
+        "network": "Transports Intercommunaux du Compiégnois",
         "network:wikidata": "Q60846198",
-        "operator": "Transdev Picardie",
-        "route": "bus"
+        "operator": "Acary",
+        "route": "bus",
+        "fee": "no"
       }
     },
     {

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -15671,8 +15671,7 @@
         "network:wikidata": "Q60846198",
         "operator": "Acary",
         "operator:wikidata": "Q118108069",
-        "route": "bus",
-        "fee": "no"
+        "route": "bus"
       }
     },
     {


### PR DESCRIPTION
Hello,

Here is a request to correct the properties of the bus network of Compiègne, France. I've separated the entities "TIC" (which is the network) and "Acary" or "Transdev Acary" (which is the operator, Transdev Picardie being the owner of Acary). I've propoed the full name of the network "Transports Intercommunaux du Compiégnois" to be used to refer to the network, while keeping the short name to be displayed.
I've also added the tag "fee":"no", as TIC is one of the very first free bus networks in France, dating back to 1975. I fully expect this to continue in the future. However, if this is not appropriate, the tag can be removed.

Thank you