### PR TITLE
JustPark is a car park brand

### DIFF
--- a/data/brands/amenity/parking.json
+++ b/data/brands/amenity/parking.json
@@ -30,6 +30,17 @@
         "name:en": "D-Parking",
         "name:ja": "Dパーキング"
       }
+    },
+    {
+      "displayName": "JustPark",
+      "id": "justpark-822ef4",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "amenity": "parking",
+        "brand": "JustPark",
+        "brand:wikidata": "Q17143517",
+        "fee": "yes"
+      }
     }
   ]
 }

--- a/data/operators/amenity/parking.json
+++ b/data/operators/amenity/parking.json
@@ -371,18 +371,6 @@
       }
     },
     {
-      "displayName": "JustPark",
-      "id": "justpark-822ef4",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "amenity": "parking",
-        "fee": "yes",
-        "operator": "JustPark",
-        "operator:type": "private",
-        "operator:wikidata": "Q17143517"
-      }
-    },
-    {
       "displayName": "London Borough of Newham",
       "id": "londonboroughofnewham-38d530",
       "locationSet": {


### PR DESCRIPTION
This resolves #8716 by treating JustPark as a car park brand and not an operator