### PR TITLE
Remove entries of route=railway with DB as operator

### DIFF
--- a/data/operators/route/railway.json
+++ b/data/operators/route/railway.json
@@ -170,26 +170,6 @@
       }
     },
     {
-      "displayName": "DB Netz AG",
-      "id": "dbnetzag-5b17c6",
-      "locationSet": {"include": ["de"]},
-      "tags": {
-        "operator": "DB Netz AG",
-        "operator:wikidata": "Q896765",
-        "route": "railway"
-      }
-    },
-    {
-      "displayName": "Deutsche Bahn",
-      "id": "deutschebahn-5b17c6",
-      "locationSet": {"include": ["de"]},
-      "tags": {
-        "operator": "Deutsche Bahn",
-        "operator:wikidata": "Q9322",
-        "route": "railway"
-      }
-    },
-    {
       "displayName": "ETS/RFV",
       "id": "euskaltrenbidesarearedferroviariavasca-eeecbf",
       "locationSet": {"include": ["es", "fx"]},


### PR DESCRIPTION
I would like to ask to remove the entries of Deutsche Bahn and its subsidiaries for routes with `route=railway` completely. The assigned operators do not make any sense. These route relations are used to model the route of a timetable sheet. There are multiple companies involved in operation. The routes usually use infrastructure by DB Netz AG but sometimes DB RegioNetz or other infrastructure operators (e.g. AVG, SWEG, WEG). The services operated on the infrastructure are operated by lots of different companies. Many are still served by DB Regio but long distance trains by DB Fernverkehr, local trains are often operated by non-DB companies. It makes no sense to provide defaults for this relations. It requires mappers experienced with public transport issues to decided in each inidividual case. Deriving any common values from that is like deriving a list operators from land registry (i.e. worthless).

The existing entries of Name Suggestion Index are based on existing OSM data but mappers sometimes [do](https://openstreetmap.org/changeset/104189895) [things](https://openstreetmap.org/changeset/108557291) [wrong](https://www.openstreetmap.org/changeset/139678047). The numbers of OSM objects backing these NSI entries are low.