### PR TITLE
Add and fix supermarkets in dk

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1620,9 +1620,7 @@
       "locationSet": {"include": ["dk"]},
       "matchNames": [
         "coop 365",
-        "coop365",
-        "coop 365discount",
-        "coop 365 discount"
+        "coop 365discount"
       ],
       "tags": {
         "brand": "365discount",
@@ -1875,6 +1873,7 @@
       "displayName": "Dagli'Brugsen",
       "id": "daglibrugsen-072052",
       "locationSet": {"include": ["dk"]},
+      "matchNames": ["DagligBrugsen"],
       "tags": {
         "brand": "Dagli'Brugsen",
         "brand:wikidata": "Q12307017",
@@ -2540,16 +2539,6 @@
       }
     },
     {
-      "displayName": "fakta",
-      "locationSet": {"include": ["de"]},
-      "tags": {
-        "brand": "fakta",
-        "brand:wikidata": "Q123942180",
-        "name": "fakta",
-        "shop": "supermarket"
-      }
-    },
-    {
       "displayName": "famila",
       "id": "famila-5d2816",
       "locationSet": {"include": ["de", "it"]},
@@ -2802,6 +2791,10 @@
       "displayName": "Føtex",
       "id": "fotex-072052",
       "locationSet": {"include": ["dk"]},
+      "matchNames": [
+        "Foetex",
+        "Fotex"
+      ],
       "tags": {
         "brand": "Føtex",
         "brand:wikidata": "Q1480395",
@@ -5153,6 +5146,10 @@
       "displayName": "Min Købmand",
       "id": "minkobmand-072052",
       "locationSet": {"include": ["dk"]},
+      "matchNames": [
+        "Min Koebmand",
+        "Min Kobmand"
+      ],
       "tags": {
         "brand": "Min Købmand",
         "brand:wikidata": "Q104310815",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -105,6 +105,20 @@
       }
     },
     {
+      "displayName": "ABC Lavpris",
+      "locationSet": {"include": ["dk"]},
+      "matchNames": [
+        "ABCLavpris",
+        "ABC-Lavpris"
+      ],
+      "tags": {
+        "brand": "ABC Lavpris",
+        "brand:wikidata": "Q12300077",
+        "name": "ABC Lavpris",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Acme",
       "id": "acme-dde59d",
       "locationSet": {"include": ["us"]},
@@ -1602,14 +1616,18 @@
       }
     },
     {
-      "displayName": "Coop 365discount",
-      "id": "coop365discount-072052",
+      "displayName": "365discount",
       "locationSet": {"include": ["dk"]},
-      "matchNames": ["coop 365"],
+      "matchNames": [
+        "coop 365",
+        "coop365",
+        "coop 365discount",
+        "coop 365 discount"
+      ],
       "tags": {
-        "brand": "Coop 365discount",
+        "brand": "365discount",
         "brand:wikidata": "Q104671354",
-        "name": "Coop 365discount",
+        "name": "365discount",
         "shop": "supermarket"
       }
     },
@@ -2523,11 +2541,10 @@
     },
     {
       "displayName": "fakta",
-      "id": "fakta-072052",
-      "locationSet": {"include": ["dk"]},
+      "locationSet": {"include": ["de"]},
       "tags": {
         "brand": "fakta",
-        "brand:wikidata": "Q3172238",
+        "brand:wikidata": "Q123942180",
         "name": "fakta",
         "shop": "supermarket"
       }
@@ -4417,6 +4434,20 @@
         "brand": "Lupa",
         "brand:wikidata": "Q58044048",
         "name": "Lupa",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "Løvbjerg",
+      "locationSet": {"include": ["dk"]},
+      "matchNames": [
+        "Loevbjerg",
+        "Lovbjerg"
+      ],
+      "tags": {
+        "brand": "Løvbjerg",
+        "brand:wikidata": "Q12325422",
+        "name": "Løvbjerg",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
* add Løvbjerg
* add ABC Lavpris

* change Coop 365discount to new branding without Coop
* remove fakta in dk; has been transformed into 365discount
* add fakta in de; border shops still fakta branded