### PR TITLE
Add "theme=irish" for O'Neill's pubs

### DIFF
--- a/data/brands/amenity/pub.json
+++ b/data/brands/amenity/pub.json
@@ -338,7 +338,8 @@
       "tags": {
         "amenity": "pub",
         "brand": "O'Neill's",
-        "brand:wikidata": "Q7071905"
+        "brand:wikidata": "Q7071905",
+        "theme": "irish"
       }
     },
     {


### PR DESCRIPTION
`theme=irish` is used to tag a place as Irish themed. 
O'Neill's describes themselves as:
>  Welcome to O’Neill’s original Irish Pubs
> A warm Irish welcome to O’Neill’s, where the good times flow as freely as the drinks.

I think it's fitting to properly tag them

https://wiki.openstreetmap.org/wiki/Tag:theme=irish