### PR TITLE
Update jewelry.json - Add 'Schaap en Citroen' in NL

### DIFF
--- a/data/brands/shop/jewelry.json
+++ b/data/brands/shop/jewelry.json
@@ -945,6 +945,16 @@
       }
     },
     {
+      "displayName": "Schaap en Citroen",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "Schaap en Citroen",
+        "brand:wikidata": "Q1984947",
+        "name": "Schaap en Citroen",
+        "shop": "jewelry"
+      }
+    },
+    {
       "displayName": "Shane Co.",
       "id": "shaneco-70f101",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Adding 'Schaap en Citroen', a jewelry store chain in the Netherlands.