### PR TITLE
Update doityourself.json name=Hornbach brand=HORNBACH

### DIFF
--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -711,7 +711,7 @@
       }
     },
     {
-      "displayName": "HORNBACH",
+      "displayName": "Hornbach",
       "id": "hornbach-92b1c1",
       "locationSet": {
         "include": [
@@ -729,7 +729,7 @@
       "tags": {
         "brand": "HORNBACH",
         "brand:wikidata": "Q685926",
-        "name": "HORNBACH",
+        "name": "Hornbach",
         "shop": "doityourself"
       }
     },


### PR DESCRIPTION
Partly revert of https://github.com/osmlab/name-suggestion-index/commit/8a843887e836b172c10d7f2800423814757292e3#diff-f5648f1a13640edcf9fdba0568655f2c139e959ff8a957216698e3b1c6f6588b

See also: https://github.com/osmlab/name-suggestion-index/issues/5510

See also how (spelling lower-case) it is used in the press:  https://archive.is/gCsIK

See also: https://taghistory.raifer.tech/?#***/name/Hornbach&***/name/HORNBACH

![grafik](https://github.com/osmlab/name-suggestion-index/assets/165812228/6db71e06-4b4a-4645-82cb-3f4062c86e51)
