### PR TITLE
Add Australian (+ GB, NL, NZ, TH) fitness centre Jetts Fitness.

### DIFF
--- a/data/brands/leisure/fitness_centre.json
+++ b/data/brands/leisure/fitness_centre.json
@@ -598,6 +598,20 @@
       }
     },
     {
+      "displayName": "Jetts Fitness",
+      "id": "jettsfitness-8f2b5b",
+      "locationSet": {
+        "include": ["au", "gb", "nl", "nz", "th"]
+      },
+      "tags": {
+        "brand": "Jetts Fitness",
+        "brand:wikidata": "Q24185346",
+        "leisure": "fitness_centre",
+        "name": "Jetts Fitness",
+        "short_name": "Jetts"
+      }
+    },
+    {
       "displayName": "KeepCool",
       "id": "keepcool-a3e665",
       "locationSet": {


### PR DESCRIPTION
Wikidata: https://www.wikidata.org/wiki/Q24185346
Website: https://jetts.com.au/ (Australia, also with TLD/suffixes .co.nz, co.uk, .co.th, .nl)
Overpass: https://overpass-turbo.eu/s/1x0M