### PR TITLE
Verkehrsverbund Tirol: network:short=VVT

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -17973,6 +17973,7 @@
       "matchNames": ["ivb"],
       "tags": {
         "network": "Verkehrsverbund Tirol",
+        "network:short": "VVT",
         "network:wikidata": "Q1668732",
         "route": "bus"
       }


### PR DESCRIPTION
For consistency with the other "Verkehrsverbund Tirol" entries.