### PR TITLE
Update hotel.json - Added Silken Hoteles

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -19,6 +19,17 @@
   },
   "items": [
     {
+      "displayName": "Silken Hoteles",
+      "locationSet": {"include": ["es"]},
+      "matchNames": ["Silken"],
+      "tags": {
+        "brand": "Silken Hoteles",
+        "brand:wikidata": "Q17088330",
+        "name": "Silken",
+        "tourism": "hotel"
+      }
+    },
+    {
       "displayName": "7天酒店",
       "id": "7daysinn-af4cd2",
       "locationSet": {"include": ["cn"]},


### PR DESCRIPTION
On the hotels list [here](https://www.hoteles-silken.com/es/hoteles-destinos/) they do not have Silken in the names, but when you click on it it does on the Hotel webpage for half of them. I then checked google street view and All of them either have Silken in big human sized letters on the building with the name or at the very least have it in normal letters near the front doors. Google also has Silken in the name for all of the ones that I checked as well.