### PR TITLE
Don't export `bic` values to taginfo.json

### DIFF
--- a/scripts/dist_files.js
+++ b/scripts/dist_files.js
@@ -507,7 +507,7 @@ function buildTaginfo() {
 
       // Don't export every value for many tags this project uses..
       // ('tag matches any of these')(?!('not followed by :type'))
-      if (/(brand|brewery|country|flag|internet_access:ssid|max_age|min_age|name|network|operator|owner|ref|subject)(?!(:type))/.test(k)) {
+      if (/(bic|brand|brewery|country|flag|internet_access:ssid|max_age|min_age|name|network|operator|owner|ref|subject)(?!(:type))/.test(k)) {
         v = '*';
       }
 


### PR DESCRIPTION
Don't export `bic` values to taginfo.json