### PR TITLE
Add Wikidata entry for Belgian waste management company IVAREM

### DIFF
--- a/data/operators/amenity/recycling.json
+++ b/data/operators/amenity/recycling.json
@@ -2161,6 +2161,7 @@
       "tags": {
         "amenity": "recycling",
         "operator": "IVAREM"
+	"operator:wikidata": "Q104502898"
       }
     },
     {

--- a/data/operators/amenity/recycling.json
+++ b/data/operators/amenity/recycling.json
@@ -2160,8 +2160,8 @@
       "locationSet": {"include": ["be"]},
       "tags": {
         "amenity": "recycling",
-        "operator": "IVAREM"
-	"operator:wikidata": "Q104502898"
+        "operator": "IVAREM",
+        "operator:wikidata": "Q104502898"
       }
     },
     {


### PR DESCRIPTION
This waste management company operating in the Belgian arrondissement of Mechelen was already present in the index, but not a linked Wikidata entry. I've completed out the Wikidata entry so it is now usable for NSI purposes (logo/social medias/website..).