### PR TITLE
Update bus.json

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -16850,12 +16850,19 @@
       }
     },
     {
-      "displayName": "TUC Cambrésis",
+      "displayName": "TUC (Cambrésis)",
       "id": "tuccambresis-add5eb",
       "locationSet": {"include": ["fx"]},
+       "matchNames": [
+        "transports urbains du cambrésis",
+        "tuc cambrésis",
+        "tuc cambrai"
+      ],
       "tags": {
-        "network": "TUC Cambrésis",
+        "network": "TUC",
+        "network:wikipedia": "fr:Transports en commun de Cambrai",
         "network:wikidata": "Q3537945",
+        "operator": "Place Mobilité",
         "route": "bus"
       }
     },


### PR DESCRIPTION
Hi. 
Changed from "TUC Cambrésis" to only "TUC", because "TUC" already means "Transports Urbains du Cambrésis". So this avoids the duplicate of "Cambrésis". I also added associated tags, the most important/common match names, and the current operator of the network.