### PR TITLE
Update kitchen.json - Add 'Superkeukens' in NL

### DIFF
--- a/data/brands/shop/kitchen.json
+++ b/data/brands/shop/kitchen.json
@@ -370,6 +370,16 @@
       }
     },
     {
+      "displayName": "Superkeukens",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "Superkeukens",
+        "brand:wikidata": "Q124339554",
+        "name": "Superkeukens",
+        "shop": "kitchen"
+      }
+    },
+    {
       "displayName": "Wren Kitchens",
       "id": "wrenkitchens-26c64e",
       "locationSet": {"include": ["gb"]},


### PR DESCRIPTION
Adding 'Superkeukens', a kitchen furnishing retail store chain in the Netherlands.