### PR TITLE
Split Himawari Pharmacy

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -4531,6 +4531,22 @@
       }
     },
     {
+      "displayName": "スーパードラッグひまわり",
+      "id": "superdrughimawari-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "スーパードラッグひまわり",
+        "brand:en": "Super Drug Himawari",
+        "brand:ja": "スーパードラッグひまわり",
+        "brand:wikidata": "Q119871355",
+        "healthcare": "pharmacy",
+        "name": "スーパードラッグひまわり",
+        "name:en": "Super Drug Himawari",
+        "name:ja": "スーパードラッグひまわり"
+      }
+    },
+    {
       "displayName": "スギ薬局",
       "id": "sugipharmacy-650eee",
       "locationSet": {"include": ["jp"]},
@@ -4689,9 +4705,65 @@
       }
     },
     {
-      "displayName": "ひまわり薬局",
-      "id": "himawaripharmacy-650eee",
-      "locationSet": {"include": ["jp"]},
+      "displayName": "ひまわり薬局(兵庫)",
+      "id": "himawaripharmacy-ac04de",
+      "locationSet": {
+        "include": ["jp-28.geojson"]
+      },
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "ひまわり薬局",
+        "brand:en": "Himawari Pharmacy",
+        "brand:ja": "ひまわり薬局",
+        "brand:wikidata": "Q119872229",
+        "healthcare": "pharmacy",
+        "name": "ひまわり薬局",
+        "name:en": "Himawari Pharmacy",
+        "name:ja": "ひまわり薬局"
+      }
+    },
+    {
+      "displayName": "ひまわり薬局(埼玉)",
+      "id": "himawaripharmacy-755958",
+      "locationSet": {
+        "include": ["jp-11.geojson"]
+      },
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "ひまわり薬局",
+        "brand:en": "Himawari Pharmacy",
+        "brand:ja": "ひまわり薬局",
+        "brand:wikidata": "Q119872175",
+        "healthcare": "pharmacy",
+        "name": "ひまわり薬局",
+        "name:en": "Himawari Pharmacy",
+        "name:ja": "ひまわり薬局"
+      }
+    },
+    {
+      "displayName": "ひまわり薬局(岡山)",
+      "id": "himawaripharmacy-55576a",
+      "locationSet": {
+        "include": ["jp-33.geojson"]
+      },
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "ひまわり薬局",
+        "brand:en": "Himawari Pharmacy",
+        "brand:ja": "ひまわり薬局",
+        "brand:wikidata": "Q119872063",
+        "healthcare": "pharmacy",
+        "name": "ひまわり薬局",
+        "name:en": "Himawari Pharmacy",
+        "name:ja": "ひまわり薬局"
+      }
+    },
+    {
+      "displayName": "ひまわり薬局(滋賀)",
+      "id": "himawaripharmacy-b307f9",
+      "locationSet": {
+        "include": ["jp-25.geojson"]
+      },
       "tags": {
         "amenity": "pharmacy",
         "brand": "ひまわり薬局",

--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -4705,17 +4705,14 @@
       }
     },
     {
-      "displayName": "ひまわり薬局(兵庫)",
-      "id": "himawaripharmacy-ac04de",
-      "locationSet": {
-        "include": ["jp-28.geojson"]
-      },
+      "displayName": "ひまわり薬局",
+      "id": "himawaripharmacy-650eee",
+      "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "pharmacy",
         "brand": "ひまわり薬局",
         "brand:en": "Himawari Pharmacy",
         "brand:ja": "ひまわり薬局",
-        "brand:wikidata": "Q119872229",
         "healthcare": "pharmacy",
         "name": "ひまわり薬局",
         "name:en": "Himawari Pharmacy",
@@ -4723,57 +4720,19 @@
       }
     },
     {
-      "displayName": "ひまわり薬局(埼玉)",
-      "id": "himawaripharmacy-755958",
-      "locationSet": {
-        "include": ["jp-11.geojson"]
-      },
+      "displayName": "ププレひまわり薬局",
+      "id": "pupulehimawaripharmacy-650eee",
+      "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "pharmacy",
-        "brand": "ひまわり薬局",
-        "brand:en": "Himawari Pharmacy",
-        "brand:ja": "ひまわり薬局",
-        "brand:wikidata": "Q119872175",
+        "brand": "ププレひまわり薬局",
+        "brand:en": "Pupule Himawari Pharmacy",
+        "brand:ja": "ププレひまわり薬局",
+        "brand:wikidata": "Q119871972",
         "healthcare": "pharmacy",
-        "name": "ひまわり薬局",
-        "name:en": "Himawari Pharmacy",
-        "name:ja": "ひまわり薬局"
-      }
-    },
-    {
-      "displayName": "ひまわり薬局(岡山)",
-      "id": "himawaripharmacy-55576a",
-      "locationSet": {
-        "include": ["jp-33.geojson"]
-      },
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "ひまわり薬局",
-        "brand:en": "Himawari Pharmacy",
-        "brand:ja": "ひまわり薬局",
-        "brand:wikidata": "Q119872063",
-        "healthcare": "pharmacy",
-        "name": "ひまわり薬局",
-        "name:en": "Himawari Pharmacy",
-        "name:ja": "ひまわり薬局"
-      }
-    },
-    {
-      "displayName": "ひまわり薬局(滋賀)",
-      "id": "himawaripharmacy-b307f9",
-      "locationSet": {
-        "include": ["jp-25.geojson"]
-      },
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "ひまわり薬局",
-        "brand:en": "Himawari Pharmacy",
-        "brand:ja": "ひまわり薬局",
-        "brand:wikidata": "Q119856870",
-        "healthcare": "pharmacy",
-        "name": "ひまわり薬局",
-        "name:en": "Himawari Pharmacy",
-        "name:ja": "ひまわり薬局"
+        "name": "ププレひまわり薬局",
+        "name:en": "Pupule Himawari Pharmacy",
+        "name:ja": "ププレひまわり薬局"
       }
     },
     {


### PR DESCRIPTION
@LaoshuBaby continuation of  https://github.com/osmlab/name-suggestion-index/commit/e776465fd19de8a9f176a89018fc244f3f0456a4

These are pharmacies with the same name, but I believe they are unrelated and just happen to use the same name.
It does not seem to be a franchisor-franchisee relationship.

I created each wikidata item and split it up, but the number of stores for each Himawari Pharmacy seems to be less than 10, is this a problem?