### PR TITLE
Added Canada to Daiso locationSet

### DIFF
--- a/data/brands/shop/variety_store.json
+++ b/data/brands/shop/variety_store.json
@@ -189,7 +189,7 @@
     {
       "displayName": "Daiso",
       "id": "daiso-14cb81",
-      "locationSet": {"include": ["my"]},
+      "locationSet": {"include": ["my","ca"]},
       "tags": {
         "brand": "Daiso",
         "brand:wikidata": "Q866991",


### PR DESCRIPTION
It's unclear to me why there are two items for Daiso outside of Asia: "Daiso" and "Daiso Japan". The branding in Canada and on the Canadian website does not use "Daiso Japan" so I have added it to the "Daiso" brand item.