### PR TITLE
Remove entries replaced by Metrorower, add Metrorower

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -1175,22 +1175,6 @@
       }
     },
     {
-      "displayName": "City by bike",
-      "id": "citybybike-b14c52",
-      "locationSet": {
-        "include": [[19.0215852, 50.2598987, 10]]
-      },
-      "note": "Katowice in Poland",
-      "tags": {
-        "amenity": "bicycle_rental",
-        "brand": "City by bike",
-        "brand:wikidata": "Q24944379",
-        "network": "City by bike",
-        "network:wikidata": "Q24944379",
-        "operator": "Nextbike Polska"
-      }
-    },
-    {
       "displayName": "CityBike Vantaa Oy",
       "id": "citybikevantaaoy-5c40d5",
       "locationSet": {"include": ["fi"]},
@@ -1901,20 +1885,6 @@
       }
     },
     {
-      "displayName": "Kajteroz",
-      "id": "kajteroz-856447",
-      "locationSet": {
-        "include": [[18.9544466, 50.2978791, 7]]
-      },
-      "note": "Chorzów in Poland",
-      "tags": {
-        "amenity": "bicycle_rental",
-        "brand": "Kajteroz",
-        "network": "Kajteroz",
-        "operator": "Nextbike Polska"
-      }
-    },
-    {
       "displayName": "Kaliski Rower Miejski",
       "id": "kaliskirowermiejski-c154f1",
       "locationSet": {
@@ -2285,6 +2255,21 @@
         "network:wikidata": "Q62104274",
         "operator": "Nextbike",
         "operator:wikidata": "Q2351279"
+      }
+    },
+    {
+      "displayName": "Metrorower",
+      "locationSet": {
+        "include": [[19.006611, 50.249056, 40]]
+      },
+      "note": "bicycle rental system in the Upper Silesian-Zagłębie Metropolis",
+      "tags": {
+        "amenity": "bicycle_rental",
+        "brand": "Metrorower",
+        "brand:wikidata": "Q123507620",
+        "network": "Metrorower",
+        "network:wikidata": "Q123507620",
+        "operator": "Nextbike Polska"
       }
     },
     {
@@ -3272,22 +3257,6 @@
         "brand": "SMTC",
         "network": "SMTC",
         "operator": "Velogik"
-      }
-    },
-    {
-      "displayName": "Sosnowiecki Rower Miejski",
-      "id": "sosnowieckirowermiejski-613e83",
-      "locationSet": {
-        "include": [[19.1342944, 50.2780834]]
-      },
-      "note": "Sosnowiec in Poland",
-      "tags": {
-        "amenity": "bicycle_rental",
-        "brand": "Sosnowiecki Rower Miejski",
-        "brand:wikidata": "Q55754308",
-        "network": "Sosnowiecki Rower Miejski",
-        "network:wikidata": "Q55754308",
-        "operator": "Nextbike Polska"
       }
     },
     {


### PR DESCRIPTION
Hi!

I think title says it all, but in GZM Metropolis in Poland bike rental systems provided by cities were integrated into one - https://metrorower.transportgzm.pl/ 