### PR TITLE
Add Stanford University and Healthcare Entities to Operator Tree

### DIFF
--- a/data/operators/amenity/hospital.json
+++ b/data/operators/amenity/hospital.json
@@ -3126,6 +3126,50 @@
         "operator:wikidata": "Q5035687",
         "operator:zh": "首都医科大学"
       }
+    },
+    {
+      "displayName": "Stanford Health Care Tri-Valley",
+      "id": "Stanford Health Care Tri-Valley-618ef9",
+      "locationSet": {"include": ["us-ca.geojson"]},
+     "tags": {
+        "amenity": "hospital",
+        "healthcare": "hospital",
+        "operator": "Stanford Health",
+        "operator:wikidata": "Q130530767"
+      }
+    },
+    {
+      "displayName": "Stanford Medicine Partners",
+      "id": "Stanford Medicine Partners-618ef9",
+      "locationSet": {"include": ["us-ca.geojson"]},
+     "tags": {
+        "amenity": "hospital",
+        "healthcare": "hospital",
+        "operator": "Stanford Medicine Partners",
+        "operator:wikidata": "Q130530794"
+      }
+    },
+    {
+      "displayName": "Stanford University Medicine Department",
+      "id": "Stanford University Medicine Department-618ef9",
+      "locationSet": {"include": ["us-ca.geojson"]},
+     "tags": {
+        "amenity": "hospital",
+        "healthcare": "hospital",
+        "operator": "Stanford University Medicine Department",
+        "operator:wikidata": "Q77247031"
+      }
+    },
+    {
+      "displayName": "Stanford Health Care",
+      "id": "Stanford Health Care-618ef9",
+      "locationSet": {"include": ["us-ca.geojson"]},
+     "tags": {
+        "amenity": "hospital",
+        "healthcare": "hospital",
+        "operator": "Stanford Health Care",
+        "operator:wikidata": "Q130530819"
+      }
     }
   ]
 }

--- a/data/operators/amenity/university.json
+++ b/data/operators/amenity/university.json
@@ -37,6 +37,18 @@
         "operator:short": "Keiser",
         "operator:wikidata": "Q6383859"
       }
+    },
+    {
+      "displayName": "Stanford University",
+      "id": "stanforduniversity-a22ec8",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "amenity": "university",
+        "operator": "Stanford University",
+        "operator:wikidata": "Q41506"
+      }
     }
   ]
 }


### PR DESCRIPTION
This PR introduces updates to the Name Suggestion Index (NSI) by adding Stanford University and related healthcare entities to the Operator Tree.

**Changes Made:**
- Stanford University has been added to data/operators/amenity/university.json as an operator, complete with the necessary tags and location set.
- Created entries for the following healthcare brands:
  - Stanford Health Care (Wikidata: [Q130530819](https://www.wikidata.org/wiki/Q130530819))
  - Stanford Medicine Partners (Wikidata: [Q130530794](https://www.wikidata.org/wiki/Q130530794))
  - Stanford Health Care Tri-Valley (Wikidata: [Q130530767](https://www.wikidata.org/wiki/Q130530767))

### Summary:
These updates reflect the operational status of Stanford University and its healthcare affiliates, ensuring compliance with NSI guidelines. The newly created Wikidata pages facilitate proper integration and reference for these entities within the OpenStreetMap community.