### PR TITLE
Update bus.json

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -11864,8 +11864,6 @@
       "locationSet": {"include": ["my"]},
       "matchNames": ["rapid kl"],
       "tags": {
-        "network": "Rapid KL Bus",
-        "network:wikidata": "Q3271384",
         "operator": "Rapid Bus",
         "operator:wikidata": "Q7294127",
         "route": "bus"


### PR DESCRIPTION
Rapid KL, might have different type of network, with 3 systems (normal, MRT Feeder Bus and LRT Feeder Bus (also different livery). Therefore my suggestion is to not adding network tagging, leave it to the mapper to add since some bus stop maybe served by 2/3 livery (can be using semicolon to add diff networks).