### PR TITLE
Correcting shop=* type for Salt and Sunrise and updating Wikidata entry for Sunrise

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -712,17 +712,6 @@
       }
     },
     {
-      "displayName": "Salt",
-      "id": "salt-741c3f",
-      "locationSet": {"include": ["ch"]},
-      "tags": {
-        "brand": "Salt",
-        "brand:wikidata": "Q17325543",
-        "name": "Salt",
-        "shop": "mobile_phone"
-      }
-    },
-    {
       "displayName": "SFR",
       "id": "sfr-ba7290",
       "locationSet": {"include": ["fr", "lu"]},
@@ -755,18 +744,6 @@
         "brand": "Sprint",
         "brand:wikidata": "Q301965",
         "name": "Sprint",
-        "shop": "mobile_phone"
-      }
-    },
-    {
-      "displayName": "Sunrise",
-      "id": "sunrise-741c3f",
-      "locationSet": {"include": ["ch"]},
-      "matchNames": ["sunrise shop"],
-      "tags": {
-        "brand": "Sunrise",
-        "brand:wikidata": "Q672648",
-        "name": "Sunrise",
         "shop": "mobile_phone"
       }
     },

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -337,6 +337,19 @@
       }
     },
     {
+      "displayName": "Salt",
+      "id": "salt-741c3f",
+      "locationSet": {"include": ["ch"]},
+      "matchNames": ["salt store"],
+      "matchTags": ["shop/mobile_phone"],
+      "tags": {
+        "brand": "Salt",
+        "brand:wikidata": "Q17325543",
+        "name": "Salt",
+        "shop": "telecommunication"
+      }
+    },
+    {
       "displayName": "Smart",
       "id": "smart-1229f4",
       "locationSet": {"include": ["ph"]},
@@ -357,6 +370,19 @@
         "brand": "Spectrum",
         "brand:wikidata": "Q7805197",
         "name": "Spectrum",
+        "shop": "telecommunication"
+      }
+    },
+    {
+      "displayName": "Sunrise",
+      "id": "sunrise-741c3f",
+      "locationSet": {"include": ["ch"]},
+      "matchNames": ["sunrise shop"],
+      "matchTags": ["shop/mobile_phone"],
+      "tags": {
+        "brand": "Sunrise",
+        "brand:wikidata": "Q672648",
+        "name": "Sunrise",
         "shop": "telecommunication"
       }
     },

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -381,7 +381,7 @@
       "matchTags": ["shop/mobile_phone"],
       "tags": {
         "brand": "Sunrise",
-        "brand:wikidata": "Q672648",
+        "brand:wikidata": "Q112573820",
         "name": "Sunrise",
         "shop": "telecommunication"
       }


### PR DESCRIPTION
Salt and Sunrise are two telecommunications companies in Switzerland. Their shops should be `shop=telecommunication`, not `shop=mobile_phone`, as they not only sell mobile phones, but primarily mobile and landline contracts. (Swisscom, the third and largest Swiss telecommunications company, is already in `shop/telecommunication`.)

Besides, the Wikidata entry for Sunrise need to be updated as the current company (Sunrise GmbH, [Q112573820](https://www.wikidata.org/wiki/Q112573820)) was created in 2022 when UPC (Schweiz) GmbH ([Q362582](https://www.wikidata.org/wiki/Q362582)) took over Sunrise Communications AG ([Q672648](https://www.wikidata.org/wiki/Q672648)) in 2021.