### PR TITLE
Korean railroad operators and networks

### DIFF
--- a/data/operators/route/railway.json
+++ b/data/operators/route/railway.json
@@ -619,7 +619,7 @@
     {
       "displayName": "국가철도공단",
       "locationSet": {"include": ["kr"]},
-      "matchNames": {"korail", "krna", "한국철도"},
+      "matchNames": ["korail", "krna", "한국철도"],
       "tags": {
         "operator": "국가철도공단",
         "operator:en": "Korea Rail Network Authority",

--- a/data/operators/route/railway.json
+++ b/data/operators/route/railway.json
@@ -625,7 +625,7 @@
         "operator:ko": "국가철도공단",
         "operator:ko-Hani": "國家鐵道公團",
         "operator:ko-Latn": "Gukga cheoldo gongdan",
-        "operator:short:en": "KRNA"
+        "operator:short:en": "KRNA",
         "operator:wikidata": "Q624022",
         "route": "railway"
       }

--- a/data/operators/route/railway.json
+++ b/data/operators/route/railway.json
@@ -619,7 +619,7 @@
     {
       "displayName": "국가철도공단",
       "locationSet": {"include": ["kr"]},
-      "matchNames": {"korail", "krna", "한국철도"}
+      "matchNames": {"korail", "krna", "한국철도"},
       "tags": {
         "operator": "국가철도공단",
         "operator:en": "Korea Rail Network Authority",

--- a/data/operators/route/railway.json
+++ b/data/operators/route/railway.json
@@ -617,14 +617,16 @@
       }
     },
     {
-      "displayName": "한국철도공사",
-      "id": "korail-70c7ea",
+      "displayName": "국가철도공단",
       "locationSet": {"include": ["kr"]},
       "tags": {
-        "operator": "한국철도공사",
-        "operator:en": "Korail",
-        "operator:ko": "한국철도공사",
-        "operator:wikidata": "Q18169",
+        "operator": "국가철도공단",
+        "operator:en": "Korea Rail Network Authority",
+        "operator:ko": "국가철도공단",
+        "operator:ko-Hani": "國家鐵道公團",
+        "operator:ko-Latn": "Gukga cheoldo gongdan",
+        "operator:short:en": "KRNA"
+        "operator:wikidata": "Q624022",
         "route": "railway"
       }
     },

--- a/data/operators/route/railway.json
+++ b/data/operators/route/railway.json
@@ -619,13 +619,13 @@
     {
       "displayName": "국가철도공단",
       "locationSet": {"include": ["kr"]},
+      "matchNames": {"korail", "krna", "한국철도"}
       "tags": {
         "operator": "국가철도공단",
         "operator:en": "Korea Rail Network Authority",
         "operator:ko": "국가철도공단",
         "operator:ko-Hani": "國家鐵道公團",
         "operator:ko-Latn": "Gukga cheoldo gongdan",
-        "operator:short:en": "KRNA",
         "operator:wikidata": "Q624022",
         "route": "railway"
       }

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -1797,10 +1797,11 @@
       "matchNames": ["에스알", "sr", "super rapid train", "supreme railway"],
       "tags": {
         "network": "SRT",
-        "network:wikidata": "3088068",
+        "network:wikidata": "Q3088068",
         "operator": "SR공사",
         "operator:en": "SR Corporation",
         "operator:ko": "SR공사",
+        "operator:wikidata": "Q15615204"
         "route": "train"
       }
     },

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -862,7 +862,7 @@
     {
       "displayName": "KTX",
       "locationSet": {"include": ["kr"]},
-      "matchName": {"한국고속철도", "케이티엑스"},
+      "matchNames": {"한국고속철도", "케이티엑스"},
       "tags": {
         "network": "KTX",
         "network:wikidata": "Q167674",
@@ -2619,7 +2619,7 @@
     {
       "displayName": "코레일",
       "locationSet": {"include": ["kr"]},
-      "matchName": {"한국철도"},
+      "matchNames": {"한국철도"},
       "tags": {
         "network": "코레일",
         "network:en": "Korail",

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -1801,7 +1801,7 @@
         "operator": "SR공사",
         "operator:en": "SR Corporation",
         "operator:ko": "SR공사",
-        "operator:wikidata": "Q15615204"
+        "operator:wikidata": "Q15615204",
         "route": "train"
       }
     },

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -862,7 +862,7 @@
     {
       "displayName": "KTX",
       "locationSet": {"include": ["kr"]},
-      "matchNames": {"한국고속철도", "케이티엑스"},
+      "matchNames": ["한국고속철도", "케이티엑스"],
       "tags": {
         "network": "KTX",
         "network:wikidata": "Q167674",
@@ -2619,7 +2619,7 @@
     {
       "displayName": "코레일",
       "locationSet": {"include": ["kr"]},
-      "matchNames": {"한국철도"},
+      "matchNames": ["한국철도", "korail", "korea railroad"],
       "tags": {
         "network": "코레일",
         "network:en": "Korail",

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -867,7 +867,7 @@
         "network": "KTX",
         "network:wikidata": "Q167674",
         "operator": "한국철도공사",
-        "operator:en": "Korea Railroad"
+        "operator:en": "Korea Railroad",
         "operator:ko": "한국철도공사",
         "route": "train"
       }
@@ -2626,7 +2626,7 @@
         "network:ko": "코레일",
         "network:wikidata": "Q18169",
         "operator": "한국철도공사",
-        "operator:en": "Korea Railroad"
+        "operator:en": "Korea Railroad",
         "operator:ko": "한국철도공사",
         "route": "train"
       }

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -860,6 +860,19 @@
       }
     },
     {
+      "displayName": "KTX",
+      "locationSet": {"include": ["kr"]},
+      "matchName": {"한국고속철도", "케이티엑스"},
+      "tags": {
+        "network": "KTX",
+        "network:wikidata": "Q167674",
+        "operator": "한국철도공사",
+        "operator:en": "Korea Railroad"
+        "operator:ko": "한국철도공사",
+        "route": "train"
+      }
+    },
+    {
       "displayName": "L",
       "id": "l-ca8f90",
       "locationSet": {"include": ["be"]},
@@ -2600,6 +2613,21 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "network": "სს \"საქართველოს რკინიგზა\"",
+        "route": "train"
+      }
+    },
+    {
+      "displayName": "코레일",
+      "locationSet": {"include": ["kr"]},
+      "matchName": {"한국철도"},
+      "tags": {
+        "network": "코레일",
+        "network:en": "Korail",
+        "network:ko": "코레일",
+        "network:wikidata": "Q18169",
+        "operator": "한국철도공사",
+        "operator:en": "Korea Railroad"
+        "operator:ko": "한국철도공사",
         "route": "train"
       }
     },

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -1792,6 +1792,19 @@
       }
     },
     {
+      "displayName": "SRT (South Korea)",
+      "locationSet": {"include": ["kr"]},
+      "matchNames": ["에스알", "sr", "super rapid train", "supreme railway"],
+      "tags": {
+        "network": "SRT",
+        "network:wikidata": "3088068",
+        "operator": "SR공사",
+        "operator:en": "SR Corporation",
+        "operator:ko": "SR공사",
+        "route": "train"
+      }
+    },
+    {
       "displayName": "STB",
       "id": "stb-f836da",
       "locationSet": {"include": ["ro"]},


### PR DESCRIPTION
adds tag presets for Korail, KTX, and SRT under route=train

also changes Korail to Korea Rail Network Authority (KRNA) for railway operator (route=railway). Korail operates trains, but the infrastructure is maintained by KRNA (compare European open-access railway networks).