### PR TITLE
fix Appalachian Power Company

### DIFF
--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -283,7 +283,7 @@
       }
     },
     {
-      "displayName": "APCO",
+      "displayName": "Appalachian Power",
       "id": "appalachianpower-33137a",
       "locationSet": {
         "include": [
@@ -294,8 +294,7 @@
       },
       "matchNames": ["appalachian power company"],
       "tags": {
-        "operator": "Appalachian Power",
-        "operator:short": "APCO",
+        "operator": "Appalachian Power Company",
         "operator:wikidata": "Q109013941",
         "power": "line"
       }

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -292,7 +292,7 @@
           "us-wv.geojson"
         ]
       },
-      "matchNames": ["appalachian power company"],
+      "matchNames": ["appalachian power","APCO"],
       "tags": {
         "operator": "Appalachian Power Company",
         "operator:wikidata": "Q109013941",

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -307,7 +307,7 @@
           "us-wv.geojson"
         ]
       },
-      "matchNames": ["appalachian power company"],
+      "matchNames": ["appalachian power","APCO"],
       "tags": {
         "operator": "Appalachian Power Company",
         "operator:wikidata": "Q109013941",

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -298,7 +298,7 @@
       }
     },
     {
-      "displayName": "APCO",
+      "displayName": "Appalachian Power",
       "id": "appalachianpower-0f82b9",
       "locationSet": {
         "include": [
@@ -309,8 +309,7 @@
       },
       "matchNames": ["appalachian power company"],
       "tags": {
-        "operator": "Appalachian Power",
-        "operator:short": "APCO",
+        "operator": "Appalachian Power Company",
         "operator:wikidata": "Q109013941",
         "power": "substation"
       }


### PR DESCRIPTION
The correct operator name is "Appalachian Power Company", not "Appalachian Power". ([Example](https://elibrary.ferc.gov/eLibrary/filelist?accession_number=20230412-8012&optimized=false))