### PR TITLE
Added MAX&Co. clothes stores

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -5684,6 +5684,16 @@
       }
     },
     {
+      "displayName": "MAX&Co.",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "MAX&Co.",
+        "brand:wikidata": "Q120570926",
+        "name": "MAX&Co.",
+        "shop": "clothes"
+      }
+    },
+    {
       "displayName": "Mayoral",
       "id": "mayoral-3937bd",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
MAX&Co. it's the youth fashion brand of Max Mara, present wordlwide.

https://www.wikidata.org/wiki/Q120570926