### PR TITLE
Add Denmark and brand:wikidata property to Recharge network

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -233,7 +233,7 @@
       "displayName": "Recharge",
       "id": "recharge-508422",
       "locationSet": {
-        "include": ["fi", "no", "se"]
+        "include": ["fi", "no", "se", "dk"]
       },
       "matchNames": [
         "fortum",
@@ -243,6 +243,7 @@
       "tags": {
         "amenity": "charging_station",
         "brand": "Recharge",
+        "brand:wikidata": "Q126540050",
         "name": "Recharge",
         "operator": "Recharge"
       }


### PR DESCRIPTION
Wikidata item:
https://www.wikidata.org/wiki/Q126540050

Source for Denmark as an available country:
https://rechargeinfra.com/how-to-charge-your-ev/#ChargingServiceProviders (dropdown menu)