### PR TITLE
Update Aerie to reflect product line expansion

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -231,7 +231,7 @@
       "tags": {
         "brand": "Aerie",
         "brand:wikidata": "Q25351619",
-        "clothes": "underwear",
+        "clothes": "women",
         "name": "Aerie",
         "shop": "clothes"
       }


### PR DESCRIPTION
Aerie [started as an intimates line](https://wwd.com/business-news/retail/american-eagle-s-strategy-for-aerie-intimates-543609/#!) in 2006, but has since expanded. As of EOY 2023, 22% of revenue is from intimates, compared with 69% from "soft apparel" and activewear ([American Eagle Outfitters Inc Long-Term Strategy and Q4 2023 Earnings Presentation](https://s26.q4cdn.com/546305894/files/doc_financials/2023/q4/15/AEO-Inc-Fourth-Quarter-Results-and-Powering-Profitable-Growth-Strategy-Presentation-1.pdf) p. 70).

First time contributor, so please feel free to correct any mistakes.