### PR TITLE
Update Fnac on electronics.json

### DIFF
--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -572,7 +572,7 @@
         "brand": "Fnac",
         "brand:wikidata": "Q676585",
         "name": "Fnac",
-        "shop": "books"
+        "shop": "electronics"
       }
     },
     {

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -554,6 +554,27 @@
         "shop": "electronics"
       }
     },
+        {
+      "displayName": "Fnac",
+      "id": "fnac-8c3017",
+      "locationSet": {
+        "include": [
+          "ad",
+          "be",
+          "ch",
+          "es",
+          "fr",
+          "mc",
+          "pt"
+        ]
+      },
+      "tags": {
+        "brand": "Fnac",
+        "brand:wikidata": "Q676585",
+        "name": "Fnac",
+        "shop": "books"
+      }
+    },
     {
       "displayName": "Frávega",
       "id": "fravega-6d37eb",


### PR DESCRIPTION
Fnac is an electronics store chain. Never been a bookstore, just marketing on wikipedia. 

Today on English Wikipedia says "Fnac (French pronunciation: ​[fnak]) is a large French retail chain selling cultural and electronic products,"

French wikipedia "La Fnac (originally called "National Purchasing Federation", then "National Purchasing Federation of Executives") is a French chain of stores specializing in the distribution of cultural products (music , literature , cinema , video games ) and electronics ( hi-fi , computers , television ), intended for the general public...

In reality it's a pure electronics store chain.