### PR TITLE
add operators/emergency/disaster_response for AU

### DIFF
--- a/data/operators/emergency/disaster_response.json
+++ b/data/operators/emergency/disaster_response.json
@@ -1,0 +1,79 @@
+{
+  "properties": {
+    "path": "operators/emergency/disaster_response"
+  },
+  "items": [
+    {
+      "displayName": "ACT State Emergency Service",
+      "locationSet": {"include": ["au-act.geojson"]},
+      "tags": {
+        "emergency": "disaster_response",
+        "operator": "ACT State Emergency Service",
+        "operator:wikidata": "Q110247330"
+      }
+    },
+    {
+      "displayName": "NSW State Emergency Service",
+      "locationSet": {"include": ["au-nsw.geojson"]},
+      "tags": {
+        "emergency": "disaster_response",
+        "operator": "NSW State Emergency Service",
+        "operator:wikidata": "Q7011790"
+      }
+    },
+    {
+      "displayName": "NT State Emergency Service",
+      "locationSet": {"include": ["au-nt.geojson"]},
+      "tags": {
+        "emergency": "disaster_response",
+        "operator": "NT State Emergency Service",
+        "operator:wikidata": "Q111660761"
+      }
+    },
+    {
+      "displayName": "Queensland State Emergency Service",
+      "locationSet": {"include": ["au-qld.geojson"]},
+      "tags": {
+        "emergency": "disaster_response",
+        "operator": "Queensland State Emergency Service",
+        "operator:wikidata": "Q17054236"
+      }
+    },
+    {
+      "displayName": "South Australian State Emergency Service",
+      "locationSet": {"include": ["au-sa.geojson"]},
+      "tags": {
+        "emergency": "disaster_response",
+        "operator": "South Australian State Emergency Service",
+        "operator:wikidata": "Q56395948"
+      }
+    },
+    {
+      "displayName": "Tasmania State Emergency Service",
+      "locationSet": {"include": ["au-tas"]},
+      "tags": {
+        "emergency": "disaster_response",
+        "operator": "Tasmania State Emergency Service",
+        "operator:wikidata": "Q111654255"
+      }
+    },
+    {
+      "displayName": "Victoria State Emergency Service",
+      "locationSet": {"include": ["au-vic.geojson"]},
+      "tags": {
+        "emergency": "disaster_response",
+        "operator": "Victoria State Emergency Service",
+        "operator:wikidata": "Q7927057"
+      }
+    },
+    {
+      "displayName": "DFES State Emergency Service",
+      "locationSet": {"include": ["au-wa.geojson"]},
+      "tags": {
+        "emergency": "disaster_response",
+        "operator": "DFES State Emergency Service",
+        "operator:wikidata": "Q111654262"
+      }
+    },
+  ]
+}


### PR DESCRIPTION
In line with the recently approved
[`emergency=disaster_response`](https://wiki.openstreetmap.org/wiki/Tag:emergency%3Ddisaster_response) tag and local [Australian Tagging
Guidelines](https://wiki.openstreetmap.org/wiki/Australian_Tagging_Guidelines/Australian_features#Emergency_Services).

There was also a community post raised https://community.openstreetmap.org/t/retagging-the-australian-seses-with-emergency-disaster-response/108922