### PR TITLE
Adding Coop City

### DIFF
--- a/data/brands/shop/department_store.json
+++ b/data/brands/shop/department_store.json
@@ -286,6 +286,17 @@
       }
     },
     {
+      "displayName": "Coop City",
+      "locationSet": {"include": ["ch"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Coop City",
+        "brand:wikidata": "Q120492050",
+        "name": "Coop City",
+        "shop": "department_store"
+      }
+    },
+    {
       "displayName": "Coppel",
       "id": "coppel-a1f638",
       "locationSet": {


### PR DESCRIPTION
Adding [Coop City](https://www.wikidata.org/wiki/Q120492050), a brand of departments stores in Switzerland operated by [Coop Genossenschaft](https://www.wikidata.org/wiki/Q432564). Currently, iD suggest Coop City stores to be retagged `shop=supermarket`.