### PR TITLE
Auto-create light rail & subway stations from routes

### DIFF
--- a/data/transit/public_transport/station_light_rail.json
+++ b/data/transit/public_transport/station_light_rail.json
@@ -1,0 +1,23 @@
+{
+  "properties": {
+    "path": "transit/public_transport/station_light_rail",
+    "skipCollection": true,
+    "preserveTags": ["^public_transport$"],
+    "exclude": {
+      "generic": ["^light rail station$"]
+    }
+  },
+  "items": [
+    {
+      "note": "Auto create public_transport/station_light_rail for all route/light_rail - #9020",
+      "templateSource": "transit/route/light_rail",
+      "templateTags": {
+        "light_rail": "yes",
+        "public_transport": "station",
+        "railway": "station",
+        "route": "",
+        "station": "light_rail"
+      }
+    }
+  ]
+}

--- a/data/transit/public_transport/station_subway.json
+++ b/data/transit/public_transport/station_subway.json
@@ -1,0 +1,21 @@
+{
+  "properties": {
+    "path": "transit/public_transport/station_subway",
+    "skipCollection": true,
+    "preserveTags": ["^public_transport$"],
+    "exclude": {"generic": ["^subway station$"]}
+  },
+  "items": [
+    {
+      "note": "Auto create public_transport/station_subway for all route/subway - #9020",
+      "templateSource": "transit/route/subway",
+      "templateTags": {
+        "public_transport": "station",
+        "railway": "station",
+        "route": "",
+        "station": "subway",
+        "subway": "yes"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
I have no idea how to test this... It is based on the equivalent files for trams and trains, in the same folder. This PR tries to apply the same logic for light_rail and subway routes.