### PR TITLE
Add bicycle_parking for brands with at least 100 already-tagged examples

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -145,6 +145,7 @@
       ],
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Bay Wheels",
         "brand:wikidata": "Q16971391",
         "fee": "yes",
@@ -340,11 +341,13 @@
       "locationSet": {"include": ["es"]},
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "BiciMAD",
         "brand:wikidata": "Q17402113",
         "network": "BiciMAD",
         "network:wikidata": "Q17402113",
-        "operator": "EMT Madrid"
+        "operator": "EMT Madrid",
+        "operator:wikidata": "Q1094755"
       }
     },
     {
@@ -372,6 +375,7 @@
       "note": "Barcelona (ES-B)",
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "bicing",
         "brand:wikidata": "Q1833385",
         "network": "bicing",
@@ -755,6 +759,7 @@
       "locationSet": {"include": ["ca"]},
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Bixi",
         "brand:wikidata": "Q4919302",
         "name": "Bixi",
@@ -806,6 +811,7 @@
       ],
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Bluebikes",
         "brand:wikidata": "Q3142157",
         "name": "Bluebikes",
@@ -1017,6 +1023,7 @@
       "matchNames": ["cabi", "lyft bike"],
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Capital Bikeshare",
         "brand:wikidata": "Q1034635",
         "fee": "yes",
@@ -3048,6 +3055,7 @@
       },
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Santander Cycles",
         "brand:wikidata": "Q807961",
         "network": "nextbike",
@@ -3086,6 +3094,7 @@
       },
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Santander Cycles MK",
         "brand:wikidata": "Q807961",
         "network": "Santander Cycles MK",
@@ -3099,6 +3108,7 @@
       "locationSet": {"include": ["gb-wls"]},
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Santander Cycles",
         "brand:wikidata": "Q807961",
         "network": "nextbike",
@@ -3694,6 +3704,7 @@
       "locationSet": {"include": [[-0.3, 39.5]]},
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Valenbisi",
         "brand:wikidata": "Q9092320",
         "network": "Valenbisi",
@@ -3803,6 +3814,7 @@
       "matchNames": ["vélib’"],
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Vélib’ Métropole",
         "brand:wikidata": "Q1120762",
         "network": "Vélib’ Métropole",
@@ -3843,6 +3855,7 @@
       "locationSet": {"include": ["be"]},
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Velo",
         "brand:wikidata": "Q2413118",
         "network": "Velo",
@@ -3906,6 +3919,7 @@
       "note": "Nice, France",
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "Vélobleu",
         "brand:wikidata": "Q3564072",
         "network": "Vélobleu",
@@ -4203,6 +4217,7 @@
       "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "YouBike 2.0",
         "brand:wikidata": "Q20687952",
         "network": "YouBike 2.0",
@@ -4217,6 +4232,7 @@
       "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "bicycle_rental",
+        "bicycle_rental": "docking_station",
         "brand": "YouBike 微笑單車",
         "brand:en": "YouBike",
         "brand:wikidata": "Q20687952",


### PR DESCRIPTION
Data from https://gist.github.com/AntiCompositeNumber/930d463811b3198344578a373f11ea70#file-bicycle_rental_unique-txt

Issue: #9070