### PR TITLE
Add brand:wikidata entry to supermarker chain Κρητικός

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -9024,6 +9024,7 @@
         "brand": "Κρητικός",
         "brand:el": "Κρητικός",
         "brand:en": "Kritikos",
+        "brand:wikidata": "Q129911567",
         "name": "Κρητικός",
         "name:el": "Κρητικός",
         "name:en": "Kritikos",


### PR DESCRIPTION
A Wikidata entry already exists for this supermarket chain:
https://www.wikidata.org/wiki/Q129911567