### PR TITLE
Match id_tagging_schema preset for office/bail_bond_agent

### DIFF
--- a/scripts/dist_files.js
+++ b/scripts/dist_files.js
@@ -290,9 +290,10 @@ function buildIDPresets() {
       }
 
       // fallback to `key/value`
-      if (!preset) {
-        presetID = presetPath;
-        preset = presetsJSON[presetID];
+      if (!preset && childPresets.size === 1) {
+        const presetKV = childPresets.entries().next().value;
+        presetID = presetKV[0];
+        preset = presetKV[1];
       }
 
       // still no match?


### PR DESCRIPTION
The problem here is the preset path that includes country codes
https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/office/bail_bond_agent-US-PH.json