### PR TITLE
Update convenience.json : add My Auchan

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -3549,6 +3549,16 @@
       }
     },
     {
+      "displayName": "My Auchan",
+      "locationSet": {"include": ["fr"]},
+      "tags": {
+        "brand": "My Auchan",
+        "brand:wikidata": "Q115800307",
+        "name": "My Auchan",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "myNEWS.com",
       "id": "mynewscom-3e5671",
       "locationSet": {"include": ["my"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -3551,6 +3551,8 @@
     {
       "displayName": "My Auchan",
       "locationSet": {"include": ["fr"]},
+      "matchNames": ["myauchan"],
+      "matchTags": ["shop/supermarket"],
       "tags": {
         "brand": "My Auchan",
         "brand:wikidata": "Q115800307",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -5585,16 +5585,6 @@
       }
     },
     {
-      "displayName": "My Auchan",
-      "locationSet": {"include": ["fr"]},
-      "tags": {
-        "brand": "My Auchan",
-        "brand:wikidata": "Q115800307",
-        "name": "My Auchan",
-        "shop": "supermarket"
-      }
-    },
-    {
       "displayName": "My market",
       "id": "mymarket-37450e",
       "locationSet": {"include": ["gr"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -5585,6 +5585,16 @@
       }
     },
     {
+      "displayName": "My Auchan",
+      "locationSet": {"include": ["fr"]},
+      "tags": {
+        "brand": "My Auchan",
+        "brand:wikidata": "Q115800307",
+        "name": "My Auchan",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "My market",
       "id": "mymarket-37450e",
       "locationSet": {"include": ["gr"]},


### PR DESCRIPTION
### What ?

Add a new supermarket "My Auchan"

### Why ?

In France, Auchan has a convenience-like chain called "My Auchan" (it used to be called "A2 Pas").

### Source

- https://www.auchan-retail.com/fr/nos-franchises/
- wikidata : https://www.wikidata.org/wiki/Q115800307
- similar : Carrefour City ([wikidata](https://www.wikidata.org/wiki/Q2940187)), Intermarché Express ([wikidata](https://www.wikidata.org/wiki/Q98278043))

### Extra info

It also sometimes spelled "MyAuchan" (without the space).
Is there a way to have both spellings ?
