### PR TITLE
feat: use json response for facebook logo fetching

### DIFF
--- a/scripts/build_wikidata.js
+++ b/scripts/build_wikidata.js
@@ -605,19 +605,19 @@ function fetchFacebookLogo(qid, username) {
   const m = username.match(/-(\d+)$/);
   if (m) userid = m[1];
 
-  return fetch(logoURL, fetchOptions)
-    .then(response => {
-      if (!response.ok) {
-        return response.json();  // we should get a response body with more information
-      }
-      if (response.headers.get('content-md5') !== 'OMs/UjwLoIRaoKN19eGYeQ==') {  // question-mark image #2750
-        target.logos.facebook = logoURL;
-      }
-      return {};
-    })
+  // Can specify no redirect to fetch json and speed up this process
+  return fetch(`${logoURL}&redirect=0`, fetchOptions)
+    .then(response => response.json())
     .then(json => {
-      if (json && json.error && json.error.message) {
+      if (!json) return true;
+
+      if (json.error && json.error.message) {
         throw new Error(json.error.message);
+      }
+
+      // Default profile pictures aren't useful to the index #2750
+      if (json.data && !json.data.is_silhouette) {
+        target.logos.facebook = logoURL;
       }
       return true;
     })


### PR DESCRIPTION
- This speeds up the wikidata sync process since fetching the json requires less bandwidth than fetching images.
- This removes a bunch or erroneous default images that were previously being set on entries in the index (there are defaults other than the question mark).

closes #8380