### PR TITLE
Split network and operator Wikidata tags for RGRTA networks

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -13016,10 +13016,12 @@
         "include": ["us-ny.geojson"]
       },
       "tags": {
-        "network": "RTS",
-        "network:wikidata": "Q7353936",
+        "network": "Regional Transit Service",
+        "network:short": "RTS",
+        "network:wikidata": "Q128016163",
         "operator": "Rochester-Genesee Regional Transportation Authority",
         "operator:short": "RGRTA",
+        "operator:wikidata": "Q7353936",
         "route": "bus"
       }
     },
@@ -13031,9 +13033,10 @@
       },
       "tags": {
         "network": "RTS Genesee",
-        "network:wikidata": "Q7353936",
+        "network:wikidata": "Q128019449",
         "operator": "Rochester-Genesee Regional Transportation Authority",
         "operator:short": "RGRTA",
+        "operator:wikidata": "Q7353936",
         "route": "bus"
       }
     },
@@ -13045,9 +13048,10 @@
       },
       "tags": {
         "network": "RTS Livingston",
-        "network:wikidata": "Q7353936",
+        "network:wikidata": "Q128019453",
         "operator": "Rochester-Genesee Regional Transportation Authority",
         "operator:short": "RGRTA",
+        "operator:wikidata": "Q7353936",
         "route": "bus"
       }
     },
@@ -13059,9 +13063,10 @@
       },
       "tags": {
         "network": "RTS Ontario",
-        "network:wikidata": "Q7353936",
+        "network:wikidata": "Q128019458",
         "operator": "Rochester-Genesee Regional Transportation Authority",
         "operator:short": "RGRTA",
+        "operator:wikidata": "Q7353936",
         "route": "bus"
       }
     },
@@ -13073,9 +13078,10 @@
       },
       "tags": {
         "network": "RTS Orleans",
-        "network:wikidata": "Q7353936",
+        "network:wikidata": "Q128019463",
         "operator": "Rochester-Genesee Regional Transportation Authority",
         "operator:short": "RGRTA",
+        "operator:wikidata": "Q7353936",
         "route": "bus"
       }
     },
@@ -13087,9 +13093,10 @@
       },
       "tags": {
         "network": "RTS Seneca",
-        "network:wikidata": "Q7353936",
+        "network:wikidata": "Q128019467",
         "operator": "Rochester-Genesee Regional Transportation Authority",
         "operator:short": "RGRTA",
+        "operator:wikidata": "Q7353936",
         "route": "bus"
       }
     },
@@ -13101,9 +13108,10 @@
       },
       "tags": {
         "network": "RTS Wayne",
-        "network:wikidata": "Q7353936",
+        "network:wikidata": "Q128019471",
         "operator": "Rochester-Genesee Regional Transportation Authority",
         "operator:short": "RGRTA",
+        "operator:wikidata": "Q7353936",
         "route": "bus"
       }
     },
@@ -13115,9 +13123,10 @@
       },
       "tags": {
         "network": "RTS Wyoming",
-        "network:wikidata": "Q7353936",
+        "network:wikidata": "Q128019475",
         "operator": "Rochester-Genesee Regional Transportation Authority",
         "operator:short": "RGRTA",
+        "operator:wikidata": "Q7353936",
         "route": "bus"
       }
     },


### PR DESCRIPTION
More from #9754. This cleans up the Wikidata tagging for the bus networks operated by RGRTA. Each network now has its own Wikidata item, and the item for RGRTA has been moved from the `network:wikidata` tag to the `operator:wikidata` tag.