### PR TITLE
Fixed caps for SOCAR

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -4751,7 +4751,7 @@
       }
     },
     {
-      "displayName": "Socar",
+      "displayName": "SOCAR",
       "id": "socar-619b60",
       "locationSet": {
         "include": [
@@ -4766,9 +4766,9 @@
       },
       "tags": {
         "amenity": "fuel",
-        "brand": "Socar",
+        "brand": "SOCAR",
         "brand:wikidata": "Q1622293",
-        "name": "Socar"
+        "name": "SOCAR"
       }
     },
     {
@@ -6524,11 +6524,11 @@
       "tags": {
         "amenity": "fuel",
         "brand": "სოკარი",
-        "brand:en": "Socar",
+        "brand:en": "SOCAR",
         "brand:ka": "სოკარი",
         "brand:wikidata": "Q1622293",
         "name": "სოკარი",
-        "name:en": "Socar",
+        "name:en": "SOCAR",
         "name:ka": "სოკარი"
       }
     },


### PR DESCRIPTION
SOCAR is an abbreviation for "State Oil Company of Azerbaijan Republic". This name is always written in caps on signs. Not sure if this is necessary, but I think it would be better