### PR TITLE
Rename Northeast Credit Union to Lighthouse Credit Union

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -8479,6 +8479,23 @@
       }
     },
     {
+      "displayName": "Lighthouse Credit Union",
+      "id": "lighthousecreditunion-02b74e",
+      "locationSet": {
+        "include": [
+          "us-me.geojson",
+          "us-nh.geojson"
+        ]
+      },
+      "matchNames": ["northeast credit union"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "Lighthouse Credit Union",
+        "brand:wikidata": "Q123397041",
+        "name": "Lighthouse Credit Union"
+      }
+    },
+    {
       "displayName": "Lloyds Bank",
       "id": "lloydsbank-28a61d",
       "locationSet": {
@@ -9274,22 +9291,6 @@
         "brand": "Nordea",
         "brand:wikidata": "Q1123823",
         "name": "Nordea"
-      }
-    },
-    {
-      "displayName": "Northeast Credit Union",
-      "id": "northeastcreditunion-02b74e",
-      "locationSet": {
-        "include": [
-          "us-me.geojson",
-          "us-nh.geojson"
-        ]
-      },
-      "tags": {
-        "amenity": "bank",
-        "brand": "Northeast Credit Union",
-        "brand:wikidata": "Q123397041",
-        "name": "Northeast Credit Union"
       }
     },
     {


### PR DESCRIPTION
As of 18 July 2024, Northeast Credit Union will rebrand all branches to Lighthouse Credit Union. https://necu.org/rebrand