### PR TITLE
Added Happy Casa houseware chain stores

### DIFF
--- a/data/brands/shop/houseware.json
+++ b/data/brands/shop/houseware.json
@@ -249,6 +249,16 @@
       }
     },
     {
+      "displayName": "Happy Casa",
+      "locationSet": {"include": ["it"]},
+      "tags": {
+        "brand": "Happy Casa",
+        "brand:wikidata": "Q126901260",
+        "name": "Happy Casa",
+        "shop": "houseware"
+      }
+    },
+    {
       "displayName": "Home Store + More",
       "id": "homestoremore-b52391",
       "locationSet": {"include": ["ie"]},


### PR DESCRIPTION
Wikidata item: https://www.wikidata.org/wiki/Q126901260

Store locator: https://shop.happycasastore.it/pages/punti-vendita