### PR TITLE
Replace DB Netz AG and DB Station&Service AG by DB InfraGo AG

### DIFF
--- a/data/operators/man_made/surveillance.json
+++ b/data/operators/man_made/surveillance.json
@@ -896,21 +896,12 @@
       }
     },
     {
-      "displayName": "DB Netz AG",
-      "id": "dbnetzag-9c1a6c",
+      "displayName": "DB InfraGO AG",
+      "id": "dbinfrago-9c1a6c",
       "locationSet": {"include": ["001"]},
       "tags": {
         "man_made": "surveillance",
-        "operator": "DB Netz AG"
-      }
-    },
-    {
-      "displayName": "DB Station&Service AG",
-      "id": "dbstationandserviceag-9c1a6c",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "man_made": "surveillance",
-        "operator": "DB Station&Service AG"
+        "operator": "DB InfraGO AG"
       }
     },
     {

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -1588,12 +1588,12 @@
       }
     },
     {
-      "displayName": "DB Netz AG",
+      "displayName": "DB InfraGO AG",
       "id": "dbnetzag-7ff171",
       "locationSet": {"include": ["de"]},
       "tags": {
-        "operator": "DB Netz AG",
-        "operator:wikidata": "Q896765",
+        "operator": "DB InfraGO AG",
+        "operator:wikidata": "Q122870674",
         "power": "substation"
       }
     },

--- a/data/operators/route/tracks.json
+++ b/data/operators/route/tracks.json
@@ -25,12 +25,12 @@
       }
     },
     {
-      "displayName": "DB Netz AG",
-      "id": "dbnetzag-7a762a",
+      "displayName": "DB InfraGO AG",
+      "id": "dbinfrago-7a762a",
       "locationSet": {"include": ["de"]},
       "tags": {
-        "operator": "DB Netz AG",
-        "operator:wikidata": "Q896765",
+        "operator": "DB InfraGO AG",
+        "operator:wikidata": "Q122870674",
         "route": "tracks"
       }
     },


### PR DESCRIPTION
The two subsidiaries are merged as of 1 January 2024.

Press release: https://www.deutschebahn.com/de/presse/pressestart_zentrales_uebersicht/DB-Aufsichtsrat-bringt-gemeinwohlorientierte-Infrastrukturgesellschaft-DB-InfraGO-AG-auf-den-Weg-11872708#