### PR TITLE
Add Iranian brands

### DIFF
--- a/data/brands/shop/appliance.json
+++ b/data/brands/shop/appliance.json
@@ -56,6 +56,20 @@
         "name": "Profilo",
         "shop": "appliance"
       }
+    },
+    {
+      "displayName": "اسنوا",
+      "locationSet": {"include": ["ir"]},
+      "tags": {
+        "brand": "اسنوا",
+        "brand:en": "Snowa",
+        "brand:fa": "اسنوا",
+        "brand:wikidata": "Q20109567",
+        "name": "اسنوا",
+        "name:en": "Snowa",
+        "name:fa": "اسنوا",
+        "shop": "appliance"
+      }
     }
   ]
 }

--- a/data/brands/shop/confectionery.json
+++ b/data/brands/shop/confectionery.json
@@ -511,6 +511,20 @@
         "name:ja": "銀座コージーコーナー",
         "shop": "confectionery"
       }
+    },
+    {
+      "displayName": "شیرین عسل",
+      "locationSet": {"include": ["ir"]},
+      "tags": {
+        "brand": "شیرین عسل",
+        "brand:en": "Shirin Asal",
+        "brand:fa": "شیرین عسل",
+        "brand:wikidata": "Q5862430",
+        "name": "شیرین عسل",
+        "name:en": "Shirin Asal",
+        "name:fa": "شیرین عسل",
+        "shop": "confectionery"
+      }
     }
   ]
 }

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5613,6 +5613,63 @@
       }
     },
     {
+      "displayName": "افق کوروش",
+      "locationSet": {"include": ["ir"]},
+      "tags": {
+        "brand": "افق کوروش",
+        "brand:en": "Ofoq Kourosh",
+        "brand:fa": "افق کوروش",
+        "brand:wikidata": "Q65199490",
+        "name": "افق کوروش",
+        "name:en": "Ofoq Kourosh",
+        "name:fa": "افق کوروش",
+        "shop": "convenience",
+        "short_name": "OK"
+      }
+    },
+    {
+      "displayName": "رفاه",
+      "locationSet": {"include": ["ir"]},
+      "tags": {
+        "brand": "رفاه",
+        "brand:en": "Refah",
+        "brand:fa": "رفاه",
+        "brand:wikidata": "Q7307085",
+        "name": "رفاه",
+        "name:en": "Refah",
+        "name:fa": "رفاه",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "جانبو",
+      "locationSet": {"include": ["ir"]},
+      "tags": {
+        "brand": "جانبو",
+        "brand:en": "Canbo",
+        "brand:fa": "جانبو",
+        "brand:wikidata": "Q119145401",
+        "name": "جانبو",
+        "name:en": "Canbo",
+        "name:fa": "جانبو",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "دیلی مارکت",
+      "locationSet": {"include": ["ir"]},
+      "tags": {
+        "brand": "دیلی مارکت",
+        "brand:en": "Daily Market",
+        "brand:fa": "دیلی مارکت",
+        "brand:wikidata": "Q119145493",
+        "name": "دیلی مارکت",
+        "name:en": "Daily Market",
+        "name:fa": "دیلی مارکت",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "세븐일레븐",
       "id": "7eleven-fab923",
       "locationSet": {"include": ["kr"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -9368,12 +9368,17 @@
     },
     {
       "displayName": "افق کوروش",
-      "id": "316800-c29ef9",
       "locationSet": {"include": ["ir"]},
       "tags": {
         "brand": "افق کوروش",
+        "brand:en": "Ofoq Kourosh",
+        "brand:fa": "افق کوروش",
+        "brand:wikidata": "Q65199490",
         "name": "افق کوروش",
-        "shop": "supermarket"
+        "name:en": "Ofoq Kourosh",
+        "name:fa": "افق کوروش",
+        "shop": "supermarket",
+        "short_name": "OK"
       }
     },
     {
@@ -9398,41 +9403,29 @@
     },
     {
       "displayName": "جانبو",
-      "id": "1a9bc2-986a24",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["ir"]},
       "tags": {
         "brand": "جانبو",
+        "brand:en": "Canbo",
+        "brand:fa": "جانبو",
+        "brand:wikidata": "Q119145401",
         "name": "جانبو",
+        "name:en": "Canbo",
+        "name:fa": "جانبو",
         "shop": "supermarket"
       }
     },
     {
-      "displayName": "سوپر",
-      "id": "3b0e76-c29ef9",
+      "displayName": "دیلی مارکت",
       "locationSet": {"include": ["ir"]},
       "tags": {
-        "brand": "سوپر",
-        "name": "سوپر",
-        "shop": "supermarket"
-      }
-    },
-    {
-      "displayName": "فروشگاه افق کوروش",
-      "id": "14a0fb-c29ef9",
-      "locationSet": {"include": ["ir"]},
-      "tags": {
-        "brand": "فروشگاه افق کوروش",
-        "name": "فروشگاه افق کوروش",
-        "shop": "supermarket"
-      }
-    },
-    {
-      "displayName": "فروشگاه رفاه",
-      "id": "9ddc31-c29ef9",
-      "locationSet": {"include": ["ir"]},
-      "tags": {
-        "brand": "فروشگاه رفاه",
-        "name": "فروشگاه رفاه",
+        "brand": "دیلی مارکت",
+        "brand:en": "Daily Market",
+        "brand:fa": "دیلی مارکت",
+        "brand:wikidata": "Q119145493",
+        "name": "دیلی مارکت",
+        "name:en": "Daily Market",
+        "name:fa": "دیلی مارکت",
         "shop": "supermarket"
       }
     },
@@ -9445,6 +9438,34 @@
       "tags": {
         "brand": "مونوبري",
         "name": "مونوبري",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "رفاه",
+      "locationSet": {"include": ["ir"]},
+      "tags": {
+        "brand": "رفاه",
+        "brand:en": "Refah",
+        "brand:fa": "رفاه",
+        "brand:wikidata": "Q7307085",
+        "name": "رفاه",
+        "name:en": "Refah",
+        "name:fa": "رفاه",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "هایپراستار",
+      "locationSet": {"include": ["ir"]},
+      "tags": {
+        "brand": "هایپراستار",
+        "brand:en": "Hyperstar",
+        "brand:fa": "هایپراستار",
+        "brand:wikidata": "Q10860330",
+        "name": "هایپراستار",
+        "name:en": "Hyperstar",
+        "name:fa": "هایپراستار",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
Following brands of Iran are added in this PR:

- Ofoq Kourosh: shop=supermarket, shop=convenience
- Refah: shop=supermarket, shop=convenience
- Canbo: shop=supermarket, shop=convenience
- Daily Market: shop=supermarket, shop=convenience
- Hyperstar: shop=supermarket
- Shirin Asal: shop=confectionery
- Snowa: shop=appliance