### PR TITLE
Add EcoOil brand

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -1436,6 +1436,17 @@
       }
     },
     {
+      "displayName": "EcoOil",
+      "locationSet": {"include": ["ph"]},
+      "matchNames": ["eco oil"],
+      "tags": {
+        "amenity": "fuel",
+        "brand": "EcoOil",
+        "brand:wikidata": "Q119985537",
+        "name": "EcoOil"
+      }
+    },
+    {
       "displayName": "Eco Petrol",
       "id": "ecopetrol-b450da",
       "locationSet": {"include": ["bg"]},


### PR DESCRIPTION
Add preset for [EcoOil](https://ecooil.ph), chain of filling stations in the Philippines.