### PR TITLE
Department of Foreign Affairs Wikidata

### DIFF
--- a/data/operators/office/government.json
+++ b/data/operators/office/government.json
@@ -365,7 +365,7 @@
         "operator:en": "Department of Foreign Affairs",
         "operator:short": "DFA",
         "operator:tl": "Kagawaran ng Ugnayang Panlabas",
-        "operator:wikidata": "Q13565023"
+        "operator:wikidata": "Q3545663"
       }
     },
     {


### PR DESCRIPTION
corrects Wikidata for Department of Foreign Affairs: Q3545663. Wikidata linked is for Civil Service Commission due to copy-paste. for immediate merging.