### PR TITLE
Add BTPN

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -3935,6 +3935,19 @@
         "official_name": "Bank Tabungan Negara"
       }
     },
+        {
+      "displayName": "BTPN",
+      "locationSet": {"include": ["id"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "BTPN",
+        "brand:en": "BTPN",
+        "brand:id": "BTPN",
+        "brand:wikidata": "Q12474535",
+        "name": "BTPN",
+        "official_name": "Bank BTPN"
+      }
+    },
     {
       "displayName": "Budapest Bank",
       "id": "budapestbank-60884a",


### PR DESCRIPTION
BTPN, formerly "Bank Tabungan Pensiunan Negara", is a Japanese bank in Indonesia