### PR TITLE
Removed Romanian pharmacy Sensiblu

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -2820,18 +2820,6 @@
       }
     },
     {
-      "displayName": "Sensiblu",
-      "id": "sensiblu-8861f5",
-      "locationSet": {"include": ["ro"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "Sensiblu",
-        "brand:wikidata": "Q12740640",
-        "healthcare": "pharmacy",
-        "name": "Sensiblu"
-      }
-    },
-    {
       "displayName": "Shoppers Drug Mart",
       "id": "shoppersdrugmart-b56451",
       "locationSet": {"include": ["ca"]},

--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -980,6 +980,7 @@
           "sk"
         ]
       },
+      "matchNames":["Sensiblu"],
       "tags": {
         "amenity": "pharmacy",
         "brand": "Dr. Max",


### PR DESCRIPTION
As stated in the [Romanian Wikipedia page](https://ro.wikipedia.org/wiki/Sensiblu), in the 2017 [Dr. Max](https://nsi.guide/index.html?t=brands&k=amenity&v=pharmacy&tt=dr.%20max#drmax-d40f7b) acquired the company behind Sensiblu pharmacies and nowadays rebranded all of them. At least in Bucharest and Ploiesti I cannot see anymore Sensiblu brand around.

Also the official website and social pages are all closed.