### PR TITLE
Add ÖoB, correct Rusta location set

### DIFF
--- a/data/brands/shop/variety_store.json
+++ b/data/brands/shop/variety_store.json
@@ -696,6 +696,17 @@
       }
     },
     {
+      "displayName": "ÖoB",
+      "locationSet": {"include": ["se"]},
+      "matchNames": ["Ö&B", "Ö & B", "Överskottsbolaget"],
+      "tags": {
+        "brand": "ÖoB",
+        "brand:wikidata": "Q10728663",
+        "name": "ÖoB",
+        "shop": "variety_store"
+      }
+    },
+    {
       "displayName": "Otto's",
       "id": "ottos-793388",
       "locationSet": {"include": ["ch"]},
@@ -804,7 +815,7 @@
       "displayName": "Rusta",
       "id": "rusta-7f2f16",
       "locationSet": {
-        "include": ["de", "fi", "sv"]
+        "include": ["de", "fi", "no", "se"]
       },
       "tags": {
         "brand": "Rusta",


### PR DESCRIPTION
Changes:
- Add Swedish store chain ÖoB
- Correct location set of Rusta, which had El Salvador (sv) instead of Sweden (se) by mistake, also added Norway.