### PR TITLE
Update "Julie's Bakeshop" entry in bakery.json

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -1077,12 +1077,17 @@
       }
     },
     {
-      "displayName": "Julie's Bakeshop",
+      "displayName": "Julie's",
       "id": "juliesbakeshop-b6c45f",
       "locationSet": {"include": ["ph"]},
+      "matchNames": [
+        "julie's bakeshop"
+      ],
       "tags": {
-        "brand": "Julie's Bakeshop",
-        "name": "Julie's Bakeshop",
+        "brand": "Julie's",
+        "brand:wikidata": "Q120020522",
+        "name": "Julie's",
+        "old_name": "Julie's Bakeshop",
         "shop": "bakery"
       }
     },


### PR DESCRIPTION
Update the previous entry for Julie's Bakeshop, which is now branded plainly as "Julie's". 

Add fields: brand:wikidata, matchnames