### PR TITLE
Tempo rebranded to Mega Maxi

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -8065,7 +8065,7 @@
         "brand:wikidata": "Q7698875",
         "name": "Mega Maxi",
         "name:sr": "Мега Макси",
-        "name:sr-Latn": "Mega Maxi",
+        "name:sr-Latn": "Mega Maksi",
         "shop": "supermarket"
       }
     },

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -8056,15 +8056,16 @@
       }
     },
     {
-      "displayName": "Tempo (Србија)",
+      "displayName": "Mega Maxi",
       "id": "tempo-b83687",
       "locationSet": {"include": ["rs"]},
+      "matchNames": ["Tempo"],
       "tags": {
-        "brand": "Tempo",
+        "brand": "Mega Maxi",
         "brand:wikidata": "Q7698875",
-        "name": "Tempo",
-        "name:sr": "Темпо",
-        "name:sr-Latn": "Tempo",
+        "name": "Mega Maxi",
+        "name:sr": "Мега Макси",
+        "name:sr-Latn": "Mega Maxi",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
All Tempo stores have been rebranded to Mega Maxi. [Tempo's website](http://www.tempocentar.rs/) now redirects to https://megamaxi.rs/