### PR TITLE
Add Vélhop

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -3781,6 +3781,19 @@
       }
     },
     {
+      "displayName": "Vélhop",
+      "locationSet": {
+        "include": [[7.75, 48.583328, 20]]
+      },
+      "tags": {
+        "amenity": "bicycle_rental",
+        "brand": "Vélhop",
+        "brand:wikidata": "Q3564044",
+        "network": "Vélhop",
+        "operator": "Strasbourg Mobilités"
+      }
+    },
+    {
       "displayName": "Vélib’ Métropole",
       "id": "velibmetropole-d44bc5",
       "locationSet": {

--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -3782,6 +3782,7 @@
     },
     {
       "displayName": "Vélhop",
+      "id": "velhop-f1e41c",
       "locationSet": {
         "include": [[7.75, 48.583328, 20]]
       },


### PR DESCRIPTION
Vélhop is a bike sharing system in Strasbourg (France).
https://www.wikidata.org/wiki/Q3564044