### PR TITLE
more Philippine gov't agencies

### DIFF
--- a/data/operators/office/government.json
+++ b/data/operators/office/government.json
@@ -78,9 +78,24 @@
         "government": "customs",
         "office": "government",
         "operator": "Bureau of Customs",
+        "operator:en": "Bureau of Customs",
         "operator:short": "BOC",
         "operator:tl": "Kawanihan ng Adwana",
         "operator:wikidata": "Q25053493"
+      }
+    },
+    {
+      "displayName": "Bureau of Fisheries and Aquatic Resources",
+      "locationSet": {"include": ["ph"]},
+      "matchNames": ["bfar regional office"],
+      "tags": {
+        "government": "agency",
+        "office": "government",
+        "operator": "Bureau of Fisheries and Aquatic Resources",
+        "operator:en": "Bureau of Fisheries and Aquatic Resources",
+        "operator:short": "BFAR",
+        "operator:tl": "Kawanihan ng Pangisdaan at Yamang-tubig",
+        "operator:wikidata": "Q4998371"
       }
     },
     {
@@ -91,6 +106,7 @@
         "government": "immigration",
         "office": "government",
         "operator": "Bureau of Immigration",
+        "operator:en": "Bureau of Immigration",
         "operator:short": "BOI",
         "operator:tl": "Kawanihan ng Inmigrasyon",
         "operator:wikidata": "Q27892670"
@@ -105,9 +121,24 @@
         "government": "tax",
         "office": "government",
         "operator": "Bureau of Internal Revenue",
+        "operator:en": "Bureau of Internal Revenue",
         "operator:short": "BIR",
         "operator:tl": "Kawanihan ng Rentas Internas",
         "operator:wikidata": "Q4998387"
+      }
+    },
+    {
+      "displayName": "Bureau of Jail Management and Penology",
+      "locationSet": {"include": ["ph"]},
+      "matchNames": ["bjmp regional office"],
+      "tags": {
+        "government": "agency",
+        "office": "government",
+        "operator": "Bureau of Jail Management and Penology",
+        "operator:en": "Bureau of Jail Management and Penology",
+        "operator:short": "BJMP",
+        "operator:tl": "Kawanihan ng Pangangasiwa mg Kulungan at Penolohiya",
+        "operator:wikidata": "Q17027213"
       }
     },
     {
@@ -274,6 +305,19 @@
       }
     },
     {
+      "displayName": "Department of Agriculture (Philippines)",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "government": "agriculture",
+        "office": "government",
+        "operator": "Department of Agriculture",
+        "operator:en": "Department of Agriculture",
+        "operator:short": "DA",
+        "operator:tl": "Kagawaran ng Agrikultura",
+        "operator:wikidata": "Q5260142"
+      }
+    },
+    {
       "displayName": "Department of Education (Philippines)",
       "id": "departmentofeducation-7987d4",
       "locationSet": {"include": ["ph"]},
@@ -286,6 +330,19 @@
         "operator:short": "DepEd",
         "operator:tl": "Kagawaran ng Edukasyon",
         "operator:wikidata": "Q3550346"
+      }
+    },
+    {
+      "displayName": "Department of Environment and Natural Resources (Philippines)",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "government": "environment",
+        "office": "government",
+        "operator": "Department of Environment and Natural Resources",
+        "operator:en": "Department of Environment and Natural Resources",
+        "operator:short": "DA",
+        "operator:tl": "Kagawaran ng Kalikasan at Likas na Yaman",
+        "operator:wikidata": "Q3277331"
       }
     },
     {


### PR DESCRIPTION
adds these Philippine gov't agencies:

- Bureau of Fisheries and Aquatic Resources (BFAR)
- Bureau of Jail Management and Penology (BJMP)
- Department of Agriculture (DA)
- Department of Environment and Natural Resources (DENR)

also adds missing English name values for some agencies.