### PR TITLE
move Guzman y Gomez from restaurant to fast_food

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -3453,6 +3453,20 @@
       }
     },
     {
+      "displayName": "Guzman y Gomez",
+      "id": "guzmanygomez-688cfd",
+      "locationSet": {
+        "include": ["au", "jp", "sg"]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Guzman y Gomez",
+        "brand:wikidata": "Q23019759",
+        "cuisine": "mexican",
+        "name": "Guzman y Gomez"
+      }
+    },
+    {
       "displayName": "Habib's",
       "id": "habibs-4b8fdf",
       "locationSet": {"include": ["br", "mx"]},

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -2253,20 +2253,6 @@
       }
     },
     {
-      "displayName": "Guzman y Gomez",
-      "id": "guzmanygomez-688cfd",
-      "locationSet": {
-        "include": ["au", "jp", "sg"]
-      },
-      "tags": {
-        "amenity": "restaurant",
-        "brand": "Guzman y Gomez",
-        "brand:wikidata": "Q23019759",
-        "cuisine": "mexican",
-        "name": "Guzman y Gomez"
-      }
-    },
-    {
       "displayName": "Gyu-Kaku",
       "id": "gyukaku-96af40",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
This was added in #3304 as restaurant, but it's a better fit under fast_food. Although most existing tagging is for restaurant, this is likely due to this index  using restaurant.