### PR TITLE
Add MAKO Bakery

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -1425,6 +1425,16 @@
       }
     },
     {
+      "displayName": "MAKO Cake and Bakery",
+      "locationSet": {"include": ["id"]},
+      "tags": {
+        "brand": "MAKO Cake and Bakery",
+        "brand:wikidata": "Q124824681",
+        "name": "MAKO Cake and Bakery",
+        "shop": "bakery"
+      }
+    },
+    {
       "displayName": "Malcolm Barnecutt",
       "id": "malcolmbarnecutt-00bbe7",
       "locationSet": {"include": ["gb-eng"]},


### PR DESCRIPTION
Add Mako, a bakery chain in Indonesia. This brand formerly called "BreadTalk", but changed its brand to "MAKO".