### PR TITLE
Removed name on Robidog waste baskets

### DIFF
--- a/data/brands/amenity/waste_basket.json
+++ b/data/brands/amenity/waste_basket.json
@@ -37,7 +37,7 @@
         "amenity": "waste_basket",
         "brand": "Robidog",
         "brand:wikidata": "Q2159689",
-        "name": "Robidog"
+        "vending": "excrement_bags"
       }
     }
   ]


### PR DESCRIPTION
Removed name on waste baskets of brand "Robidog" as per https://wiki.openstreetmap.org/wiki/Good_practice#Don't_use_name_tag_to_describe_things, added missing tag "vending=excrement_bags".