### PR TITLE
Remove Mobile Money brand from money_transfer.json

### DIFF
--- a/data/brands/amenity/money_transfer.json
+++ b/data/brands/amenity/money_transfer.json
@@ -45,21 +45,6 @@
       }
     },
     {
-      "displayName": "Mobile Money",
-      "id": "mobilemoney-1032f8",
-      "locationSet": {"include": ["001"]},
-      "matchNames": [
-        "mobil money",
-        "mobile money transfer"
-      ],
-      "tags": {
-        "amenity": "money_transfer",
-        "brand": "Mobile Money",
-        "brand:wikidata": "Q20312600",
-        "name": "Mobile Money"
-      }
-    },
-    {
       "displayName": "MoneyGram",
       "id": "moneygram-1032f8",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
[Mobile Money](https://en.wikipedia.org/wiki/Mobile_Money) is not a brand but a technology or service type. There are several mobile money brands like [Orange Money](https://en.wikipedia.org/wiki/Orange_Money) (already in NSI), MTN Mobile Money ([MoMo](https://mtn.com.gh/momo/)) , [M-Pesa](https://en.wikipedia.org/wiki/M-Pesa) etc. and I believe this generic one shouldn't be in the NSI.