### PR TITLE
Add operator presets for highway=street_lamp (CenterPoint Energy, Puget Sound Energy, and Seattle City Light)

### DIFF
--- a/data/operators/highway/street_lamp.json
+++ b/data/operators/highway/street_lamp.json
@@ -1,0 +1,39 @@
+{
+  "properties": {
+    "path": "operators/highway/street_lamp",
+    "exclude": {
+      "generic": ["^street_lamp$"]
+    }
+  },
+  "items": [
+    {
+      "displayName": "CenterPoint Energy",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "operator": "CenterPoint Energy",
+        "operator:wikidata": "Q1053560",
+        "highway": "street_lamp"
+      }
+    },
+    {
+      "displayName": "Puget Sound Energy",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "operator": "Puget Sound Energy",
+        "operator:wikidata": "Q7258927",
+        "operator:short": "PSE",
+        "highway": "street_lamp"
+      }
+    },
+    {
+      "displayName": "Seattle City Light",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "operator": "Seattle City Light",
+        "operator:wikidata": "Q7442080",
+        "operator:short": "SCL",
+        "highway": "street_lamp"
+      }
+    }
+  ]
+}

--- a/data/operators/highway/street_lamp.json
+++ b/data/operators/highway/street_lamp.json
@@ -17,7 +17,7 @@
     },
     {
       "displayName": "Puget Sound Energy",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-wa.geojson"]},
       "tags": {
         "operator": "Puget Sound Energy",
         "operator:wikidata": "Q7258927",
@@ -27,7 +27,7 @@
     },
     {
       "displayName": "Seattle City Light",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-wa.geojson"]},
       "tags": {
         "operator": "Seattle City Light",
         "operator:wikidata": "Q7442080",


### PR DESCRIPTION
CenterPoint Energy owns and operates all of the street lights here, having a preset for this would make is easy to add that info. Used this as a reference for the values of that:
https://github.com/osmlab/name-suggestion-index/blob/8c39905f1d87f31bce9b40d4359bce36cafd1374/data/operators/power/line.json#L983

Discussed this in the OSM Discord as well, and someone had these values they were using for ones in their area, so I added them as well:
https://github.com/Lumikeiju/openstreetmap/blob/main/presets/seattle_city_light_pole.xml