### PR TITLE
Add Vychodoslovenska distribucna as new line operator

### DIFF
--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -21,7 +21,7 @@
         "operator": "Východoslovenská distribučná",
         "operator:short": "VSD",
         "operator:wikidata": "Q96136456",
-        "power": "substation"
+        "power": "line"
       }
     },
     {

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -15,6 +15,16 @@
   },
   "items": [
     {
+      "displayName": "Východoslovenská distribučná",
+      "locationSet": {"include": ["sk"]},
+      "tags": {
+        "operator": "Východoslovenská distribučná",
+        "operator:short": "VSD",
+        "operator:wikidata": "Q96136456",
+        "power": "substation"
+      }
+    },
+    {
       "displayName": "4-County Electric Power Association",
       "id": "4countyelectricpowerassociation-116894",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Hi It is my first PR in name-suggestion-index project. Could you please check it?
I would like add Vychodoslovenska distribucna company between power operators. Vychodoslovenska distribucna is between substation power operators but it miss in line operators (i can't create line, pole owned by Vychodoslovenska distribucna).

Thank you