### PR TITLE
Add Kwik Fill-associated Red Apple stores

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -4052,9 +4052,25 @@
       }
     },
     {
-      "displayName": "Red Apple Food Mart",
+      "displayName": "Red Apple Food Mart (Kwik Fill)",
+      "locationSet": {
+        "include": [
+          "us-ny.geojson",
+          "us-oh.geojson",
+          "us-pa.geojson"
+        ]
+      },
+      "tags": {
+        "brand": "Red Apple Food Mart",
+        "brand:wikidata": "Q127305205",
+        "name": "Red Apple Food Mart",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "Red Apple Food Mart (Mississippi)",
       "id": "redapplefoodmart-f1e40b",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-ms.geojson"]},
       "matchTags": ["shop/supermarket"],
       "tags": {
         "brand": "Red Apple Food Mart",


### PR DESCRIPTION
This pull request narrows the existing Red Apple Food Mart brand to Mississippi (see its updated Wikidata page for more info) and adds a new entry for the Kwik Fill-associated stores of the same name in the northeastern United States.

Note: as of this writing, all of the stores linked to the current brand are actually the Kwik Fill stores, not the Mississippi locations (per Overpass turbo).