### PR TITLE
Fixup entries for RBC

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -10016,6 +10016,18 @@
       }
     },
     {
+      "displayName": "PNC",
+      "id": "pnc-ea2e2d",
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["centura", "rbc"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "PNC",
+        "brand:wikidata": "Q38928",
+        "name": "PNC"
+      }
+    },
+    {
       "displayName": "PNC Bank",
       "id": "pncbank-ea2e2d",
       "locationSet": {"include": ["us"]},

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -10557,20 +10557,20 @@
     },
     {
       "displayName": "RBC",
-      "id": "rbc-b7a026",
-      "locationSet": {"include": ["001"]},
+      "id": "rbcroyalbank-e1345b",
+      "locationSet": {"include": ["ca"]},
       "matchNames": [
         "hsbc",
         "hsbc bank canada",
         "rbc financial group",
-        "rbc royal bank",
         "royal bank"
       ],
       "tags": {
         "amenity": "bank",
-        "brand": "RBC",
+        "brand": "RBC Royal Bank",
+        "brand:short": "RBC",
         "brand:wikidata": "Q735261",
-        "name": "RBC",
+        "name": "RBC Royal Bank",
         "official_name": "Royal Bank of Canada"
       }
     },
@@ -10578,10 +10578,14 @@
       "displayName": "RBC Banque Royale",
       "id": "rbcbanqueroyale-e1345b",
       "locationSet": {"include": ["ca"]},
+      "matchNames": ["banque royale", "rbc"],
       "tags": {
         "amenity": "bank",
         "brand": "RBC Banque Royale",
-        "name": "RBC Banque Royale"
+        "brand:short": "RBC",
+        "brand:wikidata": "Q735261",
+        "name": "RBC Banque Royale",
+        "official_name": "Banque Royale du Canada"
       }
     },
     {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -10557,8 +10557,11 @@
     },
     {
       "displayName": "RBC",
-      "id": "rbcroyalbank-e1345b",
-      "locationSet": {"include": ["ca"]},
+      "id": "rbcroyalbank-9178f2",
+      "locationSet": {
+        "include": ["ca"],
+        "exclude": ["ca-qc.geojson"]
+      },
       "matchNames": [
         "hsbc",
         "hsbc bank canada",
@@ -10576,9 +10579,11 @@
     },
     {
       "displayName": "RBC Banque Royale",
-      "id": "rbcbanqueroyale-e1345b",
-      "locationSet": {"include": ["ca"]},
-      "matchNames": ["banque royale", "rbc"],
+      "id": "rbcbanqueroyale-ff5d57",
+      "locationSet": {
+        "include": ["ca-qc.geojson"]
+      },
+      "matchNames": ["banque royale"],
       "tags": {
         "amenity": "bank",
         "brand": "RBC Banque Royale",

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -10571,7 +10571,7 @@
       "displayName": "RBC",
       "id": "rbcroyalbank-9178f2",
       "locationSet": {
-        "include": ["ca"],
+        "include": ["ca","029"],
         "exclude": ["ca-qc.geojson"]
       },
       "matchNames": [


### PR DESCRIPTION
The main RBC brand does not exist in the US anymore
> In 2012, RBC Bank USA's banking division for American clients was sold to PNC Financial Services[1]

There are some mistagged entries in the USA where there is a bank named Royal Bank which is different from RBC.

In the rest of the world, the banks tagged as RBC are most likely not banks in the sense that we tag them in OSM.
I can't find any evidence that there are bank branches operated elsewhere than Canada and the Carribean under the RBC brand name

[1]: https://en.wikipedia.org/wiki/RBC_Bank