### PR TITLE
Extend locationset for some brands with "be", added some other new brands

### DIFF
--- a/data/brands/shop/department_store.json
+++ b/data/brands/shop/department_store.json
@@ -695,6 +695,17 @@
       }
     },
     {
+      "displayName": "Inno",
+      "locationSet": {"include": ["be"]},
+      "matchNames": ["Galeria Inno","Innovation"],
+      "tags": {
+        "brand": "Inno",
+        "brand:wikidata": "Q300632",
+        "name": "Inno",
+        "shop": "department_store"
+      }
+    },
+    {
       "displayName": "JCPenney",
       "id": "jcpenney-592fe0",
       "locationSet": {"include": ["us"]},

--- a/data/brands/shop/health_food.json
+++ b/data/brands/shop/health_food.json
@@ -41,7 +41,7 @@
       "displayName": "Holland & Barrett",
       "id": "hollandandbarrett-7483d3",
       "locationSet": {
-        "include": ["gb", "ie", "nl"]
+        "include": ["be","gb", "ie", "nl"]
       },
       "matchTags": [
         "shop/chemist",

--- a/data/brands/shop/sports.json
+++ b/data/brands/shop/sports.json
@@ -391,6 +391,7 @@
       "locationSet": {
         "include": [
           "au",
+          "be",
           "de",
           "es",
           "fr",

--- a/data/operators/amenity/parking.json
+++ b/data/operators/amenity/parking.json
@@ -341,6 +341,19 @@
       }
     },
     {
+      "displayName": "Interparking",
+      "locationSet": {"include": ["be"]},
+      "tags": {
+        "amenity": "parking",
+        "brand": "Interparking",
+        "brand:wikidata": "Q1895863",
+        "fee": "yes",
+        "name": "Interparking",
+        "operator": "Interparking",
+        "operator:wikidata": "Q1895863"
+      }
+    },
+    {
       "displayName": "İSPARK",
       "id": "ispark-2ec6a1",
       "locationSet": {"include": ["tr"]},


### PR DESCRIPTION
Holland & Barrett and JD Sports are also active in Belgium, therefore extending their locationSet.
Also added 2 brands that weren't featured yet, but did already have Wikidata entries: department store Inno (the Belgian version of Galeria Kaufhof/Karstadt) and the parking operator Interparking (mainly multi-storey or underground parking garages).