### PR TITLE
Update public_bookcase.json

### DIFF
--- a/data/brands/amenity/public_bookcase.json
+++ b/data/brands/amenity/public_bookcase.json
@@ -10,6 +10,15 @@
   },
   "items": [
     {
+      "displayName": "Boekentil (Stad Leuven)",
+      "locationSet": {"include": ["be"]},
+      "tags": {
+        "amenity": "public_bookcase",
+        "brand": "Boekentil (Stad Leuven)",
+        "name": "Boekentil"
+      }
+    },
+    {
       "displayName": "Boite à livres",
       "id": "boitealivres-45dad4",
       "locationSet": {"include": ["be", "fx"]},
@@ -56,6 +65,16 @@
       }
     },
     {
+      "displayName": "Enjoy a book (NMBS/SNCB)",
+      "locationSet": {"include": ["be"]},
+      "tags": {
+        "amenity": "public_bookcase",
+        "brand": "Enjoy a book",
+        "brand:wikidata": "Q524255",
+        "name": "Enjoy a book"
+      }
+    },
+    {
       "displayName": "KinderzwerfboekStation",
       "id": "kinderzwerfboekstation-2091e3",
       "locationSet": {"include": ["nl"]},
@@ -67,6 +86,34 @@
       }
     },
     {
+      "displayName": "Lesekiosk (Foreningen !les)",
+      "locationSet": {"include": ["no"]},
+      "tags": {
+        "amenity": "public_bookcase",
+        "brand": "Lesekiosk (Foreningen !les)",
+        "brand:wikidata": "Q11008642",
+        "name": "Lesekiosk"
+      }
+    },
+    {
+      "displayName": "Libros Libres",
+      "locationSet": {"include": ["pr"]},
+      "tags": {
+        "amenity": "public_bookcase",
+        "brand": "Libros Libres",
+        "name": "Libros Libres"
+      }
+    },
+    {
+      "displayName": "Lilliput Library",
+      "locationSet": {"include": ["au", "nz"]},
+      "tags": {
+        "amenity": "public_bookcase",
+        "brand": "Lilliput Libraries",
+        "name": "Lilliput Library"
+      }
+    },
+    {
       "displayName": "Little Free Library",
       "id": "littlefreelibrary-6e8312",
       "locationSet": {"include": ["001"]},
@@ -75,6 +122,16 @@
         "brand": "Little Free Library",
         "brand:wikidata": "Q6650101",
         "name": "Little Free Library"
+      }
+    },
+    {
+      "displayName": "Mercator Bücherschrank",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "amenity": "public_bookcase",
+        "brand": "Mercator Bücherschrank",
+        "brand:wikidata": "Q2349075",
+        "name": "Mercator Bücherschrank"
       }
     },
     {


### PR DESCRIPTION
Adds Boekentil (Stad Leuven), Enjoy a book (NMBS/SNCB), Lesekiosk (Foreningen !les), Libros Libres, Lilliput Library, Mercator Bücherschrank. Where brand is missing wikidata, the creator's value is added instead.

Mapped:
- Boekentil (Stad Leuven) [n/58+] (note "boekentil" is also a synonym for public bookcase.)
- Enjoy a book (NMBS/SNCB) [0?/43+]
- Lesekiosk (Foreningen !les) [n/124+] (note "lesekiosk" is also a synonym for public bookcase.)
- Libros Libres [n/6+] (community-operated Bookcrossing fork)
- Lilliput Library [n/348+]
- Mercator Bücherschrank [n/?] (at least a handful of press releases, I assume there are more cities though.)