### PR TITLE
Update locationSet for supermarket in Hokkaido (Japan)

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -10033,8 +10033,10 @@
     },
     {
       "displayName": "シティ",
-      "id": "city-fe0970",
-      "locationSet": {"include": ["jp"]},
+      "id": "city-c0ae3d",
+      "locationSet": {
+        "include": ["jp-01.geojson"]
+      },
       "tags": {
         "brand": "シティ",
         "brand:en": "CITY",
@@ -10048,8 +10050,10 @@
     },
     {
       "displayName": "シティマート",
-      "id": "citymart-fe0970",
-      "locationSet": {"include": ["jp"]},
+      "id": "citymart-c0ae3d",
+      "locationSet": {
+        "include": ["jp-01.geojson"]
+      },
       "tags": {
         "brand": "シティ",
         "brand:en": "CITY",
@@ -10524,8 +10528,10 @@
     },
     {
       "displayName": "ラッキー",
-      "id": "lucky-fe0970",
-      "locationSet": {"include": ["jp"]},
+      "id": "lucky-c0ae3d",
+      "locationSet": {
+        "include": ["jp-01.geojson"]
+      },
       "tags": {
         "brand": "ラッキー",
         "brand:en": "LUCKY",
@@ -10541,8 +10547,10 @@
     },
     {
       "displayName": "ラッキーマート",
-      "id": "luckymart-fe0970",
-      "locationSet": {"include": ["jp"]},
+      "id": "luckymart-c0ae3d",
+      "locationSet": {
+        "include": ["jp-01.geojson"]
+      },
       "tags": {
         "brand": "ラッキー",
         "brand:en": "LUCKY",


### PR DESCRIPTION
These supermarkets exist only in Hokkaido, and for LUCKY, the locationSet was changed to that of Hokkaido since other area also exist.

https://www.hokuyu-lucky.co.jp/shops/