### PR TITLE
Add brand Puuilo (Q18689102)

### DIFF
--- a/data/brands/shop/hardware.json
+++ b/data/brands/shop/hardware.json
@@ -283,6 +283,17 @@
       }
     },
     {
+      "displayName": "Puuilo",
+      "id": "puuilo-93dff8",
+      "locationSet": {"include": ["fi"]},
+      "tags": {
+        "brand": "Puuilo",
+        "brand:wikidata": "Q18689102",
+        "name": "Puuilo",
+        "shop": "hardware"
+      }
+    },
+    {
       "displayName": "Robert Dyas",
       "id": "robertdyas-a55f89",
       "locationSet": {"include": ["gb"]},


### PR DESCRIPTION
Finnish hardware store chain w/ Wikidata entry