### PR TITLE
Add Sanef toll vending machine

### DIFF
--- a/data/operators/amenity/vending_machine.json
+++ b/data/operators/amenity/vending_machine.json
@@ -183,6 +183,20 @@
         "recycling:plastic_bottles": "yes",
         "vending": "bottle_return"
       }
+    },
+    {
+      "displayName": "SANEF péage",
+      "locationSet": {"include": ["fr"]},
+      "matchNames": ["abertis", "sapn"],
+      "tags": {
+        "amenity": "vending_machine",
+        "operator": "SANEF",
+        "operator:wikidata": "Q1474126",
+        "payment:cash": "yes",
+        "payment:credit_cards": "yes",
+        "payment:debit_cards": "yes",
+        "vending": "toll"
+      }
     }
   ]
 }


### PR DESCRIPTION
With the government-dictated implementation of free-flow toll in France, most toll booths will be replaced with toll gantries, which the toll amounted by will then either be payable online, or at these vending machines spread throughout the motorways.