### PR TITLE
Update bus.json - added network:wikidata for TECN and TECX

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -15534,6 +15534,7 @@
       "locationSet": {"include": ["be", "fx"]},
       "tags": {
         "network": "TECN",
+        "network:Q3512080": "Q3512080",
         "operator": "TEC",
         "operator:wikidata": "Q366922",
         "route": "bus"
@@ -15547,6 +15548,7 @@
       },
       "tags": {
         "network": "TECX",
+        "network:Q3512080": "Q3512080",
         "operator": "TEC",
         "operator:wikidata": "Q366922",
         "route": "bus"

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -15548,7 +15548,7 @@
       },
       "tags": {
         "network": "TECX",
-        "network:Q3512080": "Q3512080",
+        "network:wikidata": "Q3512080",
         "operator": "TEC",
         "operator:wikidata": "Q366922",
         "route": "bus"

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -15534,7 +15534,7 @@
       "locationSet": {"include": ["be", "fx"]},
       "tags": {
         "network": "TECN",
-        "network:Q3512080": "Q3512080",
+        "network:wikidata": "Q3512080",
         "operator": "TEC",
         "operator:wikidata": "Q366922",
         "route": "bus"


### PR DESCRIPTION
TECN (TEC Namur) and TECX (TEC Luxembourg) are two regional networks operated by TEC (Public transport in the south of Belgium).
This commit adds "network:wikidata" for both of them.  (Yes, they point to the same wikidata entry, this is normal and expected.)

---

Related #9243 