### PR TITLE
Wikidata ID additions; locationSet refinements; other corrections

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -1826,7 +1826,9 @@
       "tags": {
         "amenity": "bicycle_rental",
         "brand": "Indiana Pacers Bikeshare",
+        "brand:wikidata": "Q109557888",
         "network": "Indiana Pacers Bikeshare",
+        "network:wikidata": "Q109557888",
         "operator": "BCycle",
         "operator:wikidata": "Q4833723"
       }
@@ -2773,7 +2775,8 @@
         "amenity": "bicycle_rental",
         "brand": "Penn State Bike Share",
         "network": "Penn State Bike Share",
-        "operator": "Zagster"
+        "operator": "Zagster",
+        "operator:wikidata": "Q5124082"
       }
     },
     {
@@ -4323,7 +4326,9 @@
       "tags": {
         "amenity": "bicycle_rental",
         "brand": "Zagster",
+        "brand:wikidata": "Q5124082",
         "network": "Zagster",
+        "network:wikidata": "Q5124082",
         "operator": "Zagster"
       }
     },

--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -2118,11 +2118,12 @@
       "displayName": "Locatel",
       "id": "locatel-930758",
       "locationSet": {
-        "include": ["co", "us", "ve"]
+        "include": ["co", "ve"]
       },
       "tags": {
         "amenity": "pharmacy",
         "brand": "Locatel",
+        "brand:wikidata": "Q109598019",
         "healthcare": "pharmacy",
         "name": "Locatel"
       }

--- a/data/brands/shop/car_repair.json
+++ b/data/brands/shop/car_repair.json
@@ -348,6 +348,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "brand": "Christian Brothers Automotive",
+        "brand:wikidata": "Q126478117",
         "name": "Christian Brothers Automotive",
         "shop": "car_repair"
       }

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -522,12 +522,14 @@
       }
     },
     {
-      "displayName": "BGE",
+      "displayName": "Baltimore Gas and Electric",
       "id": "bge-994ed4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-md.geojson"]},
       "tags": {
         "amenity": "charging_station",
-        "operator": "BGE"
+        "operator": "Baltimore Gas and Electric",
+        "operator:short": "BGE",
+        "operator:wikidata": "Q4852862"
       }
     },
     {
@@ -1962,7 +1964,8 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "charging_station",
-        "operator": "EV Connect"
+        "operator": "EV Connect",
+        "operator:wikidata": "Q126652985"
       }
     },
     {
@@ -3238,7 +3241,8 @@
       },
       "tags": {
         "amenity": "charging_station",
-        "operator": "Michigan State University"
+        "operator": "Michigan State University",
+        "operator:wikidata": "Q270222"
       }
     },
     {
@@ -5575,7 +5579,8 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "charging_station",
-        "operator": "Whole Foods"
+        "operator": "Whole Foods",
+        "operator:wikidata": "Q1809448"
       }
     },
     {

--- a/data/operators/amenity/clinic.json
+++ b/data/operators/amenity/clinic.json
@@ -118,11 +118,12 @@
     {
       "displayName": "Aspirus",
       "id": "aspirus-0ca787",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-wi.geojson","us-mi.geojson"]},
       "tags": {
         "amenity": "clinic",
         "healthcare": "clinic",
-        "operator": "Aspirus"
+        "operator": "Aspirus",
+        "operator:wikidata": "Q30270800"
       }
     },
     {
@@ -143,7 +144,8 @@
       "tags": {
         "amenity": "clinic",
         "healthcare": "clinic",
-        "operator": "Aurora Health Care"
+        "operator": "Aurora Health Care",
+        "operator:wikidata": "Q4822546"
       }
     },
     {
@@ -254,7 +256,8 @@
       "tags": {
         "amenity": "clinic",
         "healthcare": "clinic",
-        "operator": "Cleveland Clinic"
+        "operator": "Cleveland Clinic",
+        "operator:wikidata": "Q4117596"
       }
     },
     {
@@ -654,7 +657,8 @@
       "tags": {
         "amenity": "clinic",
         "healthcare": "clinic",
-        "operator": "Hattiesburg Clinic"
+        "operator": "Hattiesburg Clinic",
+        "operator:wikidata": "Q50036696"
       }
     },
     {

--- a/data/operators/amenity/drinking_water.json
+++ b/data/operators/amenity/drinking_water.json
@@ -513,14 +513,18 @@
       }
     },
     {
-      "displayName": "Miami-Dade College",
+      "displayName": "Miami Dade College",
       "id": "miamidadecollege-fc5ff1",
       "locationSet": {
-        "include": ["us-mi.geojson"]
+        "include": ["us-fl.geojson"]
       },
+      "matchNames": [
+        "miami-dade college"
+      ],
       "tags": {
         "amenity": "drinking_water",
-        "operator": "Miami-Dade College"
+        "operator": "Miami Dade College",
+        "operator:wikidata": "Q3027788"
       }
     },
     {

--- a/data/operators/amenity/fire_station.json
+++ b/data/operators/amenity/fire_station.json
@@ -96,9 +96,9 @@
       }
     },
     {
-      "displayName": "BCFD",
+      "displayName": "Bernalillo County Fire Department",
       "id": "bcfd-92f26a",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-nm.geojson"]},
       "tags": {
         "amenity": "fire_station",
         "operator": "BCFD"
@@ -2840,7 +2840,8 @@
       },
       "tags": {
         "amenity": "fire_station",
-        "operator": "Springfield Fire Department"
+        "operator": "Springfield Fire Department",
+        "operator:wikidata": "Q113623343"
       }
     },
     {
@@ -2863,7 +2864,8 @@
       },
       "tags": {
         "amenity": "fire_station",
-        "operator": "Springfield Fire Department"
+        "operator": "Springfield Fire Department",
+        "operator:wikidata": "Q65118845"
       }
     },
     {

--- a/data/operators/amenity/hospital.json
+++ b/data/operators/amenity/hospital.json
@@ -215,11 +215,12 @@
     {
       "displayName": "Aspirus",
       "id": "aspirus-888e5a",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-wi.geojson","us-mi.geojson"]},
       "tags": {
         "amenity": "hospital",
         "healthcare": "hospital",
-        "operator": "Aspirus"
+        "operator": "Aspirus",
+        "operator:wikidata": "Q30270800"
       }
     },
     {
@@ -317,13 +318,33 @@
       }
     },
     {
-      "displayName": "Baptist Health",
-      "id": "baptisthealth-888e5a",
-      "locationSet": {"include": ["us"]},
+      "displayName": "Baptist Health (Alabama)",
+      "locationSet": {"include": ["us-al.geojson"]},
       "tags": {
         "amenity": "hospital",
         "healthcare": "hospital",
         "operator": "Baptist Health"
+      }
+    },
+    {
+      "displayName": "Baptist Health (Florida)",
+      "id": "baptisthealth-888e5a",
+      "locationSet": {"include": ["us-fl.geojson"]},
+      "tags": {
+        "amenity": "hospital",
+        "healthcare": "hospital",
+        "operator": "Baptist Health",
+        "operator:wikidata": "Q4857639"
+      }
+    },
+    {
+      "displayName": "Baptist Health (Indiana-Kentucky)",
+      "locationSet": {"include": ["us-ky.geojson","us-in.geojson"]},
+      "tags": {
+        "amenity": "hospital",
+        "healthcare": "hospital",
+        "operator": "Baptist Health",
+        "operator:wikidata": "Q110932481"
       }
     },
     {
@@ -454,7 +475,8 @@
       "tags": {
         "amenity": "hospital",
         "healthcare": "hospital",
-        "operator": "Centura Health"
+        "operator": "Centura Health",
+        "operator:wikidata": "Q110940557"
       }
     },
     {
@@ -1187,7 +1209,8 @@
       "tags": {
         "amenity": "hospital",
         "healthcare": "hospital",
-        "operator": "KentuckyOne Health"
+        "operator": "KentuckyOne Health",
+        "operator:wikidata": "Q30282191"
       }
     },
     {
@@ -1370,7 +1393,8 @@
       "tags": {
         "amenity": "hospital",
         "healthcare": "hospital",
-        "operator": "Mayo Clinic Health System"
+        "operator": "Mayo Clinic Health System",
+        "operator:wikidata": "Q110932693"
       }
     },
     {
@@ -2640,11 +2664,12 @@
     {
       "displayName": "Texas Department of Aging and Disability Services",
       "id": "texasdepartmentofaginganddisabilityservices-888e5a",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-tx.geojson"]},
       "tags": {
         "amenity": "hospital",
         "healthcare": "hospital",
-        "operator": "Texas Department of Aging and Disability Services"
+        "operator": "Texas Department of Aging and Disability Services",
+        "operator:wikidata": "Q7707626"
       }
     },
     {

--- a/data/operators/amenity/library.json
+++ b/data/operators/amenity/library.json
@@ -1807,10 +1807,11 @@
     {
       "displayName": "Tulare County Library",
       "id": "tularecountylibrary-895178",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-ca.geojson"]},
       "tags": {
         "amenity": "library",
-        "operator": "Tulare County Library"
+        "operator": "Tulare County Library",
+        "operator:wikidata": "Q66369392"
       }
     },
     {

--- a/data/operators/amenity/parking.json
+++ b/data/operators/amenity/parking.json
@@ -157,8 +157,10 @@
       "tags": {
         "amenity": "parking",
         "brand": "Colonial Parking",
+        "operator:wikidata": "Q121494114",
         "name": "Colonial Parking",
-        "operator": "Colonial Parking"
+        "operator": "Colonial Parking",
+        "operator:wikidata": "Q121494114"
       }
     },
     {

--- a/data/operators/amenity/recycling.json
+++ b/data/operators/amenity/recycling.json
@@ -677,10 +677,11 @@
     {
       "displayName": "Bartow County",
       "id": "bartowcounty-624e31",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-ga.geojson"]},
       "tags": {
         "amenity": "recycling",
-        "operator": "Bartow County"
+        "operator": "Bartow County",
+        "operator:wikidata": "Q488181"
       }
     },
     {
@@ -769,10 +770,11 @@
     {
       "displayName": "Bowling Green State University",
       "id": "bowlinggreenstateuniversity-624e31",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-oh.geojson"]},
       "tags": {
         "amenity": "recycling",
-        "operator": "Bowling Green State University"
+        "operator": "Bowling Green State University",
+        "operator:wikidata": "Q895457"
       }
     },
     {
@@ -994,7 +996,8 @@
       },
       "tags": {
         "amenity": "recycling",
-        "operator": "City of Denton"
+        "operator": "City of Denton",
+        "operator:wikidata": "Q128306"
       }
     },
     {
@@ -1015,7 +1018,8 @@
       },
       "tags": {
         "amenity": "recycling",
-        "operator": "City of Lawrence"
+        "operator": "City of Lawrence",
+        "operator:wikidata": "Q493840"
       }
     },
     {
@@ -2370,10 +2374,11 @@
     {
       "displayName": "Kent State University",
       "id": "kentstateuniversity-624e31",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-oh.geojson"]},
       "tags": {
         "amenity": "recycling",
-        "operator": "Kent State University"
+        "operator": "Kent State University",
+        "operator:wikidata": "Q1473615"
       }
     },
     {
@@ -4335,7 +4340,7 @@
     {
       "displayName": "UW Facilities",
       "id": "uwfacilities-624e31",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-wa.geojson"]},
       "tags": {
         "amenity": "recycling",
         "operator": "UW Facilities"

--- a/data/operators/amenity/school.json
+++ b/data/operators/amenity/school.json
@@ -4123,7 +4123,8 @@
       },
       "tags": {
         "amenity": "school",
-        "operator": "Boone County Schools"
+        "operator": "Boone County Schools",
+        "operator:wikidata": "Q4943618"
       }
     },
     {
@@ -15524,7 +15525,8 @@
       },
       "tags": {
         "amenity": "school",
-        "operator": "Knox County Schools"
+        "operator": "Knox County Schools",
+        "operator:wikidata": "Q6423553"
       }
     },
     {

--- a/data/operators/amenity/telephone.json
+++ b/data/operators/amenity/telephone.json
@@ -233,7 +233,8 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "telephone",
-        "operator": "Futel"
+        "operator": "Futel",
+        "operator:wikidata": "Q116007010"
       }
     },
     {

--- a/data/operators/amenity/toilets.json
+++ b/data/operators/amenity/toilets.json
@@ -24,7 +24,7 @@
     {
       "displayName": "\"Red Cross\"",
       "id": "redcross-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["zw"]},
       "tags": {
         "amenity": "toilets",
         "operator": "\"Red Cross\""
@@ -87,7 +87,7 @@
     {
       "displayName": "BBMP",
       "id": "bbmp-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["in"]},
       "tags": {
         "amenity": "toilets",
         "operator": "BBMP"
@@ -96,16 +96,17 @@
     {
       "displayName": "BC Parks",
       "id": "bcparks-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["ca-bc.geojson"]},
       "tags": {
         "amenity": "toilets",
-        "operator": "BC Parks"
+        "operator": "BC Parks",
+        "operator:wikidata": "Q2876928"
       }
     },
     {
       "displayName": "BCC",
       "id": "bcc-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["au"]},
       "tags": {
         "amenity": "toilets",
         "operator": "BCC"
@@ -125,10 +126,11 @@
     {
       "displayName": "Bowling Green State University",
       "id": "bowlinggreenstateuniversity-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-oh.geojson"]},
       "tags": {
         "amenity": "toilets",
-        "operator": "Bowling Green State University"
+        "operator": "Bowling Green State University",
+        "operator:wikidata": "Q895457"
       }
     },
     {
@@ -288,10 +290,11 @@
     {
       "displayName": "City of Windhoek",
       "id": "cityofwindhoek-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["na"]},
       "tags": {
         "amenity": "toilets",
-        "operator": "City of Windhoek"
+        "operator": "City of Windhoek",
+        "operator:wikidata": "Q3935"
       }
     },
     {
@@ -324,7 +327,7 @@
     {
       "displayName": "CRS",
       "id": "crs-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["ug"]},
       "tags": {
         "amenity": "toilets",
         "operator": "CRS"
@@ -333,25 +336,28 @@
     {
       "displayName": "Curtin University",
       "id": "curtinuniversity-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["au"]},
       "tags": {
         "amenity": "toilets",
-        "operator": "Curtin University"
+        "operator": "Curtin University",
+        "operator:wikidata": "Q1145497"
       }
     },
     {
-      "displayName": "DCR",
+      "displayName": "Department of Conservation and Recreation (Massachusetts)",
       "id": "dcr-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-ma.geojson"]},
       "tags": {
         "amenity": "toilets",
-        "operator": "DCR"
+        "operator": "Department of Conservation and Recreation",
+        "operator:short": "DCR",
+        "operator:wikidata": "Q2543589"
       }
     },
     {
-      "displayName": "Department of Conservation",
+      "displayName": "Department of Conservation (New Zealand)",
       "id": "departmentofconservation-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["nz"]},
       "matchNames": ["doc"],
       "tags": {
         "amenity": "toilets",
@@ -362,7 +368,7 @@
     {
       "displayName": "DRC",
       "id": "drc-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["ug"]},
       "tags": {
         "amenity": "toilets",
         "operator": "DRC"
@@ -371,10 +377,11 @@
     {
       "displayName": "Durham Technical Community College",
       "id": "durhamtechnicalcommunitycollege-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-nc.geojson"]},
       "tags": {
         "amenity": "toilets",
-        "operator": "Durham Technical Community College"
+        "operator": "Durham Technical Community College",
+        "operator:wikidata": "Q5316567"
       }
     },
     {
@@ -455,12 +462,13 @@
       }
     },
     {
-      "displayName": "Ft Cobb State Park",
+      "displayName": "Fort Cobb State Park",
       "id": "ftcobbstatepark-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-ok.geojson"]},
       "tags": {
         "amenity": "toilets",
-        "operator": "Ft Cobb State Park"
+        "operator": "Fort Cobb State Park",
+        "operator:wikidata": "Q5470940"
       }
     },
     {
@@ -583,10 +591,11 @@
     {
       "displayName": "Kent State University",
       "id": "kentstateuniversity-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-oh.geojson"]},
       "tags": {
         "amenity": "toilets",
-        "operator": "Kent State University"
+        "operator": "Kent State University",
+        "operator:wikidata": "Q1473615"
       }
     },
     {
@@ -712,21 +721,26 @@
       }
     },
     {
-      "displayName": "Miami-Dade College",
+      "displayName": "Miami Dade College",
       "id": "miamidadecollege-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-fl.geojson"]},
+      "matchNames": [
+        "miami-dade college"
+      ],
       "tags": {
         "amenity": "toilets",
-        "operator": "Miami-Dade College"
+        "operator": "Miami Dade College",
+        "operator:wikidata": "Q3027788"
       }
     },
     {
       "displayName": "Michigan DNR",
       "id": "michigandnr-48c608",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-mi.geojson"]},
       "tags": {
         "amenity": "toilets",
-        "operator": "Michigan DNR"
+        "operator": "Michigan Department of Natural Resources",
+        "operator:wikidata": "Q6837532"
       }
     },
     {
@@ -1290,7 +1304,8 @@
       "tags": {
         "amenity": "toilets",
         "operator": "United States Forest Service",
-        "operator:short": "USFS"
+        "operator:short": "USFS",
+        "operator:wikidata": "Q1891156"
       }
     },
     {
@@ -1375,7 +1390,8 @@
       },
       "tags": {
         "amenity": "toilets",
-        "operator": "Washington Department of Fish and Wildlife"
+        "operator": "Washington Department of Fish and Wildlife",
+        "operator:wikidata": "Q28373915"
       }
     },
     {

--- a/data/operators/boundary/protected_area.json
+++ b/data/operators/boundary/protected_area.json
@@ -50,7 +50,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Alaska Division of Parks & Outdoor Recreation"
+        "operator": "Alaska Division of Parks & Outdoor Recreation",
+        "operator:wikidata": "Q109328393"
       }
     },
     {
@@ -158,32 +159,33 @@
     {
       "displayName": "Baltimore County Department of Recreation and Parks",
       "id": "baltimorecountydepartmentofrecreationandparks-7f8cf5",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-md.geojson"]},
       "tags": {
         "boundary": "protected_area",
         "operator": "Baltimore County Department of Recreation and Parks"
       }
     },
     {
-      "displayName": "Baltimore County Maryland",
+      "displayName": "Baltimore County (Maryland)",
       "id": "baltimorecountymaryland-f0b713",
       "locationSet": {
         "include": ["us-md.geojson"]
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Baltimore County Maryland"
+        "operator": "Baltimore County",
+        "operator:wikidata": "Q488668"
       }
     },
     {
-      "displayName": "BLM_FFO",
+      "displayName": "US BLM, Farmington Field Office",
       "id": "blmffo-515a72",
       "locationSet": {
         "include": ["us-nm.geojson"]
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "BLM_FFO"
+        "operator": "BLM, Farmington Field Office"
       }
     },
     {
@@ -194,7 +196,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "BNRC"
+        "operator": "BNRC",
+        "operator:wikidata": "Q4892281"
       }
     },
     {
@@ -250,7 +253,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "California Department of Fish and Wildlife"
+        "operator": "California Department of Fish and Wildlife",
+        "operator:wikidata": "Q5020421"
       }
     },
     {
@@ -261,7 +265,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "California Department of Forestry and Fire Protection"
+        "operator": "California Department of Forestry and Fire Protection",
+        "operator:wikidata": "Q5020422"
       }
     },
     {
@@ -272,7 +277,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "California Department of Parks and Recreation"
+        "operator": "California Department of Parks and Recreation",
+        "operator:wikidata": "Q2933976"
       }
     },
     {
@@ -301,7 +307,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "City and County of Denver"
+        "operator": "City and County of Denver",
+        "operator:wikidata": "Q16554"
       }
     },
     {
@@ -312,7 +319,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "City of Colorado Springs"
+        "operator": "City of Colorado Springs",
+        "operator:wikidata": "Q49258"
       }
     },
     {
@@ -323,7 +331,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "City of Los Angeles"
+        "operator": "City of Los Angeles",
+        "operator:wikidata": "Q65"
       }
     },
     {
@@ -334,7 +343,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Colorado Parks and Wildlife"
+        "operator": "Colorado Parks and Wildlife",
+        "operator:wikidata": "Q5148857"
       }
     },
     {
@@ -363,7 +373,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Conejo Open Space Conservation Agency"
+        "operator": "Conejo Open Space Conservation Agency",
+        "operator:wikidata": "Q97575610"
       }
     },
     {
@@ -392,7 +403,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "County of Douglas, Colorado"
+        "operator": "County of Douglas, Colorado",
+        "operator:wikidata": "Q115556"
       }
     },
     {
@@ -403,17 +415,27 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "County of Los Angeles"
+        "operator": "County of Los Angeles",
+        "operator:wikidata": "Q104994"
       }
     },
     {
-      "displayName": "County of Orange",
+      "displayName": "County of Orange (California)",
       "id": "countyoforange-167f6a",
-      "locationSet": {"include": ["us"]},
-      "note": "Could be Orange County in CA or NY",
+      "locationSet": {"include": ["us-ca.geojson"]},
       "tags": {
         "boundary": "protected_area",
-        "operator": "County of Orange"
+        "operator": "County of Orange",
+        "operator:wikidata": "Q5925"
+      }
+    },
+    {
+      "displayName": "County of Orange (New York)",
+      "locationSet": {"include": ["us-ny.geojson"]},
+      "tags": {
+        "boundary": "protected_area",
+        "operator": "County of Orange",
+        "operator:wikidata": "Q108618"
       }
     },
     {
@@ -428,14 +450,15 @@
       }
     },
     {
-      "displayName": "DE Division of Fish & Wildlife",
+      "displayName": "Delaware Division of Fish and Wildlife",
       "id": "dedivisionoffishandwildlife-429456",
       "locationSet": {
         "include": ["us-de.geojson"]
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "DE Division of Fish & Wildlife"
+        "operator": "Delaware Division of Fish and Wildlife",
+        "operator:wikidata": "Q107362653"
       }
     },
     {
@@ -488,14 +511,15 @@
       }
     },
     {
-      "displayName": "Department of Fish and Game",
+      "displayName": "Department of Fish and Game (Massachusetts)",
       "id": "departmentoffishandgame-dd28c3",
       "locationSet": {
         "include": ["us-ma.geojson"]
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Department of Fish and Game"
+        "operator": "Department of Fish and Game",
+        "operator:wikidata": "Q30258915"
       }
     },
     {
@@ -574,7 +598,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "East Bay Regional Park District"
+        "operator": "East Bay Regional Park District",
+        "operator:wikidata": "Q4116375"
       }
     },
     {
@@ -646,7 +671,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Forest Preserve District of Cook County"
+        "operator": "Forest Preserve District of Cook County",
+        "operator:wikidata": "Q5469080"
       }
     },
     {
@@ -657,7 +683,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Forest Preserve District of DuPage County"
+        "operator": "Forest Preserve District of DuPage County",
+        "operator:wikidata": "Q5469079"
       }
     },
     {
@@ -752,7 +779,7 @@
       "displayName": "Hawaii Department of Fish and Wildlife",
       "id": "hawaiidepartmentoffishandwildlife-64a50d",
       "locationSet": {
-        "include": ["us-hi.geojson"]
+        "include": ["us-hi"]
       },
       "tags": {
         "boundary": "protected_area",
@@ -791,7 +818,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Indiana Department of Natural Resources"
+        "operator": "Indiana Department of Natural Resources",
+        "operator:wikidata": "Q6023149"
       }
     },
     {
@@ -865,7 +893,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Iowa Department of Natural Resources"
+        "operator": "Iowa Department of Natural Resources",
+        "operator:wikidata": "Q6064364"
       }
     },
     {
@@ -1058,14 +1087,15 @@
       }
     },
     {
-      "displayName": "Littleton Conservation Trust (LCT)",
+      "displayName": "Littleton Conservation Trust",
       "id": "littletonconservationtrustlct-dd28c3",
       "locationSet": {
         "include": ["us-ma.geojson"]
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Littleton Conservation Trust (LCT)"
+        "operator": "Littleton Conservation Trust",
+        "operator:short": "LCT"
       }
     },
     {
@@ -1076,7 +1106,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Los Angeles Department of Water and Power"
+        "operator": "Los Angeles Department of Water and Power",
+        "operator:wikidata": "Q3259704"
       }
     },
     {
@@ -1087,16 +1118,17 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Marin County Parks"
+        "operator": "Marin County Parks",
+        "operator:wikidata": "Q17079019"
       }
     },
     {
-      "displayName": "Maryland Department of Natural Resources, Maryland Park Service",
+      "displayName": "Maryland Department of Natural Resources; Maryland Park Service",
       "id": "marylanddepartmentofnaturalresourcesmarylandparkservice-7f8cf5",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-md.geojson"]},
       "tags": {
         "boundary": "protected_area",
-        "operator": "Maryland Department of Natural Resources, Maryland Park Service"
+        "operator": "Maryland Department of Natural Resources;Maryland Park Service"
       }
     },
     {
@@ -1107,7 +1139,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Maryland Forest Service"
+        "operator": "Maryland Forest Service",
+        "operator:wikidata": "Q6781326"
       }
     },
     {
@@ -1118,7 +1151,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Maryland Park Service"
+        "operator": "Maryland Park Service",
+        "operator:wikidata": "Q110072482"
       }
     },
     {
@@ -1177,7 +1211,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Michigan Department of Natural Resources"
+        "operator": "Michigan Department of Natural Resources",
+        "operator:wikidata": "Q6837532"
       }
     },
     {
@@ -1203,10 +1238,11 @@
     {
       "displayName": "Minnesota Department of Natural Resources",
       "id": "minnesotadepartmentofnaturalresources-7f8cf5",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-mn.geojson"]},
       "tags": {
         "boundary": "protected_area",
-        "operator": "Minnesota Department of Natural Resources"
+        "operator": "Minnesota Department of Natural Resources",
+        "operator:wikidata": "Q6868223"
       }
     },
     {
@@ -1217,7 +1253,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Missouri Department of Conservation"
+        "operator": "Missouri Department of Conservation",
+        "operator:wikidata": "Q6879553"
       }
     },
     {
@@ -1239,7 +1276,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Montana Fish, Wildlife & Parks"
+        "operator": "Montana Fish, Wildlife & Parks",
+        "operator:wikidata": "Q17019742"
       }
     },
     {
@@ -1261,7 +1299,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Montgomery Parks"
+        "operator": "Montgomery Parks",
+        "operator:wikidata": "Q61359691"
       }
     },
     {
@@ -1281,7 +1320,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Mountains Recreation and Conservation Authority"
+        "operator": "Mountains Recreation and Conservation Authority",
+        "operator:wikidata": "Q112228334"
       }
     },
     {
@@ -1422,7 +1462,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Nebraska Game and Parks Commission"
+        "operator": "Nebraska Game and Parks Commission",
+        "operator:wikidata": "Q6984719"
       }
     },
     {
@@ -1433,18 +1474,20 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "New Jersey Division of Fish and Wildlife"
+        "operator": "New Jersey Division of Fish and Wildlife",
+        "operator:wikidata": "Q22060891"
       }
     },
     {
-      "displayName": "New Mexico Department of Game & Fish",
+      "displayName": "New Mexico Department of Game and Fish",
       "id": "newmexicodepartmentofgameandfish-515a72",
       "locationSet": {
         "include": ["us-nm.geojson"]
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "New Mexico Department of Game & Fish"
+        "operator": "New Mexico Department of Game and Fish",
+        "operator:wikidata": "Q7010174"
       }
     },
     {
@@ -1466,7 +1509,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "New York State Department of Environmental Conservation"
+        "operator": "New York State Department of Environmental Conservation",
+        "operator:wikidata": "Q3339061"
       }
     },
     {
@@ -1477,7 +1521,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "New York State Office of Parks, Recreation and Historic Preservation"
+        "operator": "New York State Office of Parks, Recreation and Historic Preservation",
+        "operator:wikidata": "Q1706660"
       }
     },
     {
@@ -1506,7 +1551,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "North Carolina Division of Parks and Recreation"
+        "operator": "North Carolina Division of Parks and Recreation",
+        "operator:wikidata": "Q109328529"
       }
     },
     {
@@ -1517,18 +1563,20 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "North Carolina Wildlife Resources Commission"
+        "operator": "North Carolina Wildlife Resources Commission",
+        "operator:wikidata": "Q7054646"
       }
     },
     {
       "displayName": "North Dakota Game and Fish Department",
       "id": "northdakotagameandfishdepartment-6d4e0c",
       "locationSet": {
-        "include": ["us-nc.geojson"]
+        "include": ["us-nd.geojson"]
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "North Dakota Game and Fish Department"
+        "operator": "North Dakota Game and Fish Department",
+        "operator:wikidata": "Q60774286"
       }
     },
     {
@@ -1654,7 +1702,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Oregon Parks and Recreation Department"
+        "operator": "Oregon Parks and Recreation Department",
+        "operator:wikidata": "Q7101287"
       }
     },
     {
@@ -1781,7 +1830,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Prince George's County Department of Parks and Recreation"
+        "operator": "Prince George's County Department of Parks and Recreation",
+        "operator:wikidata": "Q62029847"
       }
     },
     {
@@ -2210,7 +2260,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Santa Clara Valley Open Space Authority"
+        "operator": "Santa Clara Valley Open Space Authority",
+        "operator:wikidata": "Q7419318"
       }
     },
     {
@@ -2302,7 +2353,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "South Florida Water Management District"
+        "operator": "South Florida Water Management District",
+        "operator:wikidata": "Q7567249"
       }
     },
     {
@@ -2313,7 +2365,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "St. Johns River Water Management District"
+        "operator": "St. Johns River Water Management District",
+        "operator:wikidata": "Q7589023"
       }
     },
     {
@@ -2330,11 +2383,12 @@
       "displayName": "State of Hawaii",
       "id": "stateofhawaii-64a50d",
       "locationSet": {
-        "include": ["us-hi.geojson"]
+        "include": ["us-hi"]
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "State of Hawaii"
+        "operator": "State of Hawaii",
+        "operator:wikidata": "Q782"
       }
     },
     {
@@ -2583,7 +2637,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Suwannee River Water Management District"
+        "operator": "Suwannee River Water Management District",
+        "operator:wikidata": "Q7650573"
       }
     },
     {
@@ -2612,7 +2667,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Tennessee Wildlife Resources Agency"
+        "operator": "Tennessee Wildlife Resources Agency",
+        "operator:wikidata": "Q7700244"
       }
     },
     {
@@ -2623,7 +2679,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Texas Parks and Wildlife Department"
+        "operator": "Texas Parks and Wildlife Department",
+        "operator:wikidata": "Q7707904"
       }
     },
     {
@@ -2695,7 +2752,7 @@
     {
       "displayName": "Town of Medfield Conservation Commission",
       "id": "townofmedfieldconservationcommission-7f8cf5",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-ma.geojson"]},
       "tags": {
         "boundary": "protected_area",
         "operator": "Town of Medfield Conservation Commission"
@@ -2705,11 +2762,12 @@
       "displayName": "Town of Rye",
       "id": "townofrye-dd28c3",
       "locationSet": {
-        "include": ["us-ma.geojson"]
+        "include": ["us-nh.geojson"]
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Town of Rye"
+        "operator": "Town of Rye",
+        "operator:wikidata": "Q523619"
       }
     },
     {
@@ -2731,7 +2789,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Town of Sudbury"
+        "operator": "Town of Sudbury",
+        "operator:wikidata": "Q591591"
       }
     },
     {
@@ -2771,7 +2830,8 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "boundary": "protected_area",
-        "operator": "United States of America"
+        "operator": "United States of America",
+        "operator:wikidata": "Q30"
       }
     },
     {
@@ -2823,25 +2883,27 @@
       }
     },
     {
-      "displayName": "Vermont Department of Fish & Wildlife",
+      "displayName": "Vermont Fish & Wildlife Department",
       "id": "vermontdepartmentoffishandwildlife-6f8ce2",
       "locationSet": {
         "include": ["us-vt.geojson"]
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Vermont Department of Fish & Wildlife"
+        "operator": "Vermont Fish & Wildlife Department",
+        "operator:wikidata": "Q30259011"
       }
     },
     {
-      "displayName": "Vermont Department of Forests, Parks and Recreation",
+      "displayName": "Vermont Department of Forests, Parks & Recreation",
       "id": "vermontdepartmentofforestsparksandrecreation-6f8ce2",
       "locationSet": {
         "include": ["us-vt.geojson"]
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Vermont Department of Forests, Parks and Recreation"
+        "operator": "Vermont Department of Forests, Parks & Recreation",
+        "operator:wikidata": "Q115515171"
       }
     },
     {
@@ -2881,7 +2943,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Virginia Department of Game and Inland Fisheries"
+        "operator": "Virginia Department of Game and Inland Fisheries",
+        "operator:wikidata": "Q7934240"
       }
     },
     {
@@ -2938,7 +3001,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Washington State Parks and Recreation Commission"
+        "operator": "Washington State Parks and Recreation Commission",
+        "operator:wikidata": "Q7972267"
       }
     },
     {
@@ -2971,7 +3035,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Wisconsin Department of Natural Resources"
+        "operator": "Wisconsin Department of Natural Resources",
+        "operator:wikidata": "Q1467508"
       }
     },
     {
@@ -2982,7 +3047,8 @@
       },
       "tags": {
         "boundary": "protected_area",
-        "operator": "Wolf River Conservancy"
+        "operator": "Wolf River Conservancy",
+        "operator:wikidata": "Q3569662"
       }
     },
     {

--- a/data/operators/emergency/ambulance_station.json
+++ b/data/operators/emergency/ambulance_station.json
@@ -160,7 +160,7 @@
     {
       "displayName": "Hamilton County EMS",
       "id": "hamiltoncountyems-1fc346",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-tn.geojson"]},
       "tags": {
         "emergency": "ambulance_station",
         "operator": "Hamilton County EMS"

--- a/data/operators/emergency/phone.json
+++ b/data/operators/emergency/phone.json
@@ -32,7 +32,7 @@
     {
       "displayName": "Adelphi Public Safety & Transportation",
       "id": "adelphipublicsafetyandtransportation-d9e125",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-ny.geojson"]},
       "tags": {
         "emergency": "phone",
         "operator": "Adelphi Public Safety & Transportation"
@@ -177,10 +177,11 @@
     {
       "displayName": "Brown University",
       "id": "brownuniversity-d9e125",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-ri.geojson"]},
       "tags": {
         "emergency": "phone",
-        "operator": "Brown University"
+        "operator": "Brown University",
+        "operator:wikidata": "Q49114"
       }
     },
     {
@@ -195,7 +196,7 @@
     {
       "displayName": "Campus Police",
       "id": "campuspolice-d9e125",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-ny.geojson"]},
       "tags": {
         "emergency": "phone",
         "operator": "Campus Police"
@@ -231,10 +232,11 @@
     {
       "displayName": "Clemson University",
       "id": "clemsonuniversity-d9e125",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-sc.geojson"]},
       "tags": {
         "emergency": "phone",
-        "operator": "Clemson University"
+        "operator": "Clemson University",
+        "operator:wikidata": "Q631066"
       }
     },
     {
@@ -254,7 +256,8 @@
       },
       "tags": {
         "emergency": "phone",
-        "operator": "CSU, Chico Police Department"
+        "operator": "CSU, Chico Police Department",
+        "operator:wikidata": "Q120751629"
       }
     },
     {
@@ -375,7 +378,7 @@
     {
       "displayName": "Generalna Dyrekcja Dróg Krajowych i Autostrad",
       "id": "generalnadyrekcjadrogkrajowychiautostrad-d9e125",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "emergency": "phone",
         "operator": "Generalna Dyrekcja Dróg Krajowych i Autostrad"
@@ -448,7 +451,8 @@
       },
       "tags": {
         "emergency": "phone",
-        "operator": "MIT"
+        "operator": "MIT",
+        "operator:wikidata": "Q49108"
       }
     },
     {
@@ -493,7 +497,7 @@
     {
       "displayName": "Network Rail",
       "id": "networkrail-d9e125",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "emergency": "phone",
         "operator": "Network Rail"
@@ -512,10 +516,11 @@
     {
       "displayName": "North Carolina State University",
       "id": "northcarolinastateuniversity-d9e125",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-nc.geojson"]},
       "tags": {
         "emergency": "phone",
-        "operator": "North Carolina State University"
+        "operator": "North Carolina State University",
+        "operator:wikidata": "Q1132346"
       }
     },
     {
@@ -564,10 +569,11 @@
     {
       "displayName": "Rochester Institute of Technology",
       "id": "rochesterinstituteoftechnology-d9e125",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-ny.geojson"]},
       "tags": {
         "emergency": "phone",
-        "operator": "Rochester Institute of Technology"
+        "operator": "Rochester Institute of Technology",
+        "operator:wikidata": "Q2140778"
       }
     },
     {
@@ -600,10 +606,11 @@
     {
       "displayName": "Sacred Heart Medical Center at Riverbend",
       "id": "sacredheartmedicalcenteratriverbend-d9e125",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-or.geojson"]},
       "tags": {
         "emergency": "phone",
-        "operator": "Sacred Heart Medical Center at Riverbend"
+        "operator": "Sacred Heart Medical Center at Riverbend",
+        "operator:wikidata": "Q7397238"
       }
     },
     {
@@ -654,7 +661,8 @@
       },
       "tags": {
         "emergency": "phone",
-        "operator": "Seattle University"
+        "operator": "Seattle University",
+        "operator:wikidata": "Q615873"
       }
     },
     {
@@ -669,10 +677,11 @@
     {
       "displayName": "Slippery Rock University",
       "id": "slipperyrockuniversity-d9e125",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-pa.geojson"]},
       "tags": {
         "emergency": "phone",
-        "operator": "Slippery Rock University"
+        "operator": "Slippery Rock University",
+        "operator:wikidata": "Q1799642"
       }
     },
     {
@@ -692,7 +701,7 @@
     {
       "displayName": "Stadt Karlsruhe",
       "id": "stadtkarlsruhe-d9e125",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["de"]},
       "tags": {
         "emergency": "phone",
         "operator": "Stadt Karlsruhe"
@@ -728,7 +737,8 @@
       },
       "tags": {
         "emergency": "phone",
-        "operator": "Texas Woman's University"
+        "operator": "Texas Woman's University",
+        "operator:wikidata": "Q3468361"
       }
     },
     {
@@ -754,7 +764,8 @@
       },
       "tags": {
         "emergency": "phone",
-        "operator": "Towson University"
+        "operator": "Towson University",
+        "operator:wikidata": "Q1474129"
       }
     },
     {
@@ -783,19 +794,19 @@
     {
       "displayName": "Trenes Argentinos",
       "id": "trenesargentinos-d9e125",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["ar"]},
       "tags": {
         "emergency": "phone",
         "operator": "Trenes Argentinos"
       }
     },
     {
-      "displayName": "U.S Customs and Border Protection",
+      "displayName": "U.S. Customs and Border Protection",
       "id": "uscustomsandborderprotection-dc8817",
       "locationSet": {"include": ["us"]},
       "tags": {
         "emergency": "phone",
-        "operator": "U.S Customs and Border Protection",
+        "operator": "U.S. Customs and Border Protection",
         "operator:short": "CBP",
         "operator:wikidata": "Q368804"
       }
@@ -814,7 +825,7 @@
     {
       "displayName": "UF Police Department",
       "id": "ufpolicedepartment-d9e125",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-fl.geojson"]},
       "tags": {
         "emergency": "phone",
         "operator": "UF Police Department"
@@ -828,7 +839,8 @@
       },
       "tags": {
         "emergency": "phone",
-        "operator": "UMass Lowell"
+        "operator": "UMass Lowell",
+        "operator:wikidata": "Q15143"
       }
     },
     {
@@ -899,7 +911,7 @@
     {
       "displayName": "Verkehrsbetriebe Karlsruhe GmbH",
       "id": "verkehrsbetriebekarlsruhegmbh-d9e125",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["de"]},
       "tags": {
         "emergency": "phone",
         "operator": "Verkehrsbetriebe Karlsruhe GmbH"
@@ -923,7 +935,8 @@
       },
       "tags": {
         "emergency": "phone",
-        "operator": "Virginia Tech"
+        "operator": "Virginia Tech",
+        "operator:wikidata": "Q65379"
       }
     },
     {
@@ -968,7 +981,8 @@
       },
       "tags": {
         "emergency": "phone",
-        "operator": "Yale University"
+        "operator": "Yale University",
+        "operator:wikidata": "Q49112"
       }
     },
     {

--- a/data/operators/leisure/park.json
+++ b/data/operators/leisure/park.json
@@ -1164,7 +1164,8 @@
       },
       "tags": {
         "leisure": "park",
-        "operator": "City of Des Moines"
+        "operator": "City of Des Moines",
+        "operator:wikidata": "Q39709"
       }
     },
     {
@@ -1175,7 +1176,8 @@
       },
       "tags": {
         "leisure": "park",
-        "operator": "City of Des Moines"
+        "operator": "City of Des Moines",
+        "operator:wikidata": "Q163325"
       }
     },
     {
@@ -1303,7 +1305,8 @@
       },
       "tags": {
         "leisure": "park",
-        "operator": "City of Fontana"
+        "operator": "City of Fontana",
+        "operator:wikidata": "Q491128"
       }
     },
     {
@@ -2507,7 +2510,8 @@
       },
       "tags": {
         "leisure": "park",
-        "operator": "City of Warren"
+        "operator": "City of Warren",
+        "operator:wikidata": "Q499401"
       }
     },
     {
@@ -2518,7 +2522,8 @@
       },
       "tags": {
         "leisure": "park",
-        "operator": "City of Warren"
+        "operator": "City of Warren",
+        "operator:wikidata": "Q1903308"
       }
     },
     {
@@ -2529,7 +2534,8 @@
       },
       "tags": {
         "leisure": "park",
-        "operator": "City of Warren"
+        "operator": "City of Warren",
+        "operator:wikidata": "Q1184834"
       }
     },
     {
@@ -3326,7 +3332,8 @@
       "locationSet": {"include": ["us-in.geojson"]},
       "tags": {
         "leisure": "park",
-        "operator": "Hammond Parks & Recreation"
+        "operator": "Hammond Parks & Recreation",
+        "operator:wikidata": "Q118594147"
       }
     },
     {
@@ -3571,7 +3578,8 @@
       },
       "tags": {
         "leisure": "park",
-        "operator": "Jackson County"
+        "operator": "Jackson County",
+        "operator:wikidata": "Q497702"
       }
     },
     {
@@ -3582,7 +3590,8 @@
       },
       "tags": {
         "leisure": "park",
-        "operator": "Jackson County"
+        "operator": "Jackson County",
+        "operator:wikidata": "Q486215"
       }
     },
     {
@@ -3593,7 +3602,8 @@
       },
       "tags": {
         "leisure": "park",
-        "operator": "Jackson County"
+        "operator": "Jackson County",
+        "operator:wikidata": "Q450159"
       }
     },
     {
@@ -3604,7 +3614,8 @@
       },
       "tags": {
         "leisure": "park",
-        "operator": "Jackson County"
+        "operator": "Jackson County",
+        "operator:wikidata": "Q500897"
       }
     },
     {
@@ -5643,7 +5654,8 @@
       "locationSet": {"include": ["us-ny.geojson"]},
       "tags": {
         "leisure": "park",
-        "operator": "Town of Hempstead"
+        "operator": "Town of Hempstead",
+        "operator:wikidata": "Q1583289"
       }
     },
     {

--- a/data/operators/leisure/pitch.json
+++ b/data/operators/leisure/pitch.json
@@ -86,7 +86,8 @@
       },
       "tags": {
         "leisure": "pitch",
-        "operator": "City of Dubuque"
+        "operator": "City of Dubuque",
+        "operator:wikidata": "Q493794"
       }
     },
     {

--- a/data/operators/man_made/pipeline.json
+++ b/data/operators/man_made/pipeline.json
@@ -101,7 +101,8 @@
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Air Liquide Large Industries"
+        "operator": "Air Liquide Large Industries",
+        "operator:wikidata": "Q113466577"
       }
     },
     {
@@ -120,7 +121,8 @@
       "locationSet": {"include": ["ca", "us"]},
       "tags": {
         "man_made": "pipeline",
-        "operator": "Alliance Pipeline"
+        "operator": "Alliance Pipeline",
+        "operator:wikidata": "Q4732327"
       }
     },
     {
@@ -190,12 +192,14 @@
       }
     },
     {
-      "displayName": "ANR PIPELINE CO",
+      "displayName": "ANR Pipeline",
       "id": "anrpipelineco-0a386a",
       "locationSet": {"include": ["us"]},
+      "matchNames": ["anr pipeline co"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "ANR PIPELINE CO"
+        "operator": "ANR Pipeline",
+        "operator:wikidata": "Q4653023"
       }
     },
     {
@@ -226,7 +230,8 @@
       },
       "tags": {
         "man_made": "pipeline",
-        "operator": "Ascend Performance Materials"
+        "operator": "Ascend Performance Materials",
+        "operator:wikidata": "Q116714079"
       }
     },
     {

--- a/data/operators/office/government.json
+++ b/data/operators/office/government.json
@@ -1049,10 +1049,11 @@
     {
       "displayName": "Maryland State Police",
       "id": "marylandstatepolice-eaa288",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-md.geojson"]},
       "tags": {
         "office": "government",
-        "operator": "Maryland State Police"
+        "operator": "Maryland State Police",
+        "operator:wikidata": "Q3296292"
       }
     },
     {

--- a/data/operators/power/generator.json
+++ b/data/operators/power/generator.json
@@ -649,6 +649,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Avangrid Renewables",
+        "operator:wikidata": "Q5983823",
         "power": "generator"
       }
     },
@@ -1330,9 +1331,10 @@
     {
       "displayName": "City of Beaverton",
       "id": "cityofbeaverton-19ecba",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-or.geojson"]},
       "tags": {
         "operator": "City of Beaverton",
+        "operator:wikidata": "Q81856",
         "power": "generator"
       }
     },
@@ -1718,9 +1720,10 @@
     {
       "displayName": "Dominion Energy South Carolina, Inc",
       "id": "dominionenergysouthcarolinainc-19ecba",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-sc.geojson"]},
       "tags": {
         "operator": "Dominion Energy South Carolina, Inc",
+        "operator:wikidata": "Q114367619",
         "power": "generator"
       }
     },
@@ -4298,9 +4301,10 @@
     {
       "displayName": "Kendall County",
       "id": "kendallcounty-19ecba",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-il.geojson"]},
       "tags": {
         "operator": "Kendall County",
+        "operator:wikidata": "Q112512",
         "power": "generator"
       }
     },
@@ -6692,6 +6696,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Starwood Energy Group",
+        "operator:wikidata": "Q95981565",
         "power": "generator"
       }
     },

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -244,15 +244,6 @@
       }
     },
     {
-      "displayName": "American Transmission Systems",
-      "id": "americantransmissionsystems-b654b4",
-      "locationSet": {"include": ["us"]},
-      "tags": {
-        "operator": "American Transmission Systems",
-        "power": "line"
-      }
-    },
-    {
       "displayName": "Amprion",
       "id": "amprion-d5e323",
       "locationSet": {"include": ["de"]},
@@ -301,10 +292,14 @@
       }
     },
     {
-      "displayName": "APS",
+      "displayName": "Allegheny Power System",
       "id": "aps-b654b4",
-      "locationSet": {"include": ["us"]},
-      "tags": {"operator": "APS", "power": "line"}
+      "locationSet": {"include": ["us-pa.geojson","us-oh.geojson","us-wv.geojson"]},
+      "tags": {
+        "operator": "Allegheny Power System",
+        "operator:short": "APS",
+        "power": "line"
+      }
     },
     {
       "displayName": "Arendals Fossekompani",
@@ -376,11 +371,12 @@
       }
     },
     {
-      "displayName": "ATSI",
+      "displayName": "American Transmission Systems",
       "id": "atsi-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-oh.geojson","us-pa.geojson"]},
       "tags": {
-        "operator": "ATSI",
+        "operator": "American Transmission Systems",
+        "operator:short": "ATSI",
         "power": "line"
       }
     },
@@ -662,11 +658,11 @@
       }
     },
     {
-      "displayName": "Brookings Muncipal Utilities",
+      "displayName": "Brookings Municipal Utilities",
       "id": "brookingsmuncipalutilities-b654b4",
       "locationSet": {"include": ["us"]},
       "tags": {
-        "operator": "Brookings Muncipal Utilities",
+        "operator": "Brookings Municipal Utilities",
         "power": "line"
       }
     },
@@ -973,72 +969,80 @@
     {
       "displayName": "City of Ames",
       "id": "cityofames-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-ia.geojson"]},
       "tags": {
         "operator": "City of Ames",
+        "operator:wikidata": "Q470273",
         "power": "line"
       }
     },
     {
       "displayName": "City of Concord",
       "id": "cityofconcord-116894",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-nc.geojson"]},
       "tags": {
         "operator": "City of Concord",
+        "operator:wikidata": "Q1030184",
         "power": "line"
       }
     },
     {
       "displayName": "City of Elizabeth",
       "id": "cityofelizabeth-116894",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-nc.geojson"]},
       "tags": {
         "operator": "City of Elizabeth",
+        "operator:wikidata": "Q1018467",
         "power": "line"
       }
     },
     {
       "displayName": "City of High Point",
       "id": "cityofhighpoint-116894",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-nc.geojson"]},
       "tags": {
         "operator": "City of High Point",
+        "operator:wikidata": "Q631194",
         "power": "line"
       }
     },
     {
       "displayName": "City of Lakeland",
       "id": "cityoflakeland-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-fl.geojson"]},
       "tags": {
         "operator": "City of Lakeland",
+        "operator:wikidata": "Q639452",
         "power": "line"
       }
     },
     {
       "displayName": "City of Lexington",
       "id": "cityoflexington-116894",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-nc.geojson"]},
       "tags": {
         "operator": "City of Lexington",
+        "operator:wikidata": "Q181370",
         "power": "line"
       }
     },
     {
       "displayName": "City of Natchitoches",
       "id": "cityofnatchitoches-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-la.geojson"]},
       "tags": {
         "operator": "City of Natchitoches",
+        "operator:wikidata": "Q2278195",
         "power": "line"
       }
     },
     {
       "displayName": "City of Tallahassee",
       "id": "cityoftallahassee-116894",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-fl.geojson"]},
       "tags": {
         "operator": "City of Tallahassee",
+        "operator:wikidata": "Q37043",
         "power": "line"
       }
     },
@@ -1115,9 +1119,10 @@
     {
       "displayName": "Cleveland Public Power",
       "id": "clevelandpublicpower-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-oh.geojson"]},
       "tags": {
         "operator": "Cleveland Public Power",
+        "operator:wikidata": "Q5132214",
         "power": "line"
       }
     },
@@ -1441,9 +1446,11 @@
     {
       "displayName": "Dayton Power & Light",
       "id": "daytonpowerandlight-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-oh.geojson"]},
       "tags": {
         "operator": "Dayton Power & Light",
+        "operator:short": "DPL",
+        "operator:wikidata": "Q5205934",
         "power": "line"
       }
     },
@@ -2886,11 +2893,11 @@
       }
     },
     {
-      "displayName": "Florida Keys Electric Coorerative",
+      "displayName": "Florida Keys Electric Cooperative",
       "id": "floridakeyselectriccoorerative-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-fl.geojson"]},
       "tags": {
-        "operator": "Florida Keys Electric Coorerative",
+        "operator": "Florida Keys Electric Cooperative",
         "operator:short": "FKEC",
         "power": "line"
       }
@@ -3641,11 +3648,12 @@
       }
     },
     {
-      "displayName": "KEYS",
+      "displayName": "Keys Energy Services",
       "id": "keys-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-fl.geojson"]},
       "tags": {
-        "operator": "KEYS",
+        "operator": "Keys Energy Services",
+        "operator:short": "KEYS",
         "power": "line"
       }
     },
@@ -3908,7 +3916,7 @@
     {
       "displayName": "Long Island Power Authority",
       "id": "longislandpowerauthority-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-ny.geojson"]},
       "matchNames": ["lipa"],
       "tags": {
         "operator": "Long Island Power Authority",
@@ -3935,6 +3943,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "LS Power",
+        "operator:wikidata": "Q126367251",
         "power": "line"
       }
     },
@@ -3966,10 +3975,15 @@
       }
     },
     {
-      "displayName": "LUS",
+      "displayName": "Lafayette Utilities System",
       "id": "lus-b654b4",
-      "locationSet": {"include": ["us"]},
-      "tags": {"operator": "LUS", "power": "line"}
+      "locationSet": {"include": ["us-la.geojson"]},
+      "tags": {
+        "operator": "Lafayette Utilities System",
+        "operator:short": "LUS",
+        "operator:wikidata": "Q115691686",
+        "power": "line"
+      }
     },
     {
       "displayName": "Lyse",
@@ -4038,9 +4052,10 @@
     {
       "displayName": "Marshall Municipal Utilities",
       "id": "marshallmunicipalutilities-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-mn.geojson"]},
       "tags": {
         "operator": "Marshall Municipal Utilities",
+        "operator:wikidata": "Q115691708",
         "power": "line"
       }
     },
@@ -4146,6 +4161,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Minnesota Valley Cooperative Light & Power Association",
+        "operator:wikidata": "Q115691727",
         "power": "line"
       }
     },
@@ -4455,6 +4471,7 @@
       },
       "tags": {
         "operator": "Nevada Power Company",
+        "operator:wikidata": "Q17107993",
         "power": "line"
       }
     },
@@ -4505,9 +4522,10 @@
     {
       "displayName": "Niagara Mohawk",
       "id": "niagaramohawk-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-ny.geojson"]},
       "tags": {
         "operator": "Niagara Mohawk",
+        "operator:wikidata": "Q25028424",
         "power": "line"
       }
     },
@@ -4591,11 +4609,11 @@
       }
     },
     {
-      "displayName": "NORTHWESTERN ENERGY LLC",
+      "displayName": "NorthWestern Energy LLC",
       "id": "northwesternenergyllc-b654b4",
       "locationSet": {"include": ["us"]},
       "tags": {
-        "operator": "NORTHWESTERN ENERGY LLC",
+        "operator": "NorthWestern Energy LLC",
         "operator:wikidata": "Q7053620",
         "power": "line"
       }
@@ -5090,7 +5108,7 @@
     {
       "displayName": "PRPA",
       "id": "prpa-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-co.geojson"]},
       "tags": {
         "operator": "PRPA",
         "power": "line"
@@ -5196,9 +5214,10 @@
     {
       "displayName": "Reedy Creek Improvement District",
       "id": "reedycreekimprovementdistrict-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-fl.geojson"]},
       "tags": {
         "operator": "Reedy Creek Improvement District",
+        "operator:wikidata": "Q3423018",
         "power": "line"
       }
     },
@@ -5588,7 +5607,7 @@
     {
       "displayName": "SLEMCO",
       "id": "slemco-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-la.geojson"]},
       "tags": {
         "operator": "SLEMCO",
         "power": "line"
@@ -6034,11 +6053,12 @@
       }
     },
     {
-      "displayName": "SWTC",
+      "displayName": "Southwest Transmission Cooperative",
       "id": "swtc-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-az.geojson"]},
       "tags": {
-        "operator": "SWTC",
+        "operator": "Southwest Transmission Cooperative",
+        "operator:short": "SWTC",
         "power": "line"
       }
     },
@@ -6219,15 +6239,6 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Texas Municipal Power Agency",
-        "power": "line"
-      }
-    },
-    {
-      "displayName": "Texas New Mexico Power",
-      "id": "texasnewmexicopower-b654b4",
-      "locationSet": {"include": ["us"]},
-      "tags": {
-        "operator": "Texas New Mexico Power",
         "power": "line"
       }
     },
@@ -6735,9 +6746,10 @@
     {
       "displayName": "Virginia Electric & Power Company",
       "id": "virginiaelectricandpowercompany-b654b4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-va.geojson","us-nc.geojson"]},
       "tags": {
         "operator": "Virginia Electric & Power Company",
+        "operator:wikidata": "Q117834539",
         "power": "line"
       }
     },

--- a/data/operators/power/plant.json
+++ b/data/operators/power/plant.json
@@ -190,6 +190,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Avangrid Renewables LLC",
+        "operator:wikidata": "Q5983823",
         "power": "plant"
       }
     },
@@ -539,6 +540,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Eagle Creek Renewable Energy, LLC",
+        "operator:wikidata": "Q113376370",
         "power": "plant"
       }
     },
@@ -1079,6 +1081,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Exelon Power",
+        "operator:wikidata": "Q1383669",
         "power": "plant"
       }
     },
@@ -1106,6 +1109,7 @@
       ],
       "tags": {
         "operator": "Florida Power & Light",
+        "operator:wikidata": "Q1430055",
         "power": "plant"
       }
     },
@@ -1598,9 +1602,10 @@
     {
       "displayName": "MC Power Companies",
       "id": "mcpowercompanies-2ac081",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-mo.geojson","us-ks.geojson"]},
       "tags": {
         "operator": "MC Power Companies",
+        "operator:wikidata": "Q64141964",
         "power": "plant"
       }
     },
@@ -2073,11 +2078,11 @@
       }
     },
     {
-      "displayName": "Public Service Co of Colorado",
+      "displayName": "Public Service Company of Colorado",
       "id": "publicservicecoofcolorado-2ac081",
       "locationSet": {"include": ["us"]},
       "tags": {
-        "operator": "Public Service Co of Colorado",
+        "operator": "Public Service Company of Colorado",
         "power": "plant"
       }
     },
@@ -2773,13 +2778,14 @@
         "operator": "Verbund Hydro Power GmbH",
         "power": "plant"
       }
-    },
+    },    
     {
-      "displayName": "Virginia Electric & Power Co",
+      "displayName": "Virginia Electric & Power Company",
       "id": "virginiaelectricandpowerco-e6c8aa",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["us-va.geojson","us-nc.geojson"]},
       "tags": {
-        "operator": "Virginia Electric & Power Co",
+        "operator": "Virginia Electric & Power Company",
+        "operator:wikidata": "Q117834539",
         "power": "plant"
       }
     },

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -1126,10 +1126,11 @@
     {
       "displayName": "City of Lakeland",
       "id": "cityoflakeland-301545",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-fl.geojson"]},
       "tags": {
         "operator": "City of Lakeland",
-        "power": "substation"
+        "power": "substation",
+        "operator:wikidata": "Q639452"
       }
     },
     {
@@ -4756,9 +4757,10 @@
     {
       "displayName": "Linn County REC",
       "id": "linncountyrec-301545",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-ia.geojson"]},
       "tags": {
         "operator": "Linn County REC",
+        "operator:wikidata": "Q115691646",
         "power": "substation"
       }
     },
@@ -4884,11 +4886,13 @@
       }
     },
     {
-      "displayName": "LUS",
+      "displayName": "Lafayette Utilities System",
       "id": "lus-301545",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-la.geojson"]},
       "tags": {
-        "operator": "LUS",
+        "operator": "Lafayette Utilities System",
+        "operator:short": "LUS",
+        "operator:wikidata": "Q115691686",
         "power": "substation"
       }
     },
@@ -4905,7 +4909,7 @@
     {
       "displayName": "LWU",
       "id": "lwu-301545",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-fl.geojson"]},
       "tags": {
         "operator": "LWU",
         "power": "substation"
@@ -5013,9 +5017,10 @@
     {
       "displayName": "Marshall Municipal Utilities",
       "id": "marshallmunicipalutilities-301545",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-mn.geojson"]},
       "tags": {
         "operator": "Marshall Municipal Utilities",
+        "operator:wikidata": "Q115691708",
         "power": "substation"
       }
     },
@@ -5080,9 +5085,10 @@
     {
       "displayName": "Metra",
       "id": "metra-301545",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-il.geojson"]},
       "tags": {
         "operator": "Metra",
+        "operator:wikidata": "Q1814208",
         "power": "substation"
       }
     },
@@ -5127,9 +5133,10 @@
     {
       "displayName": "Minnesota Valley Cooperative Light & Power Association",
       "id": "minnesotavalleycooperativelightandpowerassociation-301545",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-mn.geojson"]},
       "tags": {
         "operator": "Minnesota Valley Cooperative Light & Power Association",
+        "operator:wikidata": "Q115691727",
         "power": "substation"
       }
     },
@@ -5530,9 +5537,10 @@
     {
       "displayName": "New Braunfels Utilities",
       "id": "newbraunfelsutilities-301545",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-tx.geojson"]},
       "tags": {
         "operator": "New Braunfels Utilities",
+        "operator:wikidata": "Q115691758",
         "power": "substation"
       }
     },
@@ -5720,6 +5728,7 @@
       },
       "tags": {
         "operator": "NOVEC",
+        "operator:wikidata": "Q115691810",
         "power": "substation"
       }
     },
@@ -5791,6 +5800,7 @@
       },
       "tags": {
         "operator": "Ohio Power",
+        "operator:wikidata": "Q115902499",
         "power": "substation"
       }
     },
@@ -6034,9 +6044,10 @@
     {
       "displayName": "Penelec",
       "id": "penelec-301545",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-pa.geojson"]},
       "tags": {
         "operator": "Penelec",
+        "operator:wikidata": "Q115691836",
         "power": "substation"
       }
     },
@@ -9286,9 +9297,10 @@
     {
       "displayName": "Virginia Electric & Power Company",
       "id": "virginiaelectricandpowercompany-301545",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-va.geojson","us-nc.geojson"]},
       "tags": {
         "operator": "Virginia Electric & Power Company",
+        "operator:wikidata": "Q117834539",
         "power": "substation"
       }
     },

--- a/data/operators/telecom/exchange.json
+++ b/data/operators/telecom/exchange.json
@@ -565,6 +565,7 @@
       "locationSet": {"include": ["us"]},
       "tags": {
         "operator": "Verizon Virginia LLC",
+        "operator:wikidata": "Q24060823",
         "telecom": "exchange"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -13574,11 +13574,12 @@
       "tags": {
         "network": "SBU Transit",
         "operator": "Stony Brook University",
+        "operator:wikidata": "Q969850",
         "route": "bus"
       }
     },
     {
-      "displayName": "SCAT (Saratosa County)",
+      "displayName": "SCAT (Sarasota County)",
       "id": "scat-e591f2",
       "locationSet": {
         "include": ["us-fl.geojson"]
@@ -17483,6 +17484,7 @@
       },
       "tags": {
         "network": "UMass Lowell",
+        "network:wikidata": "Q15143",
         "route": "bus"
       }
     },


### PR DESCRIPTION
This is a large collection of edits, many of which either add Wikidata IDs to entries or refine the locationSet of entries. There are also several outliers that edit or correct names, and two edits that eliminated duplicate entries for the same power line operators.