### PR TITLE
Change countdown to woolworths

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1766,17 +1766,6 @@
       }
     },
     {
-      "displayName": "Countdown",
-      "id": "countdown-5dc426",
-      "locationSet": {"include": ["nz"]},
-      "tags": {
-        "brand": "Countdown",
-        "brand:wikidata": "Q5176845",
-        "name": "Countdown",
-        "shop": "supermarket"
-      }
-    },
-    {
       "displayName": "Covirán",
       "id": "coviran-d9bffc",
       "locationSet": {"include": ["es", "pt"]},
@@ -8275,7 +8264,7 @@
       }
     },
     {
-      "displayName": "Woolworths",
+      "displayName": "Woolworths (Australia)",
       "id": "woolworths-c254c9",
       "locationSet": {"include": ["au"]},
       "tags": {
@@ -8288,7 +8277,19 @@
       }
     },
     {
-      "displayName": "Woolworths Metro",
+      "displayName": "Woolworths (New Zealand)",
+      "id": "woolworths-5dc426",
+      "locationSet": {"include": ["nz"]},
+      "matchNames": ["countdown", "foodtown"],
+      "tags": {
+        "brand": "Woolworths",
+        "brand:wikidata": "Q5176845",
+        "name": "Woolworths",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "Woolworths Metro (Australia)",
       "id": "woolworthsmetro-c254c9",
       "locationSet": {"include": ["au"]},
       "tags": {
@@ -8297,6 +8298,17 @@
         "name": "Woolworths Metro",
         "operator": "Woolworths Group",
         "operator:wikidata": "Q607272",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "Woolworths Metro (New Zealand)",
+      "id": "woolworthsmetro-5dc426",
+      "locationSet": {"include": ["nz"]},
+      "tags": {
+        "brand": "Woolworths Metro",
+        "brand:wikidata": "Q123699264",
+        "name": "Woolworths Metro",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
In New Zealand, "Countdown" is rebranding to Woolworths, to match the branding used in Australia. 

I have tried to make the NZ presets as close as possible to the AU presets, based on what was done in #7780 