### PR TITLE
Cyclocity is the operator of bike rental schemes

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -411,7 +411,7 @@
         "brand:wikidata": "Q2901638",
         "network": "Bicloo",
         "network:wikidata": "Q2901638",
-        "operator": "JCDecaux",
+        "operator": "Cyclocity",
         "operator:wikidata": "Q74877"
       }
     },
@@ -1224,7 +1224,7 @@
         "brand": "Cy'clic",
         "brand:wikidata": "Q3008009",
         "network": "Cy'clic",
-        "operator": "JCDecaux",
+        "operator": "Cyclocity",
         "operator:wikidata": "Q74877"
       }
     },
@@ -1236,7 +1236,7 @@
         "amenity": "bicycle_rental",
         "brand": "Cyclocity",
         "network": "Cyclocity",
-        "operator": "JCDecaux",
+        "operator": "Cyclocity",
         "operator:wikidata": "Q74877"
       }
     },
@@ -1378,7 +1378,7 @@
         "brand:wikidata": "Q5311025",
         "network": "dublinbikes",
         "network:wikidata": "Q5311025",
-        "operator": "JCDecaux",
+        "operator": "Cyclocity",
         "operator:wikidata": "Q74877"
       }
     },
@@ -2146,7 +2146,7 @@
         "brand:wikidata": "Q22666405",
         "network": "Lundahoj",
         "network:wikidata": "Q22666405",
-        "operator": "JCDecaux",
+        "operator": "Cyclocity",
         "operator:wikidata": "Q74877"
       }
     },
@@ -3125,7 +3125,7 @@
         "brand:wikidata": "Q3459493",
         "network": "Sevici",
         "network:wikidata": "Q3459493",
-        "operator": "JCDecaux",
+        "operator": "Cyclocity",
         "operator:wikidata": "Q74877"
       }
     },
@@ -3695,7 +3695,7 @@
         "brand:wikidata": "Q9092320",
         "network": "Valenbisi",
         "network:wikidata": "Q9092320",
-        "operator": "JCDecaux",
+        "operator": "Cyclocity",
         "operator:wikidata": "Q74877"
       }
     },
@@ -3738,7 +3738,7 @@
         "brand:wikidata": "Q16764959",
         "network": "Vel'oh!",
         "network:wikidata": "Q16764959",
-        "operator": "JCDecaux",
+        "operator": "Cyclocity",
         "operator:wikidata": "Q74877"
       }
     },
@@ -3751,7 +3751,7 @@
         "brand": "Vélam",
         "brand:wikidata": "Q3564038",
         "network": "Vélam",
-        "operator": "JCDecaux",
+        "operator": "Cyclocity",
         "operator:wikidata": "Q74877"
       }
     },
@@ -3860,7 +3860,7 @@
         "brand:wikidata": "Q4096",
         "network": "Vélo'v",
         "network:wikidata": "Q4096",
-        "operator": "JCDecaux",
+        "operator": "Cyclocity",
         "operator:wikidata": "Q74877"
       }
     },
@@ -3904,7 +3904,7 @@
         "brand:wikidata": "Q3564067",
         "network": "VéloCité",
         "network:wikidata": "Q3564067",
-        "operator": "JCDecaux",
+        "operator": "Cyclocity",
         "operator:wikidata": "Q74877"
       }
     },
@@ -3987,7 +3987,7 @@
         "brand:wikidata": "Q3564032",
         "network": "vélOstan'lib",
         "network:wikidata": "Q3564032",
-        "operator": "JCDecaux",
+        "operator": "Cyclocity",
         "operator:wikidata": "Q74877"
       }
     },
@@ -4012,7 +4012,7 @@
         "brand:wikidata": "Q3564141",
         "network": "VélôToulouse",
         "network:wikidata": "Q3564141",
-        "operator": "JCDecaux",
+        "operator": "Cyclocity",
         "operator:wikidata": "Q74877"
       }
     },
@@ -4053,7 +4053,7 @@
         "brand:wikidata": "Q2510744",
         "network": "Villo!",
         "network:wikidata": "Q2510744",
-        "operator": "JCDecaux",
+        "operator": "Cyclocity",
         "operator:wikidata": "Q74877"
       }
     },

--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -3877,7 +3877,7 @@
         "brand:wikidata": "Q3564030",
         "network": "VélO²",
         "network:wikidata": "Q3564030",
-        "operator": "Cyclocity"
+        "operator": "Cyclocity",
         "operator:wikidata": "Q3008464"
       }
     },

--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -412,7 +412,7 @@
         "network": "Bicloo",
         "network:wikidata": "Q2901638",
         "operator": "Cyclocity",
-        "operator:wikidata": "Q74877"
+        "operator:wikidata": "Q3008464"
       }
     },
     {
@@ -1225,7 +1225,7 @@
         "brand:wikidata": "Q3008009",
         "network": "Cy'clic",
         "operator": "Cyclocity",
-        "operator:wikidata": "Q74877"
+        "operator:wikidata": "Q3008464"
       }
     },
     {
@@ -1237,7 +1237,7 @@
         "brand": "Cyclocity",
         "network": "Cyclocity",
         "operator": "Cyclocity",
-        "operator:wikidata": "Q74877"
+        "operator:wikidata": "Q3008464"
       }
     },
     {
@@ -1379,7 +1379,7 @@
         "network": "dublinbikes",
         "network:wikidata": "Q5311025",
         "operator": "Cyclocity",
-        "operator:wikidata": "Q74877"
+        "operator:wikidata": "Q3008464"
       }
     },
     {
@@ -2052,6 +2052,7 @@
         "brand": "Le vélo",
         "name": "Le vélo",
         "operator": "Cyclocity"
+        "operator:wikidata": "Q3008464"
       }
     },
     {
@@ -2147,7 +2148,7 @@
         "network": "Lundahoj",
         "network:wikidata": "Q22666405",
         "operator": "Cyclocity",
-        "operator:wikidata": "Q74877"
+        "operator:wikidata": "Q3008464"
       }
     },
     {
@@ -3126,7 +3127,7 @@
         "network": "Sevici",
         "network:wikidata": "Q3459493",
         "operator": "Cyclocity",
-        "operator:wikidata": "Q74877"
+        "operator:wikidata": "Q3008464"
       }
     },
     {
@@ -3696,7 +3697,7 @@
         "network": "Valenbisi",
         "network:wikidata": "Q9092320",
         "operator": "Cyclocity",
-        "operator:wikidata": "Q74877"
+        "operator:wikidata": "Q3008464"
       }
     },
     {
@@ -3739,7 +3740,7 @@
         "network": "Vel'oh!",
         "network:wikidata": "Q16764959",
         "operator": "Cyclocity",
-        "operator:wikidata": "Q74877"
+        "operator:wikidata": "Q3008464"
       }
     },
     {
@@ -3752,7 +3753,7 @@
         "brand:wikidata": "Q3564038",
         "network": "Vélam",
         "operator": "Cyclocity",
-        "operator:wikidata": "Q74877"
+        "operator:wikidata": "Q3008464"
       }
     },
     {
@@ -3861,7 +3862,7 @@
         "network": "Vélo'v",
         "network:wikidata": "Q4096",
         "operator": "Cyclocity",
-        "operator:wikidata": "Q74877"
+        "operator:wikidata": "Q3008464"
       }
     },
     {
@@ -3877,6 +3878,7 @@
         "network": "VélO²",
         "network:wikidata": "Q3564030",
         "operator": "Cyclocity"
+        "operator:wikidata": "Q3008464"
       }
     },
     {
@@ -3905,7 +3907,7 @@
         "network": "VéloCité",
         "network:wikidata": "Q3564067",
         "operator": "Cyclocity",
-        "operator:wikidata": "Q74877"
+        "operator:wikidata": "Q3008464"
       }
     },
     {
@@ -3988,7 +3990,7 @@
         "network": "vélOstan'lib",
         "network:wikidata": "Q3564032",
         "operator": "Cyclocity",
-        "operator:wikidata": "Q74877"
+        "operator:wikidata": "Q3008464"
       }
     },
     {
@@ -4013,7 +4015,7 @@
         "network": "VélôToulouse",
         "network:wikidata": "Q3564141",
         "operator": "Cyclocity",
-        "operator:wikidata": "Q74877"
+        "operator:wikidata": "Q3008464"
       }
     },
     {
@@ -4054,7 +4056,7 @@
         "network": "Villo!",
         "network:wikidata": "Q2510744",
         "operator": "Cyclocity",
-        "operator:wikidata": "Q74877"
+        "operator:wikidata": "Q3008464"
       }
     },
     {

--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -2051,7 +2051,7 @@
         "amenity": "bicycle_rental",
         "brand": "Le vélo",
         "name": "Le vélo",
-        "operator": "Cyclocity"
+        "operator": "Cyclocity",
         "operator:wikidata": "Q3008464"
       }
     },


### PR DESCRIPTION
[While JCDecaux owns Cyclocity, it is Cyclocity which operates this activity](https://fr.wikipedia.org/wiki/Cyclocity).