### PR TITLE
Add 'NTB' as an alias for 'National Tire and Battery'

### DIFF
--- a/data/brands/shop/car_repair.json
+++ b/data/brands/shop/car_repair.json
@@ -882,9 +882,10 @@
         "ntb"
       ],
       "tags": {
-        "brand": "National Tire and Battery",
+        "brand": "NTB",
         "brand:wikidata": "Q6978944",
-        "name": "National Tire and Battery",
+        "name": "NTB",
+        "alt_name": "National Tire and Battery",
         "shop": "car_repair"
       }
     },

--- a/data/brands/shop/car_repair.json
+++ b/data/brands/shop/car_repair.json
@@ -878,6 +878,9 @@
       "displayName": "National Tire and Battery",
       "id": "nationaltireandbattery-878d90",
       "locationSet": {"include": ["us"]},
+      "matchNames": [
+        "ntb"
+      ],
       "tags": {
         "brand": "National Tire and Battery",
         "brand:wikidata": "Q6978944",


### PR DESCRIPTION
Most of the branding for this company just says "NTB", I had no idea their full name was "National Tire and Battery" until I found their Wikipedia page. Even their own website just says NTB on it, not the full name: https://www.ntb.com/home

Searching for "ntb" in iD does not find this brand:
![image](https://github.com/osmlab/name-suggestion-index/assets/5573038/1e4410e3-d7e1-4621-9edb-8cda5eff4a7f)

I'm not super familiar with NSI, so I'm not exactly sure if this is right. I am just hoping to add "ntb" as an alias so it shows up in searches there.