### PR TITLE
Add shop/appliance to the electronics group

### DIFF
--- a/config/matchGroups.json
+++ b/config/matchGroups.json
@@ -66,6 +66,7 @@
     ],
     "electronics": [
       "office/telecommunication",
+      "shop/appliance",
       "shop/computer",
       "shop/electronics",
       "shop/hifi",


### PR DESCRIPTION
Often these types of stores are hard to clearly categorize

Examples:
https://nsi.guide/?id=arcelik-f0338d