### PR TITLE
Bank merge in France HSBC -> CCF

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -7153,13 +7153,26 @@
       "id": "hsbc-ac0675",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["hk", "mo", "tw"]
+        "exclude": ["fr", "hk", "mo", "tw"]
       },
       "tags": {
         "amenity": "bank",
         "brand": "HSBC",
         "brand:wikidata": "Q190464",
         "name": "HSBC"
+      }
+    },
+    {
+      "displayName": "CCF",
+      "locationSet": {
+        "include": ["fr"],
+      },
+      "matchNames": ["credit commercial de france", "hsbc", "hsbc france"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "CCF",
+        "brand:wikidata": "Q3006195",
+        "name": "CCF"
       }
     },
     {


### PR DESCRIPTION
HSBC has sold their retail banking business in France to CCF: 

- https://www.fintechfutures.com/2024/01/hsbc-completes-sale-of-french-retail-banking-business-to-ccf/
- https://fr.wikipedia.org/wiki/Crédit_commercial_de_France#2023_:_renaissance_du_CCF