### PR TITLE
exclude "parkometr..." as generic

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -13,6 +13,7 @@
         "^máquina de tickets$",
         "^milchtankstelle$",
         "^pa(r|cz)komat$",
+        "^parkometr",
         "^parkscheinautomat$",
         "^parquímetro$",
         "^vending machine$",
@@ -711,17 +712,6 @@
         "operator": "City of Vancouver",
         "operator:type": "public",
         "operator:wikidata": "Q234053",
-        "vending": "parking_tickets"
-      }
-    },
-    {
-      "displayName": "Parkometr podstrefa A",
-      "id": "parkometrpodstrefaa-bd9635",
-      "locationSet": {"include": ["pl"]},
-      "tags": {
-        "amenity": "vending_machine",
-        "brand": "Parkometr podstrefa A",
-        "name": "Parkometr podstrefa A",
         "vending": "parking_tickets"
       }
     },


### PR DESCRIPTION
per https://github.com/osmlab/name-suggestion-index/issues/5934#issuecomment-1493794422

I don't speak Polish and I'm not familiar with their local mapping practices, so I want to make sure that @matkoniecz still thinks "Parkometr..." should be treated as generic.

If the local community considers these as valid, we should still exclude them from NSI as named features outside a brand network.