### PR TITLE
Add Belgian brand Neuhaus to chocolate shops

### DIFF
--- a/data/brands/shop/chocolate.json
+++ b/data/brands/shop/chocolate.json
@@ -183,6 +183,16 @@
       }
     },
     {
+      "displayName": "Neuhaus",
+      "locationSet": {"include": ["be"]},
+      "tags": {
+        "brand": "Neuhaus",
+        "brand:wikidata": "Q1813801",
+        "name": "Neuhaus",
+        "shop": "chocolate"
+      }
+    },
+    {
       "displayName": "Purdys Chocolatier",
       "id": "purdyschocolatier-a30910",
       "locationSet": {"include": ["ca"]},


### PR DESCRIPTION
Please add the Belgian chocolate brand Neuhaus to shop/chocolate.
As for the locationset: I know Neuhaus is also active in other countries, but it is retailed there as a "shop in shop" or a shop corner (department store), and a few airports here and there.
In Belgium they have the most of their physical stores under their own management, so therefore making this the primary location.