### PR TITLE
新增/刪除臺灣的店家 Add/Remove some Taiwanese brands

### DIFF
--- a/data/brands/shop/pet.json
+++ b/data/brands/shop/pet.json
@@ -868,6 +868,20 @@
         "name:ja": "イオンペット",
         "shop": "pet"
       }
+    },
+    {
+      "displayName": "東森寵物雲",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "東森寵物雲",
+        "brand:en": "Eti Pets",
+        "brand:ja": "東森寵物雲",
+        "brand:wikidata": "Q116214921",
+        "name": "東森寵物雲",
+        "name:en": "Eti Pets",
+        "name:ja": "東森寵物雲",
+        "shop": "pet"
+      }
     }
   ]
 }

--- a/data/brands/shop/sports.json
+++ b/data/brands/shop/sports.json
@@ -1105,6 +1105,20 @@
       }
     },
     {
+      "displayName": "迪卡儂",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "迪卡儂",
+        "brand:en": "Decathlon",
+        "brand:wikidata": "Q509349",
+        "brand:zh": "迪卡儂",
+        "name": "迪卡儂",
+        "name:en": "Decathlon",
+        "name:zh": "迪卡儂",
+        "shop": "sports"
+      }
+    },
+    {
       "displayName": "阿迪达斯",
       "id": "adidas-fa2206",
       "locationSet": {

--- a/data/brands/shop/stationery.json
+++ b/data/brands/shop/stationery.json
@@ -348,6 +348,20 @@
         "name:en": "Komus",
         "shop": "stationery"
       }
+    },
+    {
+      "displayName": "九乘九文具專家",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "九乘九文具專家",
+        "brand:en": "9x9 Stationery!",
+        "brand:zh": "九乘九文具專家",
+        "brand:wikidata": "Q10878649",
+        "name": "九乘九文具專家",
+        "name:en": "9x9 Stationery!",
+        "name:zh": "九乘九文具專家",
+        "shop": "stationery"
+      }
     }
   ]
 }

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -876,21 +876,6 @@
       }
     },
     {
-      "displayName": "台灣之星",
-      "id": "tstar-4f600a",
-      "locationSet": {"include": ["tw"]},
-      "tags": {
-        "brand": "台灣之星",
-        "brand:en": "T Star",
-        "brand:wikidata": "Q4006966",
-        "brand:zh": "台灣之星",
-        "name": "台灣之星",
-        "name:en": "T Star",
-        "name:zh": "台灣之星",
-        "shop": "telecommunication"
-      }
-    },
-    {
       "displayName": "台灣大哥大",
       "id": "taiwanmobile-4f600a",
       "locationSet": {"include": ["tw"]},

--- a/data/brands/shop/travel_agency.json
+++ b/data/brands/shop/travel_agency.json
@@ -723,6 +723,68 @@
         "official_name:en": "Kinki Nippon Tourist",
         "shop": "travel_agency"
       }
+    },
+    {
+      "displayName": "雄獅旅遊",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "雄獅旅遊",
+        "brand:zh": "雄獅旅遊",
+        "brand:en": "Lion Travel",
+        "brand:wikidata": "Q10565787",
+        "name": "雄獅旅遊",
+        "name:zh": "雄獅旅遊",
+        "name:en": "Lion Travel",
+        "official_name": "雄獅旅行社",
+        "official_name:zh": "雄獅旅行社",
+        "shop": "travel_agency"
+      }
+    },
+    {
+      "displayName": "易遊網",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "易遊網",
+        "brand:zh": "易遊網",
+        "brand:en": "ezTravel",
+        "brand:wikidata": "Q11638632",
+        "name": "易遊網",
+        "name:zh": "易遊網",
+        "name:en": "ezTravel",
+        "official_name": "易遊網旅行社",
+        "shop": "travel_agency"
+      }
+    },
+    {
+      "displayName": "東南旅行社",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["SET"],
+      "tags": {
+        "brand": "東南旅行社",
+        "brand:en": "South East Travel",
+        "brand:zh": "東南旅行社",
+        "brand:wikidata": "Q11638632",
+        "name": "東南旅行社",
+        "name:zh": "東南旅行社",
+        "name:en": "South East Travel",
+        "shop": "travel_agency"
+      }
+    },
+    {
+      "displayName": "可樂旅遊",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "可樂旅遊",
+        "brand:zh": "可樂旅遊",
+        "brand:en": "Cola Tour",
+        "brand:wikidata": "Q11638632",
+        "name": "可樂旅遊",
+        "name:zh": "可樂旅遊",
+        "name:en": "Cola Tour",
+        "official_name": "可樂旅遊旅行社",
+        "official_name:zh": "可樂旅遊旅行社",
+        "shop": "travel_agency"
+      }
     }
   ]
 }

--- a/data/brands/shop/variety_store.json
+++ b/data/brands/shop/variety_store.json
@@ -1305,25 +1305,6 @@
       }
     },
     {
-      "displayName": "名創優品",
-      "id": "miniso-501f06",
-      "locationSet": {"include": ["tw"]},
-      "tags": {
-        "brand": "名創優品",
-        "brand:en": "Miniso",
-        "brand:wikidata": "Q20732498",
-        "brand:zh": "名創優品",
-        "brand:zh-Hans": "名创优品",
-        "brand:zh-Hant": "名創優品",
-        "name": "名創優品",
-        "name:en": "Miniso",
-        "name:zh": "名創優品",
-        "name:zh-Hans": "名创优品",
-        "name:zh-Hant": "名創優品",
-        "shop": "variety_store"
-      }
-    },
-    {
       "displayName": "名創優品 Miniso",
       "id": "miniso-264ade",
       "locationSet": {"include": ["hk", "mo"]},
@@ -1385,6 +1366,39 @@
         "name:en": "MUJI",
         "name:ja": "無印良品",
         "official_name:en": "Ryohin Keikaku",
+        "shop": "variety_store"
+      }
+    },
+    {
+      "displayName": "大創百貨",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "大創百貨",
+        "brand:en": "Daiso",
+        "brand:ja": "ダイソー",
+        "brand:wikidata": "Q12590862",
+        "brand:zh": "大創百貨",
+        "name": "大創百貨",
+        "name:en": "Daiso",
+        "name:ja": "ダイソー",
+        "name:zh": "大創百貨",
+        "shop": "variety_store"
+      }
+    },
+    {
+      "displayName": "台隆手創館",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["ハンズ"],
+      "matchTags": ["shop/department_store"],
+      "tags": {
+        "brand": "台隆手創館",
+        "brand:en": "Hands",
+        "brand:zh": "台隆手創館",
+        "brand:wikidata": "Q859212",
+        "name": "台隆手創館",
+        "name:en": "Hands",
+        "name:ja": "ハンズ",
+        "name:zh": "台隆手創館",
         "shop": "variety_store"
       }
     }


### PR DESCRIPTION
新增以下店家： (Add following brands)

`data/brands/shop/sports.json`: 迪卡儂 <https://decathlon.tw/store/taiwan_nantun_store>
`data/brands/shop/stationery.json`: 九乘九 <https://9x9stationery.com.tw/shops>
`data/brands/shop/travel_agency.json`: 雄獅 <https://info.liontravel.com/category/zh-tw/store/index>, 易遊網 <https://www.eztravel.com.tw/branches>, 東南 <https://www.settour.com.tw/info/retail>, 可樂 <https://www.colatour.com.tw/webDM/Portal/intro/store.html>
`data/brands/shop/pet.json`: 東森寵物雲 <https://www.etipets.com/store>
`data/brands/shop/variety_store.json`:大創百貨 <https://www.daiso.com.tw/Inside/Store>, 台隆手創館 <https://shopping.hands.com.tw/v2/Shop/StoreList/39906>

刪除以下店家： (Remove following brands)
* 名創優品 (`data/brands/shop/variety_store.json`) 在臺灣幾乎消失。<https://house.dailyview.tw/article/16768>, <https://www.ettoday.net/news/20220830/2327196.htm>新聞中的新竹巨城店還沒去，但台中車站店確定倒了。 (Almost disappeared from Taiwan. Haven't checked 新竹巨城店 on the news, but can confirm 台中車站店 is closed)
* 臺灣之星 (`data/brands/shop/telecommunication.json`): 併購完成，店家幾乎消失 <https://tstarcs.taiwanmobile.com/index.html> (Acquisition has finished and the brand is almost disappeared from Taiwan)
