### PR TITLE
Add Morton Williams supermarkets

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -5611,6 +5611,22 @@
       }
     },
     {
+      "displayName": "Morton Williams",
+      "id": "mortonwilliams-ca29a0",
+      "locationSet": {
+        "include": [
+          "new_york_city.geojson",
+          "us-nj.geojson"
+        ]
+      },
+      "tags": {
+        "brand": "Morton Williams",
+        "brand:wikidata": "Q28227933",
+        "name": "Morton Williams",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "MPREIS",
       "id": "mpreis-eeb4e5",
       "locationSet": {"include": ["at", "it"]},


### PR DESCRIPTION
Adding the [Morton Williams](https://www.wikidata.org/wiki/Q28227933) supermarket chain, based in NYC (and NJ).