### PR TITLE
Deleted Camaieu

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -1713,19 +1713,6 @@
       }
     },
     {
-      "displayName": "Camaïeu",
-      "id": "camaieu-1cb4e7",
-      "locationSet": {
-        "include": ["be", "cz", "fr", "it", "pl"]
-      },
-      "tags": {
-        "brand": "Camaïeu",
-        "brand:wikidata": "Q2934647",
-        "name": "Camaïeu",
-        "shop": "clothes"
-      }
-    },
-    {
       "displayName": "Camisaria Colombo",
       "id": "camisariacolombo-c7d1e1",
       "locationSet": {"include": ["br"]},


### PR DESCRIPTION
This brand has been dissolved since 2022 according to the [wikidata](https://www.wikidata.org/wiki/Q2934647). Thus I believe it is fine to delete the entry.