### PR TITLE
Add Urban Plates to brands/amenity/fast_food

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -9512,6 +9512,19 @@
       }
     },
     {
+      "displayName": "Urban Plates",
+      "locationSet": {"include": ["us-ca.geojson"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Urban Plates",
+        "brand:wikidata": "Q96413021",
+        "cuisine": "american",
+        "delivery": "yes",
+        "name": "Urban Plates",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Usta Dönerci",
       "id": "ustadonerci-4d8bc5",
       "locationSet": {"include": ["ge", "tr"]},


### PR DESCRIPTION
I'm not 100% sure it should be classified as `fast_food`. Most of the existing locations in OSM are `restaurant`. But it looks like service is at the counter, not waited.