### PR TITLE
OVS extended to all Europe and added OVS Kids

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -7688,12 +7688,24 @@
       "displayName": "OVS",
       "id": "ovs-8c6a50",
       "locationSet": {
-        "include": ["at", "ch", "fr", "it", "si"]
+        "include": ["150"]
       },
       "tags": {
         "brand": "OVS",
         "brand:wikidata": "Q2042514",
         "name": "OVS",
+        "shop": "clothes"
+      }
+    },
+    {
+      "displayName": "OVS Kids",
+      "locationSet": {
+        "include": ["150"]
+      },
+      "tags": {
+        "brand": "OVS Kids",
+        "brand:wikidata": "Q2042514",
+        "name": "OVS Kids",
         "shop": "clothes"
       }
     },

--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -7705,6 +7705,7 @@
       "tags": {
         "brand": "OVS Kids",
         "brand:wikidata": "Q2042514",
+        "clothes": "children",
         "name": "OVS Kids",
         "shop": "clothes"
       }


### PR DESCRIPTION
OVS have at least one shop in every country of Europe.

OVS Kids it's a sub-brand of OVS, no different company, no different website, so I kept the same WIkidata item.

Ps. why do we need an OVS preset only for Georgia?