### PR TITLE
Adding British Columbian recycling collection centre

### DIFF
--- a/data/brands/amenity/recycling.json
+++ b/data/brands/amenity/recycling.json
@@ -394,6 +394,25 @@
         "owner:zh-Hant": "環境保護署",
         "recycling_type": "centre"
       }
+    },
+    {
+      "displayName": "Return-It",
+      "locationSet": {"include": ["ca-bc.geojson"]},
+      "matchNames": ["Return It","Bottle Depot"],
+      "tags": {
+        "amenity": "recycling",
+        "brand": "Return-It",
+        "brand:wikidata": "Q47508504",
+        "^name",
+        "operator:type": "private",
+        "recycling_type": "centre",
+        "recycling:beverage_cartons": "yes",
+        "recycling:cans": "yes",
+        "recycling:glass_bottles": "yes",
+        "recycling:plastic_bottles": "yes",
+        "Description": "A recycling collection centre where beverage containers can be returned for a cash refund. Some locations accept additional materials to be recycled.",
+        "Note": "All Return-It locations accept beverage containers and many accept additional materials. All locations are independently owned and operated in contract with Encorp Pacific (Canada)."
+      }
     }
   ]
 }


### PR DESCRIPTION
Return-It is the brand that all bottle recycling centres in BC operate under (~160 locations). Encorp Pacific (Canada) is the entity that owns this brand. Each location is independently owned and operated and has a unique name.