### PR TITLE
Add cinemas in Indonesia

### DIFF
--- a/data/brands/amenity/cinema.json
+++ b/data/brands/amenity/cinema.json
@@ -184,6 +184,17 @@
       }
     },
     {
+      "displayName": "Cinema XXI",
+      "locationSet": {"include": ["id"]},
+      "tags": {
+        "amenity": "cinema",
+        "brand": "Cinema XXI",
+        "brand:wikidata": "Q4630986",
+        "name": "Cinema XXI",
+        "short_name": "XXI"
+      }
+    },
+    {
       "displayName": "Cinemark",
       "id": "cinemark-dc12dc",
       "locationSet": {
@@ -228,17 +239,6 @@
         "amenity": "cinema",
         "brand": "Cinemaxx",
         "brand:wikidata": "Q881860",
-        "name": "Cinemaxx"
-      }
-    },
-    {
-      "displayName": "Cinemaxx (Indonesia)",
-      "id": "cinemaxx-ee9238",
-      "locationSet": {"include": ["id"]},
-      "tags": {
-        "amenity": "cinema",
-        "brand": "Cinemaxx",
-        "brand:wikidata": "Q19942740",
         "name": "Cinemaxx"
       }
     },
@@ -325,7 +325,7 @@
       "id": "cinepolis-dc12dc",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["pl"]
+        "exclude": ["pl","id"]
       },
       "tags": {
         "amenity": "cinema",
@@ -390,7 +390,7 @@
     {
       "displayName": "CJ CGV",
       "id": "cgvcinema-c6663f",
-      "locationSet": {"include": ["kr"]},
+      "locationSet": {"include": ["kr","id"]},
       "matchNames": ["cgv"],
       "tags": {
         "amenity": "cinema",

--- a/data/brands/amenity/cinema.json
+++ b/data/brands/amenity/cinema.json
@@ -325,7 +325,7 @@
       "id": "cinepolis-dc12dc",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["pl","id"]
+        "exclude": ["pl"]
       },
       "tags": {
         "amenity": "cinema",


### PR DESCRIPTION
Please add three cinema chain in Indonesia. I deleted "Cinemaxx" since [it has changed its name to "Cinepolis"](https://www.beritasatu.com/news/588895/cinemaxx-resmi-ganti-nama-jadi-cinpolis). I also added Indonesia region to CJ CGV since it also operating in Indonesia. I added a new data for Cinema XXI.