### PR TITLE
Add Bank BJB

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -2293,6 +2293,16 @@
         "name": "Bank Austria"
       }
     },
+        {
+      "displayName": "Bank BJB",
+      "locationSet": {"include": ["id"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "Bank BJB",
+        "brand:wikidata": "Q12474472",
+        "name": "Bank BJB"
+      }
+    },
     {
       "displayName": "Bank BPS",
       "id": "bankbps-68054b",


### PR DESCRIPTION
Please add Bank BJB, a government-owned bank in West Java and Banten, Indonesia.