### PR TITLE
Remove Kiwi minipris in Denmark

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -3910,7 +3910,7 @@
     {
       "displayName": "Kiwi",
       "id": "kiwi-2b56aa",
-      "locationSet": {"include": ["dk", "no"]},
+      "locationSet": {"include": ["no"]},
       "preserveTags": ["^name"],
       "tags": {
         "brand": "Kiwi",


### PR DESCRIPTION
Kiwi minipris closed in Denmark in 2017

https://en.wikipedia.org/wiki/Kiwi_(store)#cite_note-6