### PR TITLE
Fixed wrong name shop=electronics Commet -> Comet

### DIFF
--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -304,13 +304,13 @@
       }
     },
     {
-      "displayName": "Commet",
+      "displayName": "Comet",
       "id": "commet-41f013",
       "locationSet": {"include": ["it"]},
       "tags": {
-        "brand": "Commet",
+        "brand": "Comet",
         "brand:wikidata": "Q3777340",
-        "name": "Commet",
+        "name": "Comet",
         "shop": "electronics"
       }
     },

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -307,6 +307,7 @@
       "displayName": "Comet",
       "id": "commet-41f013",
       "locationSet": {"include": ["it"]},
+      "matchNames": ["commet"],
       "tags": {
         "brand": "Comet",
         "brand:wikidata": "Q3777340",


### PR DESCRIPTION
The name of that brand it's wrong.

See Wikidata item https://www.wikidata.org/wiki/Q3777340
and official website: https://www.comet.it/