### PR TITLE
Philippine bus networks

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -5112,7 +5112,7 @@
     {
       "displayName": "Five Star",
       "locationSet": {
-        "include": ["ph""]
+        "include": ["ph"]
       },
       "matchNames": ["5 star bus", "five star bus"],
       "tags": {
@@ -8008,7 +8008,7 @@
     {
       "displayName": "LTFRB PUB",
       "locationSet": {
-        "include": ["ph""]
+        "include": ["ph"]
       },
       "matchNames": ["ltfrb bus", "metro manila city bus", "pub", "public utility bus"],
       "tags": {
@@ -8020,9 +8020,9 @@
     {
       "displayName": "LTFRB PUJ",
       "locationSet": {
-        "include": ["ph""]
+        "include": ["ph"]
       },
-      "matchNames": ["jeepney", "ltfrb jeepney"],
+      "matchNames": ["jeepney", "ltfrb jeepney", "puj"],
       "tags": {
         "network": "LTFRB PUJ",
         "network:wikidata": "Q6483998",
@@ -11596,12 +11596,6 @@
       }
     },
     {
-      "displayName": "PUB",
-      "id": "pub-3785bf",
-      "locationSet": {"include": ["ph"]},
-      "tags": {"network": "PUB", "route": "bus"}
-    },
-    {
       "displayName": "public local bus",
       "id": "publiclocalbus-7e8526",
       "locationSet": {"include": ["gr"]},
@@ -11641,12 +11635,6 @@
         "network:wikidata": "Q7258466",
         "route": "bus"
       }
-    },
-    {
-      "displayName": "PUJ",
-      "id": "puj-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {"network": "PUJ", "route": "bus"}
     },
     {
       "displayName": "Pune Mahanagar Parivahan Mahamandal Ltd",
@@ -18046,7 +18034,7 @@
     {
       "displayName": "Victory Liner",
       "locationSet": {
-        "include": ["ph""]
+        "include": ["ph"]
       },
       "matchNames": ["victory bus"],
       "tags": {

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -5110,6 +5110,18 @@
       }
     },
     {
+      "displayName": "Five Star",
+      "locationSet": {
+        "include": ["ph""]
+      },
+      "matchNames": ["5 star bus", "five star bus"],
+      "tags": {
+        "network": "Five Star",
+        "network:wikidata": "Q5456133",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "Flixbus",
       "id": "flixbus-8cc9ca",
       "locationSet": {
@@ -7990,6 +8002,30 @@
         "network": "LTD",
         "network:wikidata": "Q6485453",
         "operator": "Lane Transit District",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "LTFRB PUB",
+      "locationSet": {
+        "include": ["ph""]
+      },
+      "matchNames": ["ltfrb bus", "metro manila city bus", "pub", "public utility bus"],
+      "tags": {
+        "network": "LTFRB PUB",
+        "network:wikidata": "Q6483998",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "LTFRB PUJ",
+      "locationSet": {
+        "include": ["ph""]
+      },
+      "matchNames": ["jeepney", "ltfrb jeepney"],
+      "tags": {
+        "network": "LTFRB PUJ",
+        "network:wikidata": "Q6483998",
         "route": "bus"
       }
     },
@@ -11128,132 +11164,6 @@
       "locationSet": {"include": ["pl"]},
       "tags": {
         "network": "PGK Suwałki",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:CAR:Baguio",
-      "id": "phcarbaguio-3785bf",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "network": "PH:CAR:Baguio",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:CAR:Benguet",
-      "id": "phcarbenguet-3785bf",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "network": "PH:CAR:Benguet",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUB",
-      "id": "phpub-3785bf",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "network": "PH:PUB",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUB:BGC",
-      "id": "phpubbgc-3785bf",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "network": "PH:PUB:BGC",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUB:Cagayan Valley",
-      "id": "phpubcagayanvalley-3785bf",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "network": "PH:PUB:Cagayan Valley",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUB:Central Luzon",
-      "id": "phpubcentralluzon-3785bf",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "network": "PH:PUB:Central Luzon",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUB:Metro Manila",
-      "id": "phpubmetromanila-3785bf",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "network": "PH:PUB:Metro Manila",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUB:QC",
-      "id": "phpubqc-3785bf",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "network": "PH:PUB:QC",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUJ:Batangas",
-      "id": "phpujbatangas-3785bf",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "network": "PH:PUJ:Batangas",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUJ:CALABARZON",
-      "id": "phpujcalabarzon-3785bf",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "network": "PH:PUJ:CALABARZON",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUJ:Cavite",
-      "id": "phpujcavite-3785bf",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "network": "PH:PUJ:Cavite",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUJ:Cebu",
-      "id": "phpujcebu-3785bf",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "network": "PH:PUJ:Cebu",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUJ:Metro Manila",
-      "id": "phpujmetromanila-3785bf",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "network": "PH:PUJ:Metro Manila",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUVMP:Metro Manila",
-      "id": "phpuvmpmetromanila-3785bf",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "network": "PH:PUVMP:Metro Manila",
         "route": "bus"
       }
     },
@@ -18130,6 +18040,18 @@
         "network:wikidata": "Q7926999",
         "operator": "BC Transit",
         "operator:wikidata": "Q4179186",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Victory Liner",
+      "locationSet": {
+        "include": ["ph""]
+      },
+      "matchNames": ["victory bus"],
+      "tags": {
+        "network": "Victory Liner",
+        "network:wikidata": "Q860459",
         "route": "bus"
       }
     },


### PR DESCRIPTION
add network tag preset for provincial bus companies Victory Liner and Five Star. also merge/deprecate PH-colon-separated values in favor of plain text values (PH:PUB/PUJ:(region) into LTFRB PUB/PUJ or more specific values). also delete PH:PUB:BGC in favor of plain text BGC Bus (using service branding).