### PR TITLE
Update bicycle.json - Add 'Profile' in NL

### DIFF
--- a/data/brands/shop/bicycle.json
+++ b/data/brands/shop/bicycle.json
@@ -137,6 +137,16 @@
         "shop": "bicycle"
       }
     },
+        {
+      "displayName": "Profile",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "Profile",
+        "brand:wikidata": "Q124339994",
+        "name": "Profile",
+        "shop": "bicycle"
+      }
+    },
     {
       "displayName": "Pure Electric",
       "id": "pureelectric-3697a8",


### PR DESCRIPTION
Adding 'Profile', a Dutch bicycle shop chain in the Netherlands.