### PR TITLE
Update hotel.json - Added biggest Swiss-Bel subbrands

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -19,6 +19,26 @@
   },
   "items": [
     {
+      "displayName": "Swiss-Belhotel",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "Swiss-Belhotel",
+        "brand:wikidata": "Q115348131",
+        "name": "Swiss-Belhotel",
+        "tourism": "hotel"
+      }
+    },
+    {
+      "displayName": "Swiss-Belinn",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "Swiss-Belinn",
+        "brand:wikidata": "Q115348139",
+        "name": "Swiss-Belinn",
+        "tourism": "hotel"
+      }
+    },
+    {
       "displayName": "7天酒店",
       "id": "7daysinn-af4cd2",
       "locationSet": {"include": ["cn"]},


### PR DESCRIPTION
These are the two largest Brands of the [Swiss-Belhotel International Hotels & Resorts](https://www.swiss-belhotel.com/en-gb/hotels/sbibrands). They do have smaller ones, but all except the two added below have less than 10 locations. 