### PR TITLE
Update operator for Metrorower and Veturilo systems

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -2288,7 +2288,8 @@
         "fee": "yes",
         "network": "Metrorower",
         "network:wikidata": "Q123507620",
-        "operator": "Nextbike Polska"
+        "operator": "Nextbike GZM",
+        "operator:wikidata": "Q127573015"
       }
     },
     {
@@ -4111,7 +4112,8 @@
         "brand:wikidata": "Q3847868",
         "network": "Veturilo",
         "network:wikidata": "Q3847868",
-        "operator": "Nextbike Polska"
+        "operator": "Nextbike GZM",
+        "operator:wikidata": "Q127573015"
       }
     },
     {


### PR DESCRIPTION
Since 2023, the "Nextbike GZM" company, and not the "Nextbike Polska" company, is the operator of the Veturilo bicycle rental system in Warsaw[1]. This is also reflected on the Veturilo website[2].
The "Nextbike GZM" company is also the operator of the Metrorower system in GZM since its inception this year, which is also stated on the Metrorower website[3].

[1] https://um-warszawa-pl.translate.goog/-/veturilo-w-latach-2023-2028-umowa-podpisana?_x_tr_sl=pl&_x_tr_tl=en&_x_tr_hl=pl&_x_tr_pto=wapp
[2] https://veturilo.waw.pl/en/privacy-policy/
[3] https://metrorower.transportgzm.pl/en/privacy-policy/
