### PR TITLE
Add Northern Tool + Equipment

### DIFF
--- a/data/brands/shop/hardware.json
+++ b/data/brands/shop/hardware.json
@@ -236,6 +236,28 @@
       }
     },
     {
+      "displayName": "Northern Tool + Equipment",
+      "id": "northerntoolequipment-a223fb",
+      "locationSet": {"include": ["us"]},
+      "matchNames": [
+        "northern tool",
+        "northern tool & equipment",
+        "northern tools",
+        "northern tools & equipment",
+        "northern tools + equipment"
+      ],
+      "matchTags": [
+        "shop/agrarian",
+        "shop/country_store"
+      ],
+      "tags": {
+        "brand": "Northern Tool + Equipment",
+        "brand:wikidata": "Q43379813",
+        "name": "Northern Tool + Equipment",
+        "shop": "hardware"
+      }
+    },
+    {
       "displayName": "Outdoor Supply Hardware",
       "id": "outdoorsupplyhardware-a223fb",
       "locationSet": {"include": ["us"]},

--- a/data/brands/shop/hardware.json
+++ b/data/brands/shop/hardware.json
@@ -242,6 +242,8 @@
       "matchNames": [
         "northern tool",
         "northern tool & equipment",
+        "northern tool & equipment company",
+        "northern tool & supply",
         "northern tools",
         "northern tools & equipment",
         "northern tools + equipment"


### PR DESCRIPTION
Hello, this adds an American tool/equipment store brand with about 130 locations (about 60 mapped).

* [Wikipedia](https://en.wikipedia.org/wiki/Northern_Tool)
* [Wikidata](https://www.wikidata.org/wiki/Q43379813)

The wiki article says their name is officially _Northern Tool + Equipment_. They also use the shorter _Northern Tool_ for their domain and social usernames, but it looks like the longer form variants vastly outnumber the shorter form variants as mapped. Their building signage and logo use the longer form. As such, this PR uses the longer form.

Existing `name` tags:
* 22 use `name=Northern Tool + Equipment`
* 12 use `name=Northern Tool`
* 11 use `name=Northern Tool & Equipment`
* 1 uses `name=Northern Tool & Supply`
* 1 uses `name=Northern Tools`
* other variants

Existing `shop` tags:
* 42 use `shop=hardware`
* 11 use `shop=doityourself`
* 2 use `shop=agrarian`
* 1 uses `shop=country_store`
* 1 uses `shop=tool_hire`
* 1 uses `shop=trade`

Since these POIs are under-tagged, I had to use name matching to find them. I didn't check every single one to make sure it was an active _Northern Tool + Equipment_ location, so the numbers above might be off, but I don't think it'd be by much.

Thanks!