### PR TITLE
Update Humanic, Office, Sizeer, Snipes and UGG on shoes.json

### DIFF
--- a/data/brands/shop/shoes.json
+++ b/data/brands/shop/shoes.json
@@ -770,10 +770,12 @@
       "locationSet": {
         "include": [
           "at",
+          "bg",
           "cz",
           "de",
           "hu",
           "ro",
+          "si",
           "sk"
         ]
       },
@@ -1237,7 +1239,7 @@
       "displayName": "Office",
       "id": "office-b22ec7",
       "locationSet": {
-        "include": ["de", "gb", "ie", "ro"]
+        "include": ["de", "gb", "ie"]
       },
       "tags": {
         "brand": "Office",
@@ -1840,12 +1842,17 @@
       "locationSet": {
         "include": [
           "at",
+          "bg",
           "cz",
           "de",
+          "ee",
+          "hr",
           "hu",
           "lt",
+          "lv",
           "pl",
           "ro",
+          "si",
           "sk"
         ]
       },
@@ -1892,6 +1899,7 @@
           "fr",
           "it",
           "nl",
+          "pl",
           "us"
         ]
       },
@@ -2093,9 +2101,7 @@
     {
       "displayName": "UGG",
       "id": "ugg-eb26c7",
-      "locationSet": {
-        "include": ["au", "nz", "us"]
-      },
+      "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "UGG",
         "brand:wikidata": "Q1138480",


### PR DESCRIPTION
Humanic is also in Bulgaria and Slovenia.  https://www.humanic.net/int/career

Office it's not in Romania, instead it's Office Shoes. https://www.officeshoes.ro/

Sizeer is also in Bulgaria, Croatia, Estonia, Latvia, Slovenia. https://sklep.sizeer.com/salony

Snipes is also in Poland. https://www.snipes.pl/storefinder

UGG is a global brand with stores also in France, Germany, Italy, UK, Japan.  https://www.ugg.com/flagship-stores-europe.html