### PR TITLE
Fix typo for Southstar Drug

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -2685,15 +2685,15 @@
       }
     },
     {
-      "displayName": "South Star Drug",
+      "displayName": "Southstar Drug",
       "id": "southstardrug-2ddb76",
       "locationSet": {"include": ["ph"]},
       "tags": {
         "amenity": "pharmacy",
-        "brand": "South Star Drug",
+        "brand": "Southstar Drug",
         "brand:wikidata": "Q7568544",
         "healthcare": "pharmacy",
-        "name": "South Star Drug"
+        "name": "Southstar Drug"
       }
     },
     {


### PR DESCRIPTION
Remove extra space from name "Southstar," not "South Star".