### PR TITLE
pipeline.json legal names

### DIFF
--- a/data/operators/man_made/pipeline.json
+++ b/data/operators/man_made/pipeline.json
@@ -137,11 +137,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "air liquide large indust u.s. lp"
+        "air liquide large indusries"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Air Liquide Large Industries",
+        "operator": "Air Liquide Large Industries U.S. LP",
         "operator:wikidata": "Q113466577"
       }
     },
@@ -220,10 +220,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["amp texas pipelines, llc"],
+      "matchNames": ["amp texas pipelines"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "AMP Texas Pipelines"
+        "operator": "AMP Texas Pipelines, LLC"
       }
     },
     {
@@ -231,11 +231,11 @@
       "id": "anadarkopetroleum-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "anadarko petroleum corporation"
+        "anadarko petroleum"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Anadarko Petroleum",
+        "operator": "Anadarko Petroleum Corporation",
         "operator:wikidata": "Q483637"
       }
     },
@@ -274,12 +274,11 @@
       "id": "anrpipeline-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "anr pipeline co",
-        "anr pipeline company"
+        "anr pipeline"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "ANR Pipeline",
+        "operator": "ANR Pipeline Company",
         "operator:wikidata": "Q4653023"
       }
     },
@@ -298,20 +297,20 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["arcadia operating, llc"],
+      "matchNames": ["arcadia operating"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Arcadia Operating"
+        "operator": "Arcadia Operating, LLC"
       }
     },
     {
       "displayName": "Arena Offshore",
       "id": "arenaoffshore-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["arena offshore, lp"],
+      "matchNames": ["arena offshore"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Arena Offshore"
+        "operator": "Arena Offshore, LP"
       }
     },
     {
@@ -321,11 +320,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "arrowhead gas services, llc"
+        "arrowhead gas services"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Arrowhead Gas Services"
+        "operator": "Arrowhead Gas Services, LLC"
       }
     },
     {
@@ -500,11 +499,11 @@
         "include": ["us-al.geojson"]
       },
       "matchNames": [
-        "bay gas storage company, llc"
+        "bay gas storage company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Bay Gas Storage Company"
+        "operator": "Bay Gas Storage Company, LLC"
       }
     },
     {
@@ -537,10 +536,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["bb-southtex, llc"],
+      "matchNames": ["bb-southtex"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "BB-Southtex"
+        "operator": "BB-Southtex, LLC"
       }
     },
     {
@@ -550,11 +549,11 @@
         "include": ["us-al.geojson"]
       },
       "matchNames": [
-        "bbt alabama intrastate, llc"
+        "bbt alabama intrastate"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "BBT Alabama Intrastate"
+        "operator": "BBT Alabama Intrastate, LLC"
       }
     },
     {
@@ -567,10 +566,10 @@
           "us-tn.geojson"
         ]
       },
-      "matchNames": ["bbt alatenn, llc"],
+      "matchNames": ["bbt alatenn"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "BBT AlaTenn"
+        "operator": "BBT AlaTenn, LLC"
       }
     },
     {
@@ -579,10 +578,10 @@
       "locationSet": {
         "include": ["us-ms.geojson"]
       },
-      "matchNames": ["bbt mississippi, llc"],
+      "matchNames": ["bbt mississippi"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "BBT Mississippi"
+        "operator": "BBT Mississippi, LLC"
       }
     },
     {
@@ -603,11 +602,11 @@
       "id": "beacongrowthcooperatingcompany-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "beacon growthco operating company, l.l.c."
+        "beacon growthco operating company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Beacon Growthco Operating Company"
+        "operator": "Beacon Growthco Operating Company, L.L.C."
       }
     },
     {
@@ -617,11 +616,11 @@
         "include": ["us-la.geojson"]
       },
       "matchNames": [
-        "bear creek storage company, l.l.c."
+        "bear creek storage company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Bear Creek Storage Company"
+        "operator": "Bear Creek Storage Company, L.L.C."
       }
     },
     {
@@ -630,10 +629,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["beehive operating, llc"],
+      "matchNames": ["beehive operating"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Beehive Operating"
+        "operator": "Beehive Operating, LLC"
       }
     },
     {
@@ -721,10 +720,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["blue cube operations, llc"],
+      "matchNames": ["blue cube operations"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Blue Cube Operations"
+        "operator": "Blue Cube Operations, LLC"
       }
     },
     {
@@ -733,10 +732,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["bluefin ressources, llc"],
+      "matchNames": ["bluefin ressources"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Bluefin Resources"
+        "operator": "Bluefin Resources, LLC"
       }
     },
     {
@@ -760,11 +759,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "boardwalk field services, llc"
+        "boardwalk field services"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Boardwalk Field Services"
+        "operator": "Boardwalk Field Services, LLC"
       }
     },
     {
@@ -792,11 +791,11 @@
       "id": "bpexplorationandproduction-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "bp exploration & production inc."
+        "bp exploration & production"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "BP Exploration & Production"
+        "operator": "BP Exploration & Production Inc."
       }
     },
     {
@@ -814,10 +813,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["bpx gathering, llc"],
+      "matchNames": ["bpx gathering"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "BPX Gathering"
+        "operator": "BPX Gathering, LLC"
       }
     },
     {
@@ -826,10 +825,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["bpx midstream, llc"],
+      "matchNames": ["bpx midstream"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "BPX Midstream"
+        "operator": "BPX Midstream, LLC"
       }
     },
     {
@@ -849,10 +848,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["brg lone star ltd."],
+      "matchNames": ["brg lone star"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "BRG Lone Star"
+        "operator": "BRG Lone Star Ltd."
       }
     },
     {
@@ -881,11 +880,11 @@
       "id": "buckeyedevelopmentandlogistics-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "buckeye development & logistics, llc"
+        "buckeye development & logistics"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Buckeye Development & Logistics"
+        "operator": "Buckeye Development & Logistics, LLC"
       }
     },
     {
@@ -904,10 +903,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["buckeye texas hub, llc"],
+      "matchNames": ["buckeye texas hub"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Buckeye Texas Hub"
+        "operator": "Buckeye Texas Hub, LLC"
       }
     },
     {
@@ -978,11 +977,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "calpine texas pipeline, l.p."
+        "calpine texas pipeline"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Calpine Texas Pipeline"
+        "operator": "Calpine Texas Pipeline, L.P."
       }
     },
     {
@@ -1005,11 +1004,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "camino real gathering company, llc"
+        "camino real gathering company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Camino Real Gathering Company"
+        "operator": "Camino Real Gathering Company, LLC"
       }
     },
     {
@@ -1046,10 +1045,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["canes midstream g&p, llc"],
+      "matchNames": ["canes midstream g&p"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Canes Midstream G&P"
+        "operator": "Canes Midstream G&P, LLC"
       }
     },
     {
@@ -1078,10 +1077,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["cantera operating, llc"],
+      "matchNames": ["cantera operating"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Cantera Operating"
+        "operator": "Cantera Operating, LLC"
       }
     },
     {
@@ -1101,11 +1100,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "canyon creek resources, llc"
+        "canyon creek resources"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Canyon Creek Resources"
+        "operator": "Canyon Creek Resources, LLC"
       }
     },
     {
@@ -1115,11 +1114,11 @@
         "include": ["us-sc.geojson"]
       },
       "matchNames": [
-        "carolina gas transmission, llc"
+        "carolina gas transmission"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Carolina Gas Transmission"
+        "operator": "Carolina Gas Transmission, LLC"
       }
     },
     {
@@ -1128,10 +1127,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["catarina midstream, llc"],
+      "matchNames": ["catarina midstream"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Catarina Midstream"
+        "operator": "Catarina Midstream, LLC"
       }
     },
     {
@@ -1159,11 +1158,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "centana intrastate pipeline, llc"
+        "centana intrastate pipeline"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Centana Intrastate Pipeline"
+        "operator": "Centana Intrastate Pipeline, LLC"
       }
     },
     {
@@ -1210,10 +1209,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["chaparral energy, llc"],
+      "matchNames": ["chaparral energy"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Chaparral Energy",
+        "operator": "Chaparral Energy, LLC",
         "operator:wikidata": "Q30271233"
       }
     },
@@ -1233,10 +1232,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["chesapeake operating, llc"],
+      "matchNames": ["chesapeake operating"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Chesapeake Operating"
+        "operator": "Chesapeake Operating, LLC"
       }
     },
     {
@@ -1272,11 +1271,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "cinco natural resources corp."
+        "cinco natural resources"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Cinco Natural Resources"
+        "operator": "Cinco Natural Resources Corp."
       }
     },
     {
@@ -1285,10 +1284,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["cinco oil & gas, llc"],
+      "matchNames": ["cinco oil & gas"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Cinco Oil & Gas"
+        "operator": "Cinco Oil & Gas, LLC"
       }
     },
     {
@@ -1313,7 +1312,7 @@
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Citgo Refining & Chemicals Company"
+        "operator": "Citgo Refining & Chemicals Company L.P."
       }
     },
     {
@@ -1424,20 +1423,20 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["cody energy llc"],
+      "matchNames": ["cody energy"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Cody Energy"
+        "operator": "Cody Energy LLC"
       }
     },
     {
       "displayName": "Colonial Pipeline",
       "id": "colonialpipeline-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["colonial pipeline company"],
+      "matchNames": ["colonial pipeline"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Colonial Pipeline",
+        "operator": "Colonial Pipeline Company",
         "operator:wikidata": "Q107145391"
       }
     },
@@ -1446,11 +1445,11 @@
       "id": "coloradointerstategas-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "colorado interstate gas company"
+        "colorado interstate gas"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Colorado Interstate Gas",
+        "operator": "Colorado Interstate Gas Company",
         "operator:wikidata": "Q5148822"
       }
     },
@@ -1459,11 +1458,11 @@
       "id": "columbiagastransmission-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "columbia gas transmission, llc"
+        "columbia gas transmission"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Columbia Gas Transmission"
+        "operator": "Columbia Gas Transmission, LLC"
       }
     },
     {
@@ -1478,11 +1477,11 @@
         ]
       },
       "matchNames": [
-        "columbia gulf transmission, llc"
+        "columbia gulf transmission"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Columbia Gulf Transmission"
+        "operator": "Columbia Gulf Transmission, LLC"
       }
     },
     {
@@ -1500,10 +1499,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["comstock oil & gas, llc"],
+      "matchNames": ["comstock oil & gas"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Comstock Oil & Gas"
+        "operator": "Comstock Oil & Gas, LLC"
       }
     },
     {
@@ -1552,11 +1551,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "copano fld serv/south texas llc"
+        "copano fld serv/south texas"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Copano Field Services South Texas"
+        "operator": "Copano Field Services South Texas LLC"
       }
     },
     {
@@ -1565,10 +1564,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["copano ngl services llc"],
+      "matchNames": ["copano ngl services"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Copano NGL Services"
+        "operator": "Copano NGL Services LLC"
       }
     },
     {
@@ -1586,10 +1585,10 @@
       "displayName": "Cox Operating",
       "id": "coxoperating-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["cox operating, l.l.c."],
+      "matchNames": ["cox operating"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Cox Operating"
+        "operator": "Cox Operating, L.L.C."
       }
     },
     {
@@ -1618,10 +1617,10 @@
       "displayName": "Crescent Midstream",
       "id": "crescentmidstream-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["crescent midstream, llc"],
+      "matchNames": ["crescent midstream"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Crescent Midstream"
+        "operator": "Crescent Midstream, LLC"
       }
     },
     {
@@ -1663,11 +1662,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "dallas petroleum group, llc"
+        "dallas petroleum group"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Dallas Petroleum Group"
+        "operator": "Dallas Petroleum Group, LLC"
       }
     },
     {
@@ -1675,11 +1674,11 @@
       "id": "dapletcooperationsmanagement-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "dapl-etco operations management, llc"
+        "dapl-etco operations management"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "DAPL-ETCO Operations Management"
+        "operator": "DAPL-ETCO Operations Management, LLC"
       }
     },
     {
@@ -1698,11 +1697,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "davis gas processing, inc."
+        "davis gas processing"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Davis Gas Processing"
+        "operator": "Davis Gas Processing, Inc."
       }
     },
     {
@@ -1711,10 +1710,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["daylight petroleum llc"],
+      "matchNames": ["daylight petroleum"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Daylight Petroleum"
+        "operator": "Daylight Petroleum LLC"
       }
     },
     {
@@ -1723,10 +1722,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["dcp hinshaw pipeline, llc"],
+      "matchNames": ["dcp hinshaw pipeline"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "DCP Hinshaw Pipeline"
+        "operator": "DCP Hinshaw Pipeline, LLC"
       }
     },
     {
@@ -1736,11 +1735,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "dcp intrastate network, llc"
+        "dcp intrastate network"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "DCP Intrastate Network"
+        "operator": "DCP Intrastate Network, LLC"
       }
     },
     {
@@ -1791,11 +1790,11 @@
         ]
       },
       "matchNames": [
-        "delek logistics operating, llc"
+        "delek logistics operating"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Delek Logistics Operating"
+        "operator": "Delek Logistics Operating, LLC"
       }
     },
     {
@@ -1805,11 +1804,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "denbury green pipeline-texas, llc"
+        "denbury green pipeline-texas"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Denbury Green Pipeline-Texas"
+        "operator": "Denbury Green Pipeline-Texas, LLC"
       }
     },
     {
@@ -1822,11 +1821,11 @@
         ]
       },
       "matchNames": [
-        "denbury gulf coast pipelines, llc"
+        "denbury gulf coast pipelines"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Denbury Gulf Coast Pipelines"
+        "operator": "Denbury Gulf Coast Pipelines, LLC"
       }
     },
     {
@@ -1838,10 +1837,10 @@
           "us-ms.geojson"
         ]
       },
-      "matchNames": ["denbury onshore, llc"],
+      "matchNames": ["denbury onshore"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Denbury Onshore"
+        "operator": "Denbury Onshore, LLC"
       }
     },
     {
@@ -1902,11 +1901,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "discovery natural resources, llc"
+        "discovery natural resources"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Discovery Natural Resources"
+        "operator": "Discovery Natural Resources, LLC"
       }
     },
     {
@@ -1933,11 +1932,11 @@
       "id": "dixiepipelinecompany-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "dixie pipeline company llc"
+        "dixie pipeline company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Dixie Pipeline Company"
+        "operator": "Dixie Pipeline Company LLC"
       }
     },
     {
@@ -1989,11 +1988,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "double eagle pipeline, llc"
+        "double eagle pipeline"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Double Eagle Pipeline"
+        "operator": "Double Eagle Pipeline, LLC"
       }
     },
     {
@@ -2002,11 +2001,11 @@
       "locationSet": {"include": ["us"]},
       "matchNames": [
         "dow chemical",
-        "the dow chemical company"
+        "dow chemical company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Dow Chemical Company",
+        "operator": "The Dow Chemical Company",
         "operator:wikidata": "Q855639"
       }
     },
@@ -2058,11 +2057,11 @@
         "include": ["us-la.geojson"]
       },
       "matchNames": [
-        "dtm louisiana gathering, llc"
+        "dtm louisiana gathering"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "DTM Louisiana Gathering"
+        "operator": "DTM Louisiana Gathering, LLC"
       }
     },
     {
@@ -2107,10 +2106,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["eagle ford gathering, llc"],
+      "matchNames": ["eagle ford gathering"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Eagle Ford Gathering"
+        "operator": "Eagle Ford Gathering, LLC"
       }
     },
     {
@@ -2119,10 +2118,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["eagle ford midstream, lp"],
+      "matchNames": ["eagle ford midstream"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Eagle Ford Midstream"
+        "operator": "Eagle Ford Midstream, LLC"
       }
     },
     {
@@ -2133,11 +2132,11 @@
       },
       "matchNames": [
         "eagle oil & gas co.",
-        "eagle oil & gas company"
+        "eagle oil & gas"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Eagle Oil & Gas"
+        "operator": "Eagle Oil & Gas Company"
       }
     },
     {
@@ -2163,11 +2162,11 @@
         ]
       },
       "matchNames": [
-        "east tennessee natural gas, llc"
+        "east tennessee natural gas"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "East Tennessee Natural Gas"
+        "operator": "East Tennessee Natural Gas, LLC"
       }
     },
     {
@@ -2181,11 +2180,11 @@
         ]
       },
       "matchNames": [
-        "eastern gas transmission and storage, inc."
+        "eastern gas transmission and storage"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Eastern Gas Transmission and Storage"
+        "operator": "Eastern Gas Transmission and Storage, Inc."
       }
     },
     {
@@ -2195,11 +2194,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "easton energy pipelines llc"
+        "easton energy pipelines"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Easton Energy Pipelines"
+        "operator": "Easton Energy Pipelines LLC"
       }
     },
     {
@@ -2219,10 +2218,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["echo canyon pipeline, llc"],
+      "matchNames": ["echo canyon pipeline"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Echo Canyon Pipeline"
+        "operator": "Echo Canyon Pipeline, LLC"
       }
     },
     {
@@ -2350,11 +2349,11 @@
       "id": "enablegastransmission-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "enable gas transmission, llc"
+        "enable gas transmission"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Enable Gas Transmission"
+        "operator": "Enable Gas Transmission, LLC"
       }
     },
     {
@@ -2368,11 +2367,11 @@
         ]
       },
       "matchNames": [
-        "enable mississippi river transmission, llc"
+        "enable mississippi river transmission"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Enable Mississippi River Transmission"
+        "operator": "Enable Mississippi River Transmission, LLC"
       }
     },
     {
@@ -2405,11 +2404,11 @@
       "locationSet": {"include": ["us"]},
       "matchNames": [
         "enbridge offshore (gas gathering)",
-        "enbridge offshore (gas gathering) l.l.c."
+        "enbridge offshore"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Enbridge Offshore"
+        "operator": "Enbridge Offshore (Gas Gathering) L.L.C."
       }
     },
     {
@@ -2417,11 +2416,11 @@
       "id": "enbridgeoffshorefacilities-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "enbridge offshore facilities, llc"
+        "enbridge offshore facilities"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Enbridge Offshore Facilities"
+        "operator": "Enbridge Offshore Facilities, LLC"
       }
     },
     {
@@ -2487,11 +2486,11 @@
         ]
       },
       "matchNames": [
-        "enerfin field services llc"
+        "enerfin field services"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Enerfin Field Services"
+        "operator": "Enerfin Field Services LLC"
       }
     },
     {
@@ -2565,11 +2564,11 @@
       "id": "energyresourcetechnology-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "energy resource technology, inc."
+        "energy resource technology."
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Energy Resource Technology"
+        "operator": "Energy Resource Technology, Inc."
       }
     },
     {
@@ -2647,11 +2646,11 @@
         "include": ["us-la.geojson"]
       },
       "matchNames": [
-        "enlink processing services, llc"
+        "enlink processing services"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "EnLink Processing Services"
+        "operator": "EnLink Processing Services, LLC"
       }
     },
     {
@@ -2672,11 +2671,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "enterprise crude pipeline, llc"
+        "enterprise crude pipeline"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Enterprise Crude Pipeline"
+        "operator": "Enterprise Crude Pipeline, LLC"
       }
     },
     {
@@ -2697,11 +2696,11 @@
       },
       "matchNames": [
         "enterprise operating, llc",
-        "enterprise products operating, llc"
+        "enterprise products operating"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Enterprise Products Operating"
+        "operator": "Enterprise Products Operating LLC"
       }
     },
     {
@@ -2710,11 +2709,11 @@
       "locationSet": {"include": ["us"]},
       "matchNames": [
         "eog resources, inc.",
-        "eog ressources, inc."
+        "eog ressources"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "EOG Resources",
+        "operator": "EOG Resources, Inc.",
         "operator:wikidata": "Q1275577"
       }
     },
@@ -2754,12 +2753,12 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "epic consolidated operations, llc",
+        "epic consolidated operations",
         "epic consolidated ops, llc"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Epic Consolidated Operations"
+        "operator": "Epic Consolidated Operations, LLC"
       }
     },
     {
@@ -2769,21 +2768,21 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "epic permian operating, llc"
+        "epic permian operating"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Epic Permian Operating"
+        "operator": "Epic Permian Operating, LLC"
       }
     },
     {
       "displayName": "EPL Oil & Gas",
       "id": "eploilandgas-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["epl oil & gas, llc"],
+      "matchNames": ["epl oil & gas"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "EPL Oil & Gas"
+        "operator": "EPL Oil & Gas, LLC"
       }
     },
     {
@@ -2811,10 +2810,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["equistar chemicals, lp"],
+      "matchNames": ["equistar chemicals"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Equistar Chemicals"
+        "operator": "Equistar Chemicals, LLC"
       }
     },
     {
@@ -2873,10 +2872,10 @@
       "locationSet": {
         "include": ["us-la.geojson"]
       },
-      "matchNames": ["etc tiger pipeline, llc"],
+      "matchNames": ["etc tiger pipeline"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "ETC Tiger Pipeline"
+        "operator": "ETC Tiger Pipeline, LLC"
       }
     },
     {
@@ -2992,10 +2991,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["faulconer energy, llc"],
+      "matchNames": ["faulconer energy"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Faulconer Energy"
+        "operator": "Faulconer Energy, LLC"
       }
     },
     {
@@ -3084,20 +3083,20 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["field petroleum corp"],
+      "matchNames": ["field petroleum"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Field Petroleum"
+        "operator": "Field Petroleum Corp"
       }
     },
     {
       "displayName": "Fieldwood Energy",
       "id": "fieldwoodenergy-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["fieldwood energy llc"],
+      "matchNames": ["fieldwood energy"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Fieldwood Energy"
+        "operator": "Fieldwood Energy LLC"
       }
     },
     {
@@ -3117,10 +3116,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["fl rich gas services, lp"],
+      "matchNames": ["fl rich gas services"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "FL Rich Gas Services"
+        "operator": "FL Rich Gas Services, LP"
       }
     },
     {
@@ -3143,11 +3142,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "flint hills resources port arthur, llc"
+        "flint hills resources port arthur"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Flint Hills Resources Port Arthur"
+        "operator": "Flint Hills Resources Port Arthur, LLC"
       }
     },
     {
@@ -3157,11 +3156,11 @@
       "matchNames": [
         "florida gas transmission co. llc",
         "florida gas transmission company",
-        "florida gas transmission company, llc"
+        "florida gas transmission"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Florida Gas Transmission"
+        "operator": "Florida Gas Transmission Company, LLC"
       }
     },
     {
@@ -3220,11 +3219,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "fourth floor operating, llc"
+        "fourth floor operating"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Fourth Floor Operating"
+        "operator": "Fourth Floor Operating, LLC"
       }
     },
     {
@@ -3245,10 +3244,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["frio lasalle pipeline, lp"],
+      "matchNames": ["frio lasalle pipeline"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Frio Lasalle Pipeline"
+        "operator": "Frio Lasalle Pipeline, L.P."
       }
     },
     {
@@ -3278,11 +3277,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "galveston bay refinery logistics llc"
+        "galveston bay refinery logistics"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Galveston Bay Refinery Logistics"
+        "operator": "Galveston Bay Refinery Logistics LLC"
       }
     },
     {
@@ -3334,11 +3333,11 @@
         ]
       },
       "matchNames": [
-        "gas transmission northwest llc"
+        "gas transmission northwest"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Gas Transmission Northwest"
+        "operator": "Gas Transmission Northwest LLC"
       }
     },
     {
@@ -3491,11 +3490,11 @@
       "id": "genesisoffshoreholdings-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "genesis offshore holdings, llc"
+        "genesis offshore holdings"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Genesis Offshore Holdings"
+        "operator": "Genesis Offshore Holdings, LLC"
       }
     },
     {
@@ -3509,11 +3508,11 @@
         ]
       },
       "matchNames": [
-        "genesis pipeline usa, l.p."
+        "genesis pipeline usa"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Genesis Pipeline USA"
+        "operator": "Genesis Pipeline USA, L.P."
       }
     },
     {
@@ -3523,11 +3522,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "genesis producing company, l.p."
+        "genesis producing company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Genesis Producing Company"
+        "operator": "Genesis Producing Company, L.P."
       }
     },
     {
@@ -3562,10 +3561,10 @@
       "displayName": "GOM Shelf",
       "id": "gomshelf-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["gom shelf llc"],
+      "matchNames": ["gom shelf"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "GOM Shelf"
+        "operator": "GOM Shelf LLC"
       }
     },
     {
@@ -3601,10 +3600,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["gravity midstream cc, llc"],
+      "matchNames": ["gravity midstream cc"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Gravity Midstream CC"
+        "operator": "Gravity Midstream CC, LLC"
       }
     },
     {
@@ -3654,10 +3653,10 @@
       "displayName": "Greyhound Energy",
       "id": "greyhoundenergy-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["greyhound energy llc"],
+      "matchNames": ["greyhound energy"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Greyhound Energy"
+        "operator": "Greyhound Energy, LLC"
       }
     },
     {
@@ -3667,11 +3666,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "grit oil & gas management, llc"
+        "grit oil & gas management"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Grit Oil & Gas Management"
+        "operator": "Grit Oil & Gas Management, LLC"
       }
     },
     {
@@ -3716,10 +3715,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["gulf coast energy, inc."],
+      "matchNames": ["gulf coast energy"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Gulf Coast Energy"
+        "operator": "Gulf Coast Energy, Inc."
       }
     },
     {
@@ -3727,11 +3726,11 @@
       "id": "gulfsouthpipelinecompany-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "gulf south pipeline company, llc"
+        "gulf south pipeline company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Gulf South Pipeline Company"
+        "operator": "Gulf South Pipeline Company, LLC"
       }
     },
     {
@@ -3741,11 +3740,11 @@
         "include": ["us-fl.geojson"]
       },
       "matchNames": [
-        "gulfstream natural gas system, l.l.c."
+        "gulfstream natural gas system"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Gulfstream Natural Gas System"
+        "operator": "Gulfstream Natural Gas System, L.L.C."
       }
     },
     {
@@ -3781,10 +3780,10 @@
       "displayName": "Harvest Alaska",
       "id": "harvestalaska-16072e",
       "locationSet": {"include": ["us-ak"]},
-      "matchNames": ["harvest alaska, llc"],
+      "matchNames": ["harvest alaska"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Harvest Alaska"
+        "operator": "Harvest Alaska, LLC"
       }
     },
     {
@@ -3844,11 +3843,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "headington energy partners, llc"
+        "headington energy partners"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Headington Energy Partners"
+        "operator": "Headington Energy Partners, LLC"
       }
     },
     {
@@ -3894,10 +3893,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["hibbard energy, lp"],
+      "matchNames": ["hibbard energy"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Hibbard Energy"
+        "operator": "Hibbard Energy, LP"
       }
     },
     {
@@ -3905,31 +3904,31 @@
       "id": "highpointgasgathering-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "high point gas gathering llc"
+        "high point gas gathering"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "High Point Gas Gathering"
+        "operator": "High Point Gas Gathering LLC"
       }
     },
     {
       "displayName": "Hilcorp Alaska",
       "id": "hilcorpalaska-16072e",
       "locationSet": {"include": ["us-ak"]},
-      "matchNames": ["hilcorp alaska, llc"],
+      "matchNames": ["hilcorp alaska"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Hilcorp Alaska"
+        "operator": "Hilcorp Alaska, LLC"
       }
     },
     {
       "displayName": "Hilcorp Energy",
       "id": "hilcorpenergy-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["hilcorp energy company"],
+      "matchNames": ["hilcorp energy"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Hilcorp Energy",
+        "operator": "Hilcorp Energy Company",
         "operator:wikidata": "Q30752849"
       }
     },
@@ -3959,10 +3958,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["hooks gas pipeline, llc"],
+      "matchNames": ["hooks gas pipeline"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Hooks Gas Pipeline"
+        "operator": "Hooks Gas Pipeline, LLC"
       }
     },
     {
@@ -3970,11 +3969,11 @@
       "id": "houstonpipelinecompany-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "houston pipe line company lp"
+        "houston pipe line company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Houston Pipe Line Company"
+        "operator": "Houston Pipe Line Company LP"
       }
     },
     {
@@ -4123,11 +4122,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "ironwood midstream energy partners, llc"
+        "ironwood midstream energy partners"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Ironwood Midstream Energy Partners"
+        "operator": "Ironwood Midstream Energy Partners, LLC"
       }
     },
     {
@@ -4174,10 +4173,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["itc pipeline company llc"],
+      "matchNames": ["itc pipeline company"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "ITC Pipeline Company"
+        "operator": "ITC Pipeline Company LLC"
       }
     },
     {
@@ -4186,10 +4185,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["j.p. oil company, inc."],
+      "matchNames": ["j.p. oil company"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "J.P. Oil Company"
+        "operator": "J.P. Oil Company, Inc."
       }
     },
     {
@@ -4307,11 +4306,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "kinder morgan crude & condensate llc"
+        "kinder morgan crude & condensate "
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Kinder Morgan Crude & Condensate"
+        "operator": "Kinder Morgan Crude & Condensate LLC"
       }
     },
     {
@@ -4324,11 +4323,11 @@
         ]
       },
       "matchNames": [
-        "kinder morgan liquids terminals llc"
+        "kinder morgan liquids terminals"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Kinder Morgan Liquids Terminals"
+        "operator": "Kinder Morgan Liquids Terminals LLC"
       }
     },
     {
@@ -4366,21 +4365,21 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "kinder morgan treating, lp"
+        "kinder morgan treating"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Kinder Morgan Treating"
+        "operator": "Kinder Morgan Treating, LP"
       }
     },
     {
       "displayName": "Kinetica Partners",
       "id": "kineticapartners-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["kinetica partners, llc"],
+      "matchNames": ["kinetica partners"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Kinetica Partners"
+        "operator": "Kinetica Partners, LLC"
       }
     },
     {
@@ -4390,11 +4389,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "koch pipeline company, l.p."
+        "koch pipeline company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Koch Pipeline Company"
+        "operator": "Koch Pipeline Company, L.P."
       }
     },
     {
@@ -4432,10 +4431,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["kudu midstream llc"],
+      "matchNames": ["kudu midstream"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Kudu Midstream"
+        "operator": "Kudu Midstream LLC"
       }
     },
     {
@@ -4460,10 +4459,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["lakeshore operating, llc"],
+      "matchNames": ["lakeshore operating"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Lakeshore Operating"
+        "operator": "Lakeshore Operating, LLC"
       }
     },
     {
@@ -4472,10 +4471,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["lamar oil & gas, inc."],
+      "matchNames": ["lamar oil & gas"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Lamar Oil & Gas"
+        "operator": "Lamar Oil & Gas, Inc."
       }
     },
     {
@@ -4504,10 +4503,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["lavaca midstream, l.l.c."],
+      "matchNames": ["lavaca midstream"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Lavaca Midstream"
+        "operator": "Lavaca Midstream, L.L.C."
       }
     },
     {
@@ -4575,10 +4574,10 @@
       "displayName": "Linde",
       "id": "linde-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["linde inc."],
+      "matchNames": ["linde"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Linde",
+        "operator": "Linde Inc.",
         "operator:wikidata": "Q30338631"
       }
     },
@@ -4588,10 +4587,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["linn operating, llc"],
+      "matchNames": ["linn operating"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Linn Operating"
+        "operator": "Linn Operating, LLC"
       }
     },
     {
@@ -4599,11 +4598,11 @@
       "id": "llogexplorationoffshore-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "llog exploration offshore, l.l.c."
+        "llog exploration offshore"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "LLOG Exploration Offshore"
+        "operator": "LLOG Exploration Offshore, L.L.C."
       }
     },
     {
@@ -4612,10 +4611,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["lonestar operating, llc"],
+      "matchNames": ["lonestar operating"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Lonestar Operating"
+        "operator": "Lonestar Operating, LLC"
       }
     },
     {
@@ -4670,11 +4669,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "magellan crude oil pipeline company, llc"
+        "magellan crude oil pipeline company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Magellan Crude Oil Pipeline Company"
+        "operator": "Magellan Crude Oil Pipeline Company, LLC"
       }
     },
     {
@@ -4683,11 +4682,11 @@
       "locationSet": {"include": ["us"]},
       "matchNames": [
         "magellan pipeline company",
-        "magellan pipeline company, l.p."
+        "magellan pipeline"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Magellan Pipeline"
+        "operator": "Magellan Pipeline Company, L.P."
       }
     },
     {
@@ -4697,11 +4696,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "magellan terminals holdings, l.p."
+        "magellan terminals holdings"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Magellan Terminals Holdings"
+        "operator": "Magellan Terminals Holdings, L.P."
       }
     },
     {
@@ -4727,11 +4726,11 @@
       "id": "mantaraygatheringcompany-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "manta ray gathering company, l.l.c."
+        "manta ray gathering company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Manta Ray Gathering Company"
+        "operator": "Manta Ray Gathering Company, L.L.C."
       }
     },
     {
@@ -4750,12 +4749,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "marathon oil ef, llc",
-        "marathon oil, llc"
+        "marathon oil"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Marathon Oil",
+        "operator": "Marathon Oil, LLC",
         "operator:wikidata": "Q1577587"
       }
     },
@@ -4763,10 +4761,10 @@
       "displayName": "Marathon Pipe Line",
       "id": "marathonpipeline-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["marathon pipe line llc"],
+      "matchNames": ["marathon pipe line"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Marathon Pipe Line",
+        "operator": "Marathon Pipe Line LLC",
         "operator:wikidata": "Q130232376"
       }
     },
@@ -4786,11 +4784,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "markwest energy s tx gas company, llc"
+        "markwest energy s tx gas company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "MarkWest Energy South Texas Gas Company"
+        "operator": "MarkWest Energy South Texas Gas Company, LLC"
       }
     },
     {
@@ -4804,7 +4802,7 @@
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "MarkWest Javelina Company"
+        "operator": "MarkWest Javelina Company, LLC"
       }
     },
     {
@@ -4818,7 +4816,7 @@
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "MarkWest Javelina Pipeline Company"
+        "operator": "MarkWest Javelina Pipeline Company, LLC"
       }
     },
     {
@@ -4828,11 +4826,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "martin operating partnership lp"
+        "martin operating partnership"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Martin Operating Partnership"
+        "operator": "Martin Operating Partnership LP"
       }
     },
     {
@@ -4854,10 +4852,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["max midstream texas, llc"],
+      "matchNames": ["max midstream texas"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Max Midstream Texas"
+        "operator": "Max Midstream Texas, LLC"
       }
     },
     {
@@ -4984,11 +4982,11 @@
       "id": "midvalleypipelinecompany-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "mid valley pipeline company llc"
+        "mid valley pipeline company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Mid Valley Pipeline Company"
+        "operator": "Mid Valley Pipeline Company LLC"
       }
     },
     {
@@ -4997,12 +4995,6 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": [
-        "midcoast pipeline l.p.",
-        "midcoast pipelines (east texas) l.p.",
-        "midcoast pipelines east texas",
-        "midcoast pipelines l.p."
-      ],
       "tags": {
         "man_made": "pipeline",
         "operator": "Midcoast Pipelines"
@@ -5013,11 +5005,11 @@
       "id": "midcontinentexpresspipeline-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "midcontinent express pipeline llc"
+        "midcontinent express pipeline"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Midcontinent Express Pipeline"
+        "operator": "Midcontinent Express Pipeline, LLC"
       }
     },
     {
@@ -5138,11 +5130,11 @@
         "include": ["us-ms.geojson"]
       },
       "matchNames": [
-        "monroe gas storage company, llc"
+        "monroe gas storage company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Monroe Gas Storage Company"
+        "operator": "Monroe Gas Storage Company, LLC"
       }
     },
     {
@@ -5151,20 +5143,20 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["monument pipeline, lp"],
+      "matchNames": ["monument pipeline"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Monument Pipeline"
+        "operator": "Monument Pipeline, LLC"
       }
     },
     {
       "displayName": "Motiva Enterprises",
       "id": "motivaenterprises-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["motiva enterprises llc"],
+      "matchNames": ["motiva enterprises"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Motiva Enterprises",
+        "operator": "Motiva Enterprises LLC",
         "operator:wikidata": "Q11201012"
       }
     },
@@ -5209,7 +5201,7 @@
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Murphy Exploration & Production"
+        "operator": "Murphy Exploration & Production Company"
       }
     },
     {
@@ -5219,11 +5211,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "mustang island gathering, llc"
+        "mustang island gathering"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Mustang Island Gathering"
+        "operator": "Mustang Island Gathering, LLC"
       }
     },
     {
@@ -5288,11 +5280,11 @@
         "natural gas p/l co of amer llc",
         "natural gas pipeline company of amar",
         "natural gas pipeline company of amar, llc",
-        "natural gas pipeline company of america, llc"
+        "natural gas pipeline company of america"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Natural Gas Pipeline Company of America",
+        "operator": "Natural Gas Pipeline Company of America, LLC",
         "operator:wikidata": "Q6980495"
       }
     },
@@ -5313,11 +5305,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "navarro midstream services, llc"
+        "navarro midstream services"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Navarro Midstream Services"
+        "operator": "Navarro Midstream Services, LLC"
       }
     },
     {
@@ -5339,11 +5331,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "net mexico pipeline partners, llc"
+        "net mexico pipeline partners"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Net Mexico Pipeline Partners"
+        "operator": "Net Mexico Pipeline Partners, LLC"
       }
     },
     {
@@ -5527,21 +5519,21 @@
       "matchNames": [
         "northern natural gas co",
         "northern natural gas company",
-        "nothern natural gas company"
+        "nothern natural gas"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Northern Natural Gas"
+        "operator": "Northern Natural Gas Company"
       }
     },
     {
       "displayName": "Northwest Pipeline",
       "id": "northwestpipeline-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["northwest pipeline llc"],
+      "matchNames": ["northwest pipeline"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Northwest Pipeline"
+        "operator": "Northwest Pipeline LLC"
       }
     },
     {
@@ -5606,10 +5598,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["nustar logistics, l.p."],
+      "matchNames": ["nustar logistics"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Nustar Logistics"
+        "operator": "Nustar Logistics, L.P."
       }
     },
     {
@@ -5617,11 +5609,11 @@
       "id": "nustarpipelineoperatingpartnership-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "nustar pipeline operating partnership l.p."
+        "nustar pipeline operating partnership"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "NuStar Pipeline Operating Partnership"
+        "operator": "NuStar Pipeline Operating Partnership L.P."
       }
     },
     {
@@ -5666,10 +5658,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["occidental permian ltd."],
+      "matchNames": ["occidental permian"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Occidental Permian"
+        "operator": "Occidental Permian Ltd."
       }
     },
     {
@@ -5688,10 +5680,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["olipdp ii, llc"],
+      "matchNames": ["olipdp ii"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Olipdp II"
+        "operator": "Olipdp II, LLC"
       }
     },
     {
@@ -5731,11 +5723,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "oneok hydrocarbon southwest, llc"
+        "oneok hydrocarbon southwest"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Oneok Hydrocarbon Southwest"
+        "operator": "Oneok Hydrocarbon Southwest, LLC"
       }
     },
     {
@@ -5744,10 +5736,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["oneok ngl pipeline, llc"],
+      "matchNames": ["oneok ngl pipeline"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Oneok NGL Pipeline"
+        "operator": "Oneok NGL Pipeline, LLC"
       }
     },
     {
@@ -5847,10 +5839,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["oxy usa inc."],
+      "matchNames": ["oxy usa"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "OXY USA"
+        "operator": "OXY USA Inc."
       }
     },
     {
@@ -5860,11 +5852,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "ozona pipeline energy company, llc"
+        "ozona pipeline energy company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Ozona Pipeline Energy Company"
+        "operator": "Ozona Pipeline Energy Company, LLC"
       }
     },
     {
@@ -5912,11 +5904,11 @@
       "id": "pantheroperatingcompany-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "panther operating company, llc"
+        "panther operating company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Panther Operating Company"
+        "operator": "Panther Operating Company, LLC"
       }
     },
     {
@@ -5925,10 +5917,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["panther pipeline, llc"],
+      "matchNames": ["panther pipeline"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Panther Pipeline"
+        "operator": "Panther Pipeline, LLC"
       }
     },
     {
@@ -5938,11 +5930,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "paradigm midstream services, llc"
+        "paradigm midstream services"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Paradigm Midstream Services"
+        "operator": "Paradigm Midstream Services, LLC"
       }
     },
     {
@@ -6010,10 +6002,10 @@
       "locationSet": {
         "include": ["us-fl.geojson"]
       },
-      "matchNames": ["peoples gas system, inc."],
+      "matchNames": ["peoples gas system"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Peoples Gas System"
+        "operator": "Peoples Gas System, Inc."
       }
     },
     {
@@ -6021,11 +6013,11 @@
       "id": "permianexpresspartners-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "permian express partners llc"
+        "permian express partners"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Permian Express Partners"
+        "operator": "Permian Express Partners LLC"
       }
     },
     {
@@ -6082,11 +6074,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "petroleum fuels company, inc"
+        "petroleum fuels company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Petroleum Fuels Company"
+        "operator": "Petroleum Fuels Company, Inc."
       }
     },
     {
@@ -6124,10 +6116,10 @@
       "displayName": "Phillips 66",
       "id": "phillips66-143312",
       "locationSet": {"include": ["001"]},
-      "matchNames": ["phillips 66 company"],
+      "matchNames": ["phillips 66"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Phillips 66",
+        "operator": "Phillips 66 Company",
         "operator:wikidata": "Q1656230"
       }
     },
@@ -6137,10 +6129,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["phillips 66 pipeline, llc"],
+      "matchNames": ["phillips 66 pipeline"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Phillips 66 Pipeline"
+        "operator": "Phillips 66 Pipeline, LLC"
       }
     },
     {
@@ -6170,10 +6162,10 @@
       "displayName": "Plains Pipeline",
       "id": "plainspipeline-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["plains pipeline, lp"],
+      "matchNames": ["plains pipeline"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Plains Pipeline"
+        "operator": "Plains Pipeline, LP"
       }
     },
     {
@@ -6224,11 +6216,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "polaris pipeline systems, llc"
+        "polaris pipeline systems"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Polaris Pipeline Systems"
+        "operator": "Polaris Pipeline Systems, LLC"
       }
     },
     {
@@ -6297,10 +6289,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["protege energy iii, llc"],
+      "matchNames": ["protege energy iii"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Protege Energy III"
+        "operator": "Protege Energy III, LLC"
       }
     },
     {
@@ -6338,10 +6330,10 @@
       "displayName": "QuarterNorth Energy",
       "id": "quarternorthenergy-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["quarternorth energy llc"],
+      "matchNames": ["quarternorth energy"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "QuarterNorth Energy"
+        "operator": "QuarterNorth Energy LLC"
       }
     },
     {
@@ -6375,11 +6367,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "recoil resources operating, inc."
+        "recoil resources operating"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Recoil Resources Operating"
+        "operator": "Recoil Resources Operating, Inc."
       }
     },
     {
@@ -6425,10 +6417,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["remora operating, llc"],
+      "matchNames": ["remora operating,"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Remora Operating"
+        "operator": "Remora Operating, LLC"
       }
     },
     {
@@ -6445,10 +6437,10 @@
       "displayName": "Renaissance Offshore",
       "id": "renaissanceoffshore-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["renaissance offshore llc"],
+      "matchNames": ["renaissance offshore"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Renaissance Offshore"
+        "operator": "Renaissance Offshore LLC"
       }
     },
     {
@@ -6457,10 +6449,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["repsol oil & gas usa, llc"],
+      "matchNames": ["repsol oil & gas usa"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Repsol Oil & Gas USA"
+        "operator": "Repsol Oil & Gas USA, LLC"
       }
     },
     {
@@ -6470,11 +6462,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "republic coast pipeline, llc"
+        "republic coast pipeline"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Republic Coast Pipeline"
+        "operator": "Republic Coast Pipeline, LLC"
       }
     },
     {
@@ -6516,10 +6508,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["rockdale energy, llc"],
+      "matchNames": ["rockdale energy"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Rockdale Energy"
+        "operator": "Rockdale Energy, LLC"
       }
     },
     {
@@ -6583,11 +6575,11 @@
       "id": "sabaltrailtransmission-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "sabal trail transmission, llc"
+        "sabal trail transmission"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Sabal Trail Transmission"
+        "operator": "Sabal Trail Transmission, LLC"
       }
     },
     {
@@ -6646,11 +6638,11 @@
       "id": "sanareenergypartners-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "sanare energy partners, llc"
+        "sanare energy partners"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Sanare Energy Partners"
+        "operator": "Sanare Energy Partners, LLC"
       }
     },
     {
@@ -6680,11 +6672,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "sarita energy resources, ltd."
+        "sarita energy resources"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Sarita Energy Resources"
+        "operator": "Sarita Energy Resources, Ltd."
       }
     },
     {
@@ -6753,10 +6745,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["sea eagle ford, llc"],
+      "matchNames": ["sea eagle ford"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Sea Eagle Ford"
+        "operator": "Sea Eagle Ford, LLC"
       }
     },
     {
@@ -6764,11 +6756,11 @@
       "id": "searobinpipelinecompany-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "sea robin pipeline company llc"
+        "sea robin pipeline company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Sea Robin Pipeline Company"
+        "operator": "Sea Robin Pipeline Company LLC"
       }
     },
     {
@@ -6779,11 +6771,11 @@
       },
       "matchNames": [
         "seadrift pipeline corp",
-        "seadrift pipeline corporation"
+        "seadrift pipeline"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Seadrift Pipeline"
+        "operator": "Seadrift Pipeline Corporation"
       }
     },
     {
@@ -6927,10 +6919,10 @@
       "displayName": "Shell Offshore",
       "id": "shelloffshore-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["shell offshore inc."],
+      "matchNames": ["shell offshore"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Shell Offshore"
+        "operator": "Shell Offshore Inc."
       }
     },
     {
@@ -6939,10 +6931,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["shell pipeline company lp"],
+      "matchNames": ["shell pipeline company"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Shell Pipeline Company"
+        "operator": "Shell Pipeline Company LP"
       }
     },
     {
@@ -6963,11 +6955,11 @@
       },
       "matchNames": [
         "sheridan production co iii, llc",
-        "sheridan production company iii, llc"
+        "sheridan production company iii"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Sheridan Production Company III"
+        "operator": "Sheridan Production Company III, LLC"
       }
     },
     {
@@ -6978,11 +6970,11 @@
       },
       "matchNames": [
         "silverbow resources operating",
-        "silverbow resources operating, llc"
+        "silverbow resources"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Silverbow Resources",
+        "operator": "Silverbow Resources Operating, LLC",
         "operator:wikidata": "Q113654251"
       }
     },
@@ -7002,10 +6994,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["sn ef maverick, llc"],
+      "matchNames": ["sn ef maverick"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "SN EF Maverick"
+        "operator": "SN EF Maverick, LLC"
       }
     },
     {
@@ -7014,10 +7006,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["sn operating, llc"],
+      "matchNames": ["sn operating"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "SN Operating"
+        "operator": "SN Operating, LLC"
       }
     },
     {
@@ -7116,11 +7108,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "southcross ccng gathering ltd."
+        "southcross ccng gathering"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Southcross CCNG Gathering"
+        "operator": "Southcross CCNG Gathering Ltd."
       }
     },
     {
@@ -7130,11 +7122,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "southcross ccng transmission ltd"
+        "southcross ccng transmission"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Southcross CCNG Transmission"
+        "operator": "Southcross CCNG Transmission Ltd."
       }
     },
     {
@@ -7144,11 +7136,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "southcross gulf coast trans. ltd"
+        "southcross gulf coast trans"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Southcross Gulf Coast Transmission"
+        "operator": "Southcross Gulf Coast Transmission Ltd."
       }
     },
     {
@@ -7158,11 +7150,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "southcross ngl pipeline ltd."
+        "southcross ngl pipeline"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Southcross NGL Pipeline"
+        "operator": "Southcross NGL Pipeline Ltd."
       }
     },
     {
@@ -7181,11 +7173,11 @@
       "id": "southeastsupplyheader-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "southeast supply header, llc"
+        "southeast supply header"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Southeast Supply Header"
+        "operator": "Southeast Supply Header, LLC"
       }
     },
     {
@@ -7217,11 +7209,11 @@
       "id": "southernnaturalgas-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "southern natural gas company, l.l.c."
+        "southern natural gas"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Southern Natural Gas",
+        "operator": "Southern Natural Gas Company, L.L.C.",
         "operator:wikidata": "Q7570164"
       }
     },
@@ -7291,10 +7283,10 @@
       "locationSet": {
         "include": ["us-al.geojson"]
       },
-      "matchNames": ["spire gulf, inc."],
+      "matchNames": ["spire gulf"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Spire Gulf"
+        "operator": "Spire Gulf, Inc."
       }
     },
     {
@@ -7339,10 +7331,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["springfield pipeline, llc"],
+      "matchNames": ["springfield pipeline"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Springfield Pipeline"
+        "operator": "Springfield Pipeline, LLC"
       }
     },
     {
@@ -7506,11 +7498,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "startex field services, llc"
+        "startex field services"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Startex Field Services"
+        "operator": "Startex Field Services, LLC"
       }
     },
     {
@@ -7518,11 +7510,11 @@
       "id": "stingraypipelinecompany-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "stingray pipeline company llc"
+        "stingray pipeline company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Stingray Pipeline Company"
+        "operator": "Stingray Pipeline Company LLC"
       }
     },
     {
@@ -7555,11 +7547,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "sulphur river exploration, inc."
+        "sulphur river exploration"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Sulphur River Exploration"
+        "operator": "Sulphur River Exploration, Inc."
       }
     },
     {
@@ -7569,21 +7561,21 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "sulphur river gathering llc"
+        "sulphur river gathering"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Sulphur River Gathering"
+        "operator": "Sulphur River Gathering LLC"
       }
     },
     {
       "displayName": "Sunoco Pipeline",
       "id": "sunocopipeline-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["sunoco pipeline l.p."],
+      "matchNames": ["sunoco pipeline"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Sunoco Pipeline"
+        "operator": "Sunoco Pipeline L.P."
       }
     },
     {
@@ -7592,10 +7584,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["superior midstream, llc"],
+      "matchNames": ["superior midstream"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Superior Midstream"
+        "operator": "Superior Midstream LLC"
       }
     },
     {
@@ -7686,10 +7678,10 @@
       "displayName": "Talos Energy Offshore",
       "id": "talosenergyoffshore-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["talos energy offshore llc"],
+      "matchNames": ["talos energy offshore"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Talos Energy Offshore"
+        "operator": "Talos Energy Offshore LLC"
       }
     },
     {
@@ -7697,11 +7689,11 @@
       "id": "talosenergyventures-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "talos energy ventures, llc"
+        "talos energy ventures"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Talos Energy Ventures"
+        "operator": "Talos Energy Ventures, LLC"
       }
     },
     {
@@ -7718,10 +7710,10 @@
       "displayName": "Talos Petroleum",
       "id": "talospetroleum-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["talos petroleum llc"],
+      "matchNames": ["talos petroleum"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Talos Petroleum"
+        "operator": "Talos Petroleum LLC"
       }
     },
     {
@@ -7740,11 +7732,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "targa ngl pipeline company llc"
+        "targa ngl pipeline company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Targa NGL Pipeline Company"
+        "operator": "Targa NGL Pipeline Company LLC"
       }
     },
     {
@@ -7767,11 +7759,11 @@
         "include": ["us-ks.geojson"]
       },
       "matchNames": [
-        "tc oil pipeline operations inc."
+        "tc oil pipeline operations"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "TC Oil Pipeline Operations"
+        "operator": "TC Oil Pipeline Operations Inc."
       }
     },
     {
@@ -7780,11 +7772,11 @@
       "locationSet": {"include": ["us"]},
       "matchNames": [
         "tennessee gas pipeline",
-        "tennessee gas pipeline company llc"
+        "tennessee gas pipeline company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Tennessee Gas Pipeline Company",
+        "operator": "Tennessee Gas Pipeline Company LLC",
         "operator:wikidata": "Q7700085",
         "substance": "gas"
       }
@@ -7863,11 +7855,11 @@
       "id": "texasgastransmission-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "texas gas transmission, llc"
+        "texas gas transmission"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Texas Gas Transmission"
+        "operator": "Texas Gas Transmission, LLC"
       }
     },
     {
@@ -7881,11 +7873,11 @@
         ]
       },
       "matchNames": [
-        "texas independent explor ltd."
+        "texas independent explor"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Texas Independent Exploration"
+        "operator": "Texas Independent Exploration Ltd."
       }
     },
     {
@@ -7894,10 +7886,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["texas pipeline, llc"],
+      "matchNames": ["texas pipeline"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Texas Pipeline"
+        "operator": "Texas Pipeline, LLC"
       }
     },
     {
@@ -7907,11 +7899,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "texas pipeline systems, llc"
+        "texas pipeline systems"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Texas Pipeline Systems"
+        "operator": "Texas Pipeline Systems, LLC"
       }
     },
     {
@@ -7920,10 +7912,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["tgg shelby assets, llc"],
+      "matchNames": ["tgg shelby assets"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "TGG Shelby Assets"
+        "operator": "TGG Shelby Assets, LLC"
       }
     },
     {
@@ -7993,10 +7985,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["torrent oil llc"],
+      "matchNames": ["torrent oil"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Torrent Oil"
+        "operator": "Torrent Oil LLC"
       }
     },
     {
@@ -8054,21 +8046,21 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "tpl southtex midstream llc"
+        "tpl southtex midstream"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "TPL Southtex Midstream"
+        "operator": "TPL Southtex Midstream LLC"
       }
     },
     {
       "displayName": "TR Offshore",
       "id": "troffshore-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["tr offshore, llc"],
+      "matchNames": ["tr offshore"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "TR Offshore"
+        "operator": "TR Offshore, LLC"
       }
     },
     {
@@ -8134,11 +8126,11 @@
         "include": ["ca-on.geojson"]
       },
       "matchNames": [
-        "trans-northern pipelines inc."
+        "trans-northern pipelines"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Trans-Northern Pipelines"
+        "operator": "Trans-Northern Pipelines, Inc."
       }
     },
     {
@@ -8146,11 +8138,11 @@
       "id": "transcontinentalgaspipelinecompany-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "transcontinental gas pipe line company, llc"
+        "transcontinental gas pipe line company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Transcontinental Gas Pipeline Company"
+        "operator": "Transcontinental Gas Pipeline Company, LLC"
       }
     },
     {
@@ -8232,10 +8224,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["trek resources, inc."],
+      "matchNames": ["trek resources"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Trek Resources"
+        "operator": "Trek Resources, Inc."
       }
     },
     {
@@ -8244,10 +8236,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["trinity operating, llc"],
+      "matchNames": ["trinity operating"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Trinity Operating"
+        "operator": "Trinity Operating, LLC"
       }
     },
     {
@@ -8257,11 +8249,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "trinity river energy operating, llc"
+        "trinity river energy operating"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Trinity River Energy Operating"
+        "operator": "Trinity River Energy Operating, LLC"
       }
     },
     {
@@ -8269,11 +8261,11 @@
       "id": "trunklinegascompany-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "trunkline gas company, llc"
+        "trunkline gas company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Trunkline Gas Company"
+        "operator": "Trunkline Gas Company, LLC"
       }
     },
     {
@@ -8419,11 +8411,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "united brine pipeline co, llc"
+        "united brine pipeline"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "United Brine Pipeline"
+        "operator": "United Brine Pipeline Company, LLC"
       }
     },
     {
@@ -8485,10 +8477,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["upp operating, llc"],
+      "matchNames": ["upp operating"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "UPP Operating"
+        "operator": "UPP Operating, LLC"
       }
     },
     {
@@ -8509,11 +8501,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "urban oil & gas group, llc"
+        "urban oil & gas group"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Urban Oil & Gas Group"
+        "operator": "Urban Oil & Gas Group, LLC"
       }
     },
     {
@@ -8557,11 +8549,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "valero refining - texas, l.p."
+        "valero refining - texas"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Valero Refining - Texas"
+        "operator": "Valero Refining - Texas, L.P."
       }
     },
     {
@@ -8571,11 +8563,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "validus nrg aquilas assetco, llc"
+        "validus nrg aquilas assetco"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Validus NRG Aquilas Assetco"
+        "operator": "Validus NRG Aquilas Assetco, LLC"
       }
     },
     {
@@ -8585,11 +8577,11 @@
         "include": ["mx", "us-tx.geojson"]
       },
       "matchNames": [
-        "valley crossing pipeline, llc"
+        "valley crossing pipeline"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Valley Crossing Pipeline"
+        "operator": "Valley Crossing Pipeline, LLC"
       }
     },
     {
@@ -8598,10 +8590,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["vanguard operating, llc"],
+      "matchNames": ["vanguard operating"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Vanguard Operating"
+        "operator": "Vanguard Operating, LLC"
       }
     },
     {
@@ -8706,10 +8698,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["verdun oil & gas, llc"],
+      "matchNames": ["verdun oil & gas"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Verdun Oil & Gas"
+        "operator": "Verdun Oil & Gas, LLC"
       }
     },
     {
@@ -8742,10 +8734,10 @@
       "locationSet": {
         "include": ["us-al.geojson"]
       },
-      "matchNames": ["w&t offshore, inc."],
+      "matchNames": ["w&t offshore"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "W&T Offshore"
+        "operator": "W&T Offshore, Inc."
       }
     },
     {
@@ -8891,11 +8883,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "white marlin operating co, llc"
+        "white marlin operating"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "White Marlin Operating"
+        "operator": "White Marlin Operating Company, LLC"
       }
     },
     {
@@ -8913,10 +8905,10 @@
       "displayName": "Whitney Oil & Gas",
       "id": "whitneyoilandgas-0a386a",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["whitney oil & gas, llc"],
+      "matchNames": ["whitney oil & gas"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Whitney Oil & Gas"
+        "operator": "Whitney Oil & Gas, LLC"
       }
     },
     {
@@ -8956,11 +8948,11 @@
       "id": "williamsfieldservicesgulfcoastcompany-0a386a",
       "locationSet": {"include": ["us"]},
       "matchNames": [
-        "williams field services - gulf coast company llc"
+        "williams field services - gulf coast company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Williams Field Services - Gulf Coast Company"
+        "operator": "Williams Field Services - Gulf Coast Company LLC"
       }
     },
     {
@@ -8969,11 +8961,11 @@
       "locationSet": {"include": ["us"]},
       "matchNames": [
         "williams mlp operating, llc",
-        "williams mpl operating, llc"
+        "williams mpl operating"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Williams MLP Operating"
+        "operator": "Williams MLP Operating, LLC"
       }
     },
     {
@@ -8993,11 +8985,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "wink to webster pipeline llc"
+        "wink to webster pipeline"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Wink to Webster Pipeline"
+        "operator": "Wink to Webster Pipeline LLC"
       }
     },
     {
@@ -9019,11 +9011,11 @@
       "locationSet": {"include": ["us"]},
       "matchNames": [
         "woodside energy (gom)",
-        "woodside energy (gom) inc."
+        "woodside energy (gom)"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Woodside Energy"
+        "operator": "Woodside Energy (GOM) Inc."
       }
     },
     {
@@ -9033,11 +9025,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "woodway bluebonnet pipeline llc"
+        "woodway bluebonnet pipeline"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Woodway Bluebonnet Pipeline"
+        "operator": "Woodway Bluebonnet Pipeline, LLC"
       }
     },
     {
@@ -9057,11 +9049,11 @@
       },
       "matchNames": [
         "wtg gas transmission co, llc",
-        "wtg gas transmission company, llc"
+        "wtg gas transmission company"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "WTG Gas Transmission Company"
+        "operator": "WTG Gas Transmission Company, LLC"
       }
     },
     {
@@ -9083,11 +9075,11 @@
         "include": ["us-tx.geojson"]
       },
       "matchNames": [
-        "wtg south permian midstream, llc"
+        "wtg south permian midstream"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "WTG South Permian Midstream"
+        "operator": "WTG South Permian Midstream, LLC"
       }
     },
     {
@@ -9109,10 +9101,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["xto energy, inc."],
+      "matchNames": ["xto energy"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "XTO Energy",
+        "operator": "XTO Energy, Inc.",
         "operator:wikidata": "Q762354"
       }
     },
@@ -9159,10 +9151,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["zarvona energy llc"],
+      "matchNames": ["zarvona energy"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Zarvona Energy"
+        "operator": "Zarvona Energy LLC"
       }
     },
     {
@@ -9171,10 +9163,10 @@
       "locationSet": {
         "include": ["us-tx.geojson"]
       },
-      "matchNames": ["zarvonia energy, llc"],
+      "matchNames": ["zarvonia energy"],
       "tags": {
         "man_made": "pipeline",
-        "operator": "Zarvonia Energy"
+        "operator": "Zarvonia Energy, LLC"
       }
     },
     {


### PR DESCRIPTION
Apparently someone shortened the "operator" values of various pipeline companies by removing all kinds of ", LLC; Company;,L. P.; Operating" extensions & so on.
For pipeline companies, at least in the US, we use the full, exact legal name for the operator field, as this avoids ambiguity - for example, many pipelines are operated by shared operating companies with complex parent company structures, where such distinctions are essential.
It appears from that most european companies are also tagged using their proper legal name, so no reason to change that for US companies.
Those automated changes also break all existing mapping, which, in the US uses comprehensively legal names, and furthermore this extremely broad change has not been discussed anywhere, which violates the Automated Edit guidelines.

Greetings