### PR TITLE
Update cinema.json

### DIFF
--- a/data/brands/amenity/cinema.json
+++ b/data/brands/amenity/cinema.json
@@ -742,7 +742,7 @@
       "displayName": "Multikino",
       "id": "multikino-2d7744",
       "locationSet": {
-        "include": ["lt", "lv", "pl"]
+        "include": ["lt", "pl"]
       },
       "tags": {
         "amenity": "cinema",


### PR DESCRIPTION
Multikino left Latvia in 2020. https://www.delfi.lv/bizness/biznesa_vide/tuksa-vieta-nepaliek-riga-plaza-rudeni-durvis-vers-jauns-kinoteatris.d?id=52138041