### PR TITLE
more Philippine govt agencies

### DIFF
--- a/data/operators/office/government.json
+++ b/data/operators/office/government.json
@@ -71,9 +71,36 @@
       }
     },
     {
+      "displayName": "Bureau of Customs",
+      "locationSet": {"include": ["ph"]},
+      "matchNames": ["boc"],
+      "tags": {
+        "government": "customs",
+        "office": "government",
+        "operator": "Bureau of Customs",
+        "operator:short": "BOC",
+        "operator:tl": "Kawanihan ng Adwana",
+        "operator:wikidata": "Q25053493"
+      }
+    },
+    {
+      "displayName": "Bureau of Immigration (Philippines)",
+      "locationSet": {"include": ["ph"]},
+      "matchNames": ["bi", "boi"],
+      "tags": {
+        "government": "immigration",
+        "office": "government",
+        "operator": "Bureau of Immigration",
+        "operator:short": "BOI",
+        "operator:tl": "Kawanihan ng Inmigrasyon",
+        "operator:wikidata": "Q27892670"
+      }
+    },
+    {
       "displayName": "Bureau of Internal Revenue",
       "id": "bureauofinternalrevenue-7987d4",
       "locationSet": {"include": ["ph"]},
+      "matchNames": ["bir", "bir revenue district"],
       "tags": {
         "government": "tax",
         "office": "government",
@@ -134,6 +161,20 @@
       }
     },
     {
+      "displayName": "Civil Service Commission (Philippines)",
+      "locationSet": {"include": ["ph"]},
+      "matchNames": ["csc"],
+      "tags": {
+        "government": "public_service",
+        "office": "government",
+        "operator": "Civil Service Commission",
+        "operator:en": "Civil Service Commission",
+        "operator:short": "CSC",
+        "operator:tl": "Komisyon sa Serbisyong Sibil",
+        "operator:wikidata": "Q13565023"
+      }
+    },
+    {
       "displayName": "CNE",
       "id": "consejonacionalelectoral-b90a8d",
       "locationSet": {"include": ["ve"]},
@@ -143,6 +184,20 @@
         "operator": "Consejo Nacional Electoral",
         "operator:short": "CNE",
         "operator:wikidata": "Q2890246"
+      }
+    },
+    {
+      "displayName": "Commission on Elections (Philippines)",
+      "locationSet": {"include": ["ph"]},
+      "matchNames": ["comelec"],
+      "tags": {
+        "government": "electoral_commission",
+        "office": "government",
+        "operator": "Commission of Elections",
+        "operator:en": "Commission of Elections",
+        "operator:short": "COMELEC",
+        "operator:tl": "Komisyon sa Halalan",
+        "operator:wikidata": "Q2459712"
       }
     },
     {
@@ -195,6 +250,7 @@
       "displayName": "Department of Education (Philippines)",
       "id": "departmentofeducation-7987d4",
       "locationSet": {"include": ["ph"]},
+      "matchNames": ["deped", "deped city schools division", "deped school division"],
       "tags": {
         "government": "education",
         "office": "government",
@@ -202,6 +258,19 @@
         "operator:short": "DepEd",
         "operator:tl": "Kagawaran ng Edukasyon",
         "operator:wikidata": "Q3550346"
+      }
+    },
+    {
+      "displayName": "Department of Foreign Affairs (Philippines)",
+      "locationSet": {"include": ["ph"]},
+      "matchNames": ["dfa"],
+      "tags": {
+        "office": "government",
+        "operator": "Department of Foreign Affairs",
+        "operator:en": "Department of Foreign Affairs",
+        "operator:short": "DFA",
+        "operator:tl": "Kagawaran ng Ugnayang Panlabas",
+        "operator:wikidata": "Q13565023"
       }
     },
     {
@@ -229,9 +298,24 @@
       }
     },
     {
+      "displayName": "Department of Public Works",
+      "id": "departmentofpublicworksandhighways-7987d4",
+      "locationSet": {"include": ["ph"]},
+       "matchNames": ["dpwh", "dpwh district engineering office"],
+      "tags": {
+        "government": "public_works",
+        "office": "government",
+        "operator": "Department of Public Works and Highways",
+        "operator:short": "DPWH",
+        "operator:tl": "Kagawaran ng Pagawaing Bayan at Lansangan" 
+        "operator:wikidata": "Q3543840"
+      }
+    },
+    {
       "displayName": "Department of Trade and Industry",
       "id": "departmentoftradeandindustry-7987d4",
       "locationSet": {"include": ["ph"]},
+      "matchNames": ["dti", "dti provincial office", "dti regional office"],
       "tags": {
         "government": "trade",
         "office": "government",
@@ -290,18 +374,6 @@
       "tags": {
         "office": "government",
         "operator": "Dinas PU"
-      }
-    },
-    {
-      "displayName": "DPWH",
-      "id": "departmentofpublicworksandhighways-7987d4",
-      "locationSet": {"include": ["ph"]},
-      "tags": {
-        "government": "public_works",
-        "office": "government",
-        "operator": "Department of Public Works and Highways",
-        "operator:short": "DPWH",
-        "operator:wikidata": "Q3543840"
       }
     },
     {
@@ -426,6 +498,7 @@
       "displayName": "Government Service Insurance System",
       "id": "governmentserviceinsurancesystem-7987d4",
       "locationSet": {"include": ["ph"]},
+      "matchNames": ["gsis"],
       "tags": {
         "government": "social_security",
         "office": "government",
@@ -601,6 +674,7 @@
       "displayName": "Land Transportation Office",
       "id": "landtransportationoffice-7987d4",
       "locationSet": {"include": ["ph"]},
+      "matchNames": ["lto"],
       "tags": {
         "government": "transportation",
         "office": "government",
@@ -1078,6 +1152,7 @@
       "displayName": "Social Security System",
       "id": "socialsecuritysystem-7987d4",
       "locationSet": {"include": ["ph"]},
+      "matchNames": ["sss"],
       "tags": {
         "government": "social_security",
         "office": "government",

--- a/data/operators/office/government.json
+++ b/data/operators/office/government.json
@@ -314,6 +314,19 @@
       }
     },
     {
+      "displayName": "Department of Science and Technology (Philippines)",
+      "locationSet": {"include": ["ph"]},
+      "matchNames": ["dost"],
+      "tags": {
+        "office": "government",
+        "operator": "Department of Science and Technology",
+        "operator:en": "Department of Science and Technology",
+        "operator:short": "DOST",
+        "operator:tl": "Kagawaran ng Agham at Teknolohiya",
+        "operator:wikidata": "Q3547215"
+      }
+    },
+    {
       "displayName": "Department of Trade and Industry",
       "id": "departmentoftradeandindustry-7987d4",
       "locationSet": {"include": ["ph"]},

--- a/data/operators/office/government.json
+++ b/data/operators/office/government.json
@@ -255,6 +255,7 @@
         "government": "education",
         "office": "government",
         "operator": "Department of Education",
+        "operator:en": "Department of Education",
         "operator:short": "DepEd",
         "operator:tl": "Kagawaran ng Edukasyon",
         "operator:wikidata": "Q3550346"
@@ -298,7 +299,7 @@
       }
     },
     {
-      "displayName": "Department of Public Works",
+      "displayName": "Department of Public Works and Highways (Philippines)",
       "id": "departmentofpublicworksandhighways-7987d4",
       "locationSet": {"include": ["ph"]},
        "matchNames": ["dpwh", "dpwh district engineering office"],
@@ -306,8 +307,9 @@
         "government": "public_works",
         "office": "government",
         "operator": "Department of Public Works and Highways",
+        "operator:en": "Department of Public Works and Highways",
         "operator:short": "DPWH",
-        "operator:tl": "Kagawaran ng Pagawaing Bayan at Lansangan" 
+        "operator:tl": "Kagawaran ng Pagawaing Bayan at Lansangan",
         "operator:wikidata": "Q3543840"
       }
     },
@@ -320,6 +322,7 @@
         "government": "trade",
         "office": "government",
         "operator": "Department of Trade and Industry",
+        "operator:en": "Department of Trade and Industry",
         "operator:short": "DTI",
         "operator:tl": "Kagawaran ng Kalakalan at Industriya",
         "operator:wikidata": "Q3545667"
@@ -679,6 +682,7 @@
         "government": "transportation",
         "office": "government",
         "operator": "Land Transportation Office",
+        "operator:en": "Land Transportation Office",
         "operator:short": "LTO",
         "operator:tl": "Tanggapan sa Transportasyon Panlupa",
         "operator:wikidata": "Q6484001"
@@ -950,6 +954,34 @@
         "operator": "Národný inšpektorát práce",
         "operator:short": "NIP",
         "operator:wikidata": "Q105160131"
+      }
+    },
+    {
+      "displayName": "National Bureau of Investigation",
+      "locationSet": {"include": ["ph"]},
+      "matchNames": ["nbi", "nbi clearance center"],
+      "tags": {
+        "government": "investigation",
+        "office": "government",
+        "operator": "National Bureau of Investigation",
+        "operator:en": "National Bureau of Investigation",
+        "operator:short": "NBI",
+        "operator:tl": "Pambansang Kawanihan ng Pagsisiyasat",
+        "operator:wikidata": "Q3336849"
+      }
+    },
+    {
+      "displayName": "National Disaster Risk Reduction and Management Council",
+      "locationSet": {"include": ["ph"]},
+      "matchNames": ["ndrrmc"],
+      "tags": {
+        "government": "civil_defence",
+        "office": "government",
+        "operator": "National Disaster Risk Reduction and Management Council",
+        "operator:en": "National Disaster Risk Reduction and Management Council",
+        "operator:short": "NDRMMC",
+        "operator:tl": "Pambansang Tanggapan para sa Pagtugon ng Sakuna",
+        "operator:wikidata": "Q6972311"
       }
     },
     {


### PR DESCRIPTION
adds more Philippine government agencies:
- Bureau of Customs (BOC)
- Bureau of Immigration (BOI)
- Civil Service Commission (CSC)
- Commission of Elections (COMELEC)
- Commission on Human Rights (CHR)
- Department of Foreign Affairs (DFA)
- Department of Health (DOH)
- Department of the Interior and Local Government (DILG)
- Department of Labor and Employment (DOLE)
- Department of Science and Technology (DOST)
- National Bureau of Investigation (NBI)
- National Disaster Risk Reduction and Management Council (NDRRMC)

This pull request also renames "DPWH" to "Department of Public Works and Highways (Philippines)". This also adds match names to other PH gov't agencies already added.