### PR TITLE
Update hotelF1, delete Formule 1

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -1200,17 +1200,6 @@
       }
     },
     {
-      "displayName": "Formule 1",
-      "id": "formule1-612c69",
-      "locationSet": {"include": ["fr"]},
-      "tags": {
-        "brand": "Formule 1",
-        "brand:wikidata": "Q1630895",
-        "name": "Formule 1",
-        "tourism": "hotel"
-      }
-    },
-    {
       "displayName": "Four Points by Sheraton",
       "id": "fourpointsbysheraton-779ccb",
       "locationSet": {"include": ["001"]},
@@ -1573,6 +1562,7 @@
       "displayName": "hotelF1",
       "id": "hotelf1-612c69",
       "locationSet": {"include": ["fr"]},
+      "matchNames": ["Formule 1"],
       "tags": {
         "brand": "hotelF1",
         "brand:wikidata": "Q1630895",


### PR DESCRIPTION
`Formule 1` is a former name of `hotelF1`, see https://en.wikipedia.org/wiki/HotelF1.
I'm not sure why it exists as a separate record, most prob from OSM import...