### PR TITLE
Fixed French drive through supermarkets

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -424,7 +424,8 @@
         "brand": "Auchan Drive",
         "brand:wikidata": "Q2870659",
         "name": "Auchan Drive",
-        "shop": "supermarket"
+        "shop": "supermarket",
+        "drive_through": "only"
       }
     },
     {
@@ -2029,7 +2030,8 @@
         "brand": "E. Leclerc Drive",
         "brand:wikidata": "Q1273376",
         "name": "E. Leclerc Drive",
-        "shop": "supermarket"
+        "shop": "supermarket",
+        "drive_through": "only"
       }
     },
     {
@@ -3351,6 +3353,18 @@
         "brand:wikidata": "Q3153200",
         "name": "Intermarché",
         "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "Intermarché Drive",
+      "id": "auchandrive-715442",
+      "locationSet": {"include": ["fr"]},
+      "tags": {
+        "brand": "Intermarché Drive",
+        "brand:wikidata": "Q3153200",
+        "name": "Intermarché Drive",
+        "shop": "supermarket",
+        "drive_through": "only"
       }
     },
     {


### PR DESCRIPTION
Hello,

I fixed the French "drive" supermarket brands by adding the tag "drive_through"="yes" to them, since their very concept is to get groceries delivered to your car. I would suggest redirecting the "Auchan Drive" wikidata page to "Auchan", since it doesn't offer much information and "Auchan/Intermarché/etc Drive" is more of a way to precisely map "drive-through" points on the map, IMO. The brands themselves are basically the same as the "non-drive" ones.

Thank you