### PR TITLE
Move 2 entries from post_office to courier

### DIFF
--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -642,17 +642,6 @@
       }
     },
     {
-      "displayName": "LBC",
-      "id": "lbc-7e1eed",
-      "locationSet": {"include": ["ph"]},
-      "matchNames": ["lbc express"],
-      "tags": {
-        "amenity": "post_office",
-        "operator": "LBC",
-        "operator:wikidata": "Q17075584"
-      }
-    },
-    {
       "displayName": "Lietuvos paštas",
       "id": "lietuvospastas-738531",
       "locationSet": {"include": ["lt"]},

--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -568,18 +568,6 @@
       }
     },
     {
-      "displayName": "J&T Express",
-      "id": "jandtexpress-b78fda",
-      "locationSet": {
-        "include": ["id", "my", "ph"]
-      },
-      "tags": {
-        "amenity": "post_office",
-        "operator": "J&T Express",
-        "operator:wikidata": "Q95690344"
-      }
-    },
-    {
       "displayName": "Jersey Post",
       "id": "jerseypost-984d36",
       "locationSet": {"include": ["je"]},

--- a/data/operators/office/courier.json
+++ b/data/operators/office/courier.json
@@ -1,0 +1,20 @@
+{
+  "properties": {
+    "path": "operators/office/courier",
+    "preserveTags": ["^name"],
+    "exclude": {"generic": ["^courier$"]}
+  },
+  "items": [
+    {
+      "displayName": "LBC",
+      "id": "lbc-7e1eed",
+      "locationSet": {"include": ["ph"]},
+      "matchNames": ["lbc express"],
+      "tags": {
+        "office": "courier",
+        "operator": "LBC",
+        "operator:wikidata": "Q17075584"
+      }
+    }
+  ]
+}

--- a/data/operators/office/courier.json
+++ b/data/operators/office/courier.json
@@ -15,6 +15,18 @@
         "operator": "LBC",
         "operator:wikidata": "Q17075584"
       }
+    },
+    {
+      "displayName": "J&T Express",
+      "id": "jandtexpress-b78fda",
+      "locationSet": {
+        "include": ["id", "my", "ph"]
+      },
+      "tags": {
+        "office": "courier",
+        "operator": "J&T Express",
+        "operator:wikidata": "Q95690344"
+      }
     }
   ]
 }


### PR DESCRIPTION
Update the NSI entry for 2 entries mis-tagged as `amenity=post_office` to `office=courier`, following the wiki documentation for [office=courier](https://wiki.openstreetmap.org/wiki/Tag:office%3Dcourier), which states "A courier delivery service, which is not a post office or national post. "

The office=courier tag is relatively newer than the post office tag, but has gained wider use in 2018, so many other establishments that fit this description are likely to be incorrectly tagged as the older `amenity=post_office.`

This is my first time to "move" an entry from an existing category, to a new one.  I'm not sure if I correctly created the courier.json file correctly.