### PR TITLE
Added Latvijas Nafta and Latvijas Propāna Gāze fuel stations

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -3146,6 +3146,28 @@
       }
     },
     {
+      "displayName": "Latvijas Nafta",
+      "locationSet": {"include": ["lv"]},
+      "tags": {
+        "amenity": "fuel",
+        "brand": "Latvijas Nafta",
+        "brand:wikidata": "Q104429461",
+        "name": "Latvijas Nafta"
+      }
+    },
+    {
+      "displayName": "Latvijas Propāna Gāze",
+      "locationSet": {"include": ["lv"]},
+      "matchNames": ["LPG"],
+      "tags": {
+        "amenity": "fuel",
+        "brand": "Latvijas Propāna Gāze",
+        "brand:wikidata": "Q104427357",
+        "fuel:lpg": "yes",
+        "name": "Latvijas Propāna Gāze"
+      }
+    },
+    {
       "displayName": "Laugfs",
       "id": "laugfs-0d1ef7",
       "locationSet": {"include": ["lk"]},


### PR DESCRIPTION
Nationally branded fuel and gas stations.
Both have ~30 locations mapped (currently with naming issues of different levels)