### PR TITLE
Remove secondary names from template entries

### DIFF
--- a/data/brands/advertising/totem.json
+++ b/data/brands/advertising/totem.json
@@ -11,7 +11,7 @@
         "amenity": "",
         "brand": "{source.tags.brand}",
         "brand:wikidata": "{source.tags.brand:wikidata}",
-        "name": ""
+        "R\\name": ""
       }
     }
   ]

--- a/data/brands/amenity/atm.json
+++ b/data/brands/amenity/atm.json
@@ -12,7 +12,7 @@
       "templateSource": "brands/amenity/bank",
       "templateTags": {
         "amenity": "atm",
-        "name": "",
+        "R\\name": "",
         "operator": "{source.tags.brand}",
         "operator:wikidata": "{source.tags.brand:wikidata}"
       }

--- a/data/brands/man_made/charge_point.json
+++ b/data/brands/man_made/charge_point.json
@@ -14,7 +14,7 @@
         "brand": "{source.tags.brand}",
         "brand:wikidata": "{source.tags.brand:wikidata}",
         "man_made": "charge_point",
-        "name": "",
+        "R\\name": "",
         "operator": "{source.tags.operator}",
         "operator:wikidata": "{source.tags.operator:wikidata}"
       }

--- a/data/operators/amenity/post_box.json
+++ b/data/operators/amenity/post_box.json
@@ -23,7 +23,7 @@
       "templateSource": "brands/amenity/post_office",
       "templateTags": {
         "amenity": "post_box",
-        "name": "",
+        "R\\name": "",
         "operator": "{source.tags.brand}",
         "operator:wikidata": "{source.tags.brand:wikidata}",
         "shop": ""
@@ -44,7 +44,7 @@
       "templateSource": "operators/amenity/post_office",
       "templateTags": {
         "amenity": "post_box",
-        "name": "",
+        "R\\name": "",
         "shop": ""
       }
     },

--- a/data/operators/man_made/charge_point.json
+++ b/data/operators/man_made/charge_point.json
@@ -14,7 +14,7 @@
         "brand": "{source.tags.brand}",
         "brand:wikidata": "{source.tags.brand:wikidata}",
         "man_made": "charge_point",
-        "name": "",
+        "R\\name": "",
         "operator": "{source.tags.operator}",
         "operator:wikidata": "{source.tags.operator:wikidata}"
       }

--- a/lib/file_tree.js
+++ b/lib/file_tree.js
@@ -380,16 +380,26 @@ expandTemplates: (cache, loco) => {
               }
               return replacement;
             });
-
-            if (tagValue === 'undefined' || tagValue === 'null') {
-              tagValue = '';   // wipe out bogus string replacements
-            }
           }
-
-          if (tagValue) {
-            tags[osmkey] = tagValue;
-          } else {
+          tags[osmkey] = tagValue;
+          if (osmkey.startsWith('R\\')) {
+            const regexKey = new RegExp(osmkey.substring(2));
+            for (const itemTag in tags) {
+              if (regexKey.test(itemTag)) {
+                tags[itemTag] = tagValue;
+              }
+            }
             delete tags[osmkey];
+          }
+        });
+
+        Object.keys(tags).forEach(key => {
+          const tagValue = tags[key];
+          // wipe out bogus string replacements
+          if (!tagValue
+            || tagValue === 'undefined'
+            || tagValue === 'null') {
+            delete tags[key];
           }
         });
 


### PR DESCRIPTION
Also would like to add functionality that will make the following valid:
`"operator*": "{source.tags.brand*}"`
but it takes more time ):