### PR TITLE
Update Anytime Fitness

### DIFF
--- a/data/brands/leisure/fitness_centre.json
+++ b/data/brands/leisure/fitness_centre.json
@@ -108,8 +108,11 @@
     },
     {
       "displayName": "Anytime Fitness",
-      "id": "anytimefitness-c8777b",
-      "locationSet": {"include": ["001"]},
+      "id": "anytimefitness-f3f46d",
+      "locationSet": {
+        "include": ["001"],
+        "exclude": ["jp"]
+      },
       "matchNames": ["anytime fitness australia"],
       "tags": {
         "brand": "Anytime Fitness",


### PR DESCRIPTION
Anytime Fitness has an [item for Japan](https://nsi.guide/index.html?t=brands&k=leisure&v=fitness_centre&tt=anytime%20fitness), so it was excluded from 001.