### PR TITLE
added local bakery chains Lagler, Taumberger and Zeppitz

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -1208,6 +1208,16 @@
       }
     },
     {
+      "displayName": "Lagler",
+      "locationSet": {"include": ["AT-2.geojson"]},
+      "matchNames": ["Naturbäckerei Lagler"],
+      "tags": {
+        "brand": "Lagler",
+        "name": "Lagler",
+        "shop": "bakery"
+      }
+    },
+    {
       "displayName": "Landbäckerei Schmidt",
       "id": "landbackereischmidt-965fe9",
       "locationSet": {"include": [[14, 51, 50]]},
@@ -1958,6 +1968,16 @@
       }
     },
     {
+      "displayName": "Taumberger",
+      "locationSet": {"include": ["AT-2.geojson"]},
+      "matchNames": ["Bäckerei Taumberger Ges.m.b.H.", "Bäckerei Taumberger"],
+      "tags": {
+        "brand": "Taumberger",
+        "name": "Taumberger",
+        "shop": "bakery"
+      }
+    },
+    {
       "displayName": "The Cheesecake Shop",
       "id": "thecheesecakeshop-4d3be5",
       "locationSet": {"include": ["au", "nz"]},
@@ -2070,6 +2090,7 @@
       "displayName": "Wienerroither",
       "id": "wienerroither-2e087b",
       "locationSet": {"include": ["at"]},
+      "matchNames": ["Bäckerei Wienerroither GmbH", "Bäckerei Wienerroither"],
       "tags": {
         "brand": "Wienerroither",
         "brand:wikidata": "Q110474658",
@@ -2096,6 +2117,17 @@
         "brand": "Zeit für Brot",
         "brand:wikidata": "Q109780385",
         "name": "Zeit für Brot",
+        "shop": "bakery"
+      }
+    },
+    {
+      "displayName": "Zeppitz",
+      "locationSet": {"include": ["AT-2.geojson"]},
+      "matchNames": ["Bäckerei Zeppitz"],
+      "tags": {
+        "brand": "Zeppitz",
+        "name": "Zeppitz",
+        "cafe": "yes",
         "shop": "bakery"
       }
     },


### PR DESCRIPTION
Adds a few local bakery chains which have multiple stores in Carinthia:
* Lagler: https://www.lagler.at/filialen/
* Taumberger: http://www.taumberger.co.at/filialen/
* Zeppitz: https://zeppitz.at/200_standorte.html