### PR TITLE
Move lifeboat_station to water_rescue

### DIFF
--- a/config/matchGroups.json
+++ b/config/matchGroups.json
@@ -175,10 +175,11 @@
       "shop/houseware",
       "shop/interior_decoration"
     ],
-    "lifeboat_station": [
+    "water_rescue": [
       "amenity/lifeboat_station",
       "emergency/lifeboat_station",
-      "emergency/marine_rescue"
+      "emergency/marine_rescue",
+      "emergency/water_rescue"
     ],
     "lodging": [
       "tourism/hotel",

--- a/data/operators/emergency/water_rescue.json
+++ b/data/operators/emergency/water_rescue.json
@@ -1,6 +1,6 @@
 {
   "properties": {
-    "path": "operators/emergency/lifeboat_station",
+    "path": "operators/emergency/water_rescue",
     "exclude": {"generic": ["^lifeboat station$"]}
   },
   "items": [
@@ -10,7 +10,7 @@
       "locationSet": {"include": ["de"]},
       "matchNames": ["gmsrs"],
       "tags": {
-        "emergency": "lifeboat_station",
+        "emergency": "water_rescue",
         "operator": "Deutsche Gesellschaft zur Rettung Schiffbrüchiger",
         "operator:en": "German Maritime Search and Rescue Service",
         "operator:short": "DGZRS",
@@ -23,7 +23,7 @@
       "locationSet": {"include": ["nl"]},
       "matchNames": ["knrm", "rnsri"],
       "tags": {
-        "emergency": "lifeboat_station",
+        "emergency": "water_rescue",
         "operator": "Koninklijke Nederlandse Redding Maatschappij",
         "operator:en": "Royal Netherlands Sea Rescue Institution",
         "operator:wikidata": "Q587175"
@@ -35,7 +35,7 @@
       "locationSet": {"include": ["za"]},
       "matchNames": ["nsri"],
       "tags": {
-        "emergency": "lifeboat_station",
+        "emergency": "water_rescue",
         "operator": "National Sea Rescue Institute",
         "operator:af": "Nasionale Seereddingsinstituut van Suid-Afrika",
         "operator:en": "National Sea Rescue Institute",
@@ -48,7 +48,7 @@
       "locationSet": {"include": ["no"]},
       "matchNames": ["nssr", "rs"],
       "tags": {
-        "emergency": "lifeboat_station",
+        "emergency": "water_rescue",
         "operator": "Redningsselskapet",
         "operator:en": "Norwegian Society for Sea Rescue",
         "operator:wikidata": "Q1462950"
@@ -60,7 +60,7 @@
       "locationSet": {"include": ["ca"]},
       "matchNames": ["rcmsar"],
       "tags": {
-        "emergency": "lifeboat_station",
+        "emergency": "water_rescue",
         "operator": "Royal Canadian Marine Search and Rescue",
         "operator:wikidata": "Q7373897"
       }
@@ -70,7 +70,7 @@
       "id": "royalnationallifeboatinstitution-0db384",
       "locationSet": {"include": ["gb", "ie"]},
       "tags": {
-        "emergency": "lifeboat_station",
+        "emergency": "water_rescue",
         "operator": "Royal National Lifeboat Institution",
         "operator:short": "RNLI",
         "operator:wikidata": "Q2166873"
@@ -85,7 +85,7 @@
         "rnzc"
       ],
       "tags": {
-        "emergency": "lifeboat_station",
+        "emergency": "water_rescue",
         "operator": "Royal New Zealand Coastguard",
         "operator:wikidata": "Q17063737"
       }
@@ -96,7 +96,7 @@
       "locationSet": {"include": ["se"]},
       "matchNames": ["ssrs"],
       "tags": {
-        "emergency": "lifeboat_station",
+        "emergency": "water_rescue",
         "operator": "Sjöräddningssällskapet",
         "operator:en": "Swedish Sea Rescue Society",
         "operator:wikidata": "Q1765275"
@@ -107,7 +107,7 @@
       "id": "societenationaledesauvetageenmer-3af1d0",
       "locationSet": {"include": ["fr"]},
       "tags": {
-        "emergency": "lifeboat_station",
+        "emergency": "water_rescue",
         "operator": "Société nationale de sauvetage en mer",
         "operator:wikidata": "Q584914"
       }
@@ -117,7 +117,7 @@
       "id": "64f32f-995e68",
       "locationSet": {"include": ["ru"]},
       "tags": {
-        "emergency": "lifeboat_station",
+        "emergency": "water_rescue",
         "operator": "Департамента по предупреждению и ликвидации чрезвычайных ситуаций Ростовской области"
       }
     }


### PR DESCRIPTION
`emergency=lifeboat_station` [has been deprecated](https://wiki.openstreetmap.org/wiki/Proposal:Emergency%3Dwater_rescue) in favour of `emergency=water_rescue`

I assume this is the right way to treat such a change, but looking for a second pair of eyes before merging.