### PR TITLE
Add Rīgas Satiksme ticket stations to vending_machine.json

### DIFF
--- a/data/operators/amenity/vending_machine.json
+++ b/data/operators/amenity/vending_machine.json
@@ -114,6 +114,19 @@
       }
     },
     {
+      "displayName": "Rīgas Satiksme",
+      "locationSet": {"include": ["lv"]},
+      "matchNames": [
+        "E-talon"
+      ],
+      "tags": {
+        "amenity": "vending_machine",
+        "operator": "Rīgas Satiksme",
+        "operator:wikidata": "Q2280274",
+        "vending": "public_transport_tickets"
+      }
+    },
+    {
       "displayName": "RingGo",
       "id": "ringgo-6fe21e",
       "locationSet": {"include": ["gb"]},


### PR DESCRIPTION
There are [already 33 mapped objects](https://overpass-turbo.eu/s/1M1v) (some without any name/operator, but they all are of this operator in Riga)

Based on information form the [site of operator](https://www.rigassatiksme.lv/en/tickets-and-e-ticket/ticket-trade-outlets/ticket-vending-machines/) there will be a couple more.