### PR TITLE
Update garden_centre.json - Add 'GroenRijk' in NL

### DIFF
--- a/data/brands/shop/garden_centre.json
+++ b/data/brands/shop/garden_centre.json
@@ -109,6 +109,16 @@
       }
     },
     {
+      "displayName": "GroenRijk",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "GroenRijk",
+        "brand:wikidata": "Q2738788",
+        "name": "GroemRijk",
+        "shop": "garden_centre"
+      }
+    },
+    {
       "displayName": "Hageland",
       "id": "hageland-664184",
       "locationSet": {"include": ["no"]},


### PR DESCRIPTION
Adding GroenRijk, a garden centre chain in the Netherlands.