### PR TITLE
Wetherspoon has a no dog policy

### DIFF
--- a/data/brands/amenity/pub.json
+++ b/data/brands/amenity/pub.json
@@ -593,7 +593,8 @@
       "tags": {
         "amenity": "pub",
         "brand": "Wetherspoon",
-        "brand:wikidata": "Q6109362"
+        "brand:wikidata": "Q6109362",
+        "dog": "no"
       }
     },
     {


### PR DESCRIPTION
Wetherspoon has a no dog policy, the following is taken from [their FAQ](https://www.jdwetherspoon.com/contact/faqs/pubs/)

> We do not permit dogs or other animals in our pubs, hotels or in external areas which belong to, or are managed by, us. This includes beer gardens, car parks and outside pavement areas.
> 
> We realise that this may seem quite strict, but our pubs are busy, with families and children present, and we serve a lot of food. Even well-trained dogs can sometimes behave unpredictably.
> 
> We do welcome assistance dogs. If possible, it would be helpful to our staff if your assistance dog were to wear a recognisable leash/collar or harness and if you could bring suitable documentation with you (although not mandatory requirements).