### PR TITLE
Add Pommesfreunde: french fries chain in Germany

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -6167,6 +6167,19 @@
       }
     },
     {
+      "displayName": "Pommesfreunde",
+      "id": "pommesfreunde-2a245c",
+      "locationSet": {"include": ["at", "de"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Pommesfreunde",
+        "brand:wikidata": "Q117083946",
+        "cuisine": "fries",
+        "name": "Pommesfreunde",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Popeyes",
       "id": "popeyes-658eea",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
[Pommesfreunde](https://pommesfreunde.de/) is a french fries fast food chain mainly in Germany and one location in Austria.