### PR TITLE
Update restaurant.json : Shoo Loong Kan/XiaoLongKan (小龙坎火锅)

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -4895,33 +4895,24 @@
       }
     },
     {
-      "displayName": "SHOO LOONG KAN",
+      "displayName": "Shoo Loong Kan",
       "id": "shooloongkan-ac0b3c",
       "locationSet": {
         "include": [
-          "au",
-          "ca",
           "de",
-          "es",
-          "fr",
-          "jp",
-          "khm",
-          "my",
-          "nz",
-          "sg",
           "us"
         ]
       },
       "matchNames": ["xiao long kan"],
       "tags": {
         "amenity": "restaurant",
-        "brand": "SHOO LOONG KAN",
-        "brand:en": "SHOO LOONG KAN",
+        "brand": "小龙坎火锅",
+        "brand:en": "XiaoLongKan",
         "brand:wikidata": "Q108212427",
         "brand:zh": "小龙坎火锅",
         "cuisine": "chinese;hot_pot",
-        "name": "SHOO LOONG KAN",
-        "name:en": "SHOO LOONG KAN",
+        "name": "Shoo Loong Kan",
+        "name:en": "Shoo Loong Kan",
         "name:zh": "小龙坎火锅"
       }
     },
@@ -5908,6 +5899,36 @@
         "brand": "Wimpy's Diner",
         "brand:wikidata": "Q16909504",
         "name": "Wimpy's Diner"
+      }
+    },
+    {
+      "displayName": "XiaoLongKan",
+      "id": "",
+      "locationSet": {
+        "include": [
+          "au",
+          "ca",
+          "de",
+          "es",
+          "fr",
+          "jp",
+          "khm",
+          "my",
+          "nz",
+          "sg",
+        ]
+      },
+      "matchNames": ["xiao long kan"],
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "XiaoLongKan",
+        "brand:en": "XiaoLongKan",
+        "brand:wikidata": "Q108212427",
+        "brand:zh": "小龙坎火锅",
+        "cuisine": "chinese;hot_pot",
+        "name": "XiaoLongKan",
+        "name:en": "XiaoLongKan",
+        "name:zh": "小龙坎火锅"
       }
     },
     {
@@ -7271,12 +7292,12 @@
       "tags": {
         "amenity": "restaurant",
         "brand": "小龙坎火锅",
-        "brand:en": "SHOO LOONG KAN",
+        "brand:en": "XiaoLongKan",
         "brand:wikidata": "Q108212427",
         "brand:zh": "小龙坎火锅",
         "cuisine": "chinese;hot_pot",
         "name": "小龙坎火锅",
-        "name:en": "SHOO LOONG KAN",
+        "name:en": "XiaoLongKan",
         "name:zh": "小龙坎火锅"
       }
     },


### PR DESCRIPTION
Fixed the entry for XiaoLongKan/Shoo Loong Kan (小龙坎火锅).

The vast majority of stores use "XiaoLongKan" for their non-Chinese name on storefronts.

Only stores in the USA and one store in DE uses "Shoo Loong Kan" on their storefront.