### PR TITLE
Update books.json

### DIFF
--- a/data/brands/shop/books.json
+++ b/data/brands/shop/books.json
@@ -386,26 +386,6 @@
       }
     },
     {
-      "displayName": "Fnac",
-      "id": "fnac-8c3017",
-      "locationSet": {
-        "include": [
-          "be",
-          "ch",
-          "es",
-          "fr",
-          "nl",
-          "pt"
-        ]
-      },
-      "tags": {
-        "brand": "Fnac",
-        "brand:wikidata": "Q676585",
-        "name": "Fnac",
-        "shop": "books"
-      }
-    },
-    {
       "displayName": "Foyles",
       "id": "foyles-e6b908",
       "locationSet": {"include": ["gb-eng"]},


### PR DESCRIPTION
Fnac is an electronics store chain. Never been a bookstore, just marketing on wikipedia. 

Today on English Wikipedia says "Fnac (French pronunciation: ​[fnak]) is a large French retail chain selling cultural and electronic products,"

French wikipedia "La Fnac (originally called "National Purchasing Federation", then "National Purchasing Federation of Executives") is a French chain of stores specializing in the distribution of cultural products (music , literature , cinema , video games ) and electronics ( hi-fi , computers , television ), intended for the general public...

In reality it's a pure electronics store chain.