### PR TITLE
Extract DPD Latvia in parcel_locker.json

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -266,6 +266,19 @@
       }
     },
     {
+      "displayName": "DPD",
+      "locationSet": {"include": ["lv"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "DPD",
+        "brand:wikidata": "Q541030",
+        "operator": "DPD Latvia",
+        "operator:wikidata": "Q125973085",
+        "parcel_pickup": "yes",
+        "parcel_mail_in": "yes"
+      }
+    },
+    {
       "displayName": "DPD Pickup Station",
       "id": "dpdpickupstation-63abf7",
       "locationSet": {
@@ -287,7 +300,6 @@
           "kz",
           "lt",
           "lu",
-          "lv",
           "nl",
           "pl",
           "pt",


### PR DESCRIPTION
Parcel lockers of DPD are not usually called DPD Pickup Station in Latvia.

Extracted instance for Latvia into a separate item, and since it's Latvia specific now, added DPD Latvia as operator.

Also @richlv confirmed at local office that all their parcel lockers are accepting packages, thus added `parcel_mail_in` tag.