### PR TITLE
Update fuel.json for Coles Express

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -1146,6 +1146,9 @@
       "matchNames": ["coles"],
       "tags": {
         "amenity": "fuel",
+        "brand": "Shell Australia",
+        "brand:wikidata": "Q7493635",
+        "fuel:discount": "Coles",
         "brand": "Coles Express",
         "brand:wikidata": "Q5144653",
         "name": "Coles Express"

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -1149,8 +1149,8 @@
         "brand": "Shell Australia",
         "brand:wikidata": "Q7493635",
         "fuel:discount": "Coles",
-        "brand": "Coles Express",
-        "brand:wikidata": "Q5144653",
+        "operator": "Coles Express",
+        "operator:wikidata": "Q5144653",
         "name": "Coles Express"
       }
     },


### PR DESCRIPTION
Coles Express uses the Shell Australia brand of fuel and Discount is aquired from Coles (Supermarkets)