### PR TITLE
Latvian grocery stores

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -4920,6 +4920,15 @@
       }
     },
     {
+      "displayName": "Vesko",
+      "locationSet": {"include": ["lv"]},
+      "tags": {
+        "brand": "Vesko",
+        "name": "Vesko",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "Viva",
       "id": "viva-856fe1",
       "locationSet": {"include": ["150"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -221,6 +221,16 @@
       }
     },
     {
+      "displayName": "Aibe",
+      "locationSet": {"include": ["lv"]},
+      "matchTags": ["shop/supermarket"],
+      "tags": {
+        "brand": "Aibe",
+        "name": "Aibe",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "Albert Heijn to go",
       "id": "albertheijntogo-f85122",
       "locationSet": {"include": ["nl"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1645,6 +1645,16 @@
       }
     },
     {
+      "displayName": "Elvi",
+      "locationSet": {"include": ["lv"]},
+      "tags": {
+        "brand": "Elvi",
+        "brand:wikidata": "Q20560513",
+        "name": "Elvi",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "Eni Shop",
       "id": "enishop-8b7ed5",
       "locationSet": {

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -3122,6 +3122,16 @@
       }
     },
     {
+      "displayName": "Mini top!",
+      "locationSet": {"include": ["lv"]},
+      "tags": {
+        "brand": "top!",
+        "brand:wikidata": "Q20803907",
+        "name": "Mini top!",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "miniピアゴ",
       "id": "minipiago-652b3e",
       "locationSet": {"include": ["jp"]},
@@ -4640,6 +4650,16 @@
         "brand": "Tommy",
         "brand:wikidata": "Q12643718",
         "name": "Tommy",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "top!",
+      "locationSet": {"include": ["lv"]},
+      "tags": {
+        "brand": "top!",
+        "brand:wikidata": "Q20803907",
+        "name": "top!",
         "shop": "convenience"
       }
     },

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -2482,6 +2482,16 @@
       }
     },
     {
+      "displayName": "Elvi",
+      "locationSet": {"include": ["lv"]},
+      "tags": {
+        "brand": "Elvi",
+        "brand:wikidata": "Q20560513",
+        "name": "Elvi",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "EMTÉ",
       "id": "emte-5811b5",
       "locationSet": {"include": ["nl"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -624,6 +624,15 @@
       }
     },
     {
+      "displayName": "Beta",
+      "locationSet": {"include": ["lv"]},
+      "tags": {
+        "brand": "Beta",
+        "name": "Beta",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Bhat-Bhateni Super Market",
       "id": "bhatbhatenisupermarket-e40c68",
       "locationSet": {"include": ["np"]},


### PR DESCRIPTION
Added Latvian grocery store networks: top!, Aibe, Elvi, Beta and Vesco. All have more than 30 locations open.

Highlights of added:
- spelling of `top!` might be a bit controversial, but it was agreed on in local community,
- Latvian Aibe is a "daughter" of Lithuanian Aibė, but due distict spelling, it's in a separate item,
- Elvi exists in two separate forms: convenience store and supermarket. It operates under same brand name, and cannot be organically pushed into a singe type, thus two items added.