### PR TITLE
delete Philippine bus network values already merged to single network

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -11212,60 +11212,6 @@
       }
     },
     {
-      "displayName": "PH:CAR:Baguio",
-      "id": "phcarbaguio-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "PH:CAR:Baguio",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:CAR:Benguet",
-      "id": "phcarbenguet-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "PH:CAR:Benguet",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUB",
-      "id": "phpub-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "PH:PUB",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUB:Cagayan Valley",
-      "id": "phpubcagayanvalley-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "PH:PUB:Cagayan Valley",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUJ:Cavite",
-      "id": "phpujcavite-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "PH:PUJ:Cavite",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "PH:PUJ:Cebu",
-      "id": "phpujcebu-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "PH:PUJ:Cebu",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "Phébus",
       "id": "phebus-add5eb",
       "locationSet": {"include": ["fx"]},


### PR DESCRIPTION
networks in question has been deleted under #8194, but has been restored yet again for some reason.

Close #8338