### PR TITLE
Add "Smartfuels" brand

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -4543,6 +4543,16 @@
       }
     },
     {
+      "displayName": "Smartfuels",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "amenity": "fuel",
+        "brand": "Smartfuels",
+        "brand:wikidata": "Q120281795",
+        "name": "Smartfuels"
+      }
+    },
+    {
       "displayName": "SNG",
       "id": "sng-b450da",
       "locationSet": {"include": ["bg"]},


### PR DESCRIPTION
Add "Smartfuels" brand, Philippine-based chain of gas stations.