### PR TITLE
fix: IDs and sorting

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -160,7 +160,7 @@
     },
     {
       "displayName": "Budbee",
-      "id": "budbee-5x94ak",
+      "id": "budbee-8c9d85",
       "locationSet": {
         "include": ["be", "dk", "fi", "nl", "se"]
       },

--- a/data/brands/shop/wholesale.json
+++ b/data/brands/shop/wholesale.json
@@ -186,23 +186,8 @@
       }
     },
     {
-      "displayName": "Metro (България)",
-      "locationSet": {
-        "include": [
-          "bg"
-        ]
-      },
-      "matchNames": ["metro cash & carry"],
-      "tags": {
-        "brand": "Metro",
-        "brand:wikidata": "Q13610282",
-        "name": "Metro",
-        "shop": "wholesale"
-      }
-    },
-    {
       "displayName": "METRO",
-      "id": "metro-101fbc",
+      "id": "metro-09b7b7",
       "locationSet": {
         "include": [
           "at",
@@ -228,6 +213,18 @@
         "brand": "METRO",
         "brand:wikidata": "Q13610282",
         "name": "METRO",
+        "shop": "wholesale"
+      }
+    },
+    {
+      "displayName": "Metro (България)",
+      "id": "metro-551edc",
+      "locationSet": {"include": ["bg"]},
+      "matchNames": ["metro cash & carry"],
+      "tags": {
+        "brand": "Metro",
+        "brand:wikidata": "Q13610282",
+        "name": "Metro",
         "shop": "wholesale"
       }
     },


### PR DESCRIPTION
In #9652 I had accidentally entered a self-generated ID that was not a
base64 value. Hence it contained invalid characters. This PR fixes that
with running `npm run build` and sorts the wholesale shops JSON as well