### PR TITLE
Add Yogya and Griya

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -3133,6 +3133,16 @@
       }
     },
     {
+      "displayName": "Griya",
+      "locationSet": {"include": ["id"]},
+      "tags": {
+        "brand": "Griya",
+        "brand:wikidata": "Q124353081",
+        "name": "Griya",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Grocery Outlet",
       "id": "groceryoutlet-dde59d",
       "locationSet": {"include": ["us"]},
@@ -8446,6 +8456,16 @@
         "name:en": "Yerevan City",
         "name:hy": "Երևան Սիթի",
         "name:ru": "Ереван Сити",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "Yogya",
+      "locationSet": {"include": ["id"]},
+      "tags": {
+        "brand": "Yogya",
+        "brand:wikidata": "Q124353073",
+        "name": "Yogya",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
Add Yogya and Griya, two Indonesian supermarket chains owned by Yogya Group