### PR TITLE
added Milton Park to operater/amenity/community_centre.json

### DIFF
--- a/data/operators/amenity/community_centre.json
+++ b/data/operators/amenity/community_centre.json
@@ -278,6 +278,16 @@
       }
     },
     {
+      "displayName":"Milton Park",
+      "locationSet": {"include": ["ca"]},
+      "tags": {
+        "amenity": "community_centre",
+        "operator": "Milton Park",
+        "operator:type": "municipal_park",
+        "operator:wikidata": "Q425057"
+      }
+    },
+    {
       "displayName": "Montpellier",
       "id": "montpellier-e4e4f8",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
this addresses  issue #9416 

```
    {
      "displayName":"Milton Park",
      "locationSet": {"include": ["ca"]},
      "tags": {
        "amenity": "community_centre",
        "operator": "Milton Park",
        "operator:type": "municipal_park",
        "operator:wikidata": "Q425057"
      }
    },
```