### PR TITLE
Remove duplicated restaurant/fast food chain Pitaya

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -6824,12 +6824,13 @@
     },
     {
       "displayName": "Pitaya",
-      "id": "pitaya-0966cc",
+      "id": "pitaya-4bf92d",
       "locationSet": {
         "include": [
+          "ad",
           "ae",
           "es",
-          "fx",
+          "fr",
           "gb-lon.geojson",
           "it",
           "tn"

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -5115,18 +5115,6 @@
       }
     },
     {
-      "displayName": "Pitaya",
-      "id": "pitaya-2fabb0",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "amenity": "restaurant",
-        "brand": "Pitaya",
-        "brand:wikidata": "Q114970230",
-        "cuisine": "thai",
-        "name": "Pitaya"
-      }
-    },
-    {
       "displayName": "Pizza Delight",
       "id": "pizzadelight-e68b16",
       "locationSet": {"include": ["ca"]},


### PR DESCRIPTION
The fast food chain Pitaya is present in the `restaurant.json` and the `fast_food.json`. 

We should only keep one of them. I think the concept of the chain corresponds more to a fast food chain than a restaurant, but I'm might be wrong.