### PR TITLE
Add TaxAssist Accountants Update tax_advisor.json

### DIFF
--- a/data/brands/office/tax_advisor.json
+++ b/data/brands/office/tax_advisor.json
@@ -4,6 +4,16 @@
     "exclude": {"generic": ["^tax advisor$"]}
   },
   "items": [
+  {
+      "displayName": "TaxAssist Accountants",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "TaxAssist Accountants",
+        "brand:wikidata": "Q122459380",
+        "name": "TaxAssist Accountants",
+        "office": "tax_advisor"
+      }
+    },
     {
       "displayName": "Block Advisors",
       "id": "blockadvisors-53d576",


### PR DESCRIPTION
https://www.taxassist.co.uk/

Please add this UK tax accountant agency chain.