### PR TITLE
Add Smartpost by Itella for Baltic countries

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -932,6 +932,18 @@
       }
     },
     {
+      "displayName": "Smartpost",
+      "locationSet": {"include": ["ee", "lt", "lv"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "Smartpost",
+        "brand:wikidata": "Q7543889",
+        "operator": "Itella",
+        "parcel_mail_in": "yes",
+        "parcel_pickup": "yes"
+      }
+    },
+    {
       "displayName": "Speedy",
       "id": "speedy-8234c4",
       "locationSet": {"include": ["bg"]},


### PR DESCRIPTION
This is the same parcel locker brand as one existing in Finland, but in these three countries it is operated by Itella (where as for Finland I think it's a Posti)