### PR TITLE
Update Cumberland Building Society brand name

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -5563,7 +5563,8 @@
       }
     },
     {
-      "displayName": "The Cumberland (formerly Cumberland Building Society)",
+      "displayName": "The Cumberland",
+      "matchNames": ["cumberland building society"],
       "id": "cumberlandbuildingsociety-ef8e70",
       "locationSet": {
         "include": [


### PR DESCRIPTION
They're trading under The Cumberland, as can be seen on their website and Wikipedia. Physical stores have The Cumberland written on them. I can only assume they used Cumberland Building Society as a name in the past