### PR TITLE
Add Irish Brands

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -60,6 +60,20 @@
       }
     },
     {
+      "displayName": "Jump Juice",
+      "id": "",
+      "locationSet": {"include": ["ie"]},
+      "matchNames": ["jump juice bar"],
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Jump Juice",
+        "brand:wikidata": "Q118139675",
+        "cuisine": "juice",
+        "name": "Jump Juice",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "72街",
       "id": "72street-65b4e8",
       "locationSet": {"include": ["cn"]},

--- a/data/brands/shop/bed.json
+++ b/data/brands/shop/bed.json
@@ -117,7 +117,7 @@
     {
       "displayName": "Dreams",
       "id": "dreams-d088e6",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {"include": ["gb", "ie"]},
       "tags": {
         "brand": "Dreams",
         "brand:wikidata": "Q5306688",

--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -53,6 +53,17 @@
       }
     },
     {
+      "displayName": "Louis Copeland and Sons",
+      "id": "",
+      "locationSet": {"include": ["ie"]},
+      "tags": {
+        "brand": "Louis Copeland and Sons",
+        "brand:wikidata": "Q118139742",
+        "name": "Louis Copeland and Sons",
+        "shop": "clothes"
+      }
+    },
+    {
       "displayName": "7 For All Mankind",
       "id": "7forallmankind-0615dc",
       "locationSet": {"include": ["ca", "us"]},

--- a/data/brands/shop/health_food.json
+++ b/data/brands/shop/health_food.json
@@ -55,6 +55,17 @@
       }
     },
     {
+      "displayName": "Evergreen Healthfoods",
+      "id": "",
+      "locationSet": {"include": ["ie"]},
+      "tags": {
+        "brand": "Evergreen Healthfoods",
+        "brand:wikidata": "Q118139610",
+        "name": "Evergreen Healthfoods",
+        "shop": "health_food"
+      }
+    },
+    {
       "displayName": "Mundo Verde",
       "id": "mundoverde-894bf8",
       "locationSet": {"include": ["br"]},

--- a/data/brands/shop/pet.json
+++ b/data/brands/shop/pet.json
@@ -56,6 +56,17 @@
       }
     },
     {
+      "displayName": "Petworld",
+      "id": "",
+      "locationSet": {"include": ["ie"]},
+      "tags": {
+        "brand": "Petworld",
+        "brand:wikidata": "Q118139531",
+        "name": "Petworld",
+        "shop": "pet"
+      }
+    },
+    {
       "displayName": "Arken Zoo",
       "id": "arkenzoo-2ff4b2",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Added IE as location to Dreams.

Created:
- Evergreen Healthfoods
- Petworld
- Louid Copeland and Sons
- Jump Juice

