### PR TITLE
Update BKK and Eviny power companies

### DIFF
--- a/data/operators/power/generator.json
+++ b/data/operators/power/generator.json
@@ -3249,6 +3249,21 @@
       }
     },
     {
+      "displayName": "Eviny Fornybar",
+      "id": "evinyfornybar-dd42ec",
+      "locationSet": {"include": ["no"]},
+      "matchNames": [
+        "bkk",
+        "bkk produksjon",
+        "eviny"
+      ],
+      "tags": {
+        "operator": "Eviny Fornybar",
+        "operator:wikidata": "Q76206398",
+        "power": "generator"
+      }
+    },
+    {
       "displayName": "EVN (Bulgaria)",
       "id": "evn-87ac22",
       "locationSet": {"include": ["bg"]},

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -3623,13 +3623,13 @@
       }
     },
     {
-      "displayName": "Eviny",
-      "id": "eviny-e0b869",
+      "displayName": "Eviny Fornybar",
+      "id": "evinyfornybar-e0b869",
       "locationSet": {"include": ["no"]},
-      "matchNames": ["bkk"],
+      "matchNames": ["eviny"],
       "tags": {
-        "operator": "Eviny",
-        "operator:wikidata": "Q4891601",
+        "operator": "Eviny Fornybar",
+        "operator:wikidata": "Q76206398",
         "power": "line"
       }
     },

--- a/data/operators/power/plant.json
+++ b/data/operators/power/plant.json
@@ -366,16 +366,6 @@
       }
     },
     {
-      "displayName": "BKK Produksjon",
-      "id": "bkkproduksjon-44cc7f",
-      "locationSet": {"include": ["no"]},
-      "tags": {
-        "operator": "BKK Produksjon",
-        "operator:wikidata": "Q4891601",
-        "power": "plant"
-      }
-    },
-    {
       "displayName": "Boralex",
       "id": "boralex-e0e75c",
       "locationSet": {
@@ -1349,8 +1339,14 @@
       "displayName": "Eviny Fornybar",
       "id": "evinyfornybar-44cc7f",
       "locationSet": {"include": ["no"]},
+      "matchNames": [
+        "bkk",
+        "bkk produksjon",
+        "eviny"
+      ],
       "tags": {
         "operator": "Eviny Fornybar",
+        "operator:wikidata": "Q76206398",
         "power": "plant"
       }
     },


### PR DESCRIPTION
- Eviny is the parent company of BKK and Eviny Fornybar, a grid company and a power generation company, respectively. Eviny does not operate infrastructure themselves, only their child companies do. Hence why I've de-listed them.
- Eviny Fornybar operates power plants, generators and  grid infrastructure on the premises of their plants. Hence why I've added them to `power/generator` and `power/line`.
- BKK Produksjon is an old name for Eviny Fornybar, hence why I've de-listed them.