### PR TITLE
Add Servpro

### DIFF
--- a/data/brands/craft/cleaning.json
+++ b/data/brands/craft/cleaning.json
@@ -4,6 +4,16 @@
     "exclude": {"generic": ["^cleaning$"]}
   },
   "items": [
+     {
+      "displayName": "Servpro",
+      "locationSet": {"include": ["ca", "us"]},
+      "tags": {
+        "brand": "Servpro",
+        "brand:wikidata": "Q7455937",
+        "craft": "cleaning",
+        "name": "Servpro"
+      }
+    },
     {
       "displayName": "Merry Maids",
       "id": "merrymaids-7432ef",


### PR DESCRIPTION
Hi

Adding Servpro - https://www.servpro.com/
This company provides multiple services, majorly cleaning and restoration. It could also belong under craft=restoration.
I think craft=cleaning is also reasonable, if you think otherwise let me know.

Thanks,