### PR TITLE
Aldi is no longer in Denmark

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -235,7 +235,6 @@
       "locationSet": {
         "include": [
           "be",
-          "dk",
           "es",
           "fr",
           "lu",


### PR DESCRIPTION
They pulled out of Denmark in the start of 2023, their stores were bought by different brands e.g. Rema 1000, Netto and others