### PR TITLE
Add enercity Netz GmbH

### DIFF
--- a/data/operators/man_made/street_cabinet.json
+++ b/data/operators/man_made/street_cabinet.json
@@ -68,11 +68,12 @@
       }
     },
     {
-      "displayName": "enercity Netz GmbH",
-      "locationSet": {"include":[[9.737670904650065, 52.37718084861254, 30]]},
+      "displayName": "enercity Netz",
+      "locationSet": {"include":["de-ni.geojson"]},
+      "matchNames": ["enercity"],
       "tags": {
         "man_made": "street_cabinet",
-        "operator": "enercity Netz GmbH",
+        "operator": "enercity Netz",
         "operator:wikidata": "Q123018653",
         "utility": "power"
       }

--- a/data/operators/man_made/street_cabinet.json
+++ b/data/operators/man_made/street_cabinet.json
@@ -66,6 +66,16 @@
         "operator:wikidata": "Q7999638",
         "utility": "telecom"
       }
+    },
+    {
+      "displayName": "enercity Netz GmbH",
+      "locationSet": {"include":[[9.737670904650065, 52.37718084861254, 30]]},
+      "tags": {
+        "man_made": "street_cabinet",
+        "operator": "enercity Netz GmbH",
+        "operator:wikidata": "Q123018653",
+        "utility": "power"
+      }
     }
   ]
 }


### PR DESCRIPTION
This adds the proper tags for this region's distribution network operator.
Documentation said that "id" is generated automatically.