### PR TITLE
fixed a copy error

### DIFF
--- a/data/transit/route/subway.json
+++ b/data/transit/route/subway.json
@@ -749,7 +749,7 @@
       "tags": {
         "network": "Московский метрополитен",
         "network:en": "Moscow Metro",
-        "network:ru": "Петербургский метрополитен",
+        "network:ru": "Московский метрополитен",
         "network:wikidata": "Q5499",
         "route": "subway"
       }


### PR DESCRIPTION
There was a copy error on the Московский метрополитен. I fixed the copy error.

There may be more changes to the Moscow metro. See this discussion: https://www.openstreetmap.org/changeset/140526171