### PR TITLE
add "Commet", "Max Elektro", "Kotsovolos", "Plaisio", "Public", modify "MediaMarkt" in electronics.json

### DIFF
--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -252,6 +252,16 @@
         "shop": "electronics"
       }
     },
+          "displayName": "Commet",
+      "id":,
+      "locationSet": {"include": ["it"]},
+      "tags": {
+        "brand": "Commet",
+        "brand:wikidata": "Q3777340",
+        "name": "Commet",
+        "shop": "electronics"
+      }
+    },
     {
       "displayName": "Comfy",
       "id": "comfy-f31684",
@@ -829,6 +839,17 @@
         "shop": "electronics"
       }
     },
+        {
+      "displayName": "Kotsovolos",
+      "id": ,
+      "locationSet": {"include": ["cy", "gr"]},
+      "tags": {
+        "brand": "Kotsovolos",
+        "brand:wikidata": "Q17050427",
+        "name": "Komputronik",
+        "shop": "electronics"
+      }
+    },
     {
       "displayName": "Krëfel",
       "id": "krefel-17d2c2",
@@ -885,6 +906,16 @@
         "shop": "electronics"
       }
     },
+        {
+      "displayName": "Max Elektro",
+      "id":,
+      "locationSet": {"include": ["pl"]},
+      "tags": {
+        "brand": "Max Elektro",
+        "name": "Max Elektro",
+        "shop": "electronics"
+      }
+    },
     {
       "displayName": "MDA",
       "id": "mda-38013c",
@@ -937,12 +968,9 @@
           "ch",
           "de",
           "es",
-          "gr",
           "hu",
           "nl",
           "pl",
-          "pt",
-          "se",
           "tr"
         ]
       },
@@ -1089,6 +1117,17 @@
       }
     },
     {
+      "displayName": "Plaisio",
+      "id": ,
+      "locationSet": {"include": ["gr"]},
+      "tags": {
+        "brand": "Plaisio",
+        "brand:wikidata": "Q7200794",
+        "name": "Plaisio",
+        "shop": "electronics"
+      }
+    },
+    {
       "displayName": "PLANEO Elektro",
       "id": "planeoelektro-8bbdd1",
       "locationSet": {"include": ["cz", "sk"]},
@@ -1131,6 +1170,17 @@
         "brand": "PRO&Cie",
         "brand:wikidata": "Q3406142",
         "name": "PRO&Cie",
+        "shop": "electronics"
+      }
+    },
+   {
+      "displayName": "Public",
+      "id": ,
+      "locationSet": {"include": ["cy", "gr"]},
+      "tags": {
+        "brand": "Public",
+        "brand:wikidata": " Q12871976",
+        "name": "Public",
         "shop": "electronics"
       }
     },

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -252,8 +252,8 @@
         "shop": "electronics"
       }
     },
-          "displayName": "Commet",
-      "id":,
+    {
+      "displayName": "Commet",
       "locationSet": {"include": ["it"]},
       "tags": {
         "brand": "Commet",
@@ -846,7 +846,7 @@
       "tags": {
         "brand": "Kotsovolos",
         "brand:wikidata": "Q17050427",
-        "name": "Komputronik",
+        "name": "Kotsovolos",
         "shop": "electronics"
       }
     },
@@ -913,6 +913,7 @@
       "tags": {
         "brand": "Max Elektro",
         "name": "Max Elektro",
+        "brand:wikidata":"Q122941607",
         "shop": "electronics"
       }
     },

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -841,7 +841,6 @@
     },
         {
       "displayName": "Kotsovolos",
-      "id": ,
       "locationSet": {"include": ["cy", "gr"]},
       "tags": {
         "brand": "Kotsovolos",
@@ -908,7 +907,6 @@
     },
         {
       "displayName": "Max Elektro",
-      "id":,
       "locationSet": {"include": ["pl"]},
       "tags": {
         "brand": "Max Elektro",
@@ -1119,7 +1117,6 @@
     },
     {
       "displayName": "Plaisio",
-      "id": ,
       "locationSet": {"include": ["gr"]},
       "tags": {
         "brand": "Plaisio",
@@ -1176,7 +1173,6 @@
     },
    {
       "displayName": "Public",
-      "id": ,
       "locationSet": {"include": ["cy", "gr"]},
       "tags": {
         "brand": "Public",


### PR DESCRIPTION
Commet, Italy (120 stores) - https://www.comet.it/negozi 
Max Elektro, Poland (429 stores) - https://maxelektro.pl/siec-sprzedazy 
Kotsovolos, Greece and Cyprus (91 stores) - https://www.kotsovolos.gr/StoresLocator 
Plaisio, Greece (25 stores) - https://www.plaisio.gr/Store-Locator 
Public, Greece and Cyprus (47 stores) - https://www.public.gr/store-locator/list