### PR TITLE
Add "Food Mart" to generic for shop/convenience

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -6,7 +6,7 @@
         "^\"продукти\"$",
         "^(bakkal|baqala|bodega|delikatesy|dépanneur|dorfladen|kisbolt|market|mercearia|parduotuvė|potraviny|prehrana|spätkauf|vegyesbolt|večerka|weltladen)$",
         "^(convenience|corner|general|sari-sari)( store)?$",
-        "^(mini|super)?\\s?(market|mart|mercado)( non-stop)?$",
+        "^(mini|super|food)?\\s?(market|mart|mercado)( non-stop)?$",
         "^(sklep )?(spożywcz(y|o))(-przemysłowy)?$",
         "^(крамниця|купец)$",
         "^(мини)?[ -]?(магазин|маркет)$",
@@ -1628,16 +1628,6 @@
         "brand": "Fastbreak",
         "brand:wikidata": "Q116731804",
         "name": "Fastbreak",
-        "shop": "convenience"
-      }
-    },
-    {
-      "displayName": "Food Mart",
-      "id": "foodmart-4d6b4b",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "brand": "Food Mart",
-        "name": "Food Mart",
         "shop": "convenience"
       }
     },


### PR DESCRIPTION
Several gas station brands use "Food Mart" to describe their convenience stores. Some might qualify for individual entries, but "Food Mart" does not describe a single brand. It might fit better in the named section than generic, not sure.