### PR TITLE
add Stanford University to brands/amenity/university

### DIFF
--- a/data/brands/amenity/university.json
+++ b/data/brands/amenity/university.json
@@ -78,6 +78,18 @@
         "name": "University of Phoenix",
         "short_name": "UOPX"
       }
+    },
+    {
+      "displayName": "Stanford University",
+      "id": "stanforduniversity-d62529",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "amenity": "university",
+        "brand": "Stanford University",
+        "brand:wikidata": "Q1889100",
+        "name": "Stanford University",
+        "short_name": "Stanford"
+      }
     }
   ]
 }


### PR DESCRIPTION
This PR adds **Stanford University** to the `brands/amenity/university` category in the NSI.

- **Wikidata ID**: Q41506
- **Reason for inclusion**: Stanford University is a globally recognized academic institution with a significant presence in various countries through research collaborations, satellite locations, and global academic influence.
- **Meets NSI requirements**: It has a valid Wikidata tag and fulfills the notability threshold due to its widespread impact and recognition.

### Additional Notes
Stanford's inclusion will improve the accuracy and comprehensiveness of university-related tagging in OpenStreetMap, particularly for editors using NSI presets like iD Editor.

