### PR TITLE
Replace the name of the french operator CTS by its full name Compagnie des Transports Strasbourgeois

### DIFF
--- a/data/operators/amenity/ticket_validator.json
+++ b/data/operators/amenity/ticket_validator.json
@@ -42,12 +42,14 @@
       }
     },
     {
-      "displayName": "CTS",
+      "displayName": "CTS (Compagnie des Transports Strasbourgeois)",
       "id": "cts-9fdb02",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["de", "fx"]},
       "tags": {
         "amenity": "ticket_validator",
-        "operator": "CTS"
+        "operator": "Compagnie des Transports Strasbourgeois",
+        "operator:short": "CTS",
+        "operator:wikidata": "Q2990068"
       }
     },
     {

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -3796,16 +3796,21 @@
       }
     },
     {
-      "displayName": "CTS",
+      "displayName": "CTS (Compagnie des Transports Strasbourgeois)",
       "id": "cts-f1d622",
-      "locationSet": {"include": ["de", "fx"]},
+      "locationSet": {"include": ["fx"]},
       "matchNames": [
         "compagnie des transports strasbourgeois",
-        "réseau cts"
+        "cts"
       ],
       "tags": {
-        "network": "CTS",
+        "gtfs:feed": "FR-GES-CTS",
+        "network": "Compagnie des Transports Strasbourgeois",
+        "network:short": "CTS",
         "network:wikidata": "Q2990068",
+        "operator": "Compagnie des Transports Strasbourgeois",
+        "operator:short": "CTS",
+        "operator:wikidata": "Q2990068",
         "route": "bus"
       }
     },

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -113,12 +113,21 @@
       }
     },
     {
-      "displayName": "CTS",
+      "displayName": "CTS (Compagnie des Transports Strasbourgeois)",
       "id": "cts-39c744",
-      "locationSet": {"include": ["fr"]},
+      "locationSet": {"include": ["de", "fx"]},
+      "matchNames": [
+        "compagnie des transports strasbourgeois",
+        "cts"
+      ],
       "tags": {
-        "network": "CTS",
+        "gtfs:feed": "FR-GES-CTS",
+        "network": "Compagnie des Transports Strasbourgeois",
+        "network:short": "CTS",
         "network:wikidata": "Q2990068",
+        "operator": "Compagnie des Transports Strasbourgeois",
+        "operator:short": "CTS",
+        "operator:wikidata": "Q2990068",
         "route": "tram"
       }
     },


### PR DESCRIPTION
Hi!

I tagged the full public transit network "Compagnie des Transports Strasbourgeois", and replaced the "CTS" value for the network and the operator tags for the full name version "Compagnie des Transports Strasbourgeois". I would like to update its name-suggestion-index.

Thanks!