### PR TITLE
Fixed Robidog poop bag dispenser

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -852,7 +852,6 @@
         "bin": "yes",
         "brand": "Robidog",
         "brand:wikidata": "Q2159689",
-        "name": "Robidog",
         "vending": "excrement_bags"
       }
     },


### PR DESCRIPTION
Removed name from dog poop bag dispenser and waste basket of brand "Robidog" as per https://wiki.openstreetmap.org/wiki/Good_practice#Don't_use_name_tag_to_describe_things.