### PR TITLE
Split EB Games AU into separate entry, update brand:wikidata

### DIFF
--- a/data/brands/shop/video_games.json
+++ b/data/brands/shop/video_games.json
@@ -33,7 +33,7 @@
       }
     },
     {
-      "displayName": "EB Games",
+      "displayName": "EB Games (Canada)",
       "id": "ebgames-c56656",
       "locationSet": {
         "include": ["ca"]
@@ -49,7 +49,7 @@
       }
     },
     {
-      "displayName": "EB Games",
+      "displayName": "EB Games (AU/NZ)",
       "locationSet": {
         "include": ["au", "nz"]
       },

--- a/data/brands/shop/video_games.json
+++ b/data/brands/shop/video_games.json
@@ -36,7 +36,7 @@
       "displayName": "EB Games",
       "id": "ebgames-c56656",
       "locationSet": {
-        "include": ["au", "ca", "nz"]
+        "include": ["ca"]
       },
       "matchNames": [
         "electronics boutique / eb games"
@@ -44,6 +44,21 @@
       "tags": {
         "brand": "EB Games",
         "brand:wikidata": "Q4993686",
+        "name": "EB Games",
+        "shop": "video_games"
+      }
+    },
+    {
+      "displayName": "EB Games",
+      "locationSet": {
+        "include": ["au", "nz"]
+      },
+      "matchNames": [
+        "electronics boutique / eb games"
+      ],
+      "tags": {
+        "brand": "EB Games",
+        "brand:wikidata": "Q5322604",
         "name": "EB Games",
         "shop": "video_games"
       }


### PR DESCRIPTION
I've split the AU/NZ EB Games from the Canadian one, they're both subsidiaries of GameStop but are two individual subsidiaries, and with separate WikiData entries.