### PR TITLE
Add Vision Source

### DIFF
--- a/data/brands/shop/optician.json
+++ b/data/brands/shop/optician.json
@@ -1274,6 +1274,17 @@
       }
     },
     {
+      "displayName": "Vision Source",
+      "id": "visionsource-5b6831",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "brand": "Vision Source",
+        "brand:wikidata": "Q21189109",
+        "healthcare": "optometrist",
+        "shop": "optician"
+      }
+    },
+    {
       "displayName": "Visionworks",
       "id": "visionworks-5b6831",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Vision Source[^1] is a network of independently-owned and operated eye doctors in the United States. For the purposes of OSM, it functions as a brand. The Vision Source logo is (usually) prominently featured on the signage for member practices, if you buy glasses they come in a Vision Source-branded plastic bag, and most member practices use the same website theme with the same marketing blog posts.

[^1]: https://www.visionsource.com; https://en.wikipedia.org/wiki/Vision_Source