### PR TITLE
Update car_rental.json - Add 'Autohopper' in NL

### DIFF
--- a/data/brands/amenity/car_rental.json
+++ b/data/brands/amenity/car_rental.json
@@ -51,6 +51,16 @@
       }
     },
     {
+      "displayName": "Autohopper",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "amenity": "car_rental",
+        "brand": "Autohopper",
+        "brand:wikidata": "Q124398113",
+        "name": "Autohopper",
+      }
+    },
+    {
       "displayName": "Avis",
       "id": "avis-d9531a",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Adding 'Autohopper', a car rental service chain in the Netherlands.