### PR TITLE
add Grand Canyon University to brands/amenity/university

### DIFF
--- a/data/brands/amenity/university.json
+++ b/data/brands/amenity/university.json
@@ -80,15 +80,15 @@
       }
     },
     {
-      "displayName": "Stanford University",
-      "id": "stanforduniversity-d62529",
+      "displayName": "Grand Canyon University",
+      "id": "grandcanyonuniversity-d62529",
       "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "university",
-        "brand": "Stanford University",
-        "brand:wikidata": "Q1889100",
-        "name": "Stanford University",
-        "short_name": "Stanford"
+        "brand": "Grand Canyon University",
+        "brand:wikidata": "Q4570025",
+        "name": "Grand Canyon University",
+        "short_name": "GCU"
       }
     }
   ]

--- a/data/brands/amenity/university.json
+++ b/data/brands/amenity/university.json
@@ -78,6 +78,18 @@
         "name": "University of Phoenix",
         "short_name": "UOPX"
       }
+    },
+    {
+      "displayName": "Stanford University",
+      "id": "stanforduniversity-d62529",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "amenity": "university",
+        "brand": "Stanford University",
+        "brand:wikidata": "Q1889100",
+        "name": "Stanford University",
+        "short_name": "Stanford"
+      }
     }
   ]
 }


### PR DESCRIPTION
### This PR adds Grand Canyon University to the brands/amenity/university category in the NSI.

- Wikidata ID: Q1378857
- Reason for inclusion: Grand Canyon University is a for-profit institution that operates like a branded business, with a strong online presence and physical campuses across the U.S. Its model is aligned with other universities already included in the index, such as the University of Phoenix.
- Meets NSI requirements: Grand Canyon University has multiple locations and meets the threshold for inclusion due to its presence as a for-profit educational entity with a valid Wikidata tag.

### Additional Notes
Grand Canyon University will improve the accuracy of university tagging for similar institutions in OpenStreetMap and help with mapping for-profit educational institutions in regions where they operate.