### PR TITLE
Remove PLN

### DIFF
--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -4829,7 +4829,8 @@
       "locationSet": {"include": ["id"]},
       "matchNames": [
         "pt perusahaan listrik negara",
-        "pt pln (persero)"
+        "pt pln (persero)",
+        "pln"
       ],
       "tags": {
         "operator": "Perusahaan Listrik Negara",
@@ -4893,16 +4894,6 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "operator": "PKP Energetyka",
-        "power": "line"
-      }
-    },
-    {
-      "displayName": "PLN",
-      "id": "pln-f1e749",
-      "locationSet": {"include": ["id"]},
-      "tags": {
-        "operator": "PLN",
-        "operator:wikidata": "Q4201636",
         "power": "line"
       }
     },


### PR DESCRIPTION
"PLN" is the acronym of "Perusahaan Listrik Negara". Both refer to the same company owned by Indonesian government.