### PR TITLE
Add Wikidata entry for bicycle rental service Donkey Republic

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -1306,6 +1306,7 @@
       "tags": {
         "amenity": "bicycle_rental",
         "brand": "Donkey Republic",
+	"brand:wikidata": "Q63753939",
         "name": "Donkey Republic",
         "operator": "Donkey Republic"
       }


### PR DESCRIPTION
The bicycle rental service Donkey Republic already had a Wikidata entry since 2019, it just wasn't linked to the relevant NSI entry. Fixing that with this PR.