### PR TITLE
Rewrite matcher of id-tagging-schema presets

### DIFF
--- a/scripts/dist_files.js
+++ b/scripts/dist_files.js
@@ -220,6 +220,13 @@ function buildIDPresets() {
     // NOTE: here we intentionally exclude `:wikidata`, in `matcher.js` we do not.
     const notName = /:(colour|type|left|right|etymology|pronunciation|wikipedia|wikidata)$/i;
 
+    let childPresets = new Map();
+    for (const checkPath in presetsJSON){
+      if (checkPath.startsWith(presetPath)) {
+        childPresets.set(checkPath, presetsJSON[checkPath]);
+      }
+    }
+
     items.forEach(item => {
       const tags = item.tags;
       const qid = tags[wdTag];
@@ -229,20 +236,58 @@ function buildIDPresets() {
 
       // Sometimes we can choose a more specific iD preset then `key/value`..
       // Attempt to match a `key/value/extravalue`
-      const tryKeys = ['beauty', 'clothes', 'cuisine', 'fast_food', 'government', 'healthcare:speciality', 'microbrewery', 'organic', 'park_ride', 'recycling_type', 'religion', 'second_hand', 'self_service', 'social_facility', 'sport', 'toilets:disposal', 'tower:type', 'vending', 'waste'];
-      tryKeys.forEach(osmkey => {
-        if (preset) return;    // matched one already
-        const val = tags[osmkey];
-        if (!val) return;
+      if (childPresets.size > 1) {
+        // The best iD preset for an NSI entry is determined by count of tags that have
+        // matched (more is better) and position for multi-value tags (e.g. cuisine)
+        let matchTagsCount = 0;
+        let matchSemicolonRating = 0;
 
-        // keys like cuisine can contain multiple values, so try each one in order
-        let vals = val.split(';');
-        for (let i = 0; i < vals.length; i++) {
-          presetID = presetPath + '/' + vals[i].trim();
-          preset = presetsJSON[presetID];
-          if (preset) return;   // it matched
-        }
-      });
+        let matchPresetPath;
+        let matchPreset;
+
+        childPresets.forEach(function(checkPreset, checkPresetPath) {
+          const checkPresetTags = Object.entries(checkPreset.tags);
+          let currentMatchSemicolonRating = 0;
+
+          const isPresetMatch = checkPresetTags.every(kv => {
+            // Tags that NSI allows to process as multi-valued
+            const semicolonSplittedKeys = ['beauty', 'clothes', 'cuisine', 'healthcare:speciality', 'social_facility', 'sport', 'vending', 'waste'];
+            const idKey = kv[0];
+            const idVal = kv[1];
+
+            const nsiVal = tags[idKey];
+            if (!nsiVal) {
+              return false;
+            }
+            if (semicolonSplittedKeys.includes(idKey)) {
+              const vals = nsiVal.split(';');
+              const findResult = vals.indexOf(idVal);
+              if (-1 === findResult) {
+                return false
+              }
+              // For a smaller element index rating will be higher
+              currentMatchSemicolonRating -= findResult;
+              return true;
+            }
+            return (idVal === nsiVal);
+          });
+
+          // If rating of current element is higher than the saved one, we overwrite saved
+          if (isPresetMatch
+            && ((checkPresetTags.length > matchTagsCount)
+              || (checkPresetTags.length === matchTagsCount
+                && currentMatchSemicolonRating > matchSemicolonRating))) {
+            matchTagsCount = checkPresetTags.length;
+            matchSemicolonRating = currentMatchSemicolonRating;
+            matchPresetPath = checkPresetPath;
+            matchPreset = checkPreset;
+          }
+        });
+
+        console.assert("Preset must already be selected", matchPresetPath);
+        presetID = matchPresetPath;
+        preset = matchPreset;
+      }
 
       // fallback to `key/value`
       if (!preset) {


### PR DESCRIPTION
**This is an alternative for https://github.com/osmlab/name-suggestion-index/pull/8586**

Now it takes into account all presets, not just those with no more than 3 tags

Now categories will be correctly defined for the following presets:

- amenity/pub/microbrewery
- amenity/recycling_container
- amenity/recycling_centre
- amenity/restaurant/steakhouse
- shop/car/second_hand
- shop/clothes/second_hand
- shop/laundry/self_service
- shop/supermarket/organic
- tourism/information/office
- tourism/information/map
- amenity/bicycle_parking/lockers
- amenity/parking/park_ride
- amenity/toilets/disposal
- man_made/mast/communication/mobile_phone
- natural/water/reservoir