### PR TITLE
Boels Rental and Loxam: add matchTags entry to resolve issue #8264

### DIFF
--- a/data/brands/shop/tool_hire.json
+++ b/data/brands/shop/tool_hire.json
@@ -24,7 +24,7 @@
       },
       "matchNames": ["boels rental"],
       "matchTags": ["shop/plant_hire"],
-      "note": ["https://github.com/osmlab/name-suggestion-index/issues/8264"],
+      "note": "https://github.com/osmlab/name-suggestion-index/issues/8264",
       "tags": {
         "brand": "Boels",
         "brand:wikidata": "Q19901961",
@@ -139,7 +139,7 @@
         ]
       },
       "matchTags": ["shop/plant_hire"],
-      "note": ["https://github.com/osmlab/name-suggestion-index/issues/8264"],
+      "note": "https://github.com/osmlab/name-suggestion-index/issues/8264",
       "tags": {
         "brand": "Loxam",
         "brand:wikidata": "Q3264407",

--- a/data/brands/shop/tool_hire.json
+++ b/data/brands/shop/tool_hire.json
@@ -23,6 +23,8 @@
         ]
       },
       "matchNames": ["boels rental"],
+      "matchTags": ["shop/plant_hire"],
+      "note": ["https://github.com/osmlab/name-suggestion-index/issues/8264"],
       "tags": {
         "brand": "Boels",
         "brand:wikidata": "Q19901961",
@@ -135,6 +137,9 @@
           "se",
           "sk"
         ]
+      "matchTags": ["shop/plant_hire"],
+      "note": ["https://github.com/osmlab/name-suggestion-index/issues/8264"],
+
       },
       "tags": {
         "brand": "Loxam",

--- a/data/brands/shop/tool_hire.json
+++ b/data/brands/shop/tool_hire.json
@@ -137,10 +137,9 @@
           "se",
           "sk"
         ]
+      },
       "matchTags": ["shop/plant_hire"],
       "note": ["https://github.com/osmlab/name-suggestion-index/issues/8264"],
-
-      },
       "tags": {
         "brand": "Loxam",
         "brand:wikidata": "Q3264407",


### PR DESCRIPTION
As discussed in issue #8264 : I'm adding a matchTags entry of shop/plant_hire to the existing entries of Boels Rental & Loxam, since they perform both functions at some of their locations.
After merging this, the issue may be closed.