### PR TITLE
added City of London to operators/amenity/community_center.json

### DIFF
--- a/data/operators/amenity/community_centre.json
+++ b/data/operators/amenity/community_centre.json
@@ -141,6 +141,16 @@
       }
     },
     {
+      "displayName": "City of London",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "amenity": "community_centre",
+        "operator": "City of London",
+        "operator:wikidata": "Q23311"
+
+      }
+    },
+    {
       "displayName": "City of Los Angeles",
       "id": "cityoflosangeles-e4e4f8",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
addresses #9414

```
    {
      "displayName": "City of London",
      "locationSet": {"include": ["gb"]},
      "tags": {
        "amenity": "community_centre",
        "operator": "City of London",
        "operator:wikidata": "Q23311"

      }
    },
```


