### PR TITLE
Include brazilian supermarket chain called Supermarket

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -7748,9 +7748,8 @@
     },
     {
       "displayName": "Supermarket (Brasil)",
-      "id": "supermarket-br",
+      "id": "supermarket-20f2a8",
       "locationSet": {"include": ["br"]},
-      "matchTags": ["shop/supermarket"],
       "tags": {
         "brand": "Supermarket",
         "brand:wikidata": "Q127375573",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -7747,6 +7747,18 @@
       }
     },
     {
+      "displayName": "Supermarket (Brasil)",
+      "id": "supermarket-br",
+      "locationSet": {"include": ["br"]},
+      "matchTags": ["shop/supermarket"],
+      "tags": {
+        "brand": "Supermarket",
+        "brand:wikidata": "Q127375573",
+        "name": "Supermarket",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Supermercados BH",
       "id": "supermercadosbh-20f2a8",
       "locationSet": {"include": ["br"]},


### PR DESCRIPTION
Adds a brazilian supermarket chain called... Supermarket (in English). Here's their website: https://redesupermarket.com.br/

Btw I wasn't sure what to put in `id`, those seem generated by you so I left a placeholder.

Thanks for the suggestion @1ec5 , ref https://github.com/openstreetmap/iD/issues/10334#issuecomment-2230984728