### PR TITLE
Update NPC24H

### DIFF
--- a/data/operators/amenity/parking.json
+++ b/data/operators/amenity/parking.json
@@ -556,8 +556,7 @@
         "brand:wikidata": "Q11506782",
         "fee": "yes",
         "name": "NPC24H",
-        "official_name": "日本パーキング",
-        "operator": "NPC",
+        "operator": "日本パーキング",
         "operator:wikidata": "Q11506782"
       }
     },


### PR DESCRIPTION
"日本パーキング" is not the official name but the name of the operator.