### PR TITLE
Added fuel company Jio BP

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -25,6 +25,18 @@
     }
   },
   "items": [
+        {
+      "displayName": "JIO BP",
+      "locationSet": {
+        "include": ["in"]
+      },
+      "matchNames": ["Reliance Petroleum", "Jio-bp", "Reliance BP"],
+      "tags": {
+        "amenity": "fuel",
+        "brand": "JIO BP",
+        "brand:wikidata": "Q7311026",
+      }
+    },
     {
       "displayName": "1-2-3",
       "id": "123-67b972",
@@ -784,7 +796,7 @@
     {
       "displayName": "BP",
       "id": "bp-b3d110",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["001"], "exclude" : ["in"]},
       "matchNames": ["bp gas station"],
       "tags": {
         "amenity": "fuel",


### PR DESCRIPTION
Jio BP is a rebrand of Reliance Petroleum in partnership with BP in India