### PR TITLE
Update public_bookcase.json - Add brand wikidata for Boekentil (Stad Leuven)

### DIFF
--- a/data/brands/amenity/public_bookcase.json
+++ b/data/brands/amenity/public_bookcase.json
@@ -15,6 +15,7 @@
       "tags": {
         "amenity": "public_bookcase",
         "brand": "Boekentil (Stad Leuven)",
+        "brand:wikidata": "Q118958",
         "name": "Boekentil"
       }
     },


### PR DESCRIPTION
Adds brand wikidata for Boekentil (Stad Leuven).