### PR TITLE
Update Transjakarta in bus.json

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -16220,7 +16220,12 @@
       "displayName": "Transjakarta",
       "id": "transjakarta-87ebe4",
       "locationSet": {"include": ["id"]},
-      "matchNames": ["tj"],
+      "matchNames": [
+        "tj",
+        "pt transjakarta",
+        "pt. transjakarta",
+        "tije",
+      ],
       "tags": {
         "network": "Transjakarta",
         "network:wikidata": "Q1671143",


### PR DESCRIPTION
I found many bus stops using "PT Transjakarta" for its network or operator tag, so I added that.