### PR TITLE
Add Sanel NAPA

### DIFF
--- a/data/brands/shop/car_parts.json
+++ b/data/brands/shop/car_parts.json
@@ -417,6 +417,24 @@
       }
     },
     {
+      "displayName": "Sanel NAPA",
+      "matchNames": ["Sanel Auto Parts"],
+      "locationSet": {
+        "include": [
+          "us-nh.geojson",
+          "us-ma.geojson",
+          "us-me.geojson",
+          "us-vt.geojson"
+        ]
+      },
+      "tags": {
+        "brand": "Sanel NAPA",
+        "brand:wikidata": "Q122564780",
+        "name": "Sanel NAPA",
+        "shop": "car_parts"
+      }
+    },
+    {
       "displayName": "StarLine",
       "id": "starline-672e72",
       "locationSet": {


### PR DESCRIPTION
Independently-owned chain of NAPA Auto Parts stores in New England. ref https://sanelnapa.com/locations/