### PR TITLE
Euroapotheka

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -1198,6 +1198,7 @@
       "tags": {
         "amenity": "pharmacy",
         "brand": "Euroaptieka",
+        "brand:wikidata": "Q124713990",
         "healthcare": "pharmacy",
         "name": "Euroaptieka"
       }

--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -1183,7 +1183,7 @@
     {
       "displayName": "Euroapteek",
       "id": "euroapteek-f5140f",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["ee"]},
       "tags": {
         "amenity": "pharmacy",
         "brand": "Euroapteek",


### PR DESCRIPTION
Added wikidata entry for Euroaptieka (LV subsidiary of Euroapotheka).
Changed location for Euroapteek (EE subsidiary of Euroapotheka).