### PR TITLE
Update mall.json - Added Central Pattana

### DIFF
--- a/data/brands/shop/mall.json
+++ b/data/brands/shop/mall.json
@@ -16,9 +16,15 @@
       ],
       "tags": {
         "alt_name": "Central",
+        "alt_name:en": "Central",
+        "alt_name:th": "ศูนย์กลาง",
         "brand": "Central Pattana",
+        "brand:en": "Central Pattana",
+        "brand:th": "เซ็นทรัลพัฒนา",
         "brand:wikidata": "Q5061633",
         "name": "Central Pattana",
+        "name:en": "Central Pattana",
+        "name:th": "เซ็นทรัลพัฒนา",
         "shop": "mall"
       }
     },

--- a/data/brands/shop/mall.json
+++ b/data/brands/shop/mall.json
@@ -9,6 +9,20 @@
   },
   "items": [
     {
+      "displayName": "Central Pattana",
+      "locationSet": {"include": ["th"]},
+      "matchNames": [
+        "Central Plaza"
+      ],
+      "tags": {
+        "alt_name": "Central",
+        "brand": "Central Pattana",
+        "brand:wikidata": "Q5061633",
+        "name": "Central Pattana",
+        "shop": "mall"
+      }
+    },
+    {
       "displayName": "CityMall",
       "id": "citymall-ff995d",
       "locationSet": {"include": ["ph"]},


### PR DESCRIPTION
Could use some help. I am not exactly sure if the brand should be Central and maybe Central Pattana should be the operator. But it seems like Central Pattana really only owns the Central Shopping Malls. Also CentralPlaza may be on a lot of the signs, but officially they got rid of the Plaza part to simplify the name. All the wikipedia pages of the malls themselves have just `Central <city/area>`. 

Also if we decide on brand should be Central will I then need to make another wikidata page for the brand itself under Central Pattana (which itself is a subsidiary of Central Group)?