### PR TITLE
[Marks & Spencer] Unify brand and add brand:short

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -2521,6 +2521,7 @@
       "tags": {
         "amenity": "cafe",
         "brand": "Marks & Spencer",
+        "brand:short": "M&S",
         "brand:wikidata": "Q714491",
         "cuisine": "coffee_shop",
         "name": "M&S Café",

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -2845,7 +2845,7 @@
     },
     {
       "displayName": "M&S Food",
-      "id": "mandsfood-4d6b4b",
+      "id": "mandsfood-232829",
       "locationSet": {"include": ["gb"]},
       "tags": {
         "brand": "Marks & Spencer",
@@ -2863,7 +2863,8 @@
         "marks & spencer simply food"
       ],
       "tags": {
-        "brand": "M&S Simply Food",
+        "brand": "Marks & Spencer",
+        "brand:short": "M&S",
         "brand:wikidata": "Q714491",
         "name": "M&S Simply Food",
         "shop": "convenience"

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -2844,6 +2844,18 @@
       }
     },
     {
+      "displayName": "M&S Food",
+      "id": "mandsfood-4d6b4b",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "Marks & Spencer",
+        "brand:short": "M&S",
+        "brand:wikidata": "Q714491",
+        "name": "M&S Food",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "M&S Simply Food",
       "id": "mandssimplyfood-4d6b4b",
       "locationSet": {"include": ["001"]},

--- a/data/brands/shop/department_store.json
+++ b/data/brands/shop/department_store.json
@@ -933,7 +933,8 @@
       "locationSet": {"include": ["001"]},
       "matchNames": ["marks & spencer outlet"],
       "tags": {
-        "brand": "M&S Outlet",
+        "brand": "Marks & Spencer",
+        "brand:short": "M&S",
         "brand:wikidata": "Q714491",
         "name": "M&S Outlet",
         "shop": "department_store"
@@ -1019,12 +1020,10 @@
       "locationSet": {
         "include": ["gb", "gr", "ie", "in", "ru"]
       },
-      "matchNames": [
-        "m and s",
-        "маркс и спенсер"
-      ],
+      "matchNames": ["маркс и спенсер"],
       "tags": {
         "brand": "Marks & Spencer",
+        "brand:short": "M&S",
         "brand:wikidata": "Q714491",
         "name": "Marks & Spencer",
         "shop": "department_store"

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -4624,7 +4624,8 @@
       "locationSet": {"include": ["001"]},
       "matchNames": ["marks & spencer foodhall"],
       "tags": {
-        "brand": "M&S Foodhall",
+        "brand": "Marks & Spencer",
+        "brand:short": "M&S",
         "brand:wikidata": "Q714491",
         "name": "M&S Foodhall",
         "shop": "supermarket"
@@ -4638,7 +4639,8 @@
         "marks & spencer simply food"
       ],
       "tags": {
-        "brand": "M&S Simply Food",
+        "brand": "Marks & Spencer",
+        "brand:short": "M&S",
         "brand:wikidata": "Q714491",
         "name": "M&S Simply Food",
         "shop": "supermarket"


### PR DESCRIPTION
I don't think this is controversial, these are all formats of the Marks & Spencer brand. I've also added "M&S Food", some new locations seem to have this facia, maybe instead of "M&S Simply Food", or as well as.