### PR TITLE
Update Coop sweden brand

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1527,11 +1527,13 @@
         "coop konsum",
         "konsum",
         "lilla coop",
+        "coop sverige",
+        "coop sweden",
         "stora coop"
       ],
       "preserveTags": ["^name"],
       "tags": {
-        "brand": "Coop (Sweden)",
+        "brand": "Coop",
         "brand:wikidata": "Q15229319",
         "name": "Coop",
         "shop": "supermarket"


### PR DESCRIPTION
I don't think this one is controversial as I can't see them [using that as term](https://www.coop.se/). But I just wanted to make sure there wasn't a specific reason for it.