### PR TITLE
Add Cambridge Trust matchNames to Eastern Bank, refine locationSet

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -5802,8 +5802,18 @@
     },
     {
       "displayName": "Eastern Bank",
-      "id": "easternbank-ea2e2d",
-      "locationSet": {"include": ["us"]},
+      "id": "easternbank-f376c6",
+      "locationSet": {
+        "include": [
+          "us-ma.geojson",
+          "us-nh.geojson"
+        ]
+      },
+      "matchNames": [
+        "cambridge trust",
+        "cambridge trust bank",
+        "cambridge trust company"
+      ],
       "tags": {
         "amenity": "bank",
         "brand": "Eastern Bank",


### PR DESCRIPTION
Cambridge Trust Bank (not previously in NSI) has been aquired by Eastern Bank, with all branches being rebranded on 15 July 2024.[^1] The three closed branches either were not mapped or have already been removed. All branches for both banks are in NH and MA.

[^1]: https://www.easternbank.com/welcome-to-eastern-bank/key-dates