### PR TITLE
remove remaining bancomer entry

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -2185,17 +2185,6 @@
       }
     },
     {
-      "displayName": "Bancomer",
-      "id": "bancomer-574575",
-      "locationSet": {"include": ["mx"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Bancomer",
-        "brand:wikidata": "Q2876794",
-        "name": "Bancomer"
-      }
-    },
-    {
       "displayName": "Bancpost",
       "id": "bancpost-9a9a30",
       "locationSet": {"include": ["ro"]},
@@ -3309,7 +3298,7 @@
       "displayName": "BBVA (México)",
       "id": "bbvamexico-574575",
       "locationSet": {"include": ["mx"]},
-      "matchNames": ["bbva bancomer"],
+      "matchNames": ["bbva bancomer", "bancomer"],
       "tags": {
         "amenity": "bank",
         "brand": "BBVA México",


### PR DESCRIPTION
As noted by @Cj-Malone in #10009, there was a remaining _Bancomer_ entry left after that PR. This one remains it and instead folds it into the same `matchName` for the now-used `BBVA (México)`.