### PR TITLE
Update Fressnapf on pet.json

### DIFF
--- a/data/brands/shop/pet.json
+++ b/data/brands/shop/pet.json
@@ -125,7 +125,7 @@
       "displayName": "Fressnapf",
       "id": "fressnapf-d58bba",
       "locationSet": {
-        "include": ["at", "ch", "de", "hu", "lu"]
+        "include": ["at", "ch", "de", "hu", "lu", "ro"]
       },
       "tags": {
         "brand": "Fressnapf",


### PR DESCRIPTION
Fressnapf is also present in Romania since 2022.

https://fressnapf.ro/magazine/