### PR TITLE
Update charging_station.json

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -201,12 +201,12 @@
       }
     },
     {
-      "displayName": "Rivian Adventure Charger",
+      "displayName": "Rivian Adventure Network",
       "id": "rivianadventurecharger-5598dd",
       "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "charging_station",
-        "brand": "Rivian Adventure Charger",
+        "brand": "Rivian Adventure Network",
         "brand:wikidata": "Q7338847"
       }
     },


### PR DESCRIPTION
Fixed name of the Rivian Adventure Network - was in index as "Rivian Adventure Charger". Do let me know if I'm doing this wrong, which is very possible.