### PR TITLE
Remarkable Pubs

### DIFF
--- a/data/operators/amenity/pub.json
+++ b/data/operators/amenity/pub.json
@@ -1,0 +1,20 @@
+{
+  "properties": {
+    "path": "operators/amenity/pub",
+    "preserveTags": ["^name"],
+    "exclude": {"generic": [], "named": []}
+  },
+  "items": [
+    {
+      "displayName": "Remarkable Pubs",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
+      "tags": {
+        "amenity": "pub",
+        "operator": "Remarkable Pubs",
+        "operator:wikidata": "Q121462737"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Remarkable Pubs operates pubs across London https://remarkablepubs.co.uk/