### PR TITLE
Add several European brands

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -3016,6 +3016,16 @@
       }
     },
     {
+      "displayName": "Lunch Garden",
+      "locationSet": {"include": ["be"]},
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "Lunch Garden",
+        "brand:wikidata": "Q2491217",
+        "name": "Lunch Garden"
+      }
+    },
+    {
       "displayName": "Mad Mex Fresh Mexican",
       "id": "madmexfreshmexicangrill-bb079b",
       "locationSet": {"include": ["au", "nz"]},

--- a/data/brands/office/employment_agency.json
+++ b/data/brands/office/employment_agency.json
@@ -7,6 +7,16 @@
   },
   "items": [
     {
+      "displayName": "Accent Jobs",
+      "locationSet": {"include": ["be"]},
+      "tags": {
+        "brand": "Accent Jobs",
+        "brand:wikidata": "Q2939495",
+        "name": "Accent Jobs",
+        "office": "employment_agency"
+      }
+    },
+    {
       "displayName": "Adecco",
       "id": "adecco-0baa05",
       "locationSet": {"include": ["001"]},

--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -6937,6 +6937,17 @@
       }
     },
     {
+      "displayName": "PME Legend",
+      "locationSet": {"include": ["nl","be"]},
+      "tags": {
+        "brand": "PME Legend",
+        "brand:wikidata": "Q94776153",
+        "clothes": "men",
+        "name": "PME Legend",
+        "shop": "clothes"
+      }
+    },
+    {
       "displayName": "Polo Ralph Lauren",
       "id": "poloralphlauren-3937bd",
       "locationSet": {"include": ["001"]},
@@ -7476,6 +7487,19 @@
         "brand": "Saltrock",
         "brand:wikidata": "Q7406195",
         "name": "Saltrock",
+        "shop": "clothes"
+      }
+    },
+    {
+      "displayName": "Samsøe Samsøe",
+      "locationSet": {
+        "include": ["be","de","dk","lu","nl","no","se"]
+      },
+      "matchNames": ["Samsoe Samsoe", "Samsoe&Samsoe"],
+      "tags": {
+        "brand": "Samsøe Samsøe",
+        "brand:wikidata": "Q12334460",
+        "name": "Samsøe Samsøe",
         "shop": "clothes"
       }
     },
@@ -9190,6 +9214,16 @@
         "brand": "Webbers",
         "brand:wikidata": "Q116619741",
         "name": "Webbers",
+        "shop": "clothes"
+      }
+    },
+    {
+      "displayName": "Weekday",
+      "locationSet": {"include": ["150"]},
+      "tags": {
+        "brand": "Weekday",
+        "brand:wikidata": "Q10719514",
+        "name": "Weekday",
         "shop": "clothes"
       }
     },

--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -424,9 +424,10 @@
     {
       "displayName": "Brit Hotel",
       "id": "brithotel-779ccb",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "brand": "Brit Hotel",
+        "brand:wikidata": "Q2925673",
         "name": "Brit Hotel",
         "tourism": "hotel"
       }


### PR DESCRIPTION
I've found a number of brands which already had Wikidata entries, but had insufficient data to be used in NSI.
That has been fixed now, so please add these brands to the index.

As for Brit Hotel it was already present in NSI but lacked a Wikidata entry: it was hardly visible since only the French name tag was filled and not the English tag. The locationset was also altered from 001 to fx (metropolitan/continental France) since the Overpass Turbo query only showed locations in France.