### PR TITLE
HSBC (Canada) is now owned and rebranded as RBC

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -7174,7 +7174,7 @@
       "id": "hsbc-752d4e",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["fr", "hk", "mo", "tw"]
+        "exclude": ["fr", "hk", "mo", "tw", "ca"]
       },
       "tags": {
         "amenity": "bank",
@@ -9881,7 +9881,8 @@
       "matchNames": [
         "rbc financial group",
         "rbc royal bank",
-        "royal bank"
+        "royal bank",
+        "HSBC"
       ],
       "tags": {
         "amenity": "bank",


### PR DESCRIPTION
See https://www.rbc.com/hsbc-canada/