### PR TITLE
Add TravisMathew to brands/shop/clothes

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -10039,6 +10039,16 @@
       }
     },
     {
+      "displayName": "TravisMathew",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "brand": "TravisMathew",
+        "brand:wikidata": "Q128212818",
+        "name": "TravisMathew",
+        "shop": "clothes"
+      }
+    },
+    {
       "displayName": "tredy",
       "id": "tredy-74806d",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
Four instances in OSM currently, out of 54 according to the website. Of the four, two are tagged with `clothes=men`, but other stores have options for women and children. One instance is tagged with `brand:wikidata=Q1027181`, which is the parent company. I added a new QID for the specific brand.