### PR TITLE
Update LePerc

### DIFF
--- a/data/operators/amenity/parking.json
+++ b/data/operators/amenity/parking.json
@@ -492,6 +492,27 @@
       }
     },
     {
+      "displayName": "NTTル・パルク",
+      "id": "nttleperc-a16317",
+      "locationSet": {"include": ["jp"]},
+      "matchNames": ["ル・パルク"],
+      "tags": {
+        "amenity": "parking",
+        "brand": "NTTル・パルク",
+        "brand:en": "NTT LePerc",
+        "brand:ja": "NTTル・パルク",
+        "brand:wikidata": "Q11236111",
+        "fee": "yes",
+        "name": "NTTル・パルク",
+        "name:en": "NTT LePerc",
+        "name:ja": "NTTル・パルク",
+        "operator": "NTTル・パルク",
+        "operator:en": "NTT LePerc",
+        "operator:ja": "NTTル・パルク",
+        "operator:wikidata": "Q11236111"
+      }
+    },
+    {
       "displayName": "One Parking Solution",
       "id": "oneparkingsolution-822ef4",
       "locationSet": {"include": ["gb"]},
@@ -896,27 +917,6 @@
         "operator:en": "Paraca",
         "operator:ja": "パラカ",
         "operator:wikidata": "Q11329318"
-      }
-    },
-    {
-      "displayName": "ル・パルク",
-      "id": "leperc-a16317",
-      "locationSet": {"include": ["jp"]},
-      "matchNames": ["nttル・パルク"],
-      "tags": {
-        "amenity": "parking",
-        "brand": "ル・パルク",
-        "brand:en": "LePerc",
-        "brand:ja": "ル・パルク",
-        "brand:wikidata": "Q11236111",
-        "fee": "yes",
-        "name": "ル・パルク",
-        "name:en": "LePerc",
-        "name:ja": "ル・パルク",
-        "operator": "ル・パルク",
-        "operator:en": "LePerc",
-        "operator:ja": "ル・パルク",
-        "operator:wikidata": "Q11236111"
       }
     },
     {


### PR DESCRIPTION
"NTTル・パルク", including "NTT", is a more accurate name. "NTTル・パルク" is used on official sites and on fare signs.

At least the operator is "NTTル・パルク".


![IMG_1911](https://github.com/osmlab/name-suggestion-index/assets/72978935/5c952a67-086f-4914-ae35-b7d53f755b72)

mapillary: https://www.mapillary.com/app/?pKey=375911020697676

official website: https://www.le-perc.co.jp