### PR TITLE
Add Taiwanese police bureaus, government agencies, brands, and Jewel cafe (新增臺灣的警局、政府機關、品牌、還有世界性的 Jewel cafe)

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -7069,6 +7069,49 @@
         "name:zh": "鹿角巷",
         "takeaway": "yes"
       }
+    },
+    {
+      "displayName": "西雅圖極品咖啡",
+      "locationSet": {
+        "include": ["tw"]
+      },
+      "tags": {
+        "amenity": "cafe",
+        "brand": "西雅圖極品咖啡",
+        "brand:en": "Barista Coffee",
+        "brand:wikidata": "Q130525295",
+        "brand:zh": "西雅圖極品咖啡",
+        "cuisine": "coffee_shop",
+        "name": "西雅圖極品咖啡",
+        "name:en": "Barista Coffee",
+        "name:zh": "西雅圖極品咖啡",
+        "operator": "馥餘實業股份有限公司",
+        "operator:en": "Full Fill Industrial Co., Ltd.",
+        "operator:zh": "馥餘實業股份有限公司",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "Mr. Brown 伯朗咖啡館",
+      "locationSet": {
+        "include": ["tw"]
+      },
+      "tags": {
+        "amenity": "cafe",
+        "brand": "Mr. Brown 伯朗咖啡館",
+        "brand:en": "Mr. Brown Café",
+        "brand:wikidata": "Q21016949",
+        "brand:zh": "伯朗咖啡館",
+        "cuisine": "coffee_shop",
+        "name": "Mr. Brown 伯朗咖啡館",
+        "name:en": "Mr. Brown Café",
+        "name:zh": "伯朗咖啡館",
+        "operator": "金車股份有限公司",
+        "operator:en": "King Car Industrial Co., Ltd.",
+        "operator:zh": "金車股份有限公司",
+        "operator:wikidata": "Q11647937",
+        "takeaway": "yes"
+      }
     }
   ]
 }

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -13072,6 +13072,9 @@
     {
       "displayName": "芳珍蔬食",
       "id": "fjveggie-60a4d5",
+      "matchNames": [
+        "和芳珍"
+      ],
       "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "fast_food",
@@ -13083,7 +13086,10 @@
         "name": "芳珍蔬食",
         "name:en": "FJ Veggie",
         "name:zh": "芳珍蔬食",
-        "takeaway": "yes"
+        "takeaway": "yes",
+        "operator": "八方雲集",
+        "operator:en": "Eight Way",
+        "operator:wikidata": "Q28417381"
       }
     },
     {

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -13072,9 +13072,6 @@
     {
       "displayName": "芳珍蔬食",
       "id": "fjveggie-60a4d5",
-      "matchNames": [
-        "和芳珍"
-      ],
       "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "fast_food",

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -9316,6 +9316,23 @@
       }
     },
     {
+      "displayName": "得來素",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "得來素",
+        "brand:en": "Der Life",
+        "brand:wikidata": "Q130525358",
+        "brand:zh": "得來素",
+        "cuisine": "breakfast",
+        "diet:vegan": "yes",
+        "diet:vegetarian": "only",
+        "name": "得來素",
+        "name:en": "Der Life",
+        "name:zh": "得來素"
+      }
+    },
+    {
       "displayName": "梁社漢排骨",
       "id": "liangshehanbuyfood-aafd63",
       "locationSet": {"include": ["tw"]},

--- a/data/brands/shop/jewelry.json
+++ b/data/brands/shop/jewelry.json
@@ -1622,6 +1622,37 @@
         "operator:wikidata": "Q10920877",
         "shop": "jewelry"
       }
+    },
+    {
+      "displayName": "Jewel Cafe",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "Jewel Cafe",
+        "brand:wikidata": "Q126457805",
+        "brand:en": "Jewel Cafe",
+        "brand:ja": "ジュエルカフェ",
+        "name": "Jewel Cafe",
+        "name:en": "Jewel Cafe",
+        "name:ja": "ジュエルカフェ",
+        "operator": "クレイン",
+        "operator:en": "Crane",
+        "operator:ja": "クレイン",
+        "operator:wikidata": "Q11299557",
+        "shop": "jewelry"
+      }
+    },
+    {
+      "displayName": "三井貴金屬",
+      "id": "9954ea-a7992b",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "三井貴金屬",
+        "brand:wikidata": "Q130525509",
+        "brand:zh": "三井貴金屬",
+        "name": "三井貴金屬",
+        "name:zh": "三井貴金屬",
+        "shop": "jewelry"
+      }
     }
   ]
 }

--- a/data/brands/shop/laundry.json
+++ b/data/brands/shop/laundry.json
@@ -115,6 +115,21 @@
       }
     },
     {
+      "displayName": "衣博士",
+      "locationSet": {"include": ["pt"]},
+      "tags": {
+        "brand": "衣博士",
+        "brand:zh": "衣博士",
+        "brand:en": "Dr. Washing",
+        "brand:wikidata": "Q130525426",
+        "name": "衣博士",
+        "name:zh": "衣博士",
+        "name:en": "Dr. Washing",
+        "self_service": "yes",
+        "shop": "laundry"
+      }
+    },
+    {
       "displayName": "Постирай",
       "id": "c0a035-ca17f3",
       "locationSet": {"include": ["001"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -12636,6 +12636,25 @@
       }
     },
     {
+      "displayName": "愛買",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "愛買",
+        "brand:en": "A.mart",
+        "brand:wikidata": "Q4648764",
+        "brand:zh": "愛買",
+        "name": "愛買",
+        "name:en": "A.mart",
+        "name:zh": "愛買",
+        "operator": "遠東百貨",
+        "operator:wikidata": "Q15898440",
+        "operator:zh": "遠東百貨",
+        "operator:en": "Far Eastern Department Stores",
+        "shop": "supermarket"
+      }
+    },
+
+    {
       "displayName": "関西スーパー",
       "id": "kansaisuper-fe0970",
       "locationSet": {"include": ["jp"]},

--- a/data/operators/amenity/fire_station.json
+++ b/data/operators/amenity/fire_station.json
@@ -4371,7 +4371,8 @@
       "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "fire_station",
-        "operator": "宜蘭縣政府消防局"
+        "operator": "宜蘭縣政府消防局",
+        "operator:wikidata": "Q131169079"
       }
     },
     {
@@ -4389,7 +4390,8 @@
       "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "fire_station",
-        "operator": "新竹市消防局"
+        "operator": "新竹市消防局",
+        "operator:wikidata": "Q131169252"
       }
     },
     {
@@ -4398,7 +4400,8 @@
       "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "fire_station",
-        "operator": "新竹縣政府消防局"
+        "operator": "新竹縣政府消防局",
+        "operator:wikidata": "Q131169255"
       }
     },
     {
@@ -4442,7 +4445,8 @@
       "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "fire_station",
-        "operator": "臺中市政府消防局"
+        "operator": "臺中市政府消防局",
+        "operator:wikidata": "Q15909995"
       }
     },
     {
@@ -4466,7 +4470,8 @@
       "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "fire_station",
-        "operator": "高雄市政府消防局"
+        "operator": "高雄市政府消防局",
+        "operator:wikidata": "Q15920569"
       }
     },
     {
@@ -4474,7 +4479,8 @@
       "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "fire_station",
-        "operator": "桃園市政府消防局"
+        "operator": "桃園市政府消防局",
+        "operator:wikidata": "Q15917916"
       }
     }
   ]

--- a/data/operators/amenity/fire_station.json
+++ b/data/operators/amenity/fire_station.json
@@ -4468,6 +4468,14 @@
         "amenity": "fire_station",
         "operator": "高雄市政府消防局"
       }
+    },
+    {
+      "displayName": "桃園市政府消防局",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "amenity": "fire_station",
+        "operator": "桃園市政府消防局"
+      }
     }
   ]
 }

--- a/data/operators/amenity/library.json
+++ b/data/operators/amenity/library.json
@@ -2760,6 +2760,18 @@
       }
     },
     {
+      "displayName": "桃園市立圖書館",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "amenity": "library",
+        "operator": "桃園市立圖書館",
+        "operator:en": "Taoyuan Public Library",
+        "operator:type": "government",
+        "operator:wikidata": "Q11112014",
+        "operator:zh": "桃園市立圖書館"
+      }
+    },
+    {
       "displayName": "首都图书馆",
       "id": "d81552-6214cc",
       "locationSet": {"include": ["cn"]},

--- a/data/operators/amenity/police.json
+++ b/data/operators/amenity/police.json
@@ -3645,6 +3645,71 @@
       }
     },
     {
+      "displayName": "彰化縣警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "chungha police",
+        "chpb",
+        "chph",
+        "彰化縣政府警察局",
+        "彰化警察",
+        "彰化警局",
+        "彰化市警察",
+        "彰化市警局"
+      ],
+      "tags": {
+        "amenity": "police",
+        "operator": "彰化縣警察局",
+        "operator:en": "Chungha Contry Police Department",
+        "operator:wikidata": "Q130487509",
+        "operator:zh": "彰化縣警察局"
+      }
+    },
+    {
+      "displayName": "新竹市警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "hsinchu police",
+        "hcpb",
+        "hcph",
+        "hccp",
+        "新竹市政府警察局",
+        "新竹警察",
+        "新竹警局",
+        "新竹市警察",
+        "新竹市警局"
+      ],
+      "tags": {
+        "amenity": "police",
+        "operator": "新竹市警察局",
+        "operator:en": "Hsinchu City Police Bureau",
+        "operator:wikidata": "Q85880448",
+        "operator:zh": "新竹市警察局"
+      }
+    },
+    {
+      "displayName": "苗栗縣警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "miaoli police",
+        "mpb",
+        "mph",
+        "mcp",
+        "新竹市政府警察局",
+        "新竹警察",
+        "新竹警局",
+        "新竹市警察",
+        "新竹市警局"
+      ],
+      "tags": {
+        "amenity": "police",
+        "operator": "苗栗縣警察局",
+        "operator:en": "Miaoli County Police Bureau",
+        "operator:wikidata": "Q15903147",
+        "operator:zh": "苗栗縣警察局"
+      }
+    },
+    {
       "displayName": "鹿児島県警察",
       "id": "kagoshimaprefecturalpolice-ae5e65",
       "locationSet": {"include": ["jp"]},
@@ -3653,6 +3718,213 @@
         "operator": "鹿児島県警察",
         "operator:en": "Kagoshima Prefectural Police",
         "operator:wikidata": "Q11676846"
+      }
+    },
+    {
+      "displayName": "嘉義市政府警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "chiayi police",
+        "ccpb",
+        "ccpd",
+        "嘉義市警察",
+        "嘉義市警局",
+        "嘉義警察",
+        "嘉義警局"
+      ],
+      "tags": {
+        "amenity": "police",
+        "operator": "嘉義市政府警察局",
+        "operator:en": "Chiayi City Police Bureau",
+        "operator:wikidata": "Q113575905",
+        "operator:zh": "嘉義市政府警察局"
+      }
+    },
+    {
+      "displayName": "基隆市警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "keelung police",
+        "kcpb",
+        "kcpd",
+        "klg",
+        "基隆市警察",
+        "基隆市警局",
+        "基隆警察",
+        "基隆警局"
+      ],
+      "tags": {
+        "amenity": "police",
+        "operator": "基隆市警察局",
+        "operator:en": "Keelung City Police Bureau",
+        "operator:wikidata": "Q22773799",
+        "operator:zh": "基隆市警察局"
+      }
+    },
+    {
+      "displayName": "澎湖縣政府警察局",
+
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "penghu police",
+        "phpb",
+        "phpd",
+        "澎湖縣警察",
+        "澎湖縣警局",
+        "澎湖警察",
+        "澎湖警局"
+      ],
+      "tags": {
+        "amenity": "police",
+        "operator": "澎湖縣政府警察局",
+        "operator:en": "Penghu County Government Police Bureau",
+        "operator:wikidata": "Q117654413",
+        "operator:zh": "澎湖縣政府警察局"
+      }
+    },
+    {
+      "displayName": "金門縣警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "kinmen police",
+        "kpb",
+        "kpd",
+        "金門縣警察",
+        "金門縣警局",
+        "金門警察",
+        "金門警局"
+      ],
+      "tags": {
+        "amenity": "police",
+        "operator": "金門縣警察局",
+        "operator:en": "Kinmen County Police Bureau",
+        "operator:wikidata": "Q122930750",
+        "operator:zh": "金門縣警察局"
+      }
+    },
+    {
+      "displayName": "南投縣政府警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "nantou police",
+        "ncpd",
+        "ncpb",
+        "南投縣警察",
+        "南投縣警局",
+        "南投警察",
+        "南投警局"
+      ],
+      "tags": {
+        "amenity": "police",
+        "operator": "南投縣政府警察局",
+        "operator:en": "Nantou County Police Bureau",
+        "operator:wikidata": "Q122930750",
+        "operator:zh": "南投縣政府警察局"
+      }
+    },
+    {
+      "displayName": "雲林縣警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "yunlin police",
+        "ylhpb",
+        "ylpb",
+        "ylpd",
+        "雲林縣警察",
+        "雲林縣警局",
+        "雲林警察",
+        "雲林警局"
+      ],
+      "tags": {
+        "amenity": "police",
+        "operator": "雲林縣警察局",
+        "operator:en": "Yunlin County Police Bureau",
+        "operator:wikidata": "Q130525125",
+        "operator:zh": "雲林縣警察局"
+      }
+    },
+    {
+      "displayName": "嘉義縣警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "chiayi police",
+        "cypb",
+        "cypd",
+        "嘉義縣警察",
+        "嘉義縣警局",
+        "嘉義警察",
+        "嘉義警局"
+      ],
+      "tags": {
+        "amenity": "police",
+        "operator": "嘉義縣警察局",
+        "operator:en": "Chiayi County Police Bureau",
+        "operator:wikidata": "Q130525194",
+        "operator:zh": "嘉義縣警察局"
+      }
+    },
+    {
+      "displayName": "宜蘭縣政府警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "yilan police",
+        "ilcpb",
+        "ilcpd",
+        "ilpb",
+        "ilpd",
+        "宜蘭縣警察",
+        "宜蘭縣警局",
+        "宜蘭警察",
+        "宜蘭警局"
+      ],
+      "tags": {
+        "amenity": "police",
+        "operator": "宜蘭縣政府警察局",
+        "operator:en": "Yilan County Police Bureau",
+        "operator:wikidata": "Q130525221",
+        "operator:zh": "宜蘭縣政府警察局"
+      }
+    },
+    {
+      "displayName": "花蓮縣警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "hualien police",
+        "hlpb",
+        "hlpd",
+        "宜蘭縣警察",
+        "宜蘭縣警局",
+        "宜蘭警察",
+        "宜蘭警局"
+      ],
+      "tags": {
+        "amenity": "police",
+        "operator": "花蓮縣警察局",
+        "operator:en": "Hualien County Police Department",
+        "operator:wikidata": "Q130525231",
+        "operator:zh": "花蓮縣警察局"
+      }
+    },
+    {
+      "displayName": "臺東縣警察局",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "taitung police",
+        "ttcpb",
+        "ttcpd",
+        "ttpb",
+        "ttpd",
+        "臺東縣警察",
+        "臺東縣警局",
+        "臺東警察",
+        "臺東警局"
+      ],
+      "tags": {
+        "amenity": "police",
+        "operator": "臺東縣警察局",
+        "operator:en": "Taitung County Police Bureau",
+        "operator:wikidata": "Q130525254",
+        "operator:zh": "臺東縣警察局"
       }
     }
   ]


### PR DESCRIPTION
# Taiwanese departments
Add the following police stations:

| 中文 | English | Wikidata | 
|---------|----|----|
| 彰化縣警察局 | Chungha Contry Police Department  | [Q130487509](https://www.wikidata.org/wiki/Q130487509) |
| 新竹市警察局 | Hsinchu City Police Department  | [Q85880448](https://www.wikidata.org/wiki/Q85880448) |
| 苗栗縣警察局 | Miaoli Contry Police Department  | [Q15903147](https://www.wikidata.org/wiki/Q15903147) |
| 嘉義市政府警察局 | Chiayi City Police Bureau | [Q113575905](https://www.wikidata.org/wiki/Q113575905) |
| 基隆市警察局 | Penghu County Government Police Bureau | [Q117654413](https://www.wikidata.org/wiki/Q117654413) |
| 澎湖縣政府警察局 | Chungha Contry Police Department  | [Q130487509](https://www.wikidata.org/wiki/Q130487509) |
| 金門縣警察局 | Kinmen County Police Bureau  | [Q122930750](https://www.wikidata.org/wiki/Q122930750) |
| 南投縣政府警察局 | Nantou County Police Bureau  | [Q122930750](https://www.wikidata.org/wiki/Q122930750) |
| 雲林縣警察局 | Yunlin County Police Bureau  | [Q130525125](https://www.wikidata.org/wiki/Q130525125) |
| 嘉義縣警察局 | Chiayi County Police Bureau  | [Q130525194](https://www.wikidata.org/wiki/Q130525194) |
| 宜蘭縣政府警察局 | Yilan County Police Bureau  | [Q130525221](https://www.wikidata.org/wiki/Q130525221) |
| 花蓮縣警察局 | Hualien County Police Department  | [Q130525231](https://www.wikidata.org/wiki/Q130525231) |
| 臺東縣警察局 | Taitung County Police Bureau  | [Q130525254](https://www.wikidata.org/wiki/Q130525254) |

Refer the [addressbook](https://www.npa.gov.tw/ch/app/data/view?module=liaison&id=1820&serno=afc427bb-43d6-4af4-994a-71faee42e3c0) for details.

The Lienchiang County Police Bureau (連江縣警察局) is omitted because there are too few stations in Lienchiang.

---

# Taiwanese government agencies

Add Taoyuan Public Library (桃園市立圖書館) and 桃園市政府消防局

---

# Taiwanese brands

Add the following police stations:

| 中文 | English | Type (類別) | Wikidata | 
|---------|----|----|----|
| 西雅圖極品咖啡 | Barista Coffee | amenity=cafe | [Q130525295](https://www.wikidata.org/wiki/Q130525295) |
| Mr. Brown 伯朗咖啡館 | Mr. Brown Café | amenity=cafe | [Q21016949](https://www.wikidata.org/wiki/Q21016949) |
| 得來素 | Der Life | amenity=restaurant | [Q130525358](https://www.wikidata.org/wiki/Q130525358) |
| 衣博士 | Dr. Washing | shop=laundry | [Q130525426](https://www.wikidata.org/wiki/Q130525426) |
| 愛買 | A.mart | shop=supermarket | [Q15898440](https://www.wikidata.org/wiki/Q15898440) |
| 三井貴金屬 | Mitsui | shop=supermarket | [Q130525509](https://www.wikidata.org/wiki/Q130525509) |

In addition, crate alias and operator for FJ Veggie (芳珍蔬食).

# Jewel Cafe

[Jewel Cafe](https://jewel-cafe.jp/) is a retail chain of luxury goods. According to its official website, it has at least 250 stores worldwide. It also has its own [Wikipedia entry](https://ja.wikipedia.org/wiki/%E3%82%B8%E3%83%A5%E3%82%A8%E3%83%AB%E3%82%AB%E3%83%95%E3%82%A7). Therefore, I believe it is worth to add.