### PR TITLE
Updated Safeway in supermarkets

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -31,6 +31,16 @@
   },
   "items": [
     {
+      "displayName": "Safeway",
+      "locationSet": {"include": ["ca"]},
+      "tags": {
+        "brand": "Safeway",
+        "brand:wikidata": "Q17111901",
+        "name": "Safeway",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "3hreeSixty",
       "id": "3hreesixty-745f9c",
       "locationSet": {"include": ["hk"]},
@@ -6366,7 +6376,7 @@
     {
       "displayName": "Safeway",
       "id": "safeway-986a24",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us"]},
       "tags": {
         "brand": "Safeway",
         "brand:wikidata": "Q1508234",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -31,8 +31,9 @@
   },
   "items": [
     {
-      "displayName": "Safeway",
+      "displayName": "Safeway Canada",
       "locationSet": {"include": ["ca"]},
+      "matchNames": ["Safeway"],
       "tags": {
         "brand": "Safeway",
         "brand:wikidata": "Q17111901",


### PR DESCRIPTION
Safeway Canada became independent in 2013. Is still uses same logo and branding, but has a different Wikidata page. Thus I think there should be 2 of them on for US and one for CA. 

https://github.com/alltheplaces/alltheplaces/pull/6208