### PR TITLE
Reduce the display name of CTS

### DIFF
--- a/data/operators/amenity/ticket_validator.json
+++ b/data/operators/amenity/ticket_validator.json
@@ -42,7 +42,7 @@
       }
     },
     {
-      "displayName": "CTS (Compagnie des Transports Strasbourgeois)",
+      "displayName": "CTS",
       "id": "compagniedestransportsstrasbourgeois-c1ee76",
       "locationSet": {"include": ["de", "fx"]},
       "tags": {

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -3815,7 +3815,7 @@
       }
     },
     {
-      "displayName": "CTS (Compagnie des Transports Strasbourgeois)",
+      "displayName": "CTS",
       "id": "compagniedestransportsstrasbourgeois-add5eb",
       "locationSet": {"include": ["fx"]},
       "tags": {

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -113,7 +113,7 @@
       }
     },
     {
-      "displayName": "CTS (Compagnie des Transports Strasbourgeois)",
+      "displayName": "CTS",
       "id": "compagniedestransportsstrasbourgeois-ffb8f7",
       "locationSet": {"include": ["de", "fx"]},
       "tags": {


### PR DESCRIPTION
The full display name "Compagnie des Transports Strasbourgeois" is a bit long and takes a lot of space in editors. This is however unneeded since there is no ambiguity with any other public transport operator. Moreover, a lot of operators have only the acronym and not the full name, so this is also a compliance commit.