### PR TITLE
Remove boîte à livres

### DIFF
--- a/data/brands/amenity/public_bookcase.json
+++ b/data/brands/amenity/public_bookcase.json
@@ -3,7 +3,7 @@
     "path": "brands/amenity/public_bookcase",
     "exclude": {
       "generic": [
-        "^(public bookcase|boîte à livres|(offener )?bücherschrank)$",
+        "^(public bookcase|bo[îi]te [aà] livres|(offener )?bücherschrank)$",
         "^knihobudka$"
       ]
     }
@@ -28,16 +28,6 @@
         "brand": "Boekentil (Stad Leuven)",
         "brand:wikidata": "Q118958",
         "name": "Boekentil"
-      }
-    },
-    {
-      "displayName": "Boite à livres",
-      "id": "boitealivres-6e8312",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "amenity": "public_bookcase",
-        "brand": "Boite à livres",
-        "name": "Boite à livres"
       }
     },
     {

--- a/data/brands/amenity/public_bookcase.json
+++ b/data/brands/amenity/public_bookcase.json
@@ -32,12 +32,11 @@
     },
     {
       "displayName": "Boite à livres",
-      "id": "boitealivres-45dad4",
-      "locationSet": {"include": ["be", "fx"]},
+      "id": "boitealivres-6e8312",
+      "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "public_bookcase",
         "brand": "Boite à livres",
-        "brand:wikidata": "Q53733828",
         "name": "Boite à livres"
       }
     },


### PR DESCRIPTION
The wikidata for the removed entry points to a lone osm node that is not a brand and not a public bookcase anymore.

I tried deleting it all-together but it comes back when I run npm run build.