### PR TITLE
Add Rostics (ex. KFC in Russia)

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -9735,6 +9735,22 @@
       }
     },
     {
+      "displayName": "Rostic's",
+      "locationSet": {"include": ["ru"]},
+      "matchNames": [
+        "ростикс",
+        "kfc"
+      ],
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Rostic's",
+        "brand:wikidata": "Q3442874",
+        "cuisine": "chicken",
+        "name": "Rostic's",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Додо Пицца",
       "id": "dodopizza-e25654",
       "locationSet": {


### PR DESCRIPTION
I'm was not sure about adding Cyrillic tags `brand:ru=` and `name:ru=Ростикс'с` as on all signs in reality I see `Rostic's`.