### PR TITLE
Add Belgian bank Europabank

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -5553,6 +5553,16 @@
       }
     },
     {
+      "displayName": "Europabank",
+      "locationSet": {"include": ["be"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "Europabank",
+        "brand:wikidata": "Q2134017",
+        "name": "Europabank"
+      }
+    },
+    {
       "displayName": "Evocabank",
       "id": "evocabank-9c44ae",
       "locationSet": {"include": ["am"]},


### PR DESCRIPTION
This Belgian bank already had a Wikidata entry, but again lacking the needed identifiers and data to be suited for NSI.
I've rectified this, so it is ready to be merged.