### PR TITLE
Added Innogy Bücherschrank, RWE Bücherschrank, Westenergie Bücherschrank

### DIFF
--- a/data/brands/amenity/public_bookcase.json
+++ b/data/brands/amenity/public_bookcase.json
@@ -202,6 +202,17 @@
         "name:en": "Trail Library",
         "name:he": "ספריית שביל"
       }
+    },
+    {
+      "displayName": "Westenergie Bücherschrank",
+      "id": "westenergiebucherschrank",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "amenity": "public_bookcase",
+        "brand": "Westenergie Bücherschrank",
+        "brand:wikidata": "Q104871107",
+        "name": "Westenergie Bücherschrank"
+      }
     }
   ]
 }

--- a/data/brands/amenity/public_bookcase.json
+++ b/data/brands/amenity/public_bookcase.json
@@ -69,6 +69,17 @@
       }
     },
     {
+      "displayName": "Innogy Bücherschrank",
+      "id": "innogybucherschrank",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "amenity": "public_bookcase",
+        "brand": "Innogy Bücherschrank",
+        "brand:wikidata": "Q2124721",
+        "name": "Innogy Bücherschrank"
+      }
+    },
+    {
       "displayName": "KinderzwerfboekStation",
       "id": "kinderzwerfboekstation-2091e3",
       "locationSet": {"include": ["nl"]},

--- a/data/brands/amenity/public_bookcase.json
+++ b/data/brands/amenity/public_bookcase.json
@@ -166,6 +166,17 @@
       }
     },
     {
+      "displayName": "RWE Bücherschrank",
+      "id": "rwebucherschrank",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "amenity": "public_bookcase",
+        "brand": "RWE Bücherschrank",
+        "brand:wikidata": "Q138133",
+        "name": "RWE Bücherschrank"
+      }
+    },
+    {
       "displayName": "Street Library",
       "id": "streetlibrary-ff483e",
       "locationSet": {"include": ["au"]},


### PR DESCRIPTION
Adds Innogy Bücherschrank, RWE Bücherschrank, Westenergie Bücherschrank.

Mapped:
* Innogy Bücherschrank (2/150+) (operator/funder: municipal / city government, local inhabitants)
* RWE Bücherschrank (11/38+) (operator/funder: municipal / city government, local inhabitants)
* Westenergie Bücherschrank (2/353) (operator/funder: municipal / city government, local inhabitants)

All should have a plaque.
Westenergie has at least two with municipal partner company NEW (identical). Would move any partners to `description`.
Innogy (and RWE) bookcases may or may not be part of Westenergie network, but signed name(/brand) remains the same.
So, I do not know if it is worth 'wrongly' adding Westenergie wikidata to 'merged' Innogy bookcase brand.