### PR TITLE
Add brand:ja to Ding Tea

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -1533,10 +1533,12 @@
         "brand:en": "Ding Tea",
         "brand:ja": "薡茶",
         "brand:wikidata": "Q112123475",
+        "brand:zh": "薡茶",
         "cuisine": "bubble_tea",
         "name": "Ding Tea 薡茶",
         "name:en": "Ding Tea",
         "name:ja": "薡茶",
+        "name:zh": "薡茶",
         "takeaway": "yes"
       }
     },

--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -1531,12 +1531,12 @@
         "amenity": "cafe",
         "brand": "Ding Tea 薡茶",
         "brand:en": "Ding Tea",
+        "brand:ja": "薡茶",
         "brand:wikidata": "Q112123475",
-        "brand:zh": "薡茶",
         "cuisine": "bubble_tea",
         "name": "Ding Tea 薡茶",
         "name:en": "Ding Tea",
-        "name:zh": "薡茶",
+        "name:ja": "薡茶",
         "takeaway": "yes"
       }
     },


### PR DESCRIPTION
Currently [Ding Tea JP](https://nsi.guide/index.html?t=brands&k=amenity&v=cafe&tt=ding%20tea#dingtea-0cf217) has only ZH, presumably it should be JA?

cc @LaoshuBaby it was added in https://github.com/osmlab/name-suggestion-index/commit/590c34b0b7260fe01f18831243084dae4515e0bf

cc @arch0345 Ding Tea (Not JP) was added in https://github.com/osmlab/name-suggestion-index/commit/aed811fc3bfb66b320946e69de759208944c3eb2

(Values are presumably wrong, do not merge)