### PR TITLE
Wikidata ID updates for multiple brands

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -1285,7 +1285,7 @@
       "tags": {
         "amenity": "fuel",
         "brand": "Conoco",
-        "brand:wikidata": "Q109341187",
+        "brand:wikidata": "Q1126518",
         "name": "Conoco"
       }
     },

--- a/data/brands/amenity/payment_terminal.json
+++ b/data/brands/amenity/payment_terminal.json
@@ -165,7 +165,7 @@
       "tags": {
         "amenity": "payment_terminal",
         "brand": "EZ-TAB",
-        "brand:wikidata": "Q110265731",
+        "brand:wikidata": "Q110265735",
         "name": "EZ-TAB",
         "operator": "Wisconsin Division of Motor Vehicles",
         "operator:wikidata": "Q115413096"
@@ -311,7 +311,7 @@
       "tags": {
         "amenity": "payment_terminal",
         "brand": "New York State DMV Now",
-        "brand:wikidata": "Q115413364",
+        "brand:wikidata": "Q115416989",
         "name": "New York State DMV Now",
         "operator": "New York State Department of Motor Vehicles",
         "operator:wikidata": "Q17109616"
@@ -321,7 +321,7 @@
       "displayName": "North Dakota MV Express",
       "id": "northdakotamvexpress-9253ed",
       "locationSet": {
-        "include": ["us-ga.geojson"]
+        "include": ["us-nd.geojson"]
       },
       "tags": {
         "amenity": "payment_terminal",
@@ -344,7 +344,7 @@
         "brand": "Ohio BMV Express",
         "brand:wikidata": "Q115417055",
         "name": "Ohio BMV Express",
-        "operator": "Ohio Beareau of Motor Vehicles",
+        "operator": "Ohio Bureau of Motor Vehicles",
         "operator:wikidata": "Q74329867"
       }
     },
@@ -431,9 +431,9 @@
       "tags": {
         "amenity": "payment_terminal",
         "brand": "West Virginia DMV Now",
-        "brand:wikidata": "Q115417103",
+        "brand:wikidata": "Q115417174",
         "name": "West Virginia DMV Now",
-        "operator": "West Virginia Division Motor Vehicles",
+        "operator": "West Virginia Division of Motor Vehicles",
         "operator:wikidata": "Q115417228"
       }
     },

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1319,7 +1319,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "brand": "Conoco",
-        "brand:wikidata": "Q109341187",
+        "brand:wikidata": "Q1126518",
         "name": "Conoco",
         "shop": "convenience"
       }

--- a/data/brands/shop/cosmetics.json
+++ b/data/brands/shop/cosmetics.json
@@ -248,7 +248,7 @@
       "locationSet": {"include": ["be"]},
       "tags": {
         "brand": "Di",
-        "brand:wikidata": "Q126195658",
+        "brand:wikidata": "Q122955082",
         "name": "Di",
         "shop": "cosmetics"
       }


### PR DESCRIPTION
This is a collection of updates, mostly to Wikidata IDs, that I compiled over the last couple of days while going through the "incomplete" entries in the NSI index. Some of the existing Wikidata IDs pointed to duplicate items, and some pointed to the wrong item in an apparent artifact of copy-pasting. There are also three other updates: two to the names of operators, and one to an item that had the wrong locationSet in another apparent artifact of copy-pasting.