### PR TITLE
Add 'locksmith' match group

### DIFF
--- a/config/matchGroups.json
+++ b/config/matchGroups.json
@@ -188,6 +188,11 @@
       "emergency/marine_rescue",
       "emergency/water_rescue"
     ],
+    "locksmith": [
+      "craft/key_cutter",
+      "craft/locksmith",
+      "shop/locksmith"
+    ],
     "lodging": [
       "tourism/guest_house",
       "tourism/hotel",


### PR DESCRIPTION
I've read the OSM wiki and from the description these tags are almost synonymous.

From brands_discard:
"craft/key_cutter|Mister Minit": 93,
"craft/key_cutter|Timpson": 112,
Both of these brands are already in NSI, as "shop/locksmith"