### PR TITLE
Added Italian houseware store chain Risparmio Casa

### DIFF
--- a/data/brands/shop/houseware.json
+++ b/data/brands/shop/houseware.json
@@ -552,6 +552,16 @@
       }
     },
     {
+      "displayName": "Risparmio Casa",
+      "locationSet": {"include": ["it"]},
+      "tags": {
+        "brand": "Risparmio Casa",
+        "brand:wikidata": "Q125936928",
+        "name": "Risparmio Casa",
+        "shop": "houseware"
+      }
+    },
+    {
       "displayName": "Sheet Street",
       "id": "sheetstreet-4abcbe",
       "locationSet": {"include": ["za"]},


### PR DESCRIPTION
Risparmio Casa is an houseware store chain with more than 200 stores in Italy.