### PR TITLE
Add some Dutch parcel locker brands

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -182,6 +182,21 @@
       }
     },
     {
+      "displayName": "de Buren",
+      "id": "deburen-476b76",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "de Buren",
+        "brand:wikidata": "Q119648956",
+        "name": "de Buren",
+        "operator": "de Buren",
+        "operator:wikidata": "Q119648956",
+        "parcel_mail_in": "yes",
+        "parcel_pickup": "yes"
+      }
+    },
+    {
       "displayName": "DHL Packstation",
       "id": "dhlpackstation-83cc4d",
       "locationSet": {"include": ["de"]},
@@ -707,6 +722,21 @@
         "name": "PackUp",
         "operator": "POST Luxembourg",
         "parcel_mail_in": "yes"
+      }
+    },
+    {
+      "displayName": "PostNL Pakketautomaat",
+      "id": "postnlpakketautomaat-476b76",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "PostNL",
+        "brand:wikidata": "Q5921598",
+        "name": "PostNL Pakketautomaat",
+        "operator": "PostNL",
+        "operator:wikidata": "Q5921598",
+        "parcel_mail_in": "yes",
+        "parcel_pickup": "yes"
       }
     },
     {

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -224,6 +224,21 @@
       }
     },
     {
+      "displayName": "DHL Pakketautomaat",
+      "id": "dhlpakketautomaat-476b76",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "DHL",
+        "brand:wikidata": "Q489815",
+        "name": "DHL Pakketautomaat",
+        "operator": "DHL Parcel",
+        "operator:wikidata": "Q489815",
+        "parcel_mail_in": "yes",
+        "parcel_pickup": "yes"
+      }
+    },
+    {
       "displayName": "DHL POP BOX",
       "id": "dhlpopbox-ce4e28",
       "locationSet": {"include": ["pl"]},


### PR DESCRIPTION
Adds PostNL, localized version of DHL and de Buren.