### PR TITLE
Update car_rental.json - Added Cicar

### DIFF
--- a/data/brands/amenity/car_rental.json
+++ b/data/brands/amenity/car_rental.json
@@ -7,6 +7,17 @@
   },
   "items": [
     {
+      "displayName": "CICAR",
+      "locationSet": {"include": ["es"]},
+      "matchNames": ["Canary Islands Car", "Cabrera Medina"],
+      "tags": {
+        "amenity": "car_rental",
+        "brand": "CICAR",
+        "brand:wikidata": "Q126181047",
+        "name": "CICAR"
+      }
+    },
+    {
       "displayName": "ADA",
       "id": "ada-d9531a",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
A lot of the shops have signs that say "Cabrera Medina" as well as "CICAR", which is why it is in matchNames. In 1989 CICAR joined the Cabrera Medina group, to expand into other Canary Islands.