### PR TITLE
Update EV charging station operators in the UK

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -12,7 +12,9 @@
         "^europark as$",
         "^jernbaneverket$",
         "kommune",
-        "privat"
+        "privat",
+        "polar",
+        "rolec"
       ]
     }
   },
@@ -384,14 +386,13 @@
     {
       "displayName": "Be.EV",
       "id": "beev-116e8a",
-      "locationSet": {
-        "include": [
-          "gb-greater-manchester.geojson"
-        ]
-      },
+      "locationSet": {"include": ["gb-eng"]},
+      "matchNames": ["iduna"],
       "tags": {
         "amenity": "charging_station",
-        "operator": "Be.EV"
+        "brand": "Be.EV",
+        "operator": "Iduna",
+        "operator:wikidata": "Q118263083"
       }
     },
     {
@@ -1219,15 +1220,6 @@
       }
     },
     {
-      "displayName": "ecarNI",
-      "id": "ecarni-6ad204",
-      "locationSet": {"include": ["gb-nir"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "ecarNI"
-      }
-    },
-    {
       "displayName": "eCarUp",
       "id": "ecarup-086737",
       "locationSet": {"include": ["ch"]},
@@ -1244,16 +1236,6 @@
       "tags": {
         "amenity": "charging_station",
         "operator": "Ecotap"
-      }
-    },
-    {
-      "displayName": "Ecotricity",
-      "id": "ecotricity-0793ce",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Ecotricity",
-        "operator:wikidata": "Q5333901"
       }
     },
     {
@@ -1743,22 +1725,23 @@
     {
       "displayName": "ESB ecars",
       "id": "esbecars-179e3e",
-      "locationSet": {"include": ["ie"]},
-      "matchNames": ["esb"],
+      "locationSet": {"include": ["ie", "gb-nir"]},
+      "matchNames": ["esb", "ecarni"],
       "tags": {
         "amenity": "charging_station",
-        "operator": "ESB ecars",
-        "operator:wikidata": "Q3050566"
+        "operator": "ESB Group",
+        "operator:wikidata": "Q3050566",
+        "brand": "ecars"
       }
     },
     {
-      "displayName": "ESB EV Solutions",
-      "id": "esbevsolutions-0793ce",
+      "displayName": "ESB Energy",
       "locationSet": {"include": ["gb"]},
-      "matchNames": ["esb"],
+      "matchNames": ["esb", "esb ev solutions"],
       "tags": {
         "amenity": "charging_station",
-        "operator": "ESB EV Solutions"
+        "operator": "ESB Energy",
+        "operator:wikidata": "Q118261834"
       }
     },
     {
@@ -2306,6 +2289,7 @@
       "displayName": "Gridserve",
       "id": "gridserve-0793ce",
       "locationSet": {"include": ["gb"]},
+      "matchNames": ["ecotricity", "electric highway"],
       "tags": {
         "amenity": "charging_station",
         "name": "Gridserve",
@@ -3492,15 +3476,6 @@
       }
     },
     {
-      "displayName": "POLAR",
-      "id": "polar-0793ce",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "POLAR"
-      }
-    },
-    {
       "displayName": "Porsche",
       "id": "porsche-28ff7e",
       "locationSet": {
@@ -3738,15 +3713,6 @@
       "tags": {
         "amenity": "charging_station",
         "operator": "Robert Bosch GmbH"
-      }
-    },
-    {
-      "displayName": "Rolec",
-      "id": "rolec-0793ce",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Rolec"
       }
     },
     {


### PR DESCRIPTION
* Be.EV is a brand of Iduna and now operates outside Greater Manchester
* ecarNI is the same brand as ecars in the Republic of Ireland
* Ecotricity's charging network ("Electric Highway") was acquired by Gridserve and I believe it has been absorbed into their network.
* "POLAR" and "Rolec" are manufacturers of charging stations, not charging networks.