### PR TITLE
Remove discontinued brand Kohihan in TW

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -5517,26 +5517,6 @@
       }
     },
     {
-      "displayName": "客喜康珈琲館",
-      "id": "kohikan-7d270d",
-      "locationSet": {"include": ["tw"]},
-      "matchNames": ["咖啡館", "客喜康咖啡館"],
-      "tags": {
-        "amenity": "cafe",
-        "brand": "客喜康珈琲館",
-        "brand:en": "Kohikan",
-        "brand:ja": "珈琲館",
-        "brand:wikidata": "Q11573290",
-        "brand:zh": "客喜康珈琲館",
-        "cuisine": "coffee_shop",
-        "name": "客喜康珈琲館",
-        "name:en": "Kohikan",
-        "name:ja": "珈琲館",
-        "name:zh": "客喜康珈琲館",
-        "takeaway": "yes"
-      }
-    },
-    {
       "displayName": "客美多咖啡",
       "id": "komedacoffeeshop-7d270d",
       "locationSet": {"include": ["tw"]},


### PR DESCRIPTION
> brands/amenity/cafe

The franchisee entity (no. 97363127) was dissolved in 2014, see https://www.twincn.com/item.aspx?no=97363127