### PR TITLE
Add “APEC Schools” brand in ‘amenity=school’ tag

### DIFF
--- a/data/brands/amenity/school.json
+++ b/data/brands/amenity/school.json
@@ -12,6 +12,18 @@
   },
   "items": [
     {
+      "displayName": "APEC Schools",
+      "locationSet": {"include": ["ph"]},
+      "matchNames": ["affordable private education center", "apec school"],
+      "tags": {
+        "amenity": "school",
+        "brand": "APEC Schools",
+        "brand:wikidata": "Q24910804",
+        "operator": "iPeople",
+        "operator:type": "private"
+      }
+    },
+    {
       "displayName": "Bahçeşehir Koleji",
       "id": "bahcesehirkoleji-8696da",
       "locationSet": {"include": ["tr"]},


### PR DESCRIPTION
APEC Schools is a chain of private high schools in the Philippines, operating in the Greater Manila Area (the National Capital Region and surrounding provinces). 

This proposal adds the chain, which has [a Wikidata entry](https://wikidata.org/wiki/Q24910804) stemming from [its Wikipedia article](https://en.wikipedia.org/wiki/APEC_Schools), as a brand for `amenity=school` tag.

This will hopefully fix the inconsistency of some of its branches being misnamed as “APEC School” (singular), when the official name of any one single campus has always been plural. (Additionally, other branches are tagged as “APEC Schools [branch name]”.)

### Compare:

- https://overpass-turbo.eu/?w=%22name%22%3D%22APEC+Schools%22+global&R (4 branches recorded: 2 tagged as nodes, 2 ways)
- https://overpass-turbo.eu/?w=%22name%22%3D%22APEC+School%22+global&R (2 branches with misspelling: 2 nodes)
- https://overpass-turbo.eu/s/1FdQ (simply "APEC" and "`amenity=school`": 8 branches, 5 nodes, 3 ways)

***Disclosure:*** I'm an alumni of one of its branches.