### PR TITLE
Update outdoor.json : add Ekosport & Espace Montagne

### DIFF
--- a/data/brands/shop/outdoor.json
+++ b/data/brands/shop/outdoor.json
@@ -189,7 +189,7 @@
     },
     {
       "displayName": "Ekosport",
-      "locationSet": {"include": ["fr"]},
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "brand": "Ekosport",
         "brand:wikidata": "Q130221125",
@@ -199,7 +199,7 @@
     },
     {
       "displayName": "Espace Montagne",
-      "locationSet": {"include": ["fr"]},
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "brand": "Espace Montagne",
         "brand:wikidata": "Q130221137",

--- a/data/brands/shop/outdoor.json
+++ b/data/brands/shop/outdoor.json
@@ -188,6 +188,26 @@
       }
     },
     {
+      "displayName": "Ekosport",
+      "locationSet": {"include": ["fr"]},
+      "tags": {
+        "brand": "Ekosport",
+        "brand:wikidata": "Q130221125",
+        "name": "Ekosport",
+        "shop": "sports"
+      }
+    },
+    {
+      "displayName": "Espace Montagne",
+      "locationSet": {"include": ["fr"]},
+      "tags": {
+        "brand": "Espace Montagne",
+        "brand:wikidata": "Q130221137",
+        "name": "Espace Montagne",
+        "shop": "sports"
+      }
+    },
+    {
       "displayName": "Fjällräven",
       "id": "fjallraven-069867",
       "locationSet": {"include": ["ca", "us"]},

--- a/data/brands/shop/sports.json
+++ b/data/brands/shop/sports.json
@@ -243,6 +243,16 @@
       }
     },
     {
+      "displayName": "Espace Montagne",
+      "locationSet": {"include": ["fr"]},
+      "tags": {
+        "brand": "Espace Montagne",
+        "brand:wikidata": "Q130221137",
+        "name": "Espace Montagne",
+        "shop": "sports"
+      }
+    },
+    {
       "displayName": "EXIsport",
       "id": "exisport-aa748e",
       "locationSet": {"include": ["cz", "sk"]},

--- a/data/brands/shop/sports.json
+++ b/data/brands/shop/sports.json
@@ -220,6 +220,16 @@
       }
     },
     {
+      "displayName": "Ekosport",
+      "locationSet": {"include": ["fr"]},
+      "tags": {
+        "brand": "Ekosport",
+        "brand:wikidata": "Q130221125",
+        "name": "Ekosport",
+        "shop": "sports"
+      }
+    },
+    {
       "displayName": "EQUIVA",
       "id": "equiva-081602",
       "locationSet": {"include": ["at", "de"]},

--- a/data/brands/shop/sports.json
+++ b/data/brands/shop/sports.json
@@ -220,16 +220,6 @@
       }
     },
     {
-      "displayName": "Ekosport",
-      "locationSet": {"include": ["fr"]},
-      "tags": {
-        "brand": "Ekosport",
-        "brand:wikidata": "Q130221125",
-        "name": "Ekosport",
-        "shop": "sports"
-      }
-    },
-    {
       "displayName": "EQUIVA",
       "id": "equiva-081602",
       "locationSet": {"include": ["at", "de"]},
@@ -240,16 +230,6 @@
         "name": "EQUIVA",
         "shop": "sports",
         "sport": "equestrian"
-      }
-    },
-    {
-      "displayName": "Espace Montagne",
-      "locationSet": {"include": ["fr"]},
-      "tags": {
-        "brand": "Espace Montagne",
-        "brand:wikidata": "Q130221137",
-        "name": "Espace Montagne",
-        "shop": "sports"
       }
     },
     {


### PR DESCRIPTION
Add 2 French sports retailers : Ekosport & Espace Montagne
- https://www.wikidata.org/wiki/Q130221125
- https://www.wikidata.org/wiki/Q130221137
