### PR TITLE
Add Belgian insurance company DVV to office/insurance

### DIFF
--- a/data/brands/office/insurance.json
+++ b/data/brands/office/insurance.json
@@ -551,6 +551,17 @@
       }
     },
     {
+      "displayName": "DVV",
+      "locationSet": {"include": ["be"]},
+      "matchNames": ["DVV Verzekeringen"],
+      "tags": {
+        "brand": "DVV",
+        "brand:wikidata": "Q1969247",
+        "name": "DVV",
+        "office": "insurance"
+      }
+    },
+    {
       "displayName": "ENSA",
       "id": "ensa-3c8773",
       "locationSet": {"include": ["ao"]},


### PR DESCRIPTION
Another Belgian brand that already had a Wikidata entry, but which was not usable in NSI due to lack of identifiers. I added the needed data so it can be added now.