### PR TITLE
Adds EMT Madrid

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -5022,6 +5022,21 @@
       "locationSet": {"include": ["es"]},
       "tags": {
         "network": "EMT Fuenlabrada",
+        "network:wikidata": "Q5831722",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Empresa Municipal de Transportes de Madrid",
+      "id": "empresamunicipaldetransportesdemadrid-cbced8",
+      "locationSet": {"include": ["es"]},
+      "tags": {
+        "network": "Empresa Municipal de Transportes de Madrid",
+        "network:short": "EMT Madrid",
+        "network:wikidata": "Q1094755",
+        "operator": "Empresa Municipal de Transportes de Madrid",
+        "operator:short": "EMT Madrid",
+        "operator:wikidata": "Q1094755",
         "route": "bus"
       }
     },
@@ -5031,6 +5046,7 @@
       "locationSet": {"include": ["es"]},
       "tags": {
         "network": "EMT Tarragona",
+        "network:wikidata": "Q28662868",
         "route": "bus"
       }
     },


### PR DESCRIPTION
Add Empresa Municipal de Transportes de Madrid, bus operator of the city of Madrid, Spain.

I also updated the wikidata code of EMT Fuenlabrada and EMT Tarragona, that was missing.