### PR TITLE
Remove defunct supermarket

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -8683,20 +8683,6 @@
       }
     },
     {
-      "displayName": "Народная 7Я семьЯ",
-      "id": "peoples7thfamily-d5eaac",
-      "locationSet": {"include": ["ru"]},
-      "matchNames": ["семья"],
-      "tags": {
-        "brand": "Народная 7Я семьЯ",
-        "brand:en": "People's 7th Family",
-        "brand:wikidata": "Q4032436",
-        "name": "Народная 7Я семьЯ",
-        "name:en": "People's 7th Family",
-        "shop": "supermarket"
-      }
-    },
-    {
       "displayName": "Наш Край",
       "id": "17c1f7-94881c",
       "locationSet": {"include": ["ua"]},


### PR DESCRIPTION
Went out of business years ago: https://ru.wikipedia.org/wiki/%D0%9D%D0%B0%D1%80%D0%BE%D0%B4%D0%BD%D0%B0%D1%8F_7%D0%AF_%D1%81%D0%B5%D0%BC%D1%8C%D1%8F

Also `name:en` here is a translation that I've never seen being used by the company.
