### PR TITLE
energy_supplier: Rename "Punto Enel" with "Spazio Enel"

### DIFF
--- a/data/operators/office/energy_supplier.json
+++ b/data/operators/office/energy_supplier.json
@@ -157,13 +157,14 @@
       }
     },
     {
-      "displayName": "Punto Enel",
+      "displayName": "Spazio Enel",
       "id": "puntoenel-7c1c4a",
       "locationSet": {"include": ["it"]},
+      "matchNames": ["Punto Enel"],
       "tags": {
-        "name": "Punto Enel",
+        "name": "Spazio Enel",
         "office": "energy_supplier",
-        "operator": "Punto Enel",
+        "operator": "Enel",
         "operator:wikidata": "Q651222"
       }
     },


### PR DESCRIPTION
Enel renamed all the offices from "Punto Enel" to "Spazio Enel". Also the operator was wrong.

See here: https://www.enel.it/spazio-enel/