### PR TITLE
Remove brand names in name=* from charging_station

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -26,7 +26,6 @@
         "amenity": "charging_station",
         "brand": "7-Eleven",
         "brand:wikidata": "Q259340",
-        "name": "7-Eleven",
         "operator": "7-Eleven",
         "operator:wikidata": "Q259340"
       }
@@ -460,7 +459,6 @@
         "amenity": "charging_station",
         "brand": "bike-energy",
         "brand:wikidata": "Q67770877",
-        "name": "bike-energy",
         "operator": "bike-energy",
         "operator:wikidata": "Q67770877"
       }
@@ -486,7 +484,6 @@
         "amenity": "charging_station",
         "brand": "Blink",
         "brand:wikidata": "Q62065645",
-        "name": "Blink",
         "operator": "Blink",
         "operator:wikidata": "Q62065645"
       }
@@ -563,7 +560,6 @@
       "tags": {
         "amenity": "charging_station",
         "brand": "Bosch eBike Systems",
-        "name": "Bosch eBike Systems",
         "operator": "Bosch eBike Systems",
         "operator:wikidata": "Q234021"
       }
@@ -714,7 +710,6 @@
       },
       "tags": {
         "amenity": "charging_station",
-        "name": "charge.brussels",
         "network": "charge.brussels",
         "network:wikidata": "Q109923471",
         "operator": "PitPoint",
@@ -763,7 +758,6 @@
         "amenity": "charging_station",
         "brand": "ChargePoint",
         "brand:wikidata": "Q5176149",
-        "name": "ChargePoint",
         "operator": "ChargePoint",
         "operator:wikidata": "Q5176149"
       }
@@ -790,7 +784,6 @@
         "amenity": "charging_station",
         "brand": "Circle K",
         "brand:wikidata": "Q3268010",
-        "name": "Circle K",
         "operator": "Circle K",
         "operator:wikidata": "Q3268010"
       }
@@ -805,9 +798,6 @@
         "brand:en": "Electric Circuit",
         "brand:fr": "Circuit électrique",
         "brand:wikidata": "Q24934590",
-        "name": "Circuit électrique",
-        "name:en": "Electric Circuit",
-        "name:fr": "Circuit électrique",
         "operator": "Circuit électrique",
         "operator:en": "Electric Circuit",
         "operator:fr": "Circuit électrique",
@@ -1126,7 +1116,6 @@
         "amenity": "charging_station",
         "brand": "E-WALD",
         "brand:wikidata": "Q61804335",
-        "name": "E-WALD",
         "operator": "E-WALD",
         "operator:wikidata": "Q61804335"
       }
@@ -1497,7 +1486,6 @@
         "amenity": "charging_station",
         "brand": "Enel",
         "brand:wikidata": "Q651222",
-        "name": "Enel",
         "operator": "Enel",
         "operator:wikidata": "Q651222"
       }
@@ -1513,7 +1501,6 @@
         "amenity": "charging_station",
         "brand": "Enel X",
         "brand:wikidata": "Q5376815",
-        "name": "Enel X",
         "operator": "Enel X",
         "operator:wikidata": "Q5376815"
       }
@@ -1866,7 +1853,6 @@
         "amenity": "charging_station",
         "brand": "EVgo",
         "brand:wikidata": "Q61803820",
-        "name": "EVgo",
         "operator": "EVgo",
         "operator:wikidata": "Q61803820"
       }
@@ -2082,7 +2068,6 @@
         "amenity": "charging_station",
         "brand": "FLO",
         "brand:wikidata": "Q64971203",
-        "name": "FLO",
         "operator": "FLO",
         "operator:wikidata": "Q64971203"
       }
@@ -2249,7 +2234,6 @@
         "amenity": "charging_station",
         "brand": "Gogoro 電池交換站",
         "brand:wikidata": "Q19880591",
-        "name": "Gogoro 電池交換站",
         "operator": "Gogoro 電池交換站",
         "operator:wikidata": "Q19880591"
       }
@@ -2308,7 +2292,6 @@
       "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
-        "name": "Gridserve",
         "operator": "Gridserve",
         "operator:wikidata": "Q89575318"
       }
@@ -2501,7 +2484,6 @@
         "amenity": "charging_station",
         "brand": "InCharge",
         "brand:wikidata": "Q71041027",
-        "name": "InCharge",
         "operator": "InCharge",
         "operator:wikidata": "Q71041027"
       }
@@ -2528,7 +2510,6 @@
         "amenity": "charging_station",
         "brand": "Innogy",
         "brand:wikidata": "Q2124721",
-        "name": "Innogy",
         "operator": "Innogy",
         "operator:wikidata": "Q2124721"
       }
@@ -3073,7 +3054,6 @@
       "tags": {
         "amenity": "charging_station",
         "brand": "Mobiliti",
-        "name": "Mobiliti",
         "operator": "Mobiliti"
       }
     },
@@ -4159,7 +4139,6 @@
         "amenity": "charging_station",
         "brand": "Source London",
         "brand:wikidata": "Q7565133",
-        "name": "Source London",
         "operator": "Source London",
         "operator:wikidata": "Q7565133"
       }
@@ -4920,7 +4899,6 @@
         "amenity": "charging_station",
         "brand": "Toka",
         "brand:wikidata": "Q117745034",
-        "name": "Toka",
         "operator": "Toka",
         "operator:wikidata": "Q117745034"
       }
@@ -5099,7 +5077,6 @@
       "tags": {
         "amenity": "charging_station",
         "brand": "VIRTA",
-        "name": "VIRTA",
         "operator": "VIRTA"
       }
     },
@@ -5411,9 +5388,6 @@
         "brand:en": "State Grid",
         "brand:wikidata": "Q209078",
         "brand:zh": "国家电网",
-        "name": "国家电网",
-        "name:en": "State Grid",
-        "name:zh": "国家电网",
         "operator": "国家电网有限公司",
         "operator:en": "State Grid Corporation of China",
         "operator:wikidata": "Q209078",
@@ -5442,9 +5416,6 @@
         "brand:en": "Takaoka Toko",
         "brand:ja": "東光高岳",
         "brand:wikidata": "Q17220263",
-        "name": "東光高岳",
-        "name:en": "Takaoka Toko",
-        "name:ja": "東光高岳",
         "operator": "東光高岳",
         "operator:en": "Takaoka Toko",
         "operator:ja": "東光高岳",


### PR DESCRIPTION
The name tag should be used for the name of the individual feature, not the brand name. It also duplicates the info in brand/operator.