### PR TITLE
Add entry for boat shoe brand Sebago

### DIFF
--- a/data/brands/shop/shoes.json
+++ b/data/brands/shop/shoes.json
@@ -1632,6 +1632,16 @@
       }
     },
     {
+      "displayName": "Sebago",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "Sebago",
+	"brand:wikidata": "Q3476844",
+        "name": "Sebago",
+        "shop": "shoes"
+      }
+    },
+    {
       "displayName": "Shagovita",
       "id": "shagovita-18cb77",
       "locationSet": {


### PR DESCRIPTION
This is a brand for its well-known boat shoes & loafers. The Wikidata entry already existed but missed entries to be NSI-compatible, so I fixed those as well.