### PR TITLE
Update public_bookcase.json - Added Bücherhäuschen

### DIFF
--- a/data/brands/amenity/public_bookcase.json
+++ b/data/brands/amenity/public_bookcase.json
@@ -53,6 +53,17 @@
       }
     },
     {
+      "displayName": "Bücherhäuschen (Seiteneinsteiger e.V.)",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "amenity": "public_bookcase",
+        "books": "children",
+        "brand": "Bücherhäuschen",
+        "brand:wikidata": "Q1589627",
+        "name": "Bücherhäuschen"
+      }
+    },
+    {
       "displayName": "Bücherzelle",
       "id": "bucherzelle-8843d5",
       "locationSet": {"include": ["at", "de"]},


### PR DESCRIPTION
Adds Bücherhäuschen (for Hamburg and surroundings)

Mapped:
* Bücherhäuschen (0/15-20) (operator: association (eingetragener verein) working for city government, schools, local inhabitants. funder: nonprofit neighbourhood foundation part of housing association. manufacturer: commercial woodworking company.)

At least 15 (the initial, funded ones) have a plaque. Registration is with the association, not with the government. Since there is only wikidata for the funder, it has been used instead of the association.