### PR TITLE
Simple spelling mistake

### DIFF
--- a/data/brands/shop/trade.json
+++ b/data/brands/shop/trade.json
@@ -717,13 +717,13 @@
       }
     },
     {
-      "displayName": "Monter",
+      "displayName": "Montér",
       "id": "monter-db4f61",
       "locationSet": {"include": ["no"]},
       "note": "https://github.com/osmlab/name-suggestion-index/issues/5500",
       "preserveTags": ["^name"],
       "tags": {
-        "brand": "Monter",
+        "brand": "Montér",
         "brand:wikidata": "Q11989912",
         "shop": "trade",
         "trade": "building_supplies"


### PR DESCRIPTION
The building supply shop with Wikidata ID [Q11989912](https://www.wikidata.org/wiki/Q11989912) is spelled "Montér", both at Wikidata, and at there [home page](https://www.monter.no).