### PR TITLE
Add WiiiZ network of electric car chargers in the French Var and Alpes-Maritimes departments

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -5537,6 +5537,17 @@
       }
     },
     {
+      "displayName": "WiiiZ",
+      "locationSet": {"include": ["fr-pac.geojson"]},
+      "tags": {
+        "amenity": "charging_station",
+	"network": "WiiiZ",
+	"network:wikidata": "Q81747336",
+        "operator": "Izivia",
+        "operator:wikidata": "Q86671322"
+      }
+    },
+    {
       "displayName": "Wirelane",
       "id": "wirelane-c22d3a",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Several intermunicipal cooperations have contracted Izivia (EDF's electric mobility subsidiary) to operate a number of charging points under the WiiiZ brand name, in the French Var and Alpes-Maritimes departments (themselves part of the French PACA region, therefore restricting locationSet to fr-pac).