### PR TITLE
workaround for #7692 kiosk not recogised as shop

### DIFF
--- a/data/brands/shop/kiosk.json
+++ b/data/brands/shop/kiosk.json
@@ -42,8 +42,8 @@
     {
       "displayName": "Kiosk",
       "id": "kiosk-c47323",
-      "matchNames": ["Kiosk"],
       "locationSet": {"include": ["nl"]},
+      "matchNames": ["kiosk"],
       "tags": {
         "brand": "Kiosk",
         "brand:wikidata": "Q109186217",

--- a/data/brands/shop/kiosk.json
+++ b/data/brands/shop/kiosk.json
@@ -42,6 +42,7 @@
     {
       "displayName": "Kiosk",
       "id": "kiosk-c47323",
+      "matchNames": ["Kiosk"],
       "locationSet": {"include": ["nl"]},
       "tags": {
         "brand": "Kiosk",


### PR DESCRIPTION
A suggestion in #7692 said to add the generic name as the match name to workaround the issue of discarding the match.

This pr will try this "fix".