### PR TITLE
Add bakeries and remove Lila Bäcker

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -212,6 +212,19 @@
       }
     },
     {
+      "displayName": "Bäckerei Wahl",
+      "id": "backereiwahl-e03be8",
+      "locationSet": {
+        "include": ["de-bb", "de-be"]
+      },
+      "tags": {
+        "brand": "Bäckerei Wahl",
+        "brand:wikidata": "Q124726142",
+        "name": "Bäckerei Wahl",
+        "shop": "bakery"
+      }
+    },
+    {
       "displayName": "Backhaus Hackner",
       "id": "backhaushackner-7367b5",
       "locationSet": {
@@ -1208,6 +1221,17 @@
       }
     },
     {
+      "displayName": "KONRAD",
+      "id": "konrad-c5c58c",
+      "locationSet": {"include": ["de-bb"]},
+      "tags": {
+        "brand": "KONRAD",
+        "brand:wikidata": "Q124726120",
+        "name": "KONRAD",
+        "shop": "bakery"
+      }
+    },
+    {
       "displayName": "Kuhn",
       "id": "kuhn-903073",
       "locationSet": {"include": ["ch"]},
@@ -1331,17 +1355,6 @@
         "brand": "Les Fournils de France",
         "brand:wikidata": "Q104649900",
         "name": "Les Fournils de France",
-        "shop": "bakery"
-      }
-    },
-    {
-      "displayName": "Lila Bäcker",
-      "id": "lilabacker-3f448e",
-      "locationSet": {"include": ["de"]},
-      "tags": {
-        "brand": "Lila Bäcker",
-        "brand:wikidata": "Q57516591",
-        "name": "Lila Bäcker",
         "shop": "bakery"
       }
     },


### PR DESCRIPTION
Adding two bakery brands and remove Lila Bäcker which is no longer in business. 
- Some of the Lila Bäcker shops are now reopened as these already exiting smaller brands.