### PR TITLE
Move Pokawa from restaurant to fast_food

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -6748,6 +6748,28 @@
       }
     },
     {
+      "displayName": "Pokawa",
+      "id": "pokawa-6a2ed9",
+      "locationSet": {
+        "include": [
+          "be",
+          "ch",
+          "es",
+          "fr",
+          "lu",
+          "pt"
+        ]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Pokawa",
+        "brand:wikidata": "Q123018553",
+        "cuisine": "poke",
+        "name": "Pokawa",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Poke Bros.",
       "id": "pokebros-eebea8",
       "locationSet": {

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -4695,27 +4695,6 @@
       }
     },
     {
-      "displayName": "Pokawa",
-      "id": "pokawa-cd2a5c",
-      "locationSet": {
-        "include": [
-          "be",
-          "ch",
-          "es",
-          "fr",
-          "lu",
-          "pt"
-        ]
-      },
-      "tags": {
-        "amenity": "restaurant",
-        "brand": "Pokawa",
-        "brand:wikidata": "Q123018553",
-        "cuisine": "poke",
-        "name": "Pokawa"
-      }
-    },
-    {
       "displayName": "Pomodoro",
       "id": "pomodoro-acf031",
       "locationSet": {"include": ["es"]},


### PR DESCRIPTION
Pokawa (added in #8912) is a poke bowl system gastronomy concept where you order food at a counter and not a sit-down restaurant with waiters. In my opinion this should be `amenity=fast_food` instead of `amenity=restaurant`.

Check out some pictures:

* https://parisladefense.com/en/discover/restaurants-bars/pokawa
* https://www.loiretal-atlantik.com/objet_touristique/195284
* https://www.macommune.info/besancon-pokawa-restaurant-de-poke-bowls-sinstalle-rue-des-granges/
* https://www.quefairepaysbasque.com/pokawa-pokebowl-bayonne/

OSM is undecided in the current tagging. Here’s a query for the currently existing Pokawa: https://overpass-turbo.eu/s/1Ga0

* 35 amenity=restaurant
* 1 disused:amenity=restaurant
* 30 amenity=fast_food