### PR TITLE
Merge "BCA" to "Bank Central Asia"

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -2235,7 +2235,7 @@
       "displayName": "Bank Central Asia",
       "id": "bankcentralasia-aa7852",
       "locationSet": {"include": ["id"]},
-      "matchNames": ["bca"],
+      "matchNames": ["bca","bank bca"],
       "tags": {
         "amenity": "bank",
         "brand": "Bank Central Asia",

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -2235,6 +2235,7 @@
       "displayName": "Bank Central Asia",
       "id": "bankcentralasia-aa7852",
       "locationSet": {"include": ["id"]},
+      "matchNames": ["bca"],
       "tags": {
         "amenity": "bank",
         "brand": "Bank Central Asia",
@@ -3133,19 +3134,6 @@
         "brand": "BBVA Provincial",
         "brand:wikidata": "Q4835087",
         "name": "BBVA Provincial"
-      }
-    },
-    {
-      "displayName": "BCA",
-      "id": "bca-aa7852",
-      "locationSet": {"include": ["id"]},
-      "matchNames": ["bank bca"],
-      "tags": {
-        "amenity": "bank",
-        "brand": "BCA",
-        "brand:wikidata": "Q806626",
-        "name": "BCA",
-        "official_name": "Bank Central Asia"
       }
     },
     {


### PR DESCRIPTION
BCA and Bank Central Asia are the same entity. I deleted the "BCA" one and included that acronym to "Bank Central Asia".