### PR TITLE
Update operator name

### DIFF
--- a/data/operators/leisure/park.json
+++ b/data/operators/leisure/park.json
@@ -4251,14 +4251,14 @@
       }
     },
     {
-      "displayName": "Moreton Bay Regional Council",
+      "displayName": "City of Moreton Bay",
       "id": "moretonbayregionalcouncil-f88a26",
       "locationSet": {
         "include": ["au-qld.geojson"]
       },
       "tags": {
         "leisure": "park",
-        "operator": "Moreton Bay Regional Council",
+        "operator": "City of Moreton Bay",
         "operator:wikidata": "Q85372032"
       }
     },


### PR DESCRIPTION
Moreton Bay Regional Council has changed it's name to City of Moreton Bay effective from 24/07/2023 local time