### PR TITLE
Update Selgros on wholesale.json

### DIFF
--- a/data/brands/shop/wholesale.json
+++ b/data/brands/shop/wholesale.json
@@ -226,17 +226,16 @@
       }
     },
     {
-      "displayName": "SELGROS cash & carry",
+      "displayName": "Selgros",
       "id": "selgroscashandcarry-8ea7cd",
       "locationSet": {
         "include": ["de", "pl", "ro", "ru"]
       },
       "tags": {
-        "brand": "SELGROS cash & carry",
+        "brand": "Selgros",
         "brand:wikidata": "Q473918",
-        "name": "SELGROS cash & carry",
+        "name": "Selgros",
         "shop": "wholesale",
-        "short_name": "SELGROS"
       }
     },
     {


### PR DESCRIPTION
Selgros is currently the main and most frequently used name by the Transgourmet company.  Also the logo no longer includes the words "cash and carry".

https://www.selgros.de/
https://www.facebook.com/Selgros