### PR TITLE
Removed obsolete/discontinued Italian fuel stations: Agip Eni, Erg, TotalErg, Api, Api-Ip

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -127,22 +127,15 @@
     {
       "displayName": "Agip",
       "id": "agip-b3d110",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": ["001"],
+        "exclude": ["it", "ch"]
+      },
       "tags": {
         "amenity": "fuel",
         "brand": "Agip",
         "brand:wikidata": "Q377915",
         "name": "Agip"
-      }
-    },
-    {
-      "displayName": "Agip Eni",
-      "id": "agipeni-e8f712",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "amenity": "fuel",
-        "brand": "Agip Eni",
-        "name": "Agip Eni"
       }
     },
     {
@@ -308,27 +301,6 @@
         "brand": "ANP",
         "brand:wikidata": "Q119198381",
         "name": "ANP"
-      }
-    },
-    {
-      "displayName": "Api",
-      "id": "api-e8f712",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "amenity": "fuel",
-        "brand": "Api",
-        "brand:wikidata": "Q646807",
-        "name": "Api"
-      }
-    },
-    {
-      "displayName": "Api-Ip",
-      "id": "apiip-e8f712",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "amenity": "fuel",
-        "brand": "Api-Ip",
-        "name": "Api-Ip"
       }
     },
     {
@@ -1725,19 +1697,6 @@
       }
     },
     {
-      "displayName": "Eni Station",
-      "id": "enistation-4e932a",
-      "locationSet": {
-        "include": ["at", "ch", "fr", "it"]
-      },
-      "tags": {
-        "amenity": "fuel",
-        "brand": "Eni",
-        "brand:wikidata": "Q565594",
-        "name": "Eni Station"
-      }
-    },
-    {
       "displayName": "Enmarket",
       "id": "enmarket-c5cf43",
       "locationSet": {"include": ["us"]},
@@ -1762,17 +1721,6 @@
         "brand": "Equador",
         "brand:wikidata": "Q119851742",
         "name": "Equador"
-      }
-    },
-    {
-      "displayName": "Erg",
-      "id": "erg-e8f712",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "amenity": "fuel",
-        "brand": "Erg",
-        "brand:wikidata": "Q739503",
-        "name": "Erg"
       }
     },
     {
@@ -2688,6 +2636,9 @@
     {
       "displayName": "IP",
       "id": "ip-16b3c2",
+      "matchNames": [
+        "Api/Ip",
+      ],
       "locationSet": {
         "include": ["001"],
         "exclude": ["pl"]
@@ -5407,17 +5358,6 @@
         "brand": "TotalEnergies",
         "brand:wikidata": "Q154037",
         "name": "TotalEnergies"
-      }
-    },
-    {
-      "displayName": "TotalErg",
-      "id": "totalerg-e8f712",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "amenity": "fuel",
-        "brand": "TotalErg",
-        "brand:wikidata": "Q3995933",
-        "name": "TotalErg"
       }
     },
     {

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -1689,6 +1689,7 @@
         "include": ["at", "ch", "fr", "it"]
       },
       "matchNames": ["agip/eni", "Agip Eni", "Eni Station"],
+      "preserveTags": ["^name"],
       "tags": {
         "amenity": "fuel",
         "brand": "Eni",

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -2638,6 +2638,10 @@
       "id": "ip-16b3c2",
       "matchNames": [
         "Api/Ip",
+        "Api-Ip",
+        "Erg",
+        "TotalErg",
+        "Api",
       ],
       "locationSet": {
         "include": ["001"],

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -1688,7 +1688,7 @@
       "locationSet": {
         "include": ["at", "ch", "fr", "it"]
       },
-      "matchNames": ["agip/eni"],
+      "matchNames": ["agip/eni", "Agip Eni", "Eni Station"],
       "tags": {
         "amenity": "fuel",
         "brand": "Eni",


### PR DESCRIPTION
This is related to [8597](https://github.com/osmlab/name-suggestion-index/issues/8597)

In additions to the removed brands, I added matchmans "Api/Ip" for IP (Api, is the main company group) and excluded Italy and Switzerland for Agip (seems still alive in Germany and somewhere else).