### PR TITLE
Split Soriana up into the different formats

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -4928,6 +4928,17 @@
       }
     },
     {
+      "displayName": "MEGA Soriana",
+      "id": "megasoriana-9b2dfb",
+      "locationSet": {"include": ["mx"]},
+      "tags": {
+        "brand": "Soriana",
+        "brand:wikidata": "Q735562",
+        "name": "MEGA Soriana",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Megasave",
       "id": "megasave-6d06e8",
       "locationSet": {
@@ -6959,13 +6970,35 @@
       }
     },
     {
-      "displayName": "Soriana",
-      "id": "soriana-9b2dfb",
+      "displayName": "Soriana Híper",
+      "id": "sorianahiper-9b2dfb",
       "locationSet": {"include": ["mx"]},
       "tags": {
         "brand": "Soriana",
         "brand:wikidata": "Q735562",
-        "name": "Soriana",
+        "name": "Soriana Híper",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "Soriana Mercado",
+      "id": "sorianamercado-9b2dfb",
+      "locationSet": {"include": ["mx"]},
+      "tags": {
+        "brand": "Soriana",
+        "brand:wikidata": "Q735562",
+        "name": "Soriana Mercado",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "Soriana Súper",
+      "id": "sorianasuper-9b2dfb",
+      "locationSet": {"include": ["mx"]},
+      "tags": {
+        "brand": "Soriana",
+        "brand:wikidata": "Q735562",
+        "name": "Soriana Súper",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
Due to "Soriana" being only one entry before, many Soriana locations are mistagged, with iD suggesting `name=Soriana Híper` to be split up into `name=Soriana` `branch=Híper` which is wrong the same way `name=Walmart` `branch=Supercenter` is.

I split up Soriana into the different formats "Soriana Híper", "Soriana Súper", "Soriana Mercado" and "MEGA Soriana".

> Until December 2023, Soriana operates 804 stores nationwide (368 Soriana Híper stores; 162 Soriana Mercado stores; 129 Soriana Súper stores; 106 Soriana Express stores; 39 City Club price clubs and 13 Sodimac Homecenter stores).

from Wikipedia (https://en.wikipedia.org/wiki/Soriana)