### PR TITLE
Added Italian clothing store chain Calliope

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -1716,6 +1716,16 @@
       }
     },
     {
+      "displayName": "Calliope",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "Calliope",
+        "brand:wikidata": "Q125703464",
+        "name": "Calliope",
+        "shop": "clothes"
+      }
+    },
+    {
       "displayName": "Calvin Klein",
       "id": "calvinklein-3937bd",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Calliope is a fashion label with various stores in Europe and Middle East.

See Wikidata item for more details: https://www.wikidata.org/wiki/Q125703464