### PR TITLE
Add Forevers from Latvia into butcher.json

### DIFF
--- a/data/brands/shop/butcher.json
+++ b/data/brands/shop/butcher.json
@@ -60,6 +60,16 @@
       }
     },
     {
+      "displayName": "Forevers",
+      "locationSet": {"include": ["lv"]},
+      "tags": {
+        "brand": "Forevers",
+        "brand:wikidata": "Q65297361",
+        "name": "Forevers",
+        "shop": "butcher"
+      }
+    },
+    {
       "displayName": "føtex Slagter",
       "id": "fotexslagter-4aef2d",
       "locationSet": {"include": ["dk"]},


### PR DESCRIPTION
Butcher shop Forevers from Latvia has already 43 shops mapped on the OSM (and based on data from their site total of more than a hundred)