### PR TITLE
Added brands/operator information for Rochester Regional Health and UR Medicine networks

### DIFF
--- a/data/brands/amenity/clinic.json
+++ b/data/brands/amenity/clinic.json
@@ -130,6 +130,23 @@
       }
     },
     {
+      "displayName": "RRH Urgent Care",
+      "locationSet": {
+        "include": [
+          "us-ny.geojson"
+        ]
+      },
+      "matchNames": ["rrh urgent care"],
+      "tags": {
+        "amenity": "clinic",
+        "brand": "Rochester Regional Health Urgent Care",
+        "brand:wikidata": "Q127996131",
+        "healthcare": "clinic",
+        "healthcare:speciality": "urgent",
+        "name": "Rochester Regional Health Urgent Care",
+      }
+    },
+    {
       "displayName": "Sentara Healthcare",
       "id": "sentara-b3ff53",
       "locationSet": {"include": ["us"]},
@@ -226,6 +243,22 @@
         "brand": "Vein Clinics of America",
         "brand:wikidata": "Q113712355",
         "healthcare": "clinic"
+      }
+    },
+    {
+      "displayName": "UR Medicine Urgent Care",
+      "locationSet": {
+        "include": [
+          "us-ny.geojson"
+        ]
+      },
+      "tags": {
+        "amenity": "clinic",
+        "brand": "UR Medicine Urgent Care",
+        "brand:wikidata": "Q59488288",
+        "healthcare": "clinic",
+        "healthcare:speciality": "urgent",
+        "name": "UR Medicine Urgent Care",
       }
     }
   ]

--- a/data/brands/healthcare/laboratory.json
+++ b/data/brands/healthcare/laboratory.json
@@ -501,6 +501,23 @@
       }
     },
     {
+      "displayName": "RRH Laboratories",
+      "locationSet": {
+        "include": [
+          "us-ny.geojson"
+        ]
+      },
+      "matchNames": ["rrh laboratories"],
+      "tags": {
+        "brand": "Rochester Regional Health Laboratories",
+        "brand:wikidata": "Q128000494",
+        "healthcare": "laboratory",
+        "name": "Rochester Regional Health Laboratories",
+        "operator": "Rochester Regional Health",
+        "operator:wikidata": "Q7353978"
+      }
+    },
+    {
       "displayName": "Sabin",
       "id": "sabin-4627ab",
       "locationSet": {"include": ["br"]},
@@ -612,6 +629,23 @@
         "healthcare": "laboratory",
         "healthcare:speciality": "biology",
         "name": "Unilians"
+      }
+    },
+    {
+      "displayName": "UR Medicine Labs",
+      "locationSet": {
+        "include": [
+          "us-ny.geojson"
+        ]
+      },
+      "tags": {
+        "brand": "UR Medicine Labs",
+        "brand:wikidata": "Q128000327",
+        "healthcare": "laboratory",
+        "name": "UR Medicine Labs",
+        "operator": "University of Rochester Medical Center",
+        "operator:short": "UR Medicine",
+        "operator:wikidata": "Q7896217"
       }
     },
     {

--- a/data/operators/amenity/clinic.json
+++ b/data/operators/amenity/clinic.json
@@ -1665,6 +1665,22 @@
       }
     },
     {
+      "displayName": "Rochester Regional Health",
+      "locationSet": {
+        "include": [
+          "us-ny.geojson"
+        ]
+      },
+      "matchNames": ["rochester regional"],
+      "tags": {
+        "amenity": "clinic",
+        "healthcare": "clinic",
+        "operator": "Rochester Regional Health",
+        "operator:type": "private_non_profit",
+        "operator:wikidata": "Q7353978"
+      }
+    },
+    {
       "displayName": "SACYL",
       "id": "sacyl-edc4ef",
       "locationSet": {"include": ["es"]},
@@ -2051,6 +2067,23 @@
         "healthcare": "clinic",
         "operator": "UPMC",
         "operator:wikidata": "Q30281140"
+      }
+    },
+    {
+      "displayName": "UR Medicine",
+      "locationSet": {
+        "include": [
+          "us-ny.geojson"
+        ]
+      },
+      "matchNames": ["urmc"],
+      "tags": {
+        "amenity": "clinic",
+        "healthcare": "clinic",
+        "operator": "University of Rochester Medical Center",
+        "operator:short": "UR Medicine",
+        "operator:type": "university",
+        "operator:wikidata": "Q7896217"
       }
     },
     {

--- a/data/operators/amenity/doctors.json
+++ b/data/operators/amenity/doctors.json
@@ -212,6 +212,21 @@
       }
     },
     {
+      "displayName": "Rochester Regional Health",
+      "locationSet": {
+        "include": [
+          "us-ny.geojson"
+        ]
+      },
+      "matchNames": ["rochester regional"],
+      "tags": {
+        "amenity": "doctors",
+        "healthcare": "doctor",
+        "operator": "Rochester Regional Health",
+        "operator:wikidata": "Q7353978"
+      }
+    },
+    {
       "displayName": "RU-VGG-2-23",
       "id": "ruvgg223-402f23",
       "locationSet": {"include": ["001"]},
@@ -239,6 +254,22 @@
         "amenity": "doctors",
         "healthcare": "doctor",
         "operator": "Sanlas Holding"
+      }
+    },
+    {
+      "displayName": "UR Medicine",
+      "locationSet": {
+        "include": [
+          "us-ny.geojson"
+        ]
+      },
+      "matchNames": ["urmc"],
+      "tags": {
+        "amenity": "doctors",
+        "healthcare": "doctor",
+        "operator": "University of Rochester Medical Center",
+        "operator:short": "UR Medicine",
+        "operator:wikidata": "Q7896217"
       }
     },
     {

--- a/data/operators/amenity/hospital.json
+++ b/data/operators/amenity/hospital.json
@@ -2249,6 +2249,22 @@
       }
     },
     {
+      "displayName": "Rochester Regional Health",
+      "locationSet": {
+        "include": [
+          "us-ny.geojson"
+        ]
+      },
+      "matchNames": ["rochester regional"],
+      "tags": {
+        "amenity": "hospital",
+        "healthcare": "hospital",
+        "operator": "Rochester Regional Health",
+        "operator:type": "private_non_profit",
+        "operator:wikidata": "Q7353978"
+      }
+    },
+    {
       "displayName": "RSUD Selayar",
       "id": "rsudselayar-03d8c5",
       "locationSet": {"include": ["id"]},
@@ -2743,6 +2759,23 @@
         "operator": "University of Pittsburgh Medical Center",
         "operator:short": "UPMC",
         "operator:wikidata": "Q7896131"
+      }
+    },
+    {
+      "displayName": "UR Medicine",
+      "locationSet": {
+        "include": [
+          "us-ny.geojson"
+        ]
+      },
+      "matchNames": ["urmc"],
+      "tags": {
+        "amenity": "hospital",
+        "healthcare": "hospital",
+        "operator": "University of Rochester Medical Center",
+        "operator:short": "UR Medicine",
+        "operator:type": "university",
+        "operator:wikidata": "Q7896217"
       }
     },
     {


### PR DESCRIPTION
The final piece of #9754, and the largest (and possibly most controversial). This adds the Rochester Regional Health and UR Medicine networks to NSI as clinic, doctor, and hospital operators, and their owned/operated urgent care and lab patient service centers as brands. Each network is centered on Rochester, NY, but their reaches extend all over western and central New York.