### PR TITLE
Update English names of Athens and Mumbai Suburban Railway

### DIFF
--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -1235,11 +1235,11 @@
       }
     },
     {
-      "displayName": "Mumbai Suburban Rail Network",
+      "displayName": "Mumbai Suburban Railway",
       "id": "mumbaisuburbanrailnetwork-7147b7",
       "locationSet": {"include": ["in"]},
       "tags": {
-        "network": "Mumbai Suburban Rail Network",
+        "network": "Mumbai Suburban Railway",
         "network:wikidata": "Q3273422",
         "route": "train"
       }
@@ -2774,7 +2774,7 @@
       "locationSet": {"include": ["gr"]},
       "tags": {
         "network": "Προαστιακός Αθήνας",
-        "network:en": "Proastiakos",
+        "network:en": "Athens Suburban Railway",
         "network:wikidata": "Q18176333",
         "route": "train"
       }


### PR DESCRIPTION
Update the English names of "Athens Suburban Railway" and "Mumbai Suburban Railway" per Wikidata entries [Q18176333](https://www.wikidata.org/wiki/Q18176333) and [Q3273422](https://www.wikidata.org/wiki/Q3273422) respectively.