### PR TITLE
Add fast food entries in Taiwan

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -12885,6 +12885,47 @@
         "name:zh": "齊柏林熱狗",
         "takeaway": "yes"
       }
+    },
+    {
+      "displayName": "はま寿司 (臺灣)",
+      "locationSet": {
+        "include": ["tw"]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "はま寿司",
+        "brand:en": "HAMA-SUSHI",
+        "brand:ja": "はま寿司",
+        "brand:zh": "はま寿司",
+        "brand:wikidata": "Q17220385",
+        "cuisine": "sushi",
+        "name": "はま寿司",
+        "name:en": "Hamasushi",
+        "name:ja": "はま寿司",
+        "name:zh": "はま寿司",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "達美樂披薩",
+      "locationSet": {
+        "include": ["tw"]
+      },
+      "matchNames": ["Domino's"],
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "達美樂披薩",
+        "brand:en": "Domino's",
+        "brand:wikidata": "Q839466",
+        "brand:zh": "達美樂披薩",
+        "cuisine": "pizza",
+        "name": "達美樂披薩",
+        "name:en": "Domino's",
+        "name:zh": "達美樂披薩",
+        "takeaway": "yes",
+        "operator": "晶華國際酒店集團",
+        "operator:wikidata": "Q11090227"
+      }
     }
   ]
 }

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -3167,7 +3167,8 @@
         "brand": "Freddy Fresh",
         "brand:wikidata": "Q124255344",
         "cuisine": "pizza",
-        "name": "Freddy Fresh"
+        "name": "Freddy Fresh",
+        "takeaway": "yes"
       }
     },
     {
@@ -11333,6 +11334,25 @@
       }
     },
     {
+      "displayName": "はま寿司 (臺灣)",
+      "id": "hamasushi-60a4d5",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "はま寿司",
+        "brand:en": "HAMA-SUSHI",
+        "brand:ja": "はま寿司",
+        "brand:wikidata": "Q17220385",
+        "brand:zh": "はま寿司",
+        "cuisine": "sushi",
+        "name": "はま寿司",
+        "name:en": "Hamasushi",
+        "name:ja": "はま寿司",
+        "name:zh": "はま寿司",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "ピザ・カリフォルニア",
       "id": "pizzacalifornia-3e7699",
       "locationSet": {"include": ["jp"]},
@@ -12125,7 +12145,7 @@
     },
     {
       "displayName": "摩斯漢堡",
-      "id": "mosburger-70aa35",
+      "id": "mosburger-c9f110",
       "locationSet": {
         "include": ["tw"],
         "exclude": ["hk", "mo"]
@@ -12717,6 +12737,25 @@
       }
     },
     {
+      "displayName": "達美樂披薩",
+      "id": "dominos-60a4d5",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "達美樂披薩",
+        "brand:en": "Domino's",
+        "brand:wikidata": "Q839466",
+        "brand:zh": "達美樂披薩",
+        "cuisine": "pizza",
+        "name": "達美樂披薩",
+        "name:en": "Domino's",
+        "name:zh": "達美樂披薩",
+        "operator": "晶華國際酒店集團",
+        "operator:wikidata": "Q11090227",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "銚子丸",
       "id": "choushimaru-3e7699",
       "locationSet": {"include": ["jp"]},
@@ -12884,47 +12923,6 @@
         "name:en": "Zeppelin Hot Dog",
         "name:zh": "齊柏林熱狗",
         "takeaway": "yes"
-      }
-    },
-    {
-      "displayName": "はま寿司 (臺灣)",
-      "locationSet": {
-        "include": ["tw"]
-      },
-      "tags": {
-        "amenity": "fast_food",
-        "brand": "はま寿司",
-        "brand:en": "HAMA-SUSHI",
-        "brand:ja": "はま寿司",
-        "brand:zh": "はま寿司",
-        "brand:wikidata": "Q17220385",
-        "cuisine": "sushi",
-        "name": "はま寿司",
-        "name:en": "Hamasushi",
-        "name:ja": "はま寿司",
-        "name:zh": "はま寿司",
-        "takeaway": "yes"
-      }
-    },
-    {
-      "displayName": "達美樂披薩",
-      "locationSet": {
-        "include": ["tw"]
-      },
-      "matchNames": ["Domino's"],
-      "tags": {
-        "amenity": "fast_food",
-        "brand": "達美樂披薩",
-        "brand:en": "Domino's",
-        "brand:wikidata": "Q839466",
-        "brand:zh": "達美樂披薩",
-        "cuisine": "pizza",
-        "name": "達美樂披薩",
-        "name:en": "Domino's",
-        "name:zh": "達美樂披薩",
-        "takeaway": "yes",
-        "operator": "晶華國際酒店集團",
-        "operator:wikidata": "Q11090227"
       }
     }
   ]

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -789,6 +789,7 @@
     },
     {
       "displayName": "Pocztex",
+      "id": "pocztex-ce4e28",
       "locationSet": {"include": ["pl"]},
       "tags": {
         "amenity": "parcel_locker",

--- a/data/brands/shop/travel_agency.json
+++ b/data/brands/shop/travel_agency.json
@@ -693,7 +693,7 @@
       "tags": {
         "brand": "可樂旅遊",
         "brand:en": "Cola Tour",
-        "brand:wikidata": "Q11638632",
+        "brand:wikidata": "Q126898686",
         "brand:zh": "可樂旅遊",
         "name": "可樂旅遊",
         "name:en": "Cola Tour",

--- a/data/operators/amenity/community_centre.json
+++ b/data/operators/amenity/community_centre.json
@@ -325,7 +325,7 @@
     },
     {
       "displayName": "Scouts South Africa",
-      "id": "scoutssouthafrica-e4e4f8",
+      "id": "scoutssouthafrica-2d14a3",
       "locationSet": {"include": ["za"]},
       "tags": {
         "amenity": "community_centre",
@@ -345,7 +345,7 @@
     },
     {
       "displayName": "Svenska kyrkan",
-      "id": "svenskakyrkan-e4e4f8",
+      "id": "svenskakyrkan-57685d",
       "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "community_centre",

--- a/data/operators/amenity/recycling.json
+++ b/data/operators/amenity/recycling.json
@@ -293,14 +293,12 @@
       }
     },
     {
-      "displayName": "Friedensdorf International",
-      "id": "aktionfriedensdorf-6737d9",
-      "locationSet": {"include": ["de"]},
-      "preserveTags": ["Aktion Friedensdorf"],
+      "displayName": "Aktion Friedensdorf",
+      "id": "aktionfriedensdorf-91c985",
+      "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "recycling",
-        "operator": "Friedensdorf International",
-        "operator:wikidata": "Q1456718"
+        "operator": "Aktion Friedensdorf"
       }
     },
     {
@@ -1732,6 +1730,17 @@
       "tags": {
         "amenity": "recycling",
         "operator": "Fretex"
+      }
+    },
+    {
+      "displayName": "Friedensdorf International",
+      "id": "friedensdorfinternational-6737d9",
+      "locationSet": {"include": ["de"]},
+      "preserveTags": ["Aktion Friedensdorf"],
+      "tags": {
+        "amenity": "recycling",
+        "operator": "Friedensdorf International",
+        "operator:wikidata": "Q1456718"
       }
     },
     {
@@ -4384,7 +4393,7 @@
     },
     {
       "displayName": "Ville de Paris",
-      "id": "villedeparis-91c985",
+      "id": "villedeparis-59e4c1",
       "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "recycling",

--- a/data/operators/amenity/ticket_validator.json
+++ b/data/operators/amenity/ticket_validator.json
@@ -109,8 +109,13 @@
     },
     {
       "displayName": "S-Bahn Berlin GmbH",
-      "id": "sbahnberlingmbh-f980d0",
-      "locationSet": {"include": ["de-bb.geojson", "de-be.geojson"]},
+      "id": "sbahnberlingmbh-666711",
+      "locationSet": {
+        "include": [
+          "de-bb.geojson",
+          "de-be.geojson"
+        ]
+      },
       "tags": {
         "amenity": "ticket_validator",
         "operator": "S-Bahn Berlin GmbH",


### PR DESCRIPTION
新增：

1. 達美樂披薩。臺灣的達美樂披薩由晶華國際酒店集團經營 ( https://zh.wikipedia.org/wiki/%E6%99%B6%E8%8F%AF%E5%9C%8B%E9%9A%9B%E9%85%92%E5%BA%97%E9%9B%86%E5%9C%98 and https://www.dominos.com.tw/Home/Brand )
2. はま寿司。是的，那間命名すき家的台灣善商，又給他們的壽司店命作「はま寿司」 ( https://www.104.com.tw/company/1a2x6bit7j?job=%E3%81%AF%E3%81%BE%E5%AF%BF%E5%8F%B8 and https://www.facebook.com/hamazushi.zensho.taiwan )

另外修了可樂旅遊的 Wikidata、並重 build 一次。