### PR TITLE
Add novelty car brands Alpine (Renault) and Cupra (SEAT) to the car brand list

### DIFF
--- a/data/brands/shop/car.json
+++ b/data/brands/shop/car.json
@@ -46,6 +46,16 @@
       }
     },
     {
+      "displayName": "Alpine",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "Alpine",
+        "brand:wikidata": "Q26944",
+        "name": "Alpine",
+        "shop": "car"
+      }
+    },
+    {
       "displayName": "Arnold Clark",
       "id": "arnoldclark-42e946",
       "locationSet": {"include": ["gb"]},
@@ -238,6 +248,16 @@
         "brand": "Citroën",
         "brand:wikidata": "Q6746",
         "name": "Citroën",
+        "shop": "car"
+      }
+    },
+    {
+      "displayName": "Cupra",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "Cupra",
+        "brand:wikidata": "Q8352675",
+        "name": "Cupra",
         "shop": "car"
       }
     },


### PR DESCRIPTION
I know these are novelty car (sub-)brands from Renault and SEAT respectively, and they are unlikely to have seperate dealerships. In Europe at least, these are mostly grouped with the dealerships in the big cities, that are sometimes owned by the car distribution company itself. In my country: just 5 Alpine dealerships (4 in Flanders, 1 in Wallonia) ! Cupra seems to have more - at least service points - they may not have any Cupra car in the showroom.

But still, in the instance when they have dedicated dealerships it might be useful. (like Polestar - started off as the performance sub-brand from Volvo and eventually became a separate brand on its own, with their own showrooms separate from Volvo. Service points tend to be at Volvo or Geely-group garages).