### PR TITLE
Update fuel.json

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -3963,7 +3963,7 @@
       }
     },
         {
-      "displayName": "Petrom",
+      "displayName": "Petrom (MA)",
       "locationSet": {"include": ["ma"]},
       "tags": {
         "amenity": "fuel",
@@ -3973,7 +3973,7 @@
       }
     },
     {
-      "displayName": "Petrom",
+      "displayName": "Petrom (MD & RO)",
       "id": "petrom-b3d110",
       "locationSet": {"include": ["md", "ro"]},
       "tags": {

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -1708,7 +1708,7 @@
       "displayName": "Eni",
       "id": "eni-4e932a",
       "locationSet": {
-        "include": ["at", "ch", "fr", "it"]
+        "include": ["at", "ch", "cy", "de", "es", "fr", "it"]
       },
       "matchNames": ["agip/eni", "eni station"],
       "preserveTags": ["^name"],
@@ -3962,10 +3962,21 @@
         "name": "Petrolina"
       }
     },
+        {
+      "displayName": "Petrom",
+      "id": ,
+      "locationSet": {"include": ["ma"]},
+      "tags": {
+        "amenity": "fuel",
+        "brand": "Petrom",
+        "brand:wikidata": "Q110028558",
+        "name": "Petrom"
+      }
+    },
     {
       "displayName": "Petrom",
       "id": "petrom-b3d110",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["md", "ro"]},
       "tags": {
         "amenity": "fuel",
         "brand": "Petrom",

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -3964,7 +3964,6 @@
     },
         {
       "displayName": "Petrom",
-      "id": ,
       "locationSet": {"include": ["ma"]},
       "tags": {
         "amenity": "fuel",


### PR DESCRIPTION
corrected Petrom (wikidata: Q1755034) as it operates only in Romania and Moldova.

added Petrom Morocco (wikidata: Q110028558).

completed Eni (Q565594) country list.