### PR TITLE
Update entries for certain pawnbrokers (PH)

### DIFF
--- a/data/brands/shop/pawnbroker.json
+++ b/data/brands/shop/pawnbroker.json
@@ -97,6 +97,16 @@
       }
     },
     {
+      "displayName": "CB Estrada Pawnshop",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "brand": "CB Estrada Pawnshop",
+        "brand:wikidata": "Q121230820",
+        "name": "CB Estrada Pawnshop",
+        "shop": "pawnbroker"
+      }
+    },
+    {
       "displayName": "Cebuana Lhuillier",
       "id": "cebuanalhuillier-6d9487",
       "locationSet": {"include": ["ph"]},

--- a/data/brands/shop/pawnbroker.json
+++ b/data/brands/shop/pawnbroker.json
@@ -235,7 +235,7 @@
       "tags": {
         "brand": "RD Pawnshop",
         "brand:wikidata": "Q118556221",
-        "name": "RD Pawnshop",
+        "name": "RD",
         "shop": "pawnbroker"
       }
     },

--- a/data/brands/shop/pawnbroker.json
+++ b/data/brands/shop/pawnbroker.json
@@ -21,6 +21,18 @@
       }
     },
     {
+      "displayName": "BHF Pawnshop & Jewelry Store",
+      "locationSet": {"include": ["ph"]},
+      "matchNames": ["bhf pawnshop"],
+      "tags": {
+        "brand": "BHF Pawnshop & Jewelry Store",
+        "brand:wikidata": "Q121230377",
+        "name": "BHF Pawnshop & Jewelry Store",
+        "shop": "pawnbroker",
+        "bureau_de_change": "yes"
+      }
+    },
+    {
       "displayName": "Cash America Pawn",
       "id": "cashamericapawn-9520ff",
       "locationSet": {"include": ["us"]},

--- a/data/brands/shop/pawnbroker.json
+++ b/data/brands/shop/pawnbroker.json
@@ -163,6 +163,16 @@
       }
     },
     {
+      "displayName": "Jaro Pawnshop",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "brand": "Jaro Pawnshop",
+        "brand:wikidata": "Q121229698",
+        "name": "Jaro Pawnshop",
+        "shop": "pawnbroker"
+      }
+    },
+    {
       "displayName": "Loombard",
       "id": "loombard-aaadfd",
       "locationSet": {"include": ["pl"]},


### PR DESCRIPTION
Update entries for the pawnbrokers in the Philippines:
- [x] RD Pawnshop
- [x] Jaro Pawnshop
- [x]  BHF Pawnshop & Jewelry Store (Q121230377)  
- [x] CB Estrada Pawnshop