### PR TITLE
fixed eslint and linted files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@
   "extends": [
     "eslint:recommended"
   ],
+  "parser": "@babel/eslint-parser",
   "parserOptions": {
     "ecmaVersion": 6,
     "sourceType": "module"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
     - run: npm install
       env:
         FORCE_COLOR: 2
+    - run: npm run lint
+      env:
+        FORCE_COLOR: 2
     - run: npm run test
       env:
         FORCE_COLOR: 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,41 +1,68 @@
 {
-  "editor.formatOnSave": false,
-  "json.schemas": [
-    {
-        "fileMatch": [
-            "data/**/*.json"
-        ],
-        "url": "./schema/categories.json"
-    },
-    {
-        "fileMatch": [
-            "data/**/*.json"
-        ],
-        "url": "./schema/feature.json"
-    },
-    {
-        "fileMatch": [
-            "config/genericWords.json"
-        ],
-        "url": "./schema/genericWords.json"
-    },
-    {
-        "fileMatch": [
-            "features/**/*.geojson"
-        ],
-        "url": "./schema/geojson.json"
-    },
-    {
-        "fileMatch": [
-            "config/replacements.json"
-        ],
-        "url": "./schema/replacements.json"
-    },
-    {
-        "fileMatch": [
-            "config/trees.json"
-        ],
-        "url": "./schema/trees.json"
-    }
-  ]
+    "editor.formatOnSave": false,
+    "json.schemas": [
+        {
+            "fileMatch": [
+                "data/**/*.json"
+            ],
+            "url": "./schema/categories.json"
+        },
+        {
+            "fileMatch": [
+                "data/**/*.json"
+            ],
+            "url": "./schema/feature.json"
+        },
+        {
+            "fileMatch": [
+                "config/genericWords.json"
+            ],
+            "url": "./schema/genericWords.json"
+        },
+        {
+            "fileMatch": [
+                "features/**/*.geojson"
+            ],
+            "url": "./schema/geojson.json"
+        },
+        {
+            "fileMatch": [
+                "config/replacements.json"
+            ],
+            "url": "./schema/replacements.json"
+        },
+        {
+            "fileMatch": [
+                "config/trees.json"
+            ],
+            "url": "./schema/trees.json"
+        }
+    ],
+    "cSpell.words": [
+        "aitodotai",
+        "Applebees",
+        "brandkey",
+        "fontawesome",
+        "fortawesome",
+        "honeybakedham",
+        "ideditor",
+        "idgen",
+        "Kebabai",
+        "mapbox",
+        "Multipolygon",
+        "multivalue",
+        "newid",
+        "nsimple",
+        "openstreetmap",
+        "operatorkey",
+        "osmkey",
+        "rapideditor",
+        "regexes",
+        "sparql",
+        "Taginfo",
+        "tagpair",
+        "wikibase",
+        "wiphala",
+        "xmlbuilder"
+    ]
 }

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,5 @@
+{
+    "plugins": [
+        ["@babel/plugin-syntax-import-attributes", { "deprecatedAssertSyntax": true }]
+    ]
+}

--- a/lib/file_tree.js
+++ b/lib/file_tree.js
@@ -4,7 +4,7 @@ import fs from 'fs-extra';
 import { globSync } from 'glob';
 import JSON5 from 'json5';
 import localeCompare from 'locale-compare';
-import stringify from '@aitodotai/json-stringify-pretty-compact';
+import stringify from 'json-stringify-pretty-compact';
 const withLocale = localeCompare('en-US');
 
 // Internal

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "build:features": "node scripts/build_features.js",
     "build:index": "node scripts/build_index.js",
     "tap": "c8 tap --reporter terse --no-cov tests/*.js",
-    "lint": "eslint scripts/*.js lib/*.js",
+    "lint": "eslint scripts/*.js lib/*.js tests/*.js",
     "test": "run-s build tap",
     "validate": "node scripts/validate.js",
     "wikidata": "node scripts/build_wikidata.js"
@@ -105,7 +105,10 @@
     "which-polygon": "^2.2.1"
   },
   "devDependencies": {
-    "@aitodotai/json-stringify-pretty-compact": "^1.3.0",
+    "json-stringify-pretty-compact": "^4.0.0",
+    "@babel/core": "^7.23.2",
+    "@babel/eslint-parser": "^7.22.15",
+    "@babel/plugin-syntax-import-attributes": "^7.22.5",
     "@fortawesome/fontawesome-svg-core": "^6.4.2",
     "@fortawesome/free-brands-svg-icons": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
@@ -119,7 +122,7 @@
     "chalk": "5.3.0",
     "clear": "^0.1.0",
     "esbuild": "^0.19.4",
-    "eslint": "^8.50.0",
+    "eslint": "^8.52.0",
     "fs-extra": "^11.1.1",
     "geojson-bounds": "^1.0.2",
     "geojson-precision": "^1.0.0",

--- a/scripts/build_features.js
+++ b/scripts/build_features.js
@@ -1,8 +1,6 @@
 // External
 import chalk from 'chalk';
 import fs from 'node:fs';
-import geojsonArea from '@mapbox/geojson-area';
-import geojsonBounds from 'geojson-bounds';
 import geojsonPrecision from 'geojson-precision';
 import geojsonRewind from '@mapbox/geojson-rewind';
 import { globSync } from 'glob';
@@ -10,7 +8,7 @@ import JSON5 from 'json5';
 import jsonschema from 'jsonschema';
 import path from 'node:path';
 import localeCompare from 'locale-compare';
-import stringify from '@aitodotai/json-stringify-pretty-compact';
+import stringify from 'json-stringify-pretty-compact';
 const withLocale = localeCompare('en-US');
 
 // Internal
@@ -86,22 +84,6 @@ function collectFeatures() {
     const id = path.basename(file).toLowerCase();
     feature.id = id;
 
-    // // Warn if this feature is so small/complex it would better be represented as a circular area.
-    // const except = { 'new_york_city.geojson': true };
-    // if (!except[id]) {
-    //   const coordLength = countCoordinates(feature.geometry.coordinates);
-    //   let area = geojsonArea.geometry(feature.geometry) / 1e6;   // m² to km²
-    //   area = Number(area.toFixed(2));
-    //   if (area < 2000 && coordLength > 15) {
-    //     const extent = geojsonBounds.extent(feature);
-    //     const lon = ((extent[0] + extent[2]) / 2).toFixed(4);
-    //     const lat = ((extent[1] + extent[3]) / 2).toFixed(4);
-    //     console.warn('');
-    //     console.warn(chalk.yellow(`Warning - GeoJSON feature for small area (${area} km²).  Consider circular include location instead: [${lon}, ${lat}]`));
-    //     console.warn('  ' + chalk.yellow(file));
-    //   }
-    // }
-
     // sort properties
     let obj = {};
     if (feature.type)  { obj.type = feature.type; }
@@ -146,35 +128,12 @@ function collectFeatures() {
   });
 
   // sort features by id, see: 800ca866f
-  features.sort((a, b) => withLocale(a.id, b.id))
+  features.sort((a, b) => withLocale(a.id, b.id));
 
   const featureCount = Object.keys(files).length;
   console.log(`🧩  features:\t${featureCount}`);
   return features;
 }
-
-
-//
-// countCoordinates()
-// Counts the number of coordinates in a GeoJSON Polygon or MultiPolygon
-//
-function countCoordinates(coords) {
-  const a = Array.isArray(coords);
-  const b = a && Array.isArray(coords[0]);
-  const c = b && Array.isArray(coords[0][0]);
-  const d = c && Array.isArray(coords[0][0][0]);
-
-  let length = 0;
-  if (d) {  // Multipolygon
-    coords.forEach(polys => {
-      polys.forEach(rings => length += rings.length);
-    });
-  } else {  // Polygon
-    coords.forEach(rings => length += rings.length);
-  }
-  return length;
-}
-
 
 
 //

--- a/scripts/build_index.js
+++ b/scripts/build_index.js
@@ -5,7 +5,7 @@ import JSON5 from 'json5';
 import localeCompare from 'locale-compare';
 import LocationConflation from '@rapideditor/location-conflation';
 import safeRegex from 'safe-regex';
-import stringify from '@aitodotai/json-stringify-pretty-compact';
+import stringify from 'json-stringify-pretty-compact';
 const withLocale = localeCompare('en-US');
 
 // Internal
@@ -14,14 +14,12 @@ import { idgen } from '../lib/idgen.js';
 import { Matcher } from '../lib/matcher.js';
 import { simplify } from '../lib/simplify.js';
 import { sortObject } from '../lib/sort_object.js';
-import { stemmer } from '../lib/stemmer.js';
 import { validate } from '../lib/validate.js';
 import { writeFileWithMeta } from '../lib/write_file_with_meta.js';
 const matcher = new Matcher();
 
 // JSON
-import treesJSON from '../config/trees.json' assert {type: 'json'};
-const trees = treesJSON.trees;
+
 
 // We use LocationConflation for validating and processing the locationSets
 import featureCollectionJSON from '../dist/featureCollection.json' assert {type: 'json'};
@@ -348,7 +346,7 @@ function mergeItems() {
   // Any country codes which should be replaced by more standard ones in the locationSets
   const countryReplacements = {
     'uk': 'gb',  // Exceptionally reserved, United Kingdom is officially assigned the alpha-2 code GB
-  }
+  };
 
   const START = '🏗   ' + chalk.yellow(`Merging items...`);
   const END = '👍  ' + chalk.green(`done merging`);
@@ -510,7 +508,7 @@ function mergeItems() {
         } else if (/[\u1700-\u171F]/.test(name)) {   // Tagalog
           if (!item.locationSet)  item.locationSet = { include: ['ph'] };
           setLanguageTags(tags, 'tl');
-        } else if (/[\u3040-\u30FF]/.test(name)) {   // Hirgana or Katakana
+        } else if (/[\u3040-\u30FF]/.test(name)) {   // Hiragana or Katakana
           if (!item.locationSet)  item.locationSet = { include: ['jp'] };
           setLanguageTags(tags, 'ja');
         } else if (/[\u3130-\u318F]/.test(name)) {   // Hangul
@@ -587,11 +585,11 @@ function mergeItems() {
   }
 
   function normalizeCountryCode(countries, country) {
-    const index = countries.indexOf(country.toLowerCase())
+    const index = countries.indexOf(country.toLowerCase());
     if (index >= 0) {
       const replace = countryReplacements[country.toLowerCase()];
       if (replace && replace !== undefined) {
-        countries[index] = replace.toLowerCase()
+        countries[index] = replace.toLowerCase();
       }
     }
   }
@@ -613,7 +611,6 @@ function checkItems(t) {
   let warnFormatWikidata = [];
   let warnMissingTag = [];
   let warnFormatTag = [];
-  let seenName = {};
 
   let total = 0;      // total items
   let totalWd = 0;    // total items with wikidata
@@ -625,7 +622,7 @@ function checkItems(t) {
     const items = _cache.path[tkv].items;
     if (!Array.isArray(items) || !items.length) return;
 
-    const [t, k, v] = tkv.split('/', 3);     // tkv = "tree/key/value"
+    const [, k, v] = tkv.split('/', 3);     // tkv = "tree/key/value"
     const kv = `${k}/${v}`;
 
     items.forEach(item => {
@@ -698,37 +695,6 @@ function checkItems(t) {
           warnFormatTag.push([display(item), `${osmkey} = ${val}`]);
         }
       });
-
-
-// TODO ?
-  //     // Warn about "new" (no wikidata) items that may duplicate an "existing" (has wikidata) item.
-  //     // The criteria for this warning is:
-  //     // - One of the items has no `brand:wikidata`
-  //     // - The items have nearly the same name
-  //     // - The items have the same locationSet (or the one without wikidata is worldwide)
-  //     const name = tags.name || tags.brand;
-  //     const stem = stemmer(name) || name;
-  //     const itemwd = tags[tree.mainTag];
-  //     const itemls = loco.validateLocationSet(item.locationSet).id;
-
-  //     if (!seenName[stem]) seenName[stem] = new Set();
-  //     seenName[stem].add(item);
-
-  //     if (seenName[stem].size > 1) {
-  //       seenName[stem].forEach(other => {
-  //         if (other.id === item.id) return;   // skip self
-  //         const otherwd = other.tags[tree.mainTag];
-  //         const otherls = loco.validateLocationSet(other.locationSet).id;
-
-  //         // pick one of the items without a wikidata tag to be the "duplicate"
-  //         if (!itemwd && (itemls === otherls || itemls === '+[Q2]')) {
-  //           warnDuplicate.push([display(item), display(other)]);
-  //         } else if (!otherwd && (otherls === itemls || otherls === '+[Q2]')) {
-  //           warnDuplicate.push([display(other), display(item)]);
-  //         }
-  //       });
-  //     }
-
     });
   });
 

--- a/scripts/build_wikidata.js
+++ b/scripts/build_wikidata.js
@@ -9,7 +9,7 @@ import JSON5 from 'json5';
 import localeCompare from 'locale-compare';
 import LocationConflation from '@rapideditor/location-conflation';
 import shell from 'shelljs';
-import stringify from '@aitodotai/json-stringify-pretty-compact';
+import stringify from 'json-stringify-pretty-compact';
 import wikibase from 'wikibase-sdk';
 import wikibaseEdit from 'wikibase-edit';
 const withLocale = localeCompare('en-US');
@@ -762,12 +762,6 @@ function enLabelForQID(qid) {
 
 function delay(msec) {
   return new Promise(resolve => setTimeout(resolve, msec));
-}
-
-
-// Clamp a number between min and max
-function clamp(num, min, max) {
-  return Math.min(Math.max(num, min), max);
 }
 
 

--- a/scripts/dist_files.js
+++ b/scripts/dist_files.js
@@ -6,7 +6,7 @@ import JSON5 from 'json5';
 import localeCompare from 'locale-compare';
 import LocationConflation from '@rapideditor/location-conflation';
 import shell from 'shelljs';
-import stringify from '@aitodotai/json-stringify-pretty-compact';
+import stringify from 'json-stringify-pretty-compact';
 import xmlbuilder2 from 'xmlbuilder2';
 
 const withLocale = localeCompare('en-US');
@@ -263,7 +263,7 @@ function buildIDPresets() {
               const vals = nsiVal.split(';');
               const findResult = vals.indexOf(idVal);
               if (-1 === findResult) {
-                return false
+                return false;
               }
               // For a smaller element index rating will be higher
               currentMatchSemicolonRating -= findResult;

--- a/tests/matcher.test.js
+++ b/tests/matcher.test.js
@@ -40,7 +40,7 @@ test('index building', t => {
           }
         ]
       }
-    }
+    };
     const orig = console.warn;   // silence console.warn
     console.warn = () => {};
     t.doesNotThrow(() => t.context.matcher.buildLocationIndex(bad, loco));
@@ -61,7 +61,7 @@ test('index building', t => {
           }
         ]
       }
-    }
+    };
     const orig = console.warn;   // silence console.warn
     console.warn = () => {};
     t.doesNotThrow(() => t.context.matcher.buildLocationIndex(bad, loco));
@@ -83,7 +83,7 @@ test('match', t => {
   t.context.matcher.buildMatchIndex(data);
   t.context.matcher.buildLocationIndex(data, loco);
 
-  // In practice, duplidate ids can't happen anymore.
+  // In practice, duplicated ids can't happen anymore.
   // We should find a better way to flag potential duplicates in the index.
   t.test('getWarnings', t => {
     const warnings  = t.context.matcher.getWarnings();
@@ -101,7 +101,7 @@ test('match', t => {
   t.test('excluded/generic name matching', t => {
     t.test('matches excluded generic pattern with main tagpair', t => {
       const result = t.context.matcher.match('amenity', 'fast_food', 'Food Court');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'excludeGeneric');      // 'excludeGeneric' = matched a generic exclude pattern
       t.equal(result[0].pattern, '/^(fast food|food court)$/i');
@@ -111,7 +111,7 @@ test('match', t => {
 
     t.test('match excluded generic pattern with alternate tagpair in matchGroups', t => {
       const result = t.context.matcher.match('amenity', 'cafe', 'Food Court');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'excludeGeneric');      // 'excludeGeneric' = matched a generic exclude pattern
       t.equal(result[0].pattern, '/^(fast food|food court)$/i');
@@ -120,7 +120,7 @@ test('match', t => {
     });
     t.test('match globally excluded generic pattern from genericWords.json', t => {
       const result = t.context.matcher.match('amenity', 'cafe', '???');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'excludeGeneric');      // 'excludeGeneric' = matched a generic exclude pattern
       t.equal(result[0].pattern, '/^\\?+$/i');
@@ -130,7 +130,7 @@ test('match', t => {
 
     t.test('matches excluded name pattern with main tagpair', t => {
       const result = t.context.matcher.match('amenity', 'fast_food', 'Kebabai');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'excludeNamed');      // 'excludeNamed' = matched a named exclude pattern
       t.equal(result[0].pattern, '/^(city (grill|pizza)|kebabai)$/i');
@@ -139,7 +139,7 @@ test('match', t => {
     });
     t.test('match excluded name pattern with alternate tagpair in matchGroups', t => {
       const result = t.context.matcher.match('amenity', 'cafe', 'Kebabai');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'excludeNamed');      // 'excludeNamed' = matched a named exclude pattern
       t.equal(result[0].pattern, '/^(city (grill|pizza)|kebabai)$/i');
@@ -153,7 +153,7 @@ test('match', t => {
   t.test('basic matching, single result', t => {
     t.test('matches exact key/value/name', t => {
       const result = t.context.matcher.match('amenity', 'fast_food', 'Honey Baked Ham');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'primary');      // 'primary' = matched the `name` tag
       t.equal(result[0].itemID, 'honeybakedham-4d2ff4');
@@ -166,7 +166,7 @@ test('match', t => {
 
     t.test('match on `official_name` tag', t => {
       const result = t.context.matcher.match('amenity', 'fast_food', 'The Honey Baked Ham Company');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'alternate');    // 'alternate' = an alternate tag like `official_name`
       t.equal(result[0].itemID, 'honeybakedham-4d2ff4');
@@ -177,7 +177,7 @@ test('match', t => {
 
     t.test('match on local `name:*` tag', t => {
       const result = t.context.matcher.match('amenity', 'fast_food', 'Honig Bebackener Schinken');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'primary');      // localized `name:*` tags are 'primary' matches too
       t.equal(result[0].itemID, 'honeybakedham-4d2ff4');
@@ -188,7 +188,7 @@ test('match', t => {
 
     t.test('match on `*:wikidata` tag', t => {
       const result = t.context.matcher.match('amenity', 'fast_food', 'Q5893363');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'alternate');    // `brand:wikidata` qid values are 'alternate' matches too
       t.equal(result[0].itemID, 'honeybakedham-4d2ff4');
@@ -205,7 +205,7 @@ test('match', t => {
 
     t.test('fuzzy match name', t => {
       const result = t.context.matcher.match('amenity', 'fast_food', 'HoNeyBaKed\thäm!');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'primary');
       t.equal(result[0].itemID, 'honeybakedham-4d2ff4');
@@ -216,7 +216,7 @@ test('match', t => {
 
     t.test('match alternate tagpairs in matchTags', t => {
       const result = t.context.matcher.match('shop', 'deli', 'Honey Baked Ham');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'primary');           // the name still makes this a 'primary' match
       t.equal(result[0].itemID, 'honeybakedham-4d2ff4');
@@ -227,7 +227,7 @@ test('match', t => {
 
     t.test('match alternate names in matchNames', t => {
       const result = t.context.matcher.match('amenity', 'fast_food', 'honey baked ham company');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'alternate');             // 'alternate' = matchNames are 'alternate' matches
       t.equal(result[0].itemID, 'honeybakedham-4d2ff4');
@@ -238,7 +238,7 @@ test('match', t => {
 
     t.test('match alternate tagpairs in matchGroups', t => {
       const result = t.context.matcher.match('amenity', 'cafe', 'honey baked ham');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'primary');           // the name still makes this a 'primary' match
       t.equal(result[0].itemID, 'honeybakedham-4d2ff4');
@@ -249,7 +249,7 @@ test('match', t => {
 
     t.test('match generic tagpair amenity/yes', t => {
       const result = t.context.matcher.match('amenity', 'yes', 'honey baked ham');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'primary');           // the name still makes this a 'primary' match
       t.equal(result[0].itemID, 'honeybakedham-4d2ff4');
@@ -260,7 +260,7 @@ test('match', t => {
 
     t.test('match generic tagpair shop/yes', t => {
       const result = t.context.matcher.match('shop', 'yes', 'honey baked ham');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'primary');        // the name still makes this a 'primary' match
       t.equal(result[0].itemID, 'honeybakedham-4d2ff4');
@@ -271,7 +271,7 @@ test('match', t => {
 
     t.test('match generic tagpair building/yes', t => {
       const result = t.context.matcher.match('building', 'yes', 'honey baked ham');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'primary');           // the name still makes this a 'primary' match
       t.equal(result[0].itemID, 'honeybakedham-4d2ff4');
@@ -286,7 +286,7 @@ test('match', t => {
   t.test('advanced matching, multiple result', t => {
     t.test('matches KFC with unspecified location, results sort by area descending', t => {
       const result = t.context.matcher.match('amenity', 'fast_food', 'KFC');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 3);
 
       t.equal(result[0].match, 'primary');            // 'primary' = matched the `name` tag
@@ -314,7 +314,7 @@ test('match', t => {
 
     t.test('matches KFC in USA', t => {
       const result = t.context.matcher.match('amenity', 'fast_food', 'KFC', USA);
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'primary');        // 'primary' = matched the `name` tag
       t.equal(result[0].itemID, 'kfc-658eea');    // KFC worldwide
@@ -333,7 +333,7 @@ test('match', t => {
 
     t.test('matches PFK in Quebec', t => {
       const result = t.context.matcher.match('amenity', 'fast_food', 'PFK', QUEBEC);
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'primary');        // 'primary' = matched the `name` tag
       t.equal(result[0].itemID, 'pfk-a54c14');
@@ -341,7 +341,7 @@ test('match', t => {
     });
     t.test('matches KFC in Quebec, but sorts PFK first', t => {
       const result = t.context.matcher.match('amenity', 'fast_food', 'KFC', QUEBEC);
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 2);
       t.equal(result[0].match, 'primary');        // 'primary' = matched the `name:en` tag
       t.equal(result[0].itemID, 'pfk-a54c14');    // quebec area = 1821913 km²
@@ -357,7 +357,7 @@ test('match', t => {
 
     t.test('matches 肯德基 in China', t => {
       const result = t.context.matcher.match('amenity', 'fast_food', '肯德基', HONGKONG);
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'primary');        // 'primary' = matched the `name` tag
       t.equal(result[0].itemID, 'kfc-1ff19c');
@@ -365,7 +365,7 @@ test('match', t => {
     });
     t.test('matches KFC in China, but sorts 肯德基 first', t => {
       const result = t.context.matcher.match('amenity', 'fast_food', 'KFC', HONGKONG);
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 2);
       t.equal(result[0].match, 'primary');        // 'primary' = matched the `name:en` tag
       t.equal(result[0].itemID, 'kfc-1ff19c');    // china area = 10386875 km²
@@ -381,7 +381,7 @@ test('match', t => {
 
     t.test('matches Gap with unspecified location, sorts primary before alternate', t => {
       const result = t.context.matcher.match('shop', 'clothes', 'Gap');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 2);
 
       t.equal(result[0].match, 'primary');            // 'primary' = matched the `name` tag
@@ -402,7 +402,7 @@ test('match', t => {
 
     t.test('matches Baby Gap with unspecified location, sorts primary before alternate', t => {
       const result = t.context.matcher.match('shop', 'clothes', 'Baby Gap');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'primary');            // 'primary' = matched the `name` tag
       t.equal(result[0].itemID, 'babygap-0a21d9');    // Baby Gap
@@ -419,7 +419,7 @@ test('match', t => {
   t.test('nothing bad happens if a k/v category is present in multiple trees', t => {
     t.test('matches an item from the brands tree', t => {
       const result = t.context.matcher.match('amenity', 'post_office', 'UPS');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'alternate');      // 'alternate' = matched the `short_name` tag
       t.equal(result[0].itemID, 'theupsstore-d4e3fc');
@@ -429,7 +429,7 @@ test('match', t => {
     });
     t.test('matches an item from the operators tree', t => {
       const result = t.context.matcher.match('amenity', 'post_office', 'USPS');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'alternate');      // 'alternate' = matched the `short_name` tag
       t.equal(result[0].itemID, 'unitedstatespostalservice-b9aa24');
@@ -438,7 +438,7 @@ test('match', t => {
     });
     t.test('matches a generic from the brands tree', t => {
       const result = t.context.matcher.match('amenity', 'post_office', 'Copyshop');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'excludeNamed');   // 'excludeNamed' = matched a named exclude pattern
       t.equal(result[0].pattern, '/^copyshop$/i');
@@ -447,7 +447,7 @@ test('match', t => {
     });
     t.test('matches a generic from the operators tree', t => {
       const result = t.context.matcher.match('amenity', 'post_office', 'Spar');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'excludeNamed');   // 'excludeNamed' = matched a named exclude pattern
       t.equal(result[0].pattern, '/^spar$/i');
@@ -460,7 +460,7 @@ test('match', t => {
   t.test('transit matching', t => {
     t.test('match on `network` tag', t => {
       const result = t.context.matcher.match('route', 'train', 'verkehrs und tarifverbund stuttgart');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'primary');      // 'primary' = matched the `network` tag
       t.equal(result[0].itemID, 'verkehrsundtarifverbundstuttgart-da20e0');
@@ -471,7 +471,7 @@ test('match', t => {
 
     t.test('match on `network:short` tag', t => {
       const result = t.context.matcher.match('route', 'train', 'VVS');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'alternate');    // 'alternate' = matched the `network:short` tag
       t.equal(result[0].itemID, 'verkehrsundtarifverbundstuttgart-da20e0');
@@ -480,7 +480,7 @@ test('match', t => {
 
     t.test('match on `network:guid` tag', t => {
       const result = t.context.matcher.match('route', 'train', 'DE-BW-VVS');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'alternate');    // 'alternate' = matched the `network:guid` tag
       t.equal(result[0].itemID, 'verkehrsundtarifverbundstuttgart-da20e0');
@@ -489,7 +489,7 @@ test('match', t => {
 
     t.test('match on `network:wikidata` tag', t => {
       const result = t.context.matcher.match('route', 'train', 'Q2516108');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'alternate');    // 'alternate' = matched the `network:wikidata` tag
       t.equal(result[0].itemID, 'verkehrsundtarifverbundstuttgart-da20e0');
@@ -515,7 +515,7 @@ test('match', t => {
   t.test('flag matching', t => {
     t.test('match on `flag:name/subject` tag', t => {
       const result = t.context.matcher.match('man_made', 'flagpole', 'New Zealand');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'primary');    // 'primary' = matched the `flag:name` tag
       t.equal(result[0].itemID, 'newzealand-e5dc93');
@@ -529,7 +529,7 @@ test('match', t => {
 
     t.test('match on `country` tag', t => {
       const result = t.context.matcher.match('man_made', 'flagpole', 'NZ');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'alternate');    // 'alternate' = matched the `country` tag
       t.equal(result[0].itemID, 'newzealand-e5dc93');
@@ -540,7 +540,7 @@ test('match', t => {
 
     t.test('match on `flag:wikidata` tag', t => {
       const result = t.context.matcher.match('man_made', 'flagpole', 'Q160260');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'alternate');    // 'alternate' = matched the `flag:wikidata` tag
       t.equal(result[0].itemID, 'newzealand-e5dc93');
@@ -551,7 +551,7 @@ test('match', t => {
 
     t.test('match on `subject:wikidata` tag', t => {
       const result = t.context.matcher.match('man_made', 'flagpole', 'Q664');
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'alternate');    // 'alternate' = matched the `subject:wikidata` tag
       t.equal(result[0].itemID, 'newzealand-e5dc93');
@@ -574,7 +574,7 @@ test('match', t => {
 
     t.test('matches state flag of Georgia before country flag of Georgia in USA', t => {
       const result = t.context.matcher.match('man_made', 'flagpole', 'georgia', USA);
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 2);
 
       t.equal(result[0].match, 'primary');            // 'primary' = matched the `flag:name` tag
@@ -595,7 +595,7 @@ test('match', t => {
 
     t.test('matches only country flag of Georgia outside the USA', t => {
       const result = t.context.matcher.match('man_made', 'flagpole', 'georgia', HONGKONG);
-      t.type(result, Array)
+      t.type(result, Array);
       t.equal(result.length, 1);
       t.equal(result[0].match, 'primary');            // 'primary' = matched the `flag:name` tag
       t.equal(result[0].itemID, 'georgia-e5dc93');    // Georgia, the country


### PR DESCRIPTION
Hello,

In this PR, I fixed eslint because it breaks on the new `assert {type: 'json'}` syntax. I fixed it by introducing Babel to interpret the syntax. I then solved the lining issues that arose.

There is a lot to like in this PR. But there are a few controversial decisions I made.

**Why do we need Babel?**  
https://github.com/eslint/eslint/discussions/15305 states that eslint will only be implemented when the TC accepts it, so we need Babel as a temporary stopgap.

**Why did you remove the commented-out code?**  
there were a lot of unused variables and imports that were only there for the unused code. So that either needed to be commented out or needed to be removed. I disliked "dead" code because it does not get updated, keeping it in a working state code-wise and idea-wise.

**You switched the fork of json-stringify-pretty-compact. Why?**  
I saw that typescript was complaining about the import. That is why I started looking at what was happening, and I saw that this was a fork of another repo. I don't know the original reason for changing, but the original repo started getting updates again. So I switched back, and that fixed the problem and introduced no new regressions.

**You added lining to the GitHub actions. This means that people who want to update the index will need to fix the lining errors in the glue code.**  
Because we now get a notification when there is a linting error, we can let the person who introduced it fix it.

**Why is cSpell now included in .vscode?**
cSpell is the most used spellchecker for vscode. So, capturing some OSM-specific words will help prevent error fatigue.

I am open to feedback and applying any changes you feel necessary.
-wvdp

