### PR TITLE
Update furniture.json - Add Pronto Wonen in NL

### DIFF
--- a/data/brands/shop/furniture.json
+++ b/data/brands/shop/furniture.json
@@ -1632,6 +1632,16 @@
       }
     },
     {
+      "displayName": "Pronto Wonen",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "Pronto Wonen",
+        "brand:wikidata": "Q124129152",
+        "name": "Pronto Wonen",
+        "shop": "furniture"
+      }
+    },
+    {
       "displayName": "Provincial Home Living",
       "id": "provincialhomeliving-0da980",
       "locationSet": {"include": ["au"]},


### PR DESCRIPTION
Adding the Pronto Wonen furniture store chain in the Netherlands.