### PR TITLE
Zest charging stations

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -6860,7 +6860,7 @@
     {
       "displayName": "Zest",
       "locationSet": {
-        "include": ["gb-eng", "gb-sct"]
+        "include": ["gb"]
       },
       "tags": {
         "amenity": "charging_station",

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -6858,6 +6858,17 @@
       }
     },
     {
+      "displayName": "Zest",
+      "locationSet": {
+        "include": ["gb-eng", "gb-sct"]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Zest",
+        "operator:wikidata": "Q122871256"
+      }
+    },
+    {
       "displayName": "Zeus",
       "id": "zeus-2c5517",
       "locationSet": {"include": ["it"]},


### PR DESCRIPTION
Zest, in their own words: "operate EV charging solutions for local authorities, brands and destinations"

A map of current locations: https://map.zest.uk.com/