### PR TITLE
Add "Ablaza Pawnshop"

### DIFF
--- a/data/brands/shop/pawnbroker.json
+++ b/data/brands/shop/pawnbroker.json
@@ -11,7 +11,7 @@
   "items": [
     {
       "displayName": "Ablaza Pawnshop",
-      "locationSet": {"include": ["ph"]}
+      "locationSet": {"include": ["ph"]},
       "tags": {
         "brand": "Ablaza Pawnshop",
         "brand:wikidata": "",

--- a/data/brands/shop/pawnbroker.json
+++ b/data/brands/shop/pawnbroker.json
@@ -14,7 +14,7 @@
       "locationSet": {"include": ["ph"]},
       "tags": {
         "brand": "Ablaza Pawnshop",
-        "brand:wikidata": "",
+        "brand:wikidata": "Q120292414",
         "name": "Ablaza Pawnshop",
         "shop": "pawnbroker"
       }

--- a/data/brands/shop/pawnbroker.json
+++ b/data/brands/shop/pawnbroker.json
@@ -10,6 +10,15 @@
   },
   "items": [
     {
+      "displayName": "Ablaza Pawnshop",
+      "locationSet": {"include": ["ph"]}
+      "tags": {
+        "brand": "Ablaza Pawnshop",
+        "brand:wikidata": "",
+        "name": "Ablaza Pawnshop",
+        "shop": "pawnbroker"
+      }
+    },{
       "displayName": "Cash America Pawn",
       "id": "cashamericapawn-9520ff",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Add brand for Philippine-based chain of pawnbrokers, "Ablaza Pawnshop"