### PR TITLE
Update mortgage.json - Adding 3 mortgage intermediary chains in NL

### DIFF
--- a/data/brands/office/mortgage.json
+++ b/data/brands/office/mortgage.json
@@ -38,6 +38,26 @@
       }
     },
     {
+      "displayName": "De Hypotheekshop",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "De Hypotheekshop",
+        "brand:wikidata": "Q124052986",
+        "name": "De Hypotheekshop",
+        "office": "mortgage"
+      }
+    },
+    {
+      "displayName": "De Hypotheker",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "De Hypotheker",
+        "brand:wikidata": "Q2210766",
+        "name": "De Hypotheker",
+        "office": "mortgage"
+      }
+    },
+    {
       "displayName": "Embrace Financial Services",
       "id": "embracefinancialservices-3afe40",
       "locationSet": {"include": ["gb"]},
@@ -67,6 +87,16 @@
         "brand": "Guild Mortgage Company",
         "brand:wikidata": "Q122074693",
         "name": "Guild Mortgage Company",
+        "office": "mortgage"
+      }
+    },
+    {
+      "displayName": "Huis & Hypotheek",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "Huis & Hypotheek",
+        "brand:wikidata": "Q124128783",
+        "name": "Huis & Hypotheek",
         "office": "mortgage"
       }
     },


### PR DESCRIPTION
Adding 3 mortgage intermediary chains in the Netherlands: De Hypotheker, De Hypotheekshop and Huis & Hypotheek.