### PR TITLE
Check more id-tagging-schema presets

### DIFF
--- a/scripts/build_index.js
+++ b/scripts/build_index.js
@@ -678,7 +678,7 @@ function checkItems(t) {
       }
 
       // Warn if OSM tags contain odd punctuation or spacing..
-      ['beauty', 'cuisine', 'flush:disposal', 'gambling', 'government', 'sport', 'training', 'vending'].forEach(osmkey => {
+      ['beauty', 'cuisine', 'gambling', 'government', 'sport', 'training', 'vending'].forEach(osmkey => {
         const val = tags[osmkey];
         if (val && oddChars.test(val)) {
           warnFormatTag.push([display(item), `${osmkey} = ${val}`]);

--- a/scripts/dist_files.js
+++ b/scripts/dist_files.js
@@ -229,7 +229,7 @@ function buildIDPresets() {
 
       // Sometimes we can choose a more specific iD preset then `key/value`..
       // Attempt to match a `key/value/extravalue`
-      const tryKeys = ['beauty', 'clothes', 'cuisine', 'fast_food', 'flush:disposal', 'government', 'healthcare:speciality', 'park_ride', 'religion', 'social_facility', 'sport', 'tower:type', 'vending', 'waste'];
+      const tryKeys = ['beauty', 'clothes', 'cuisine', 'fast_food', 'government', 'healthcare:speciality', 'microbrewery', 'organic', 'park_ride', 'recycling_type', 'religion', 'second_hand', 'self_service', 'social_facility', 'sport', 'toilets:disposal', 'tower:type', 'vending', 'waste'];
       tryKeys.forEach(osmkey => {
         if (preset) return;    // matched one already
         const val = tags[osmkey];


### PR DESCRIPTION
Also removed unused tag `flush:disposal` which is not in OSM DB.
Maybe it was replaced by `toilets:disposal`