### PR TITLE
Add Sibelga the utility network operator in the Brussels Capital Region to substation operators

### DIFF
--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -6810,6 +6810,7 @@
         "power": "substation"
       }
     },
+    {
       "displayName": "Sibelga",
       "locationSet": {
         "include": ["be"]

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -6810,6 +6810,16 @@
         "power": "substation"
       }
     },
+      "displayName": "Sibelga",
+      "locationSet": {
+        "include": ["be"]
+      },
+      "tags": {
+        "operator": "Sibelga",
+        "operator:wikidata": "Q743846",
+        "power": "substation"
+      }
+    },
     {
       "displayName": "SICAE Oise",
       "id": "sicaeoise-86d13b",


### PR DESCRIPTION
Sibelga is the utility network operator for gas & power utilities in the Brussels Capital Region. Please add it to the substation operators.