### PR TITLE
Remove Education Queensland

### DIFF
--- a/data/operators/amenity/school.json
+++ b/data/operators/amenity/school.json
@@ -8351,7 +8351,10 @@
       "locationSet": {
         "include": ["au-qld.geojson"]
       },
-      "matchNames": ["department of education"],
+      "matchNames": [
+        "department of education",
+        "education queensland"
+      ],
       "tags": {
         "amenity": "school",
         "operator": "Queensland Department of Education",
@@ -10669,17 +10672,6 @@
       "tags": {
         "amenity": "school",
         "operator": "Education Nationale"
-      }
-    },
-    {
-      "displayName": "Education Queensland",
-      "id": "educationqueensland-37f40e",
-      "locationSet": {
-        "include": ["au-qld.geojson"]
-      },
-      "tags": {
-        "amenity": "school",
-        "operator": "Education Queensland"
       }
     },
     {


### PR DESCRIPTION
Remove Education Queensland and change "matchNames" for Department of Education (Queensland) to refelct the removal