### PR TITLE
Unabbreviate "St. Louis County"

### DIFF
--- a/data/operators/emergency/siren.json
+++ b/data/operators/emergency/siren.json
@@ -500,7 +500,7 @@
       },
       "tags": {
         "emergency": "siren",
-        "operator": "St. Louis County Emergency Communications Commission",
+        "operator": "Saint Louis County Emergency Communications Commission",
         "operator:wikidata": "Q123689350",
         "siren:purpose": "civil_defense;tornado",
         "siren:type": "electronic"


### PR DESCRIPTION
I expanded the operator tags for tornado sirens in Saint Louis County, Missouri, and added missing `operator:wikidata` tags in [157187397](https://www.openstreetmap.org/changeset/157187397). Most of the nodes were unchanged since I added them a year ago. I originally added them with an abbreviated "St.", but now I know that should have been expanded.