### PR TITLE
Added Clean Harbors as a waste water operator

### DIFF
--- a/data/operators/man_made/wastewater_plant.json
+++ b/data/operators/man_made/wastewater_plant.json
@@ -5,6 +5,15 @@
   },
   "items": [
     {
+      "displayName": "Clean Harbors",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "man_made": "wastewater_plant",
+        "operator": "Clean Harbors",
+        "operator:wikidata": "Q5130494"
+      }
+    },
+    {
       "displayName": "Águas Públicas do Alentejo",
       "id": "aguaspublicasdoalentejo-9ed6d8",
       "locationSet": {"include": ["pt"]},


### PR DESCRIPTION
Not sure if this is exactly a operator (have not added an operator before), but I think it belongs here. It does many services, which you can see in the dropdown [cleanharbors](https://www.cleanharbors.com/). Also in the [wikipedia](https://en.wikipedia.org/wiki/Clean_Harbors) page it has waste services. Then lastly, [wikidata](https://www.wikidata.org/wiki/Q5130494) says an industrial and water waste management business.