### PR TITLE
Split baltic supermarket Rimi into 4 items

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -3928,6 +3928,19 @@
       }
     },
     {
+      "displayName": "Rimi Express",
+      "locationSet": {
+        "include": ["ee", "lt", "lv"]
+      },
+      "matchTags": ["shop/supermarket"],
+      "tags": {
+        "brand": "Rimi",
+        "brand:wikidata": "Q3741108",
+        "name": "Rimi Express",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "Road Ranger",
       "id": "roadranger-f1e40b",
       "locationSet": {"include": ["us"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -6487,15 +6487,38 @@
       }
     },
     {
-      "displayName": "Rimi",
-      "id": "rimi-45f6bc",
+      "displayName": "Rimi Hyper",
       "locationSet": {
         "include": ["ee", "lt", "lv"]
       },
       "tags": {
         "brand": "Rimi",
         "brand:wikidata": "Q3741108",
-        "name": "Rimi",
+        "name": "Rimi Hyper",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "Rimi Super",
+      "locationSet": {
+        "include": ["ee", "lt", "lv"]
+      },
+      "tags": {
+        "brand": "Rimi",
+        "brand:wikidata": "Q3741108",
+        "name": "Rimi Super",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "Rimi Mini",
+      "locationSet": {
+        "include": ["ee", "lv"]
+      },
+      "tags": {
+        "brand": "Rimi",
+        "brand:wikidata": "Q3741108",
+        "name": "Rimi Mini",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
Rimi has four types of stores: Rimi Hyper, Rimi Super, Rimi Mini, and Rimi Express. They operate under same brand, but differ in size.

This leads to mappers erroneously agreeing for suggestion to "correct tags" by editor. For example, `name=Rimi Mini` is suggested to be changed to 
```
name=Rimi
branch=Mini
```
which is against recommendations for use of tag [`branch`](https://wiki.openstreetmap.org/wiki/Key:branch). Misuse can be seen [here](https://overpass-turbo.eu/s/1M1U).

---
A couple additional notes regarding changes: 
- Express fits description of `shop=convenience`, so I extracted it there, but added `"matchTags": ["shop/supermarket"]` to ease fixes,
- For some unknown to me reason Lithuania's branch is missing Rimi Mini kind of shops (can be seen [here](https://www.rimi.lt/parduotuves), as opposed to [ee](https://www.rimi.ee/kauplused) and [lv](https://www.rimi.lv/veikali) ones), so I excluded it from `locationSet` of that item.