### PR TITLE
Add Fiiz Drinks (US Chain)

### DIFF
--- a/data/brands/shop/beverages.json
+++ b/data/brands/shop/beverages.json
@@ -52,6 +52,19 @@
       }
     },
     {
+      "displayName": "Fiiz Drinks",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "brand": "Fiiz Drinks",
+        "brand:wikidata": "Q124327883",
+        "drink:cola": "yes",
+        "drink:hot_chocolate": "yes",
+        "drink:soda": "yes",
+        "name": "Fiiz Drinks",
+        "shop": "beverages"
+      }
+    },
+    {
       "displayName": "Finkbeiner",
       "id": "finkbeiner-4a45fb",
       "locationSet": {


### PR DESCRIPTION
Locally known as a 'dirty soda' shop. I received no alternate suggestions for appropriate tags after asking on the OSM World Discord.