### PR TITLE
Updated exclude locations in Yves Rocher

### DIFF
--- a/data/brands/shop/cosmetics.json
+++ b/data/brands/shop/cosmetics.json
@@ -857,7 +857,10 @@
     {
       "displayName": "Yves Rocher",
       "id": "yvesrocher-a08666",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": ["001"],
+        "exclude": ["at", "de", "ch"]
+      },
       "matchNames": ["ив роше"],
       "tags": {
         "brand": "Yves Rocher",


### PR DESCRIPTION
According to the press, one cannot buy on physical Yves Rocher cosmetic stores anymore, rather only in e-shops in 'DE', 'AT', and 'CH'
https://www.hln.be/buitenland/cosmeticabedrijf-yves-rocher-sluit-al-zijn-winkels-in-duitsland-oostenrijk-en-zwitserland~a86c68ec/

This is confirmed by their websites when you try to search for a store:
https://www.yves-rocher.ch/fr/fermeture-magasin-et-institut-de-beaute