### PR TITLE
O'Tacos is not mexican food despite the name

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -5205,7 +5205,7 @@
         "amenity": "fast_food",
         "brand": "O'Tacos",
         "brand:wikidata": "Q28494040",
-        "cuisine": "mexican",
+        "cuisine": "french_tacos",
         "name": "O'Tacos",
         "takeaway": "yes"
       }


### PR DESCRIPTION
Hello,
I propose another pull request. Simple correction: the french fast food brand O'Tacos does not sell mexican food. French tacos are an entirely different kind of food; I propose the value "french_tacos" to represent it.
Thank you