### PR TITLE
Add Nioga Library System

### DIFF
--- a/data/operators/amenity/library.json
+++ b/data/operators/amenity/library.json
@@ -1344,6 +1344,18 @@
       }
     },
     {
+      "displayName": "Nioga Library System",
+      "locationSet": {
+        "include": ["us-ny.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Nioga Library System",
+        "operator:type": "public",
+        "operator:wikidata": "Q127599956"
+      }
+    },
+    {
       "displayName": "Norfolk County Council",
       "id": "norfolkcountycouncil-088e6d",
       "locationSet": {


### PR DESCRIPTION
Public library system for **Ni**agara, **O**rleans, and **G**enesee counties in New York, USA (hence the unusual name chosen by said system)