### PR TITLE
Audika now also operates branches in Belgium

### DIFF
--- a/data/brands/shop/hearing_aids.json
+++ b/data/brands/shop/hearing_aids.json
@@ -33,7 +33,7 @@
     {
       "displayName": "Audika",
       "id": "audika-4892bd",
-      "locationSet": {"include": ["ch", "fr"]},
+      "locationSet": {"include": ["be", "ch", "fr"]},
       "tags": {
         "brand": "Audika",
         "brand:wikidata": "Q2870745",


### PR DESCRIPTION
This chain of hearing aid stores originating in France now also operates branches in Belgium. Therefore adding "be" to the locationSet.