### PR TITLE
Update public_bookcase.json - Added Bieb Bieb Aalst, Minibib Torhout

### DIFF
--- a/data/brands/amenity/public_bookcase.json
+++ b/data/brands/amenity/public_bookcase.json
@@ -10,6 +10,15 @@
   },
   "items": [
     {
+      "displayName": "Bieb Bieb Aalst",
+      "locationSet": {"include": ["be"]},
+      "tags": {
+        "amenity": "public_bookcase",
+        "brand": "Bieb Bieb Aalst",
+        "name": "Bieb Bieb"
+      }
+    },
+    {
       "displayName": "Boekentil (Stad Leuven)",
       "id": "boekentil-31eb16",
       "locationSet": {"include": ["be"]},
@@ -139,6 +148,16 @@
         "brand": "Mercator Bücherschrank",
         "brand:wikidata": "Q2349075",
         "name": "Mercator Bücherschrank"
+      }
+    },
+    {
+      "displayName": "Minibib Torhout",
+      "locationSet": {"include": ["be"]},
+      "tags": {
+        "amenity": "public_bookcase",
+        "brand": "Minibib Torhout",
+        "brand:wikidata": "Q270633",
+        "name": "Minibib"
       }
     },
     {


### PR DESCRIPTION
Adds Bieb Bieb Aalst, Minibib Torhout (both are for a local area)

Mapped:
- Bieb Bieb Aalst [>0/16] (operator: neighborhood committee, local inhabitants. funder: city's neighborhood idea program)
- Minibib Torhout [2/16] (operator: one person, local inhabitants. manufacturer, installer: the city's technical service department)

There is also Zwerfbib (mainly Antwerpen-Geel, organized by De Bib, the city's library). These have the same make, but seem to be mostly (also) part of the Little Free Library brand. Here is a draft entry if still wanted. (Mapped: >0/12+)
```
    {
      "displayName": "Zwerfbib (De Bib)",
      "locationSet": {"include": ["be"]},
      "tags": {
        "amenity": "public_bookcase",
        "brand": "Zwerfbib (De Bib)",
        "brand:wikidata": "Q464454",
        "name": "Zwerfbib"
      }
    },
```
(for the wikidata here I have fallen back to the city it is most in, but the entry can be adjusted accordingly. De Bib is actually part of Bibnet, which itself is now part of Cultuurconnect. There is currently only an entry for [Bibnet/Q2267661](https://www.wikidata.org/wiki/Q2267661) though.)

Please let me know what you think. These are fewer, though still noteable in amount imo and (still) having custom name and design usually. No local area is specified, since it can spill into other areas and I do not directly see other noteable ones.