### PR TITLE
Adding another H&M-group fashion label to NSI - Monki

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -5886,6 +5886,16 @@
       }
     },
     {
+      "displayName": "Monki",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "Monki",
+        "brand:wikidata": "Q10588271",
+        "name": "Monki",
+        "shop": "clothes"
+      }
+    },
+    {
       "displayName": "Monnari",
       "id": "monnari-196c99",
       "locationSet": {"include": ["pl"]},


### PR DESCRIPTION
Another fashion label of the H&M-group with its dedicated stores, but where the Wikidata entry fell short for NSI use. I've completed it with the usual identifiers, so the brand can be added to NSI.