### PR TITLE
Add Spanish furniture retailer Ofiprix

### DIFF
--- a/data/brands/shop/furniture.json
+++ b/data/brands/shop/furniture.json
@@ -1464,7 +1464,6 @@
       "displayName": "Ofiprix",
       "id": "ofiprix-53177d",
       "locationSet": {"include": ["es"]},
-      "matchTags": ["building/warehouse"],
       "tags": {
         "brand": "Ofiprix",
         "brand:wikidata": "Q116970185",

--- a/data/brands/shop/furniture.json
+++ b/data/brands/shop/furniture.json
@@ -1461,6 +1461,18 @@
       }
     },
     {
+      "displayName": "Ofiprix",
+      "id": "ofiprix-53177d",
+      "locationSet": {"include": ["es"]},
+      "matchTags": ["building/warehouse"],
+      "tags": {
+        "brand": "Ofiprix",
+        "brand:wikidata": "Q116970185",
+        "name": "Ofiprix",
+        "shop": "furniture"
+      }
+    },
+    {
       "displayName": "OK Furniture",
       "id": "okfurniture-e98456",
       "locationSet": {


### PR DESCRIPTION
Adds [Ofiprix](https://www.ofiprix.com/), a Spanish furniture retailer and manufacturer with several brick and mortar stores all around the country.