### PR TITLE
Update supermarket.json - Updated Netto City

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -5783,7 +5783,7 @@
       "id": "nettocity-0a839e",
       "locationSet": {"include": ["de"]},
       "tags": {
-        "brand": "Netto City",
+        "brand": "Netto Marken-Discount",
         "brand:wikidata": "Q879858",
         "name": "Netto City",
         "shop": "supermarket"


### PR DESCRIPTION
I see in the ATP spider some store names are called "Netto City" but when I checked google street view. They all look like 
https://commons.wikimedia.org/wiki/File:NETTO-Wandsbek.jpg
Thus I think the brand could be `Netto Marken-Discount` with the name still being Netto City. I cannot tell the difference between `Netto Marken-Discount` and `Netto City Marken-Discount`. It seems less obvious than Taco Bell and Taco Bell Cantina which both have same brand tag. 