### PR TITLE
BikeAway locker access

### DIFF
--- a/data/operators/amenity/bicycle_parking.json
+++ b/data/operators/amenity/bicycle_parking.json
@@ -42,6 +42,7 @@
         "include": ["gb-eng", "ie"]
       },
       "tags": {
+        "access": "permit",
         "amenity": "bicycle_parking",
         "bicycle_parking": "lockers",
         "fee": "yes",


### PR DESCRIPTION
Add `access=permit` to BikeAway lockers as you need to apply for one

https://www.bikeaway.com/secure-cycle-locker-rental-diamond-rated-cycle-locker-rental-e-bike-locker-rental-bikeaway-warrior-cycle-lockers.html