### PR TITLE
Added brand:wikidata to Kople charging_station network

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -120,7 +120,8 @@
       "locationSet": {"include": ["no"]},
       "tags": {
         "amenity": "charging_station",
-        "brand": "Kople"
+        "brand": "Kople",
+        "brand:wikidata": "Q126708777"
       }
     },
     {


### PR DESCRIPTION
This:
https://www.wikidata.org/wiki/Q126708777

To be added to:
https://nsi.guide/index.html?t=brands&k=amenity&v=charging_station#kople-054d0f