### PR TITLE
Fix Obs bygg linking to Obs supermarket's wikidata

### DIFF
--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -1059,7 +1059,7 @@
       "preserveTags": ["^name"],
       "tags": {
         "brand": "Obs Bygg",
-        "brand:wikidata": "Q5167707",
+        "brand:wikidata": "Q111534576",
         "shop": "doityourself"
       }
     },

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -6061,6 +6061,18 @@
       }
     },
     {
+      "displayName": "Obs",
+      "locationSet": {"include": ["no"]},
+      "matchNames": ["coop obs"],
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Obs",
+        "brand:wikidata": "Q5167707",
+        "name": "Obs",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Odin",
       "id": "odin-5811b5",
       "locationSet": {"include": ["nl"]},


### PR DESCRIPTION
Obs bygg wikidata entry was for the Obs supermarket, a different chain owned by the same parent organization.

Corrected the wikidata ID and added Obs supermarket as a separate entity.