### PR TITLE
Update White Express

### DIFF
--- a/data/brands/shop/dry_cleaning.json
+++ b/data/brands/shop/dry_cleaning.json
@@ -194,15 +194,15 @@
     },
     {
       "displayName": "ホワイト急便",
-      "id": "whitekyuubin-3105a6",
+      "id": "whiteexpress-3105a6",
       "locationSet": {"include": ["jp"]},
       "tags": {
         "brand": "ホワイト急便",
-        "brand:en": "White Kyuubin",
+        "brand:en": "WHITE EXPRESS",
         "brand:ja": "ホワイト急便",
-        "brand:wikidata": "Q11505557",
+        "brand:wikidata": "Q117804791",
         "name": "ホワイト急便",
-        "name:en": "White Kyuubin",
+        "name:en": "White Express",
         "name:ja": "ホワイト急便",
         "shop": "dry_cleaning"
       }


### PR DESCRIPTION
Changed name:en to English because it was written in Roman letters.