### PR TITLE
Adding Fisker Inc. as new automotive brand

### DIFF
--- a/data/brands/shop/car.json
+++ b/data/brands/shop/car.json
@@ -366,6 +366,16 @@
       }
     },
     {
+      "displayName": "Fisker",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "Fisker Inc.",
+        "brand:wikidata": "Q1420893",
+        "name": "Fisker",
+        "shop": "car"
+      }
+    },
+    {
       "displayName": "Ford",
       "id": "ford-13eeb7",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Recently Henrik Fisker has returned with a new incarnation of his car brand Fisker, now named Fisker Inc. It seems to get some traction in my area (West Europe) now, so probably a good time to add the brand to NSI.