### PR TITLE
Remove `name` from Desjardins

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -5439,10 +5439,12 @@
         "caisses desjardins",
         "desjardins"
       ],
+      "preserveTags": ["^name"],
       "tags": {
         "amenity": "bank",
         "brand": "Desjardins",
         "brand:wikidata": "Q2933350",
+        "name": "Desjardins"
       }
     },
     {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -5436,13 +5436,13 @@
       "locationSet": {"include": ["ca"]},
       "matchNames": [
         "caisse desjardins",
-        "caisses desjardins"
+        "caisses desjardins",
+        "desjardins"
       ],
       "tags": {
         "amenity": "bank",
         "brand": "Desjardins",
         "brand:wikidata": "Q2933350",
-        "name": "Desjardins"
       }
     },
     {


### PR DESCRIPTION
Remove the `name` from Desjardins, as it is a federation of credit unions and not a single entity.