### PR TITLE
Update bank merging info in Taiwan and format documents.

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -15899,7 +15899,20 @@
       "displayName": "星展（台灣）商業銀行",
       "id": "dbsbanktaiwan-47d9e2",
       "locationSet": {"include": ["tw"]},
-      "matchNames": ["dbs", "台灣星展", "星展台灣"],
+      "matchNames": [
+        "dbs",
+        "台灣星展",
+        "星展台灣",
+        "occb",
+        "僑銀",
+        "台灣花旗",
+        "花旗台灣",
+        "華僑商業銀行",
+        "華僑銀行",
+        "花旗（台灣）商業銀行",
+        "花旗銀行",
+        "花旗商銀"
+      ],
       "tags": {
         "amenity": "bank",
         "brand": "星展銀行",
@@ -16566,29 +16579,6 @@
         "name": "芝信用金庫",
         "name:en": "Shiba Shinkin Bank",
         "name:ja": "芝信用金庫"
-      }
-    },
-    {
-      "displayName": "花旗（台灣）商業銀行",
-      "id": "citibanktaiwan-47d9e2",
-      "locationSet": {"include": ["tw"]},
-      "matchNames": [
-        "occb",
-        "僑銀",
-        "台灣花旗",
-        "花旗台灣",
-        "華僑商業銀行",
-        "華僑銀行"
-      ],
-      "tags": {
-        "amenity": "bank",
-        "brand": "花旗銀行",
-        "brand:en": "Citibank",
-        "brand:wikidata": "Q857063",
-        "brand:zh": "花旗銀行",
-        "name": "花旗（台灣）商業銀行",
-        "name:en": "Citibank Taiwan",
-        "name:zh": "花旗（台灣）商業銀行"
       }
     },
     {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -15319,6 +15319,9 @@
       "id": "taipeifubonbank-47d9e2",
       "locationSet": {"include": ["tw"]},
       "matchNames": [
+        "baodao bank",
+        "baodao commercial bank",
+        "jihsun bank",
         "tfc",
         "台北富邦",
         "台北富邦銀",
@@ -15327,16 +15330,13 @@
         "台北銀行",
         "富邦銀",
         "富邦銀行",
-        "baodao bank",
-        "baodao commercial bank",
-        "jihsun bank",
         "寶島商業銀行",
         "寶島商銀",
         "寶島銀行",
         "日盛",
         "日盛商銀",
-        "日盛銀行",
-        "日盛國際商業銀行"
+        "日盛國際商業銀行",
+        "日盛銀行"
       ],
       "tags": {
         "amenity": "bank",
@@ -15880,19 +15880,19 @@
       "id": "dbsbanktaiwan-47d9e2",
       "locationSet": {"include": ["tw"]},
       "matchNames": [
+        "citibank",
         "dbs",
-        "台灣星展",
-        "星展台灣",
         "occb",
         "僑銀",
+        "台灣星展",
         "台灣花旗",
-        "花旗台灣",
-        "華僑商業銀行",
-        "華僑銀行",
+        "星展台灣",
         "花旗（台灣）商業銀行",
-        "花旗銀行",
+        "花旗台灣",
         "花旗商銀",
-        "citibank"
+        "花旗銀行",
+        "華僑商業銀行",
+        "華僑銀行"
       ],
       "tags": {
         "amenity": "bank",

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -15326,7 +15326,17 @@
         "台北銀",
         "台北銀行",
         "富邦銀",
-        "富邦銀行"
+        "富邦銀行",
+        "baodao bank",
+        "baodao commercial bank",
+        "jihsun bank",
+        "寶島商業銀行",
+        "寶島商銀",
+        "寶島銀行",
+        "日盛",
+        "日盛商銀",
+        "日盛銀行",
+        "日盛國際商業銀行"
       ],
       "tags": {
         "amenity": "bank",
@@ -15866,36 +15876,6 @@
       }
     },
     {
-      "displayName": "日盛國際商業銀行",
-      "id": "jihsuninternationalcommercialbank-47d9e2",
-      "locationSet": {"include": ["tw"]},
-      "matchNames": [
-        "baodao bank",
-        "baodao commercial bank",
-        "jihsun bank",
-        "寶島商業銀行",
-        "寶島商銀",
-        "寶島銀行",
-        "日盛",
-        "日盛商銀",
-        "日盛銀行"
-      ],
-      "tags": {
-        "amenity": "bank",
-        "brand": "日盛國際商業銀行",
-        "brand:en": "Jih Sun International Commercial Bank",
-        "brand:wikidata": "Q11086841",
-        "brand:zh": "日盛國際商業銀行",
-        "name": "日盛國際商業銀行",
-        "name:en": "Jih Sun International Commercial Bank",
-        "name:nan": "Ji̍t-sēng Kok-chè Siong-gia̍p Gîn-hâng",
-        "name:nan-HJ": "日盛國際商業銀行",
-        "name:nan-POJ": "Ji̍t-sēng Kok-chè Siong-gia̍p Gîn-hâng",
-        "name:nan-TL": "Ji̍t-sīng Kok-tsè Siong-gia̍p Gîn-hâng",
-        "name:zh": "日盛國際商業銀行"
-      }
-    },
-    {
       "displayName": "星展（台灣）商業銀行",
       "id": "dbsbanktaiwan-47d9e2",
       "locationSet": {"include": ["tw"]},
@@ -15911,7 +15891,8 @@
         "華僑銀行",
         "花旗（台灣）商業銀行",
         "花旗銀行",
-        "花旗商銀"
+        "花旗商銀",
+        "citibank"
       ],
       "tags": {
         "amenity": "bank",

--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -4074,8 +4074,10 @@
     },
     {
       "displayName": "WienMobil Rad",
-      "id": "wienmobilrad-cda769",
-      "locationSet": {"include": ["at-9.geojson"]},
+      "id": "wienmobilrad-9cd234",
+      "locationSet": {
+        "include": ["at-9.geojson"]
+      },
       "matchNames": ["citybike wien"],
       "tags": {
         "amenity": "bicycle_rental",

--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -3542,6 +3542,7 @@
     },
     {
       "displayName": "WatchHouse",
+      "id": "watchhouse-418c6b",
       "locationSet": {"include": ["gb-eng"]},
       "tags": {
         "amenity": "cafe",

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -210,7 +210,7 @@
     },
     {
       "displayName": "DPD Pickup Station",
-      "id": "dpdpickupstation-ce4e28",
+      "id": "dpdpickupstation-946abd",
       "locationSet": {"include": ["pl", "ro"]},
       "tags": {
         "amenity": "parcel_locker",

--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -6125,14 +6125,14 @@
     },
     {
       "displayName": "Moreboards",
+      "id": "moreboards-daa173",
       "locationSet": {"include": ["at"]},
-      "matchTags": ["shop/sports"],
       "tags": {
         "brand": "Moreboards",
         "brand:wikidata": "Q121297435",
+        "clothes": "sports",
         "name": "Moreboards",
-        "shop": "clothes",
-        "clothes": "sports"
+        "shop": "clothes"
       }
     },
     {

--- a/data/brands/shop/electrical.json
+++ b/data/brands/shop/electrical.json
@@ -5,16 +5,6 @@
   },
   "items": [
     {
-      "displayName": "City Electric Supply",
-      "locationSet": {"include": ["ca", "us"]},
-      "tags": {
-        "brand": "City Electric Supply",
-        "brand:wikidata": "Q121357206",
-        "name": "City Electric Supply",
-        "shop": "electrical"
-      }
-    },
-    {
       "displayName": "CEF",
       "id": "cef-7c8ef7",
       "locationSet": {"include": ["gb"]},
@@ -25,6 +15,17 @@
         "brand": "CEF",
         "brand:wikidata": "Q116495226",
         "name": "CEF",
+        "shop": "electrical"
+      }
+    },
+    {
+      "displayName": "City Electric Supply",
+      "id": "cityelectricsupply-83ef7e",
+      "locationSet": {"include": ["ca", "us"]},
+      "tags": {
+        "brand": "City Electric Supply",
+        "brand:wikidata": "Q121357206",
+        "name": "City Electric Supply",
         "shop": "electrical"
       }
     },

--- a/data/brands/shop/perfumery.json
+++ b/data/brands/shop/perfumery.json
@@ -168,7 +168,7 @@
     },
     {
       "displayName": "Marionnaud",
-      "id": "marionnaud-798a74",
+      "id": "marionnaud-40e2d5",
       "locationSet": {
         "include": [
           "at",

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -11317,6 +11317,20 @@
       }
     },
     {
+      "displayName": "Pittsburgh Regional Transit",
+      "id": "pittsburghregionaltransit-1319b8",
+      "locationSet": {
+        "include": [[-80, 40.5, 35]]
+      },
+      "matchNames": ["paac", "pat"],
+      "tags": {
+        "network": "Pittsburgh Regional Transit",
+        "network:short": "PRT",
+        "network:wikidata": "Q7230500",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "PKS Gdynia",
       "id": "pksgdynia-9340cc",
       "locationSet": {"include": ["pl"]},
@@ -11428,16 +11442,11 @@
       "tags": {"network": "Pori", "route": "bus"}
     },
     {
-      "displayName": "Pittsburgh Regional Transit",
-      "id": "portauthorityofalleghenycounty-1319b8",
-      "locationSet": {
-        "include": [[-80, 40.5, 35]]
-      },
-      "matchNames": ["pat", "paac"],
+      "displayName": "Port Authority of Allegheny County",
+      "id": "portauthorityofalleghenycounty-a45453",
+      "locationSet": {"include": ["001"]},
       "tags": {
-        "network": "Pittsburgh Regional Transit",
-        "network:short": "PRT",
-        "network:wikidata": "Q7230500",
+        "network": "Port Authority of Allegheny County",
         "route": "bus"
       }
     },


### PR DESCRIPTION
Changes:

1. Citi Taiwan is acquired by DBS Taiwan ( [中文](https://www.dbs.com.tw/personal-zh/citiwelcome/index.html), [English](https://www.dbs.com/newsroom/DBS_to_acquire_Citis_consumer_banking_business_in_Taiwan_sg) )
2. Jih Sun is acquired by Fubon ( [中文](https://www.fubon.com/banking/merger), [English](https://www.fubon.com/financialholdings/en/news/news_1221226_058929.htm) )
3. Format documents with `npm run build` script.