### PR TITLE
Remove name and short_name from Tesla SuC

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -315,10 +315,8 @@
         "amenity": "charging_station",
         "brand": "Tesla Supercharger",
         "brand:wikidata": "Q17089620",
-        "name": "Tesla Supercharger",
         "operator": "Tesla, Inc.",
         "operator:wikidata": "Q478214",
-        "short_name": "Tesla"
       }
     },
     {


### PR DESCRIPTION
According to [documentation](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dcharging_station/Tesla_Motors#Destination_Chargers) name should be official name, not "Tesla Supercharger"