### PR TITLE
Update furniture.json - Add 'Goossens' in NL/BE

### DIFF
--- a/data/brands/shop/furniture.json
+++ b/data/brands/shop/furniture.json
@@ -751,6 +751,16 @@
       }
     },
     {
+      "displayName": "Goossens",
+      "locationSet": {"include": ["nl","be"]},
+      "tags": {
+        "brand": "Goossens",
+        "brand:wikidata": "Q124760045",
+        "name": "Goossens",
+        "shop": "furniture"
+      }
+    },
+    {
       "displayName": "Habitat (France)",
       "id": "habitat-18f673",
       "locationSet": {"include": ["fr"]},


### PR DESCRIPTION
Adding 'Goossens', a furniture store chain in the Netherlands and Belgium.