### PR TITLE
Add Wiener Städtische Versicherung (AT)

### DIFF
--- a/data/brands/office/insurance.json
+++ b/data/brands/office/insurance.json
@@ -35,6 +35,16 @@
         "short_name": "AAA"
       }
     },
+        {
+      "displayName": "Wiener Städtische Versicherung",
+      "locationSet": {"include": ["at"]},
+      "tags": {
+        "brand": "Wiener Städtische Versicherung",
+        "brand:wikidata": "Q16088560",
+        "name": "Wiener Städtische Versicherung",
+        "office": "insurance",
+      }
+    },
     {
       "displayName": "Aésio Mutuelle",
       "id": "aesiomutuelle-6ae572",


### PR DESCRIPTION
Currently 137 offices in Austria (https://www.wienerstaedtische.at/standorte.html)