### PR TITLE
Move "CoCo壱番屋" to restaurant from fast_food; Set cuisine.

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -1805,26 +1805,6 @@
       }
     },
     {
-      "displayName": "CoCo壱番屋",
-      "id": "cocoichibanya-3e7699",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "fast_food",
-        "brand": "CoCo壱番屋",
-        "brand:en": "CoCo ICHIBANYA",
-        "brand:ja": "CoCo壱番屋",
-        "brand:wikidata": "Q5986105",
-        "cuisine": "japanese",
-        "name": "CoCo壱番屋",
-        "name:en": "CoCo ICHIBANYA",
-        "name:ja": "CoCo壱番屋",
-        "short_name": "ココイチ",
-        "short_name:en": "CoCoICHI",
-        "short_name:ja": "ココイチ",
-        "takeaway": "yes"
-      }
-    },
-    {
       "displayName": "Cœur de Blé",
       "id": "coeurdeble-e4dee6",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -1452,7 +1452,7 @@
         "brand:en": "CoCo Ichibanya",
         "brand:ja": "CoCo壱番屋",
         "brand:wikidata": "Q5986105",
-        "cuisine": "japanese",
+        "cuisine": "curry;japanese",
         "name": "CoCo Ichibanya",
         "name:en": "CoCo Ichibanya",
         "name:ja": "CoCo壱番屋",
@@ -1473,6 +1473,26 @@
       }
     },
     {
+      "displayName": "CoCo壱番屋",
+      "id": "cocoichibanya-36ca8e",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "CoCo壱番屋",
+        "brand:en": "CoCo ICHIBANYA",
+        "brand:ja": "CoCo壱番屋",
+        "brand:wikidata": "Q5986105",
+        "cuisine": "curry;japanese",
+        "name": "CoCo壱番屋",
+        "name:en": "CoCo ICHIBANYA",
+        "name:ja": "CoCo壱番屋",
+        "short_name": "ココイチ",
+        "short_name:en": "CoCoICHI",
+        "short_name:ja": "ココイチ",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "CoCo壹番屋咖喱",
       "id": "cocoichibanya-2b8b0b",
       "locationSet": {
@@ -1486,7 +1506,7 @@
         "brand:ja": "CoCo壱番屋",
         "brand:wikidata": "Q5986105",
         "brand:zh": "CoCo壹番屋咖喱",
-        "cuisine": "japanese",
+        "cuisine": "curry;japanese",
         "name": "CoCo壹番屋咖喱",
         "name:en": "CoCo Ichibanya",
         "name:ja": "CoCo壱番屋",


### PR DESCRIPTION
In Japan, "CoCo ICHIBANYA" is considered a restaurant in OSM terms, since in most cases there are seats, waiter service, and the serving is not very fast.

see: https://github.com/osmlab/name-suggestion-index/wiki/Judge-Case#is-an-amenity-a-restaurant-or-fast_food

and specify cuisine to (Japanese) curry.