### PR TITLE
Use own engine for wikidata search

### DIFF
--- a/app/src/CategoryRow.jsx
+++ b/app/src/CategoryRow.jsx
@@ -245,7 +245,7 @@ relation[${k}=${v}][network:wikidata=${qid}]
 
   function searchWikidataLink(name) {
     const q = encodeURIComponent(name);
-    const href = `https://google.com/search?q=${q}+site%3Awikidata.org`;
+    const href = `https://www.wikidata.org/?search=${q}`;
     const title = `Search Wikidata for ${name}`;
     return (<a target='_blank' href={href} title={title}>Wikidata</a>);
   }


### PR DESCRIPTION
The main improvement here that the Google engine does not know how to search by aliases ("Also known as" fields) in Wikidata, unlike the built-in