### PR TITLE
bicycle_rental=docking_station

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -511,6 +511,7 @@
       "locationSet": {"include": ["ca"]},
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Bike Share Toronto",
         "brand:wikidata": "Q17018523",
         "name": "Bike Share Toronto",
@@ -755,6 +756,7 @@
       "locationSet": {"include": ["ca"]},
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Bixi",
         "brand:wikidata": "Q4919302",
         "name": "Bixi",

--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -346,7 +346,8 @@
         "brand:wikidata": "Q17402113",
         "network": "BiciMAD",
         "network:wikidata": "Q17402113",
-        "operator": "EMT Madrid"
+        "operator": "EMT Madrid",
+        "operator:wikidata": "Q1094755"
       }
     },
     {
@@ -3096,6 +3097,7 @@
       },
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Santander Cycles MK",
         "brand:wikidata": "Q807961",
         "network": "Santander Cycles MK",
@@ -3109,6 +3111,7 @@
       "locationSet": {"include": ["gb-wls"]},
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Santander Cycles",
         "brand:wikidata": "Q807961",
         "network": "nextbike",
@@ -4232,6 +4235,7 @@
       "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "YouBike 微笑單車",
         "brand:en": "YouBike",
         "brand:wikidata": "Q20687952",

--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -145,6 +145,7 @@
       ],
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Bay Wheels",
         "brand:wikidata": "Q16971391",
         "fee": "yes",
@@ -340,6 +341,7 @@
       "locationSet": {"include": ["es"]},
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "BiciMAD",
         "brand:wikidata": "Q17402113",
         "network": "BiciMAD",
@@ -372,6 +374,7 @@
       "note": "Barcelona (ES-B)",
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "bicing",
         "brand:wikidata": "Q1833385",
         "network": "bicing",
@@ -507,8 +510,10 @@
     },
     {
       "displayName": "Bike Share Toronto",
-      "id": "bikesharetoronto-3eadaa",
-      "locationSet": {"include": ["ca"]},
+      "id": "bikesharetoronto-843836",
+      "locationSet": {
+        "include": ["ca-on.geojson"]
+      },
       "tags": {
         "amenity": "bicycle_rental",
         "bicycle_rental": "docking_station",
@@ -808,6 +813,7 @@
       ],
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Bluebikes",
         "brand:wikidata": "Q3142157",
         "name": "Bluebikes",
@@ -1019,6 +1025,7 @@
       "matchNames": ["cabi", "lyft bike"],
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Capital Bikeshare",
         "brand:wikidata": "Q1034635",
         "fee": "yes",
@@ -3050,6 +3057,7 @@
       },
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Santander Cycles",
         "brand:wikidata": "Q807961",
         "network": "nextbike",
@@ -3696,6 +3704,7 @@
       "locationSet": {"include": [[-0.3, 39.5]]},
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Valenbisi",
         "brand:wikidata": "Q9092320",
         "network": "Valenbisi",
@@ -3805,6 +3814,7 @@
       "matchNames": ["vélib’"],
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Vélib’ Métropole",
         "brand:wikidata": "Q1120762",
         "network": "Vélib’ Métropole",
@@ -3845,6 +3855,7 @@
       "locationSet": {"include": ["be"]},
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Velo",
         "brand:wikidata": "Q2413118",
         "network": "Velo",
@@ -3908,6 +3919,7 @@
       "note": "Nice, France",
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Vélobleu",
         "brand:wikidata": "Q3564072",
         "network": "Vélobleu",
@@ -4205,6 +4217,7 @@
       "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "YouBike 2.0",
         "brand:wikidata": "Q20687952",
         "network": "YouBike 2.0",


### PR DESCRIPTION
Add bicycle_rental=docking_station to Bike Share Toronto and Bixi

I guess we could mark some other systems based on https://gist.github.com/AntiCompositeNumber/930d463811b3198344578a373f11ea70 but I'm not very familiar with bike shares in other countries, would need to do some research but bicycle_rental=docking_station is the most common isn't it?