### PR TITLE
Create survey_point.json including Ordnance Survey

### DIFF
--- a/data/operators/man_made/survey_point.json
+++ b/data/operators/man_made/survey_point.json
@@ -1,0 +1,23 @@
+{
+  "properties": {
+    "path": "operators/man_made/survey_point",
+    "skipCollection": true,
+    "exclude": {"generic": ["^(survey point)$"]}
+  },
+  "items": [
+    {
+      "displayName": "Ordnance Survey",
+      "locationSet": {"include": ["gb-eng", "gb-sco", "gb-wls"]},
+      "matchNames": [
+        "ordnance survey",
+        "os",
+        "ordinance survey"
+      ],
+      "tags": {
+        "man_made": "survey_point",
+        "operator": "Ordnance Survey",
+        "operator:wikidata": "Q548721"
+      }
+    }
+  ]
+}

--- a/data/operators/man_made/survey_point.json
+++ b/data/operators/man_made/survey_point.json
@@ -7,7 +7,7 @@
   "items": [
     {
       "displayName": "Ordnance Survey",
-      "locationSet": {"include": ["gb-eng", "gb-sco", "gb-wls"]},
+      "locationSet": {"include": ["gb-eng", "gb-sct", "gb-wls"]},
       "matchNames": [
         "ordnance survey",
         "os",


### PR DESCRIPTION
Adds operator tagging for man_made=survey point operated by Ordnance Survey in England, Scotland and Wales, with match for common misspelling "Ordinance Survey".