### PR TITLE
More New York State library systems

### DIFF
--- a/data/operators/amenity/library.json
+++ b/data/operators/amenity/library.json
@@ -383,6 +383,19 @@
       }
     },
     {
+      "displayName": "Chautauqua-Cattaraugus Library System",
+      "locationSet": {
+        "include": ["us-ny.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Chautauqua-Cattaraugus Library System",
+        "operator:short": "CCLS",
+        "operator:type": "public",
+        "operator:wikidata": "Q128797809"
+      }
+    },
+    {
       "displayName": "Chicago Public Library",
       "id": "chicagopubliclibrary-f51cb2",
       "locationSet": {
@@ -690,6 +703,32 @@
         "amenity": "library",
         "operator": "Essex County Council",
         "operator:wikidata": "Q5399679"
+      }
+    },
+    {
+      "displayName": "Finger Lakes Library System",
+      "locationSet": {
+        "include": ["us-ny.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Finger Lakes Library System",
+        "operator:short": "FLLS",
+        "operator:type": "public",
+        "operator:wikidata": "Q108565304"
+      }
+    },
+    {
+      "displayName": "Four County Library System",
+      "locationSet": {
+        "include": ["us-ny.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Four County Library System",
+        "operator:short": "4CLS",
+        "operator:type": "public",
+        "operator:wikidata": "Q30258025"
       }
     },
     {
@@ -1369,6 +1408,19 @@
       }
     },
     {
+      "displayName": "North Country Library System",
+      "locationSet": {
+        "include": ["us-ny.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "North Country Library System",
+        "operator:short": "NCLS",
+        "operator:type": "public",
+        "operator:wikidata": "Q128798933"
+      }
+    },
+    {
       "displayName": "North Northamptonshire",
       "id": "northnorthamptonshire-f83674",
       "locationSet": {
@@ -1750,6 +1802,19 @@
         "operator": "Somerset Council",
         "operator:type": "government",
         "operator:wikidata": "Q6386270"
+      }
+    },
+    {
+      "displayName": "Southern Tier Library System",
+      "locationSet": {
+        "include": ["us-ny.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Southern Tier Library System",
+        "operator:short": "STLS",
+        "operator:type": "public",
+        "operator:wikidata": "Q128798470"
       }
     },
     {


### PR DESCRIPTION
These are the last five library systems in Western and Central New York State that are not in or proposed to be in the NSI.