### PR TITLE
Adding wikidata to 10 generator operators, removing 1

### DIFF
--- a/data/operators/power/generator.json
+++ b/data/operators/power/generator.json
@@ -230,9 +230,10 @@
     {
       "displayName": "Alabama Power",
       "id": "alabamapower-74685d",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Alabama Power",
+        "operator:wikidata": "Q4705296",
         "power": "generator"
       }
     },
@@ -356,6 +357,7 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "operator": "Ameren",
+        "operator:wikidata": "Q462984",
         "power": "generator"
       }
     },
@@ -439,6 +441,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Apex Clean Energy",
+        "operator:wikidata": "Q124800550",
         "power": "generator"
       }
     },
@@ -1103,9 +1106,10 @@
     {
       "displayName": "Capstone Infrastructure",
       "id": "capstoneinfrastructure-74685d",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["ca"]},
       "tags": {
         "operator": "Capstone Infrastructure",
+        "operator:wikidata": "Q5036370",
         "power": "generator"
       }
     },
@@ -1230,6 +1234,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Chevron",
+        "operator:wikidata": "Q319642",
         "power": "generator"
       }
     },
@@ -1275,6 +1280,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "City of Shafter",
+        "operator:wikidata": "Q985258",
         "power": "generator"
       }
     },
@@ -1284,6 +1290,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "City of Truth or Consequences",
+        "operator:wikidata": "Q431932",
         "power": "generator"
       }
     },
@@ -3036,6 +3043,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "FirstEnergy",
+        "operator:wikidata": "Q1419248",
         "power": "generator"
       }
     },
@@ -4976,15 +4984,6 @@
       }
     },
     {
-      "displayName": "NextEra Wind Energy",
-      "id": "nexterawindenergy-4cccf0",
-      "locationSet": {"include": ["ca", "us"]},
-      "tags": {
-        "operator": "NextEra Wind Energy",
-        "power": "generator"
-      }
-    },
-    {
       "displayName": "Noble Power",
       "id": "noblepower-19ecba",
       "locationSet": {"include": ["us"]},
@@ -6474,6 +6473,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Southern Power Co",
+        "operator:wikidata": "Q116866621",
         "power": "generator"
       }
     },
@@ -6902,6 +6902,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Target Corporation",
+        "operator:wikidata": "Q1046951",
         "power": "generator"
       }
     },


### PR DESCRIPTION
NextEra Wind Energy doesn't return anything in overpass. It appears those generators have been changed to use the NextEra entry.