### PR TITLE
Add shop/deli to Subway

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -7841,6 +7841,7 @@
         "subway sandwiches",
         "subway uk & ireland"
       ],
+      "matchTags": ["shop/deli"],
       "tags": {
         "amenity": "fast_food",
         "brand": "Subway",


### PR DESCRIPTION
Add shop/deli to "matchNames" to Subway (amenity=fast_food). Some users are selecting deli by mistake (fixed a bunch of them).