### PR TITLE
Update variety_store.json - Add Dille & Kamille in NL, BE, DE

### DIFF
--- a/data/brands/shop/variety_store.json
+++ b/data/brands/shop/variety_store.json
@@ -228,6 +228,18 @@
       }
     },
     {
+      "displayName": "Dille & Kamille",
+      "locationSet": {
+        "include": ["nl", "be", "de"]
+      },
+      "tags": {
+        "brand": "Dille & Kamille",
+        "brand:wikidata": "Q65154379",
+        "name": "Dille & Kamille",
+        "shop": "variety_store",
+      }
+    },
+    {
       "displayName": "Dollar General",
       "id": "dollargeneral-c85191",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Adding the Dutch store chain Dille & Kamille with stores in the Netherlands, Belgium and Germany.