### PR TITLE
Added translations for Ukrainian bank and transport systems

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -9725,11 +9725,16 @@
         "amenity": "bank",
         "brand": "Сенс Банк",
         "brand:en": "Sense Bank",
+        "brand:it": "Sense Bank",
         "brand:uk": "Сенс Банк",
+        "brand:ru": "Сенс Банк",
         "brand:wikidata": "Q16691757",
         "name": "Сенс Банк",
         "name:en": "Sense Bank",
-        "name:uk": "Сенс Банк"
+        "name:it": "Sense Bank",
+        "name:uk": "Сенс Банк",
+        "name:ru": "Сенс Банк",
+        "operator": "Сенс Банк"
       }
     },
     {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -9725,13 +9725,11 @@
         "amenity": "bank",
         "brand": "Сенс Банк",
         "brand:en": "Sense Bank",
-        "brand:it": "Sense Bank",
         "brand:uk": "Сенс Банк",
         "brand:ru": "Сенс Банк",
         "brand:wikidata": "Q16691757",
         "name": "Сенс Банк",
         "name:en": "Sense Bank",
-        "name:it": "Sense Bank",
         "name:uk": "Сенс Банк",
         "name:ru": "Сенс Банк",
         "operator": "Сенс Банк"

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -21476,6 +21476,18 @@
         "network:zh-yue": "龍運機場巴士",
         "route": "bus"
       }
+    },
+    {
+      "displayName": "Київський автобус",
+      "id": "3u49ix-t85m44",
+      "locationSet": {"include": ["ua"]},
+      "tags": {
+        "network": "Київський автобус",
+        "network:wikidata": "Q3399835",
+        "operator": "Київпастранс",
+        "operator:wikidata": "Q12110155",
+        "route": "bus"
+      }
     }
   ]
 }

--- a/data/transit/route/subway.json
+++ b/data/transit/route/subway.json
@@ -1428,6 +1428,17 @@
         "operator:zh": "高雄捷運股份有限公司",
         "route": "subway"
       }
+    },
+    {
+      "displayName": "Київський метрополітен",
+      "id": "pe5n65-cfad25",
+      "locationSet": {"include": ["ua"]},
+      "tags": {
+        "network": "Київський метрополітен",
+        "network:wikidata": "Q215871",
+        "operator": "Київський метрополітен",
+        "route": "subway"
+      }
     }
   ]
 }


### PR DESCRIPTION
POI Alfa Bank (now Sens Bank) had translations into Russian and Italian. Added these translations for automatic replacement.