### PR TITLE
Added Italian supermarket chain Coop.fi

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1673,6 +1673,16 @@
       }
     },
     {
+      "displayName": "Coop.fi",
+      "locationSet": {"include": ["it"]},
+      "tags": {
+        "brand": "Coop.fi",
+        "brand:wikidata": "Q4004707",
+        "name": "Coop.fi",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "CoopCompact",
       "id": "coopcompact-5811b5",
       "locationSet": {"include": ["nl"]},


### PR DESCRIPTION
The italian coop supermarket system it's composed by multiple companies using the same brand for marketing resasons. One of them, Unicoop Firenze, rebranded their stores with "coop.fi" and I think we need a different preset for them.

See some images here: https://commons.wikimedia.org/wiki/Category:Unicoop_Firenze

Will close https://github.com/osmlab/name-suggestion-index/issues/7317