### PR TITLE
Fix operator in parcel_locker.json

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -468,7 +468,8 @@
         "brand": "Orlen Paczka",
         "brand:wikidata": "Q110457879",
         "operator": "Orlen",
-        "operator:wikidata": "Q110457879",
+        "operator:wikidata": "Q971649",
+        "operator:wikipedia": "pl:Orlen",
         "parcel_mail_in": "yes",
         "parcel_pickup": "yes"
       }


### PR DESCRIPTION
Orlen Paczka had wrong tagging - operator should be Orlen - a national petrol company.
At the moment both brand and operator link to **Orlen Paczka** wikidata