### PR TITLE
遠亞併： Merge APTG to FET

### DIFF
--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -871,21 +871,6 @@
       }
     },
     {
-      "displayName": "亞太電信",
-      "id": "asiapacifictelecom-4f600a",
-      "locationSet": {"include": ["tw"]},
-      "tags": {
-        "brand": "亞太電信",
-        "brand:en": "Asia Pacific Telecom",
-        "brand:wikidata": "Q10882737",
-        "brand:zh": "亞太電信",
-        "name": "亞太電信",
-        "name:en": "Asia Pacific Telecom",
-        "name:zh": "亞太電信",
-        "shop": "telecommunication"
-      }
-    },
-    {
       "displayName": "台灣之星",
       "id": "tstar-4f600a",
       "locationSet": {"include": ["tw"]},
@@ -978,6 +963,12 @@
       "displayName": "遠傳電信",
       "id": "fareastone-4f600a",
       "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "亞太電信",
+        "Asia Pacific Telecom",
+        "APTG",
+        "FET"
+      ],
       "tags": {
         "brand": "遠傳電信",
         "brand:en": "FarEasTone",

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -966,7 +966,7 @@
       "matchNames": [
         "亞太電信",
         "Asia Pacific Telecom",
-        "APTG",
+        "APT",
         "FET"
       ],
       "tags": {


### PR DESCRIPTION
亞太電信，在2023年12月15日正式與遠傳電信合併。在此以前，已經有數家亞太電信關閉，或改使用遠傳電信的看板了。剩下的亞太電信招牌，大概也是時間問題，所以在此提出合併兩家品牌的 PR。

Asia Pacific Telecom (APT) was merged with FarEasTone (FET) on December 15, 2023. Before the official merge, many APT stores were closed or renamed as FET. I believe the closure or renaming date of the remaining APT stores after the merge is only a matter of time. Therefore, I opened a pull request, merging the APT entry into the FET entry.

References:

* [遠亞合併專區](https://www.fetnet.net/content/cbu/tw/merge/index.html)
* [遠傳亞太完成合併　電信產業進入「新三雄」 榮登「頻譜三冠王」　遠傳力拼三分天下　服務千萬用戶](https://corporate.fetnet.net/content/corp/tw/LatestNews/LatestNews_Contents.html?uuid=b45f76a7-b893-4160-bc13-2358493b890f)
* [NCC to monitor two telecom mergers next month](https://www.taipeitimes.com/News/taiwan/archives/2023/11/23/2003809595)