### PR TITLE
add entries for other nsw public transport modes

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -16307,6 +16307,24 @@
       }
     },
     {
+      "displayName": "Transport Buses",
+      "id": "transportbuses-4ab973",
+      "locationSet": {
+        "include": ["au-nsw.geojson"]
+      },
+      "matchNames": [
+        "nsw",
+        "sydney busses",
+        "tfnsw",
+        "transport for nsw"
+      ],
+      "tags": {
+        "network": "Transport Buses",
+        "network:wikidata": "Q5001345",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "Transport Canberra",
       "id": "transportcanberra-6395c3",
       "locationSet": {

--- a/data/transit/route/light_rail.json
+++ b/data/transit/route/light_rail.json
@@ -505,6 +505,24 @@
       }
     },
     {
+      "displayName": "Sydney Light Rail",
+      "id": "sydneylightrail-fa5af0",
+      "locationSet": {
+        "include": ["au-nsw.geojson"]
+      },
+      "matchNames": [
+        "nsw",
+        "tfnsw",
+        "transport for nsw",
+        "transport light rail"
+      ],
+      "tags": {
+        "network": "Sydney Light Rail",
+        "network:wikidata": "Q771666",
+        "route": "light_rail"
+      }
+    },
+    {
       "displayName": "Takst Sjælland",
       "id": "takstsjaelland-75470b",
       "locationSet": {"include": ["dk"]},

--- a/data/transit/route/subway.json
+++ b/data/transit/route/subway.json
@@ -582,6 +582,20 @@
       }
     },
     {
+      "displayName": "Sydney Metro",
+      "id": "sydneymetro-20be20",
+      "locationSet": {
+        "include": ["au-nsw.geojson"]
+      },
+      "tags": {
+        "network": "Sydney Metro",
+        "network:wikidata": "Q14774571",
+        "operator": "Metro Trains Sydney",
+        "operator:wikidata": "Q20861549",
+        "route": "subway"
+      }
+    },
+    {
       "displayName": "TCL",
       "id": "tcl-c48f12",
       "locationSet": {"include": ["fr"]},


### PR DESCRIPTION
there are already entries for trains and ferries in NSW, this PR adds 3 more entries for other modes of transport: bus, light rail, and metro. 