### PR TITLE
Update pharmacy.json - Add 'Service Apotheek' in NL

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -2822,6 +2822,17 @@
       }
     },
     {
+      "displayName": "Service Apotheek",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "Service Apotheek",
+        "brand:wikidata": "Q124129179",
+        "healthcare": "pharmacy",
+        "name": "Service Apotheek"
+      }
+    },
+    {
       "displayName": "Shoppers Drug Mart",
       "id": "shoppersdrugmart-b56451",
       "locationSet": {"include": ["ca"]},


### PR DESCRIPTION
Adding 'Service Apotheek', a pharmacy chain in the Netherlands.