### PR TITLE
Add Virši fuel stations and convenience stores

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6020,6 +6020,16 @@
       }
     },
     {
+      "displayName": "Virši",
+      "locationSet": {"include": ["lv"]},
+      "tags": {
+        "amenity": "fuel",
+        "brand": "Virši",
+        "brand:wikidata": "Q50378789",
+        "name": "Virši"
+      }
+    },
+    {
       "displayName": "Vito",
       "id": "vito-3772a0",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5032,6 +5032,16 @@
       }
     },
     {
+      "displayName": "Virši",
+      "locationSet": {"include": ["lv"]},
+      "tags": {
+        "amenity": "fuel",
+        "brand": "Virši",
+        "brand:wikidata": "Q50378789",
+        "name": "Virši"
+      }
+    },
+    {
       "displayName": "Viva",
       "id": "viva-856fe1",
       "locationSet": {"include": ["150"]},


### PR DESCRIPTION
Fuel stations and shops are operated by company "Virši-A" under the brand Virši. `brand:wikidata` links to the entry for "Virši-A".

Currently 65 fuels station and 18 shops are mapped.