### PR TITLE
Fix groups for shop/beauty

### DIFF
--- a/config/matchGroups.json
+++ b/config/matchGroups.json
@@ -12,7 +12,7 @@
     ],
     "beauty": [
       "shop/beauty",
-      "shop/hairdresser_supply"
+      "shop/hairdresser"
     ],
     "bed": [
       "shop/bed",
@@ -45,7 +45,6 @@
       "healthcare/dialysis"
     ],
     "convenience": [
-      "shop/beauty",
       "shop/chemist",
       "shop/convenience",
       "shop/cosmetics",


### PR DESCRIPTION
**shop/beauty** - places where services are provided. Therefore, it shouldn't be in a group with a categories where sell goods

It seems that **shop/hairdresser** and **shop/hairdresser_supply** were confused