### PR TITLE
Remove unnecessary capitalization 'TOPGUN' -> 'TopGun'

### DIFF
--- a/data/brands/shop/hairdresser.json
+++ b/data/brands/shop/hairdresser.json
@@ -758,12 +758,12 @@
       }
     },
     {
-      "displayName": "TOPGUN",
+      "displayName": "TopGun",
       "id": "topgun-634538",
       "locationSet": {"include": ["kz", "ru"]},
       "tags": {
-        "brand": "TOPGUN",
-        "name": "TOPGUN",
+        "brand": "TopGun",
+        "name": "TopGun",
         "shop": "hairdresser"
       }
     },


### PR DESCRIPTION
Not an abbreviation.

See in another preset:
https://github.com/ruosm-presets/literan-moscow/blob/6c22490b90777fc0dc8b9c72404d5fbb4d561c94/russian_shops.xml#LL2370C32-L2370C38
although they kept brand tag in all caps for some reason.