### PR TITLE
Add Apotek K-24

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -269,6 +269,18 @@
       }
     },
     {
+      "displayName": "Apotek K-24",
+      "locationSet": {"include": ["id"]},
+      "matchNames": ["k-24"],
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "Apotek K-24",
+        "brand:wikidata": "Q56390232",
+        "healthcare": "pharmacy",
+        "name": "Apotek K-24"
+      }
+    },
+    {
       "displayName": "Apoteket",
       "id": "apoteket-bc5266",
       "locationSet": {"include": ["se"]},


### PR DESCRIPTION
Add Apotek K-24, a pharmaceutical store chain in Indonesia.