### PR TITLE
Corrected `displayName` and `tags` of MOL Bubi bike share system

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -909,15 +909,15 @@
       }
     },
     {
-      "displayName": "BuBi",
+      "displayName": "MOL Bubi",
       "id": "bubi-7b42f4",
       "locationSet": {"include": ["hu"]},
       "matchNames": ["mol bubi"],
       "tags": {
         "amenity": "bicycle_rental",
-        "brand": "BuBi",
+        "brand": "MOL Bubi",
         "brand:wikidata": "Q16971969",
-        "network": "BuBi",
+        "network": "MOL Bubi",
         "network:wikidata": "Q16971969",
         "operator": "BKK",
         "operator:wikidata": "Q608917"


### PR DESCRIPTION
Corrected capitalization (_BuBi_ ➡️ _Bubi_) and added sponsor name (_MOL_) to the bike share system of _BKK Centre for Budapest Transport_.

Source: https://molbubi.hu/en/about/