### PR TITLE
Link to YouTube when there is handle but not channel in wikidata

### DIFF
--- a/app/src/CategoryRowSocialLinks.jsx
+++ b/app/src/CategoryRowSocialLinks.jsx
@@ -46,8 +46,12 @@ export function CategoryRowSocialLinks(props) {
       <a key='pinterest' target='_blank' href={href}><FontAwesomeIcon icon={faPinterestSquare} size='lg' /></a>
     );
   }
-  if (props.youtube) {
-    href = 'https://www.youtube.com/channel/' + props.youtube;
+  if (props.youtube || props.youtubeHandle) {
+    if (props.youtube) {
+      href = 'https://www.youtube.com/channel/' + props.youtube;
+    } else {
+      href = 'https://www.youtube.com/@' + props.youtubeHandle;
+    }
     items.push(
       <a key='youtube' target='_blank' href={href}><FontAwesomeIcon icon={faYoutubeSquare} size='lg' /></a>
     );

--- a/scripts/build_wikidata.js
+++ b/scripts/build_wikidata.js
@@ -318,6 +318,12 @@ function processEntities(result) {
     if (youtubeUser) {
       target.identities.youtube = youtubeUser;
     }
+    
+    // P11245 - YouTube Handle
+    const youtubeHandle = getClaimValue(entity, 'P2397');
+    if (youtubeHandle) {
+      target.identities.youtubeHandle = youtubeHandle;
+    }
 
     // P2984 - Snapchat ID
     const snapchatUser = getClaimValue(entity, 'P2984');


### PR DESCRIPTION
Noting for example https://www.wikidata.org/wiki/Q7190735, I thought that there could be some entities with a YouTube handle set, but without the YouTube channel ID set (I'm not sure how to find statistics on this). Also, I don't know that there is a bot automatically setting one from the other on Wikidata.