### PR TITLE
Add Oslo kommune as a kindergarten operator

### DIFF
--- a/data/operators/amenity/kindergarten.json
+++ b/data/operators/amenity/kindergarten.json
@@ -1086,6 +1086,17 @@
       }
     },
     {
+      "displayName": "Oslo kommune",
+      "id": "oslokommune-04f073",
+      "locationSet": {"include": ["no"]},
+      "tags": {
+        "amenity": "kindergarten",
+        "operator": "Oslo kommune",
+        "operator:type": "public",
+        "operator:wikidata": "Q5245991"
+      }
+    },
+    {
       "displayName": "Outlaw",
       "id": "outlaw-747d0f",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
Oslo kommune (Oslo municipality, in English), are already listed as a school operator, but aren't yet listed as a kindergarten operator, which they are. This PR fixes that.