### PR TITLE
Update Big C Mini

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -3024,13 +3024,14 @@
       }
     },
     {
-      "displayName": "Mini Big C",
+      "displayName": "Big C Mini",
       "id": "minibigc-f572b3",
       "locationSet": {"include": ["th"]},
+      "matchNames": ["bcm"],
       "tags": {
-        "brand": "Mini Big C",
+        "brand": "Big C Mini",
         "brand:wikidata": "Q858665",
-        "name": "Mini Big C",
+        "name": "Big C Mini",
         "shop": "convenience"
       }
     },

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -3027,7 +3027,7 @@
       "displayName": "Big C Mini",
       "id": "minibigc-f572b3",
       "locationSet": {"include": ["th"]},
-      "matchNames": ["bcm"],
+      "matchNames": ["bcm", "Mini Big C"],
       "tags": {
         "brand": "Big C Mini",
         "brand:wikidata": "Q858665",


### PR DESCRIPTION
Mini Big C is referred to as Big C Mini on their website (https://corporate.bigc.co.th/callchatshop?lang=en) instead of Mini Big C.

Also, in their store list, the store name sometimes starts with BCM. Therefore, adding BCM to the match names. See https://corporate.bigc.co.th/include/get_store.php.