### PR TITLE
Update bakery.json Update COBS Bread Wikidata

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -563,7 +563,7 @@
       "locationSet": {"include": ["ca", "us"]},
       "tags": {
         "brand": "COBS Bread",
-        "brand:wikidata": "Q4849261",
+        "brand:wikidata": "Q116771375",
         "name": "COBS Bread",
         "shop": "bakery"
       }


### PR DESCRIPTION
Updating COBS Bread brand:wikidata to Q116771375 - https://www.wikidata.org/wiki/Q116771375