### PR TITLE
Change Tesco Lotus Express to Lotus's go fresh

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -4555,12 +4555,13 @@
       }
     },
     {
-      "displayName": "Tesco Lotus Express",
+      "displayName": "Lotus's go fresh",
       "id": "tescolotusexpress-f572b3",
-      "locationSet": {"include": ["th"]},
+      "locationSet": {"include": ["th", "my"]},
       "tags": {
-        "brand": "Tesco Lotus Express",
-        "name": "Tesco Lotus Express",
+        "brand": "Lotus's go fresh",
+        "brand:wikidata": "Q125937967",
+        "name": "Lotus's go fresh",
         "shop": "convenience"
       }
     },

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -4558,6 +4558,9 @@
       "displayName": "Lotus's go fresh",
       "id": "tescolotusexpress-f572b3",
       "locationSet": {"include": ["th", "my"]},
+      "matchNames": [
+        "Tesco Lotus Express"
+      ],
       "tags": {
         "brand": "Lotus's go fresh",
         "brand:wikidata": "Q125937967",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -31,6 +31,18 @@
   },
   "items": [
     {
+      "displayName": "Lotus's go fresh",
+      "locationSet": {"include": ["th", "my"]},
+      "matchNames": [
+        "Tesco Lotus Express"
+      ],
+      "tags": {
+        "brand": "Lotus's go fresh",
+        "brand:wikidata": "Q125937967",
+        "name": "Lotus's go fresh",
+        "shop": "supermarket"
+      }
+    {
       "displayName": "365discount",
       "id": "365discount-072052",
       "locationSet": {"include": ["dk"]},


### PR DESCRIPTION
From this [conversation](https://community.openstreetmap.org/t/name-for-lotuss-go-fresh-supermarkets/4117/5) it seems like Lotus's go fresh can be big enough to be considered a supermarket as well as a convenience store. Thus I added it to both. 

Then from [Wikipedia](https://th.wikipedia.org/wiki/%E0%B9%82%E0%B8%A5%E0%B8%95%E0%B8%B1%E0%B8%AA_(%E0%B8%AB%E0%B9%89%E0%B8%B2%E0%B8%87%E0%B8%AA%E0%B8%A3%E0%B8%A3%E0%B8%9E%E0%B8%AA%E0%B8%B4%E0%B8%99%E0%B8%84%E0%B9%89%E0%B8%B2)#%22%E0%B9%82%E0%B8%A5%E0%B8%95%E0%B8%B1%E0%B8%AA%E0%B8%AA%E0%B9%8C%22_%E0%B8%A0%E0%B8%B2%E0%B8%A2%E0%B9%83%E0%B8%95%E0%B9%89%E0%B8%81%E0%B8%A5%E0%B8%B8%E0%B9%88%E0%B8%A1%E0%B8%8B%E0%B8%B5%E0%B8%9E%E0%B8%B5) we can see that once CP Group took control they started by removing Tesco from the names. I put it under match names as some stores may still have the sign up. Not sure how long that takes to completely change all shops.