### PR TITLE
Split Shoe Dept. and Shoe Dept. Encore from Shoe Show

### DIFF
--- a/data/brands/shop/shoes.json
+++ b/data/brands/shop/shoes.json
@@ -1887,6 +1887,29 @@
       }
     },
     {
+      "displayName": "Shoe Dept.",
+      "locationSet": {"include": ["us"]},
+      "matchNames": [
+        "the shoe dept"
+      ],
+      "tags": {
+        "brand": "Shoe Dept.",
+        "brand:wikidata": "Q128119319",
+        "name": "Shoe Dept.",
+        "shop": "shoes"
+      }
+    },
+    {
+      "displayName": "Shoe Dept. Encore",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "brand": "Shoe Dept. Encore",
+        "brand:wikidata": "Q128119319",
+        "name": "Shoe Dept. Encore",
+        "shop": "shoes"
+      }
+    },
+    {
       "displayName": "Shoe Palace",
       "id": "shoepalace-c5ede1",
       "locationSet": {"include": ["us"]},
@@ -1912,10 +1935,6 @@
       "displayName": "Shoe Show",
       "id": "shoeshow-9b62dc",
       "locationSet": {"include": ["001"]},
-      "matchNames": [
-        "shoe dept. encore",
-        "the shoe dept"
-      ],
       "tags": {
         "brand": "Shoe Show",
         "brand:wikidata": "Q7500015",


### PR DESCRIPTION
More from #9754. This splits the entry for Shoe Show to give Shoe Dept. its own Wikidata item and NSI entries, eliminating erroneous suggestions by iD/NSI to retag Shoe Dept./Encore stores as Shoe Show stores.