### PR TITLE
Fix romantik hotel name

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -5344,7 +5344,7 @@
       "displayName": "Romantik",
       "id": "romantikhotelsandrestaurants-2fabb0",
       "locationSet": {"include": ["001"]},
-      "matchNames": ["Romantik Hotels & Restaurants"]
+      "matchNames": ["Romantik Hotels & Restaurants"],
       "tags": {
         "amenity": "restaurant",
         "brand": "Romantik Hotels & Restaurants",

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -5341,14 +5341,15 @@
       }
     },
     {
-      "displayName": "Romantik Hotels & Restaurants",
+      "displayName": "Romantik",
       "id": "romantikhotelsandrestaurants-2fabb0",
       "locationSet": {"include": ["001"]},
+      "matchNames": ["Romantik Hotels & Restaurants"]
       "tags": {
         "amenity": "restaurant",
         "brand": "Romantik Hotels & Restaurants",
         "brand:wikidata": "Q126075497",
-        "name": "Romantik Hotels & Restaurants"
+        "name": "Romantik Restaurant"
       }
     },
     {

--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -947,7 +947,9 @@
       "tags": {
         "brand": "Delta Hotels",
         "brand:wikidata": "Q5254663",
-        "name": "Delta Hotels",
+        "name": "Delta Hotels",SELECT DISTINCT brand FROM team_coral.top100lb_top10c_category_qcode
+-- WHERE country == "THA";
+
         "tourism": "hotel"
       }
     },
@@ -2999,13 +3001,14 @@
       }
     },
     {
-      "displayName": "Romantik Hotels & Restaurants",
+      "displayName": "Romantik",
       "id": "romantikhotelsandrestaurants-779ccb",
       "locationSet": {"include": ["001"]},
+      "matchNames": ["Romantik", "Romantik Hotels & Restaurants"]
       "tags": {
         "brand": "Romantik Hotels & Restaurants",
         "brand:wikidata": "Q126075497",
-        "name": "Romantik Hotels & Restaurants",
+        "name": "Romantik Hotel",
         "tourism": "hotel"
       }
     },

--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -42,7 +42,7 @@
           "at",
           "cz",
           "de",
-          "dk",
+          "dk","matchNames": ["Romantik", "Romantik Hotels & Restaurants"]
           "gb",
           "hu",
           "it",
@@ -3004,7 +3004,7 @@
       "displayName": "Romantik",
       "id": "romantikhotelsandrestaurants-779ccb",
       "locationSet": {"include": ["001"]},
-      "matchNames": ["Romantik", "Romantik Hotels & Restaurants"]
+      "matchNames": ["Romantik Hotels & Restaurants"],
       "tags": {
         "brand": "Romantik Hotels & Restaurants",
         "brand:wikidata": "Q126075497",

--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -42,7 +42,7 @@
           "at",
           "cz",
           "de",
-          "dk","matchNames": ["Romantik", "Romantik Hotels & Restaurants"]
+          "dk",
           "gb",
           "hu",
           "it",
@@ -947,9 +947,7 @@
       "tags": {
         "brand": "Delta Hotels",
         "brand:wikidata": "Q5254663",
-        "name": "Delta Hotels",SELECT DISTINCT brand FROM team_coral.top100lb_top10c_category_qcode
--- WHERE country == "THA";
-
+        "name": "Delta Hotels",
         "tourism": "hotel"
       }
     },


### PR DESCRIPTION
ref: https://github.com/osmlab/name-suggestion-index/pull/9536
I think the brand itself should be Romantik Hotels & Restaurants as that is what the Website and Wikidata page has. On the website, "Romantik" is in larger font than "Hotels & Restaurants", but I think it is not a big enough difference that Hotels & Restaurants should be taken off completely.

Also should the name be Romantik Hotel and Romantik Restaurant? The [website](https://www.romantikhotels.com/en/hotels/#/map/) has Hotels named as `Romantik Hotel <City>`. Thus not sure what to do.