### PR TITLE
Update pastry.json

### DIFF
--- a/data/brands/shop/pastry.json
+++ b/data/brands/shop/pastry.json
@@ -173,6 +173,17 @@
       }
     },
     {
+      "displayName": "Maison Dandoy",
+      "locationSet": {"include": ["be"]},
+      "tags": {
+        "brand": "Maison Dandoy",
+        "brand:wikidata": "Q60233731",
+        "name": "Maison Dandoy",
+        "shop": "pastry"
+      }
+    },
+
+    {
       "displayName": "Mrs. Fields",
       "id": "mrsfields-e944b6",
       "locationSet": {


### PR DESCRIPTION
Added Maison Dandoy a Belgian (mostly in Brussels) chain of biscuiteries