### PR TITLE
Update computer.json for LDLC

### DIFF
--- a/data/brands/shop/computer.json
+++ b/data/brands/shop/computer.json
@@ -76,7 +76,7 @@
       "locationSet": {"include": ["fx"]},
       "tags": {
         "brand": "LDLC",
-        "brand:wikidata": "Q3117461",
+        "brand:wikidata": "Q127164489",
         "name": "LDLC",
         "shop": "computer"
       }


### PR DESCRIPTION
Replace LDLC brand:wikidata for the item Q127164489 (retail chain) instead of holding company Q3117461.