### PR TITLE
Update bicycle.json - Adding Bike Totaal

### DIFF
--- a/data/brands/shop/bicycle.json
+++ b/data/brands/shop/bicycle.json
@@ -50,6 +50,16 @@
       }
     },
     {
+      "displayName": "Bike Totaal",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "Bike Totaal",
+        "brand:wikidata": "Q123536506",
+        "name": "Bike Totaal",
+        "shop": "bicycle"
+      }
+    },
+    {
       "displayName": "Evans Cycles",
       "id": "evanscycles-3697a8",
       "locationSet": {"include": ["gb"]},


### PR DESCRIPTION
Adding Bike Totaal, bicycle shop chain with ~140 stores in the Netherlands.