### PR TITLE
Added Bar Louie Restaurants

### DIFF
--- a/data/brands/amenity/bar.json
+++ b/data/brands/amenity/bar.json
@@ -10,6 +10,17 @@
   },
   "items": [
     {
+      "displayName": "Bar Louie Restaurants",
+      "locationSet": { "include": ["us"]},
+      "tags": {
+        "amenity": "bar",
+        "brand": "Bar Louie Restaurants",
+        "brand:wikidata": "Q16935493",
+        "cocktails": "yes",
+        "name": "Bar Louie Restaurants"
+      }
+    },
+    {
       "displayName": "All Bar One",
       "id": "allbarone-60d62f",
       "locationSet": {"include": ["gb"]},


### PR DESCRIPTION
Added in bar even though wikidata has its name as Bar Louie Restaurants. From the website they do have food. But it seems much more of a bar with cocktails instead of food as all the pictures are of drinks instead of food on main page.