### PR TITLE
[brands/office/government] add new file, add "My documents" brand

### DIFF
--- a/data/brands/office/government.json
+++ b/data/brands/office/government.json
@@ -1,0 +1,26 @@
+{
+  "properties": {
+    "path": "brands/office/government",
+    "exclude": {"generic": ["^government$"]}
+  },
+  "items": [
+    {
+      "displayName": "Мои документы",
+      "locationSet": {"include": ["ru"]},
+      "matchNames": ["госуслуги", "центр госуслуг"],
+      "tags": {
+        "brand": "Мои документы",
+        "brand:ru": "Мои документы",
+        "brand:en": "My documents",
+        "brand:wikidata": "Q57449742",
+        "short_name": "МФЦ",
+        "short_name:ru": "МФЦ",
+        "office": "government",
+        "government": "public_service",
+        "official_name": "Центр государственных и муниципальных услуг \"Мои документы\"",
+        "official_name:ru": "Центр государственных и муниципальных услуг \"Мои документы\"",
+        "official_name:en": "Center for State and Municipal Services \"My Documents\""
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- This PR adds `brands/office/government.json`. I'm adding a file for the first time, so please suggest any improvements if needed.
- Regarding the brand in this PR: 
    - there is some order for this one in OSM (https://overpass-turbo.eu/s/1PyO), almost all nodes have this brand name and most of them have `office=government,government=public_service`. 
    - `name` is omitted for this NSI item as in OSM it's usually have `brand/short_name + name of the branch` in `name`.