### PR TITLE
Bosch Car Service has its own, dedicated Wikidata entry

### DIFF
--- a/data/brands/shop/car_repair.json
+++ b/data/brands/shop/car_repair.json
@@ -208,7 +208,7 @@
       "matchNames": ["bosch service"],
       "tags": {
         "brand": "Bosch Car Service",
-        "brand:wikidata": "Q234021",
+        "brand:wikidata": "Q894368",
         "name": "Bosch Car Service",
         "shop": "car_repair"
       }


### PR DESCRIPTION
Instead of using the Wikidata entry of the huge parent company Robert Bosch, it seems more fitting to use the specific Wikidata entry for this business entity:
https://www.wikidata.org/wiki/Q894368

We also get the correct logo then, instead of the generic Bosch logo.