### PR TITLE
Cache all wikidata offical websites in wikidata.json

### DIFF
--- a/scripts/build_wikidata.js
+++ b/scripts/build_wikidata.js
@@ -284,6 +284,12 @@ function processEntities(result) {
       target.identities.website = officialWebsite;
     }
 
+    // P11707 - location URL match pattern
+    const urlMatchPatterns = getClaimValues(entity, 'P11707');
+    if (urlMatchPatterns) {
+      target.urlMatchPatterns = urlMatchPatterns;
+    }
+
     // P2002 - Twitter username
     const twitterUser = getClaimValue(entity, 'P2002');
     if (twitterUser) {

--- a/scripts/build_wikidata.js
+++ b/scripts/build_wikidata.js
@@ -249,6 +249,7 @@ function processEntities(result) {
     target.logos = {};
     target.identities = {};
     target.dissolutions = [];
+    target.officialWebsites = [];
 
 
     let imageFile;
@@ -269,6 +270,12 @@ function processEntities(result) {
         target.logos.wikidata = 'https://commons.wikimedia.org/w/index.php?' +
           utilQsString({ title: `Special:Redirect/file/${imageFile}`, width: 150 });
       }
+    }
+
+    // P856 - official website
+    const officialWebsites = getClaimValues(entity, 'P856');
+    if (officialWebsites) {
+      target.officialWebsites = officialWebsites;
     }
 
     // P856 - official website
@@ -450,7 +457,7 @@ function processEntities(result) {
 
 // `getClaimValue`
 // Get the claim value, considering any claim rank..
-//   - disregard any claimes with an end date qualifier in the past
+//   - disregard any claims with an end date qualifier in the past
 //   - disregard any claims with "deprecated" rank
 //   - accept immediately any claim with "preferred" rank
 //   - return the latest claim with "normal" rank
@@ -482,6 +489,44 @@ function getClaimValue(entity, prop) {
     if (c.rank === 'preferred') return value;  // return immediately
   }
   return value;
+}
+
+// `getClaimValues`
+// Get all the claim values
+//   - disregard any claims with an end date qualifier in the past
+//   - disregard any claims with "deprecated" rank
+//   - push any claims with "preferred" rank to the front
+function getClaimValues(entity, prop) {
+  if (!entity.claims) return;
+  if (!entity.claims[prop]) return;
+
+  let values = [];
+  for (let i = 0; i < entity.claims[prop].length; i++) {
+    const c = entity.claims[prop][i];
+    if (c.rank === 'deprecated') continue;
+    if (c.mainsnak.snaktype !== 'value') continue;
+
+    // skip if we find an end time qualifier - P582
+    let ended = false;
+    const qualifiers = (c.qualifiers && c.qualifiers.P582) || [];
+    for (let j = 0; j < qualifiers.length; j++) {
+      const q = qualifiers[j];
+      if (q.snaktype !== 'value') continue;
+      const enddate = wbk.wikibaseTimeToDateObject(q.datavalue.value.time);
+      if (new Date() > enddate) {
+        ended = true;
+        break;
+      }
+    }
+    if (ended) continue;
+
+    if (c.rank === 'preferred'){  // List preferred values first
+      values.unshift(c.mainsnak.datavalue.value);
+    } else {
+      values.push(c.mainsnak.datavalue.value);
+    }
+  }
+  return values;
 }
 
 


### PR DESCRIPTION
Hey, so may as well say this publicly now.

I've been pushing TomTom to be a consumer of NSI. It's going quite well. I've been putting some of there suppliers through to show them how good it can be. Some suppliers (like [OPIS](https://en.wikipedia.org/wiki/Oil_Price_Information_Service)) already have a brand, so I've expanded some NSI `matchNames` and everything works great.

There are however some suppliers that don't have a brand label, or the brand is just bad. With the current one I'm looking at, it does however have good website urls. So I'm matching based on domain names. But it would be beneficial for me if the `wikidata.json` cache stored all the websites, not just one. Cases like `https://www.burgerking.co.uk/store-locator/store/restaurant_3614` can't match to `"Q177054": {"identities": {"website": "https://www.bk.com/"}}`

I've added a `officialWebsites` array, and not changed the current `website` to avoid breaking anything.

```json
    "Q177054": {
      "description": "global chain of hamburger fast food restaurants headquartered in Florida, United States",
      "identities": {
        "facebook": "burgerking",
        "instagram": "burgerking",
        "linkedin": "burger-king",
        "pinterest": "burgerkingkorea",
        "tiktok": "burgerking",
        "twitter": "burgerking_es",
        "website": "https://www.bk.com/",
        "youtube": "UC23ZqC2LTzl7dfOi6EmwJhg"
      },
      "label": "Burger King",
      "logos": {
        "facebook": "https://graph.facebook.com/burgerking/picture?type=large",
        "wikidata": "https://commons.wikimedia.org/wiki/Special:FilePath/Burger King 2020.svg"
      },
      "officialWebsites": [
        "https://www.bk.com/",
        "https://www.burgerking.co.uk/"
      ]
    },
```

I've also added `urlMatchPatterns`, while this probably wont be beneficial for matching, at least not right now. I have a personal goal of getting iD and JOSM to have a validator warning when there is a bad website tag on a POI.

```json
    "Q127120": {
      "description": "British multinational fitness center chain",
      "identities": {
        "facebook": "FitnessFirstGER",
        "instagram": "fitnessfirstger",
        "twitter": "fitnessfirst_uk",
        "website": "https://www.dwfitnessfirst.com",
        "youtube": "UCQ9asDDs--XEKYJK1G7Ug8A"
      },
      "label": "Fitness First",
      "logos": {
        "facebook": "https://graph.facebook.com/FitnessFirstGER/picture?type=large",
        "wikidata": "https://commons.wikimedia.org/wiki/Special:FilePath/Fitness First Logo.svg"
      },
      "officialWebsites": [
        "https://www.dwfitnessfirst.com",
        "https://www.fitnessfirst.co.uk/",
        "https://www.fitnessfirst.de/"
      ],
      "urlMatchPatterns": [
        "^https:\\/\\/www\\.fitnessfirst\\.co\\.uk\\/find-a-gym\\/([^\\/]+)",
        "^https:\\/\\/www\\.fitnessfirst\\.de\\/clubs\\/([^\\/]+)"
      ]
    },
```