### PR TITLE
Update to several brands in the Philippines

### DIFF
--- a/data/brands/shop/candles.json
+++ b/data/brands/shop/candles.json
@@ -8,7 +8,7 @@
       "displayName": "Yankee Candle",
       "id": "yankeecandle-742731",
       "locationSet": {
-        "include": ["ca", "gb", "us"]
+        "include": ["ca", "gb", "ph", "us"]
       },
       "tags": {
         "brand": "Yankee Candle",

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -260,6 +260,17 @@
       }
     },
     {
+      "displayName": "All Day",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "brand": "All Day",
+        "brand:wikidata": "Q120142311",
+        "name": "All Day",
+        "official_name": "All Day Convenience Store",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "Allsup's",
       "id": "allsups-f1e40b",
       "locationSet": {"include": ["us"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -260,13 +260,12 @@
       }
     },
     {
-      "displayName": "All Day",
+      "displayName": "All Day Convenience Store",
       "locationSet": {"include": ["ph"]},
       "tags": {
         "brand": "All Day",
         "brand:wikidata": "Q120142311",
-        "name": "All Day",
-        "official_name": "All Day Convenience Store",
+        "name": "All Day Convenience Store",
         "shop": "convenience"
       }
     },

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -230,6 +230,16 @@
       }
     },
     {
+      "displayName": "All Day Supermarket",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "brand": "All Day Supermarket",
+        "brand:wikidata": "Q120142311",
+        "name": "All Day Supermarket",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "ALDI (ALDI Nord group)",
       "id": "aldi-b5be76",
       "locationSet": {


### PR DESCRIPTION
This PR contains the following changes:
- Add "ph" to location field, for the "Yankee Candle" entry in shop.json
- Add different "All Day" brand entries for supermarket.json, and convenience.json

