### PR TITLE
Update DHL Poststation wikidata identifier

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -276,7 +276,7 @@
       "tags": {
         "amenity": "parcel_locker",
         "brand": "DHL Poststation",
-        "brand:wikidata": "Q1766703",
+        "brand:wikidata": "Q123120984",
         "operator": "DHL",
         "operator:wikidata": "Q489815",
         "parcel_mail_in": "yes"


### PR DESCRIPTION
`Q1766703` Refers to "DHL Packstation" even though there is an actual wikidata identifier for "DHL Poststation".

A side effect of reusing the same wikidata identifier for both entities is that iD suggests renaming Poststations to Packstations.