### PR TITLE
Update Japanese convenience stores

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5623,7 +5623,7 @@
       "id": "seicomart-652b3e",
       "locationSet": {"include": ["jp"]},
       "tags": {
-        "brand": "セイコーマート",
+        "brand": "Seicomart",
         "brand:en": "Seicomart",
         "brand:ja": "セイコーマート",
         "brand:wikidata": "Q11314123",
@@ -5642,8 +5642,8 @@
         "セブンイレブン(seven-eleven)"
       ],
       "tags": {
-        "brand": "セブン-イレブン",
-        "brand:en": "7-Eleven",
+        "brand": "7-ELEVEN",
+        "brand:en": "7-ELEVEN",
         "brand:ja": "セブン-イレブン",
         "brand:wikidata": "Q259340",
         "name": "セブン-イレブン",
@@ -5659,8 +5659,8 @@
       "locationSet": {"include": ["jp"]},
       "matchNames": ["デイリーストア"],
       "tags": {
-        "brand": "デイリーヤマザキ",
-        "brand:en": "Daily Yamazaki",
+        "brand": "Daily YAMAZAKI",
+        "brand:en": "Daily YAMAZAKI",
         "brand:ja": "デイリーヤマザキ",
         "brand:wikidata": "Q5209392",
         "name": "デイリーヤマザキ",
@@ -5674,7 +5674,7 @@
       "id": "naturallawson-652b3e",
       "locationSet": {"include": ["jp"]},
       "tags": {
-        "brand": "ナチュラルローソン",
+        "brand": "NATURAL LAWSON",
         "brand:en": "NATURAL LAWSON",
         "brand:ja": "ナチュラルローソン",
         "brand:wikidata": "Q11323850",
@@ -5742,8 +5742,8 @@
       "id": "ministop-652b3e",
       "locationSet": {"include": ["jp"]},
       "tags": {
-        "brand": "ミニストップ",
-        "brand:en": "Ministop",
+        "brand": "MINISTOP",
+        "brand:en": "MINISTOP",
         "brand:ja": "ミニストップ",
         "brand:wikidata": "Q1038929",
         "name": "ミニストップ",
@@ -5814,22 +5814,7 @@
       }
     },
     {
-      "displayName": "ローソンストア100",
-      "id": "lawsonstore100-652b3e",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "brand": "LAWSON STORE 100",
-        "brand:en": "LAWSON STORE 100",
-        "brand:ja": "ローソンストア100",
-        "brand:wikidata": "Q11350960",
-        "name": "ローソンストア100",
-        "name:en": "Lawson Store 100",
-        "name:ja": "ローソンストア100",
-        "shop": "convenience"
-      }
-    },
-    {
-      "displayName": "ローソンプラストークス",
+      "displayName": "ローソン+トークス",
       "id": "lawsontoks-652b3e",
       "locationSet": {"include": ["jp"]},
       "note": "LAWSON+toks has two types of stores: convenience store and kiosk.",
@@ -5841,6 +5826,21 @@
         "name": "ローソン+トークス",
         "name:en": "Lawson+toks",
         "name:ja": "ローソンプラストークス",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "ローソンストア100",
+      "id": "lawsonstore100-652b3e",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "LAWSON STORE 100",
+        "brand:en": "LAWSON STORE 100",
+        "brand:ja": "ローソンストア100",
+        "brand:wikidata": "Q11350960",
+        "name": "ローソンストア100",
+        "name:en": "Lawson Store 100",
+        "name:ja": "ローソンストア100",
         "shop": "convenience"
       }
     },

--- a/data/brands/shop/kiosk.json
+++ b/data/brands/shop/kiosk.json
@@ -234,7 +234,7 @@
       }
     },
     {
-      "displayName": "ローソンプラストークス",
+      "displayName": "ローソン+トークス",
       "id": "lawsontoks-84165a",
       "locationSet": {"include": ["jp"]},
       "note": "LAWSON+toks has two types of stores: convenience store and kiosk.",


### PR DESCRIPTION
Updated tag with reference to [JA:Naming sample](https://wiki.openstreetmap.org/wiki/JA:Naming_sample#shop=convenience).