### PR TITLE
Change typo on network Tisséo

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -15776,12 +15776,12 @@
       }
     },
     {
-      "displayName": "Tisseo",
+      "displayName": "Tisséo",
       "id": "tisseo-add5eb",
       "locationSet": {"include": ["fx"]},
-      "matchNames": ["fr_tisseo"],
+      "matchNames": ["fr_tisseo", "Tisseo"],
       "tags": {
-        "network": "Tisseo",
+        "network": "Tisséo",
         "network:wikidata": "Q3529461",
         "route": "bus"
       }


### PR DESCRIPTION
See https://www.google.com/search?q=tiss%C3%A9o
On the logo, there is an accent on the network name.