### PR TITLE
Remove incorrect wikidata and brand translation 'Krasnyj Jar'

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -8597,8 +8597,6 @@
       "locationSet": {"include": ["ru"]},
       "tags": {
         "brand": "Красный Яр",
-        "brand:en": "Krasnyj Jar",
-        "brand:wikidata": "Q1786753",
         "name": "Красный Яр",
         "shop": "supermarket"
       }


### PR DESCRIPTION
- Brand wikidata links to a disambiguation page https://www.wikidata.org/wiki/Q1786753
- English brand name is not English and probably not used by the brand. Here's their website: https://www.krasyar.ru/ . As you can see, there's no "jar" in their domain name.
- How it was added here: https://github.com/osmlab/name-suggestion-index/issues/1778 https://github.com/osmlab/name-suggestion-index/commit/be33cbd72f https://github.com/osmlab/name-suggestion-index/pull/2359
- And then it was added to wikidata https://www.wikidata.org/w/index.php?title=Q1786753&diff=1307981279&oldid=1280307475 without anyone paying attention.