### PR TITLE
mobile_phone.json: Added Iliad shops

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -356,6 +356,17 @@
       }
     },
     {
+      "displayName": "Iliad",
+      "locationSet": {"include": ["it"]},
+      "matchNames": ["iliad store"],
+      "tags": {
+        "brand": "Iliad",
+        "brand:wikidata": "Q55433734",
+        "name": "Iliad",
+        "shop": "mobile_phone"
+      }
+    },
+    {
       "displayName": "iPlace",
       "id": "iplace-1b1a0a",
       "locationSet": {"include": ["br", "uy"]},


### PR DESCRIPTION
Iliad it's an Italian mobile phone operator (owned by French Iliad group) who recently started to open physical shops in Italy.

I choosed [Q55433734](https://www.wikidata.org/wiki/Q55433734) over [Q1239347](https://www.wikidata.org/wiki/Q1239347) because despite the group name, the brand "Iliad" it's only used in Italy. France use "Free" brand (already in NSI).