### PR TITLE
Remove "excluded: au" from Shell

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -4605,7 +4605,7 @@
       "id": "shell-4a6616",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["au", "jp"]
+        "exclude": ["jp"]
       },
       "matchNames": [
         "posto shell",


### PR DESCRIPTION
Shell operates in Australia in additon to the Coles Express brand #8392. Some service stations are not operated by OTR as discussed in #8392. It is more common for Shell to be operated by ether the Shell company or small convinence stores such as NIght Owl, Fast & Easy and Pie Face Convenience.