### PR TITLE
Add Indomaret Point and Maxx Coffee

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -2497,11 +2497,10 @@
     },
     {
       "displayName": "Maxx Coffee",
-      "locationSet": {
-        "include": ["id"]},
+      "locationSet": {"include": ["id"]},
       "tags": {
         "amenity": "cafe",
-        "brand": "Max Coffee",
+        "brand": "Maxx Coffee",
         "brand:wikidata": "Q124651563",
         "cuisine": "coffee_shop",
         "name": "Maxx Coffee",

--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -2046,15 +2046,15 @@
       }
     },
         {
-      "displayName": "Indomaret Point",
+      "displayName": "Point Coffee",
       "locationSet": {"include": ["id"]},
       "tags": {
         "amenity": "cafe",
-        "brand": "Indomaret",
-        "brand:wikidata": "Q4262825",
+        "brand": "Point Coffee",
+        "brand:wikidata": "Q124651558",
         "cuisine": "coffee_shop",
-        "name": "Indomaret Point",
-        "alt_name": "Point Coffee",
+        "name": "Point Coffee",
+        "alt_name": "Indomaret Point",
         "takeaway": "yes"
       }
     },

--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -2498,8 +2498,7 @@
     {
       "displayName": "Maxx Coffee",
       "locationSet": {
-        "include": ["id"]
-      },
+        "include": ["id"]},
       "tags": {
         "amenity": "cafe",
         "brand": "Max Coffee",

--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -2045,6 +2045,19 @@
         "takeaway": "yes"
       }
     },
+        {
+      "displayName": "Indomaret Point",
+      "locationSet": {"include": ["id"]},
+      "tags": {
+        "amenity": "cafe",
+        "brand": "Indomaret",
+        "brand:wikidata": "Q4262825",
+        "cuisine": "coffee_shop",
+        "name": "Indomaret Point",
+        "alt_name": "Point Coffee",
+        "takeaway": "yes"
+      }
+    },
     {
       "displayName": "Insomnia",
       "id": "insomnia-180c7a",
@@ -2479,6 +2492,20 @@
         "name": "Max Brenner",
         "name:en": "Max Brenner",
         "name:he": "מקס ברנר",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "Maxx Coffee",
+      "locationSet": {
+        "include": ["id"]
+      },
+      "tags": {
+        "amenity": "cafe",
+        "brand": "Max Coffee",
+        "brand:wikidata": "Q124651563",
+        "cuisine": "coffee_shop",
+        "name": "Maxx Coffee",
         "takeaway": "yes"
       }
     },


### PR DESCRIPTION
Indomaret Point and Maxx Coffee are coffee shop chains in Indonesia.

Indomaret Point brand is owned by Indomaret. Indomaret Point usually located inside the Indomaret itself.
Maxx Coffee stores are located in Indonesia's big cities.