### PR TITLE
Add Hotshots Sports Bar and Grill

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -2993,6 +2993,18 @@
       }
     },
     {
+      "displayName": "Hotshots Sports Bar and Grill",
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["hotshots"],
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "Hotshots Sports Bar and Grill",
+        "brand:wikidata": "Q130344931",
+        "cuisine": "burger;pizza",
+        "name": "Hotshots Sports Bar and Grill"
+      }
+    },
+    {
       "displayName": "House of Blues",
       "id": "houseofblues-96af40",
       "locationSet": {"include": ["us"]},

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -2994,6 +2994,7 @@
     },
     {
       "displayName": "Hotshots Sports Bar and Grill",
+      "id": "hotshotssportsbarandgrill-96af40",
       "locationSet": {"include": ["us"]},
       "matchNames": ["hotshots"],
       "tags": {


### PR DESCRIPTION
This adds an American sports bar chain called Hotshots Sports Bar and Grill (https://hotshotsnet.com) Only two locations seem to be mapped. They're in 5 states, 14 locations, and another coming soon according to their website. I tagged it as a restaurant with cuisine=burger;pizza after looking at how other sports bar chains are tagged. Feel free to change that.