### PR TITLE
amenity/fast_food: use correct Wikidata item for Checkers

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -1339,7 +1339,7 @@
       "tags": {
         "amenity": "fast_food",
         "brand": "Checkers",
-        "brand:wikidata": "Q3419341",
+        "brand:wikidata": "Q63919315",
         "cuisine": "burger",
         "name": "Checkers",
         "takeaway": "yes"


### PR DESCRIPTION
The previous Wikidata item is for the company which owns Checkers and Rally's brands. The new Wikidata item of this change is just for the Checkers brand.