### PR TITLE
Update Wikidata ID for Mobil

### DIFF
--- a/config/replacements.json
+++ b/config/replacements.json
@@ -102,9 +102,9 @@
       "note": "MEO - Wikidata redirect, https://github.com/osmlab/name-suggestion-index/issues/9543",
       "wikidata": "Q1365938"
     },
-    "Q3088656": {
-      "note": "Mobil the brand, not Mobil the former company",
-      "wikidata": "Q109676002"
+    "Q109676002": {
+      "note": "Mobil - Wikidata redirect",
+      "wikidata": "Q3088656"
     },
     "Q2565040": {
       "note": "Евроопт - Wikidata redirect",

--- a/data/brands/amenity/car_wash.json
+++ b/data/brands/amenity/car_wash.json
@@ -408,7 +408,7 @@
       "tags": {
         "amenity": "car_wash",
         "brand": "Mobil",
-        "brand:wikidata": "Q109676002",
+        "brand:wikidata": "Q3088656",
         "name": "Mobil"
       }
     },

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -3759,11 +3759,10 @@
         "exclude": ["jp"]
       },
       "matchNames": ["mobile"],
-      "note": "This wikidata isn't Q3088656",
       "tags": {
         "amenity": "fuel",
         "brand": "Mobil",
-        "brand:wikidata": "Q109676002",
+        "brand:wikidata": "Q3088656",
         "name": "Mobil"
       }
     },

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -3503,7 +3503,7 @@
       "matchNames": ["mobil"],
       "tags": {
         "brand": "Mobil Mart",
-        "brand:wikidata": "Q109676002",
+        "brand:wikidata": "Q3088656",
         "name": "Mobil Mart",
         "shop": "convenience"
       }


### PR DESCRIPTION
The Mobil brand was previously under a separate Wikidata ID ([Q109676002](https://www.wikidata.org/w/index.php?title=Q109676002&redirect=no)) from the company ([Q3088656](https://www.wikidata.org/wiki/Q3088656)), but now [it has been merged into a single entry](https://www.wikidata.org/w/index.php?title=Q109676002&action=history). I've updated the IDs in the dataset accordingly and created a replacement to follow the redirect.