### PR TITLE
Add Wheel Works

### DIFF
--- a/data/brands/shop/tyres.json
+++ b/data/brands/shop/tyres.json
@@ -490,6 +490,21 @@
         "name:ru": "Колесо",
         "shop": "tyres"
       }
+    },
+    {
+      "displayName": "Wheel Works",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "brand": "Wheel Works",
+        "brand:wikidata": "Q121088283",
+        "name": "Wheel Works",
+        "service:vehicle:car_repair": "yes",
+        "shop": "tyres"
+      },
+      "matchNames": ["wheelworks"],
+      "matchTags": ["shop/car_repair", "shop/car_parts"]
     }
   ]
 }


### PR DESCRIPTION
There are 37 locations [listed on their site](https://www.wheelworks.net/site-map/). I'm open to suggestions for how these should be tagged. Until yesterday they were in OSM variously as `shop=tyres`, `shop=car_repair`, and `shop=car_parts`. Locations do offer car repair/maintenance in areas other than the tires/wheels.