### PR TITLE
Change import assertions to import attributes

### DIFF
--- a/lib/file_tree.js
+++ b/lib/file_tree.js
@@ -13,9 +13,9 @@ import { sortObject } from './sort_object.js';
 import { validate } from './validate.js';
 
 // JSON
-import treesJSON from '../config/trees.json' assert {type: 'json'};
+import treesJSON from '../config/trees.json' with {type: 'json'};
 const trees = treesJSON.trees;
-import categoriesSchemaJSON from '../schema/categories.json' assert {type: 'json'};
+import categoriesSchemaJSON from '../schema/categories.json' with {type: 'json'};
 
 
 // The code in here

--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -5,9 +5,9 @@ import whichPolygon from 'which-polygon';
 import { simplify } from './simplify.js';
 
 // JSON
-import matchGroupsJSON from '../config/matchGroups.json' assert {type: 'json'};
-import genericWordsJSON from '../config/genericWords.json' assert {type: 'json'};
-import treesJSON from '../config/trees.json' assert {type: 'json'};
+import matchGroupsJSON from '../config/matchGroups.json' with {type: 'json'};
+import genericWordsJSON from '../config/genericWords.json' with {type: 'json'};
+import treesJSON from '../config/trees.json' with {type: 'json'};
 
 const matchGroups = matchGroupsJSON.matchGroups;
 const trees = treesJSON.trees;

--- a/lib/write_file_with_meta.js
+++ b/lib/write_file_with_meta.js
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import JSON5 from 'json5';
 
 // JSON
-import packageJSON from '../package.json' assert {type: 'json'};
+import packageJSON from '../package.json' with {type: 'json'};
 
 const URLRoot = 'https://raw.githubusercontent.com/osmlab/name-suggestion-index/main';
 

--- a/scripts/build_features.js
+++ b/scripts/build_features.js
@@ -17,8 +17,8 @@ const withLocale = localeCompare('en-US');
 import { writeFileWithMeta } from '../lib/write_file_with_meta.js';
 
 // JSON
-import geojsonSchemaJSON from '../schema/geojson.json' assert {type: 'json'};
-import featureSchemaJSON from '../schema/feature.json' assert {type: 'json'};
+import geojsonSchemaJSON from '../schema/geojson.json' with {type: 'json'};
+import featureSchemaJSON from '../schema/feature.json' with {type: 'json'};
 
 const Validator = jsonschema.Validator;
 let v = new Validator();

--- a/scripts/build_index.js
+++ b/scripts/build_index.js
@@ -20,11 +20,11 @@ import { writeFileWithMeta } from '../lib/write_file_with_meta.js';
 const matcher = new Matcher();
 
 // JSON
-import treesJSON from '../config/trees.json' assert {type: 'json'};
+import treesJSON from '../config/trees.json' with {type: 'json'};
 const trees = treesJSON.trees;
 
 // We use LocationConflation for validating and processing the locationSets
-import featureCollectionJSON from '../dist/featureCollection.json' assert {type: 'json'};
+import featureCollectionJSON from '../dist/featureCollection.json' with {type: 'json'};
 const loco = new LocationConflation(featureCollectionJSON);
 
 console.log(chalk.blue('-'.repeat(70)));

--- a/scripts/build_wikidata.js
+++ b/scripts/build_wikidata.js
@@ -19,12 +19,12 @@ import { fileTree } from '../lib/file_tree.js';
 import { writeFileWithMeta } from '../lib/write_file_with_meta.js';
 
 // JSON
-import packageJSON from '../package.json' assert {type: 'json'};
-import treesJSON from '../config/trees.json' assert {type: 'json'};
+import packageJSON from '../package.json' with {type: 'json'};
+import treesJSON from '../config/trees.json' with {type: 'json'};
 const trees = treesJSON.trees;
 
 // We use LocationConflation for validating and processing the locationSets
-import featureCollectionJSON from '../dist/featureCollection.json' assert {type: 'json'};
+import featureCollectionJSON from '../dist/featureCollection.json' with {type: 'json'};
 const loco = new LocationConflation(featureCollectionJSON);
 
 const wbk = wikibase({

--- a/scripts/dist_files.js
+++ b/scripts/dist_files.js
@@ -17,20 +17,20 @@ import { sortObject } from '../lib/sort_object.js';
 import { writeFileWithMeta } from '../lib/write_file_with_meta.js';
 
 // JSON
-import dissolvedJSON from '../dist/dissolved.json' assert {type: 'json'};
-import packageJSON from '../package.json' assert {type: 'json'};
-import treesJSON from '../config/trees.json' assert {type: 'json'};
-import wikidataJSON from '../dist/wikidata.json' assert {type: 'json'};
+import dissolvedJSON from '../dist/dissolved.json' with {type: 'json'};
+import packageJSON from '../package.json' with {type: 'json'};
+import treesJSON from '../config/trees.json' with {type: 'json'};
+import wikidataJSON from '../dist/wikidata.json' with {type: 'json'};
 
 const dissolved = dissolvedJSON.dissolved;
 const trees = treesJSON.trees;
 const wikidata = wikidataJSON.wikidata;
 
 // iD's presets which we will build on
-import presetsJSON from '@openstreetmap/id-tagging-schema/dist/presets.json' assert {type: 'json'};
+import presetsJSON from '@openstreetmap/id-tagging-schema/dist/presets.json' with {type: 'json'};
 
 // We use LocationConflation for validating and processing the locationSets
-import featureCollectionJSON from '../dist/featureCollection.json' assert {type: 'json'};
+import featureCollectionJSON from '../dist/featureCollection.json' with {type: 'json'};
 const loco = new LocationConflation(featureCollectionJSON);
 
 let _cache = {};
@@ -330,7 +330,7 @@ function buildIDPresets() {
         targetTags[k] = tags[k] || preset.tags[k];
       }
 
-      // Prefer a wiki commons logo sometimes.. 
+      // Prefer a wiki commons logo sometimes..
       // Related issues list: openstreetmap/iD#6361, #2798, #3122, #8042, #8373
       const preferCommons = {
         Q177054: true,    // Burger King

--- a/scripts/dist_version.js
+++ b/scripts/dist_version.js
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import fs from 'node:fs';
 
 // JSON
-import packageJSON from '../package.json' assert {type: 'json'};
+import packageJSON from '../package.json' with {type: 'json'};
 
 // YYYYMMDD
 const now = new Date();

--- a/tests/matcher.test.js
+++ b/tests/matcher.test.js
@@ -3,10 +3,10 @@ import { strict as assert } from 'node:assert';
 import LocationConflation from '@rapideditor/location-conflation';
 import { Matcher } from '../index.mjs';
 
-import data from './matcher.data.json' assert {type: 'json'};
+import data from './matcher.data.json' with {type: 'json'};
 
 // We use LocationConflation for validating and processing the locationSets
-import featureCollection from '../dist/featureCollection.json' assert {type: 'json'};
+import featureCollection from '../dist/featureCollection.json' with {type: 'json'};
 const loco = new LocationConflation(featureCollection);
 
 const USA = [-98.58, 39.828];


### PR DESCRIPTION
I couldn't get the project to build on Node v22, so I looked around and found this issue: https://stackoverflow.com/questions/78876691/syntaxerror-unexpected-identifier-assert-on-json-import-in-node-v22

After following one of the proposals, swapping import assertions to import attributes, the project builds on node v22 just fine. However, this means it won't build on Node v17 anymore.