### PR TITLE
Merge CLH and GPSS pipeline operators into Exolum

### DIFF
--- a/data/operators/man_made/pipeline.json
+++ b/data/operators/man_made/pipeline.json
@@ -940,15 +940,6 @@
       }
     },
     {
-      "displayName": "CLH",
-      "id": "clh-143312",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "man_made": "pipeline",
-        "operator": "CLH"
-      }
-    },
-    {
       "displayName": "CNR",
       "id": "cnr-143312",
       "locationSet": {"include": ["001"]},
@@ -1967,10 +1958,12 @@
     {
       "displayName": "Exolum",
       "id": "exolum-143312",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["es", "gb"]},
+      "matchNames": ["clh", "clh-ps", "gpss"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Exolum"
+        "operator": "Exolum",
+        "operator:wikidata": "Q5156175"
       }
     },
     {
@@ -2476,15 +2469,6 @@
       "tags": {
         "man_made": "pipeline",
         "operator": "GPEC"
-      }
-    },
-    {
-      "displayName": "GPSS",
-      "id": "gpss-143312",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "man_made": "pipeline",
-        "operator": "GPSS"
       }
     },
     {


### PR DESCRIPTION
The CLH-PS (formerly GPSS) pipelines in the UK are now called the Exolum Pipeline System.

Exolum only appears to operate in Spain and the UK.

https://www.linewatch.org.uk/news/2021-03-15/clh-ps-becomes-exolum-pipeline-system