### PR TITLE
Remove recycling_type=centre from LV Depozīta punkts

### DIFF
--- a/data/brands/amenity/recycling.json
+++ b/data/brands/amenity/recycling.json
@@ -122,7 +122,6 @@
         "brand": "Depozīta punkts",
         "brand:wikidata": "Q110979381",
         "name": "Depozīta punkts",
-        "recycling_type": "centre",
         "recycling:cans": "yes",
         "recycling:glass_bottles": "yes",
         "recycling:plastic_bottles": "yes"


### PR DESCRIPTION
This fixes the entry for bottle recycling "Depozīta punkts"-branded kiosks in Latvia after local discussion about these. This removes the `recycling_type=centre`, which is incorrect for what these are. OSM currently does not have an established `recycling_type` tag for this type of recycling location, so for now there is no value to use here - it's neither a container, nor a recycling center. And tagging these as recycling centers is incorrect for data consumers.

Relevant local discussion https://osmlatvija.github.io/zulip-archive/stream/358602-general/topic/depoz.C4.ABta.20punkti.html