### PR TITLE
Name of Allied Pharmacies branches should be singular

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -152,7 +152,7 @@
         "brand": "Allied Pharmacies",
         "brand:wikidata": "Q116272370",
         "healthcare": "pharmacy",
-        "name": "Allied Pharmacies"
+        "name": "Allied Pharmacy"
       }
     },
     {


### PR DESCRIPTION
While the company name is "Allied Pharmacies", the fascia signs on individual branches say "Allied Pharmacy" (singular) - see e.g. https://alliedpharmacies.com/pharmacy/allied-pharmacy-church-street - and this should be reflected in the OSM name.