### PR TITLE
Remove unused translation 'Red&White'

### DIFF
--- a/data/brands/shop/alcohol.json
+++ b/data/brands/shop/alcohol.json
@@ -964,12 +964,8 @@
       "matchNames": ["красное и белое"],
       "tags": {
         "brand": "Красное&Белое",
-        "brand:en": "Red&White",
-        "brand:ru": "Красное&Белое",
         "brand:wikidata": "Q24933790",
         "name": "Красное&Белое",
-        "name:en": "Red&White",
-        "name:ru": "Красное&Белое",
         "shop": "alcohol"
       }
     },


### PR DESCRIPTION
I've never seen them using this name in English, not even in their domain name (https://krasnoeibeloe.ru/).

It was in Wikidata for a while, then it got replaced by a transliteration: https://www.wikidata.org/w/index.php?title=Q24933790&diff=955200070&oldid=955199908