### PR TITLE
Update bank.json - Added Krungsri as alt_name

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -15246,13 +15246,15 @@
       "displayName": "กรุงศรี",
       "id": "983e55-3229f1",
       "locationSet": {"include": ["th"]},
-      "note": "Is this 'Krungsri' actually Bank of Ayudhya?",
       "tags": {
+        "alt_name:en": "Krungsri",
         "amenity": "bank",
         "brand": "กรุงศรี",
+        "brand:en": "Bank of Ayudhya",
         "brand:th": "กรุงศรี",
         "brand:wikidata": "Q782537",
         "name": "กรุงศรี",
+        "name:en": "Bank of Ayudhya"",
         "name:th": "กรุงศรี"
       }
     },


### PR DESCRIPTION
From what I can see online Krungsri is what Bank of Ayudhya is commonly referred to. Thus I believe it could be put at as an alt_name. I could see an argument for it being short_name, but when I hear short name I think of an abbreviated "name" or truncated "name".