### PR TITLE
Mio Amore

### DIFF
--- a/data/brands/shop/pastry.json
+++ b/data/brands/shop/pastry.json
@@ -515,6 +515,20 @@
         "operator:zh": "苏州稻香村食品有限公司",
         "shop": "pastry"
       }
+    },
+    {
+      "displayName": "Mio Amore",
+      "id": "null",
+      "locationSet": {"include": ["in"]},
+      "tags": {
+        "brand": "Mio Amore",
+        "brand:wikidata": "Q130534919",
+        "name": "Mio Amore",
+        "name:bn": "মিও আমোরে",
+        "takeaway": "yes",
+        "diet:vegetarian": "yes",
+        "shop": "pastry"
+      }
     }
   ]
 }


### PR DESCRIPTION
Added Mio Amore, an Indian bakery and snack chain, primarily operating in West Bengal and East India.
