### PR TITLE
Rename "Bantierra" to "Caja Rural de Aragón"

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -2932,14 +2932,14 @@
       }
     },
     {
-      "displayName": "Bantierra",
+      "displayName": "Caja Rural de Aragón",
       "id": "bantierra-ce59ab",
       "locationSet": {"include": ["es"]},
       "tags": {
         "amenity": "bank",
-        "brand": "Bantierra",
+        "brand": "Caja Rural de Aragón",
         "brand:wikidata": "Q5719155",
-        "name": "Bantierra"
+        "name": "Caja Rural de Aragón"
       }
     },
     {


### PR DESCRIPTION
Bantierra is the former brand of Caja Rural de Aragón. Bantierra brand was discontinued in 2019 ( https://es.wikipedia.org/wiki/Caja_Rural_de_Arag%C3%B3n )