### PR TITLE
Add Budbee parcel locker (#7174)

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -159,6 +159,21 @@
       }
     },
     {
+      "displayName": "Budbee",
+      "id": "budbee-5x94ak",
+      "locationSet": {
+        "include": ["be", "dk", "fi", "nl", "se"]
+      },
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "Budbee",
+        "brand:wikidata": "Q123582538",
+        "name": "Budbee",
+        "parcel_mail_in": "returns_only",
+        "parcel_pickup": "yes"
+      }
+    },
+    {
       "displayName": "CityPaq",
       "id": "citypaq-0d29dc",
       "locationSet": {"include": ["es"]},


### PR DESCRIPTION
https://budbee.com/how-budbee-works/

Fixes #7174 

> Founded in 2016, Budbee is a Sweden-based tech company with the mission to make online shopping easier. Charged with a self-learning system and bespoke algorithms, Budbee reaches more than 40 million people in Sweden, Finland, Denmark, Belgium, and the Netherlands - either through the extensive network of parcel lockers or with home deliveries.