### PR TITLE
Update fuel.json - Add 'OK' in NL

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -3639,6 +3639,16 @@
       }
     },
     {
+      "displayName": "OK",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "amenity": "fuel",
+        "brand": "OK",
+        "brand:wikidata": "Q123472183",
+        "name": "OK"
+      }
+    },
+    {
       "displayName": "OKQ8",
       "id": "okq8-a1affa",
       "locationSet": {"include": ["se"]},

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -3639,7 +3639,7 @@
       }
     },
     {
-      "displayName": "OK",
+      "displayName": "OK (NL)",
       "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "fuel",


### PR DESCRIPTION
Adding 'OK', a Dutch chain of petrol stations in the Netherlands.

This company has the same logo as the Danish and Swedish OK, but the three companies seem to be disconnected as far as I can tell.