### PR TITLE
Poczta Polska is branded, no need for operator tag

### DIFF
--- a/data/brands/amenity/post_office.json
+++ b/data/brands/amenity/post_office.json
@@ -267,6 +267,20 @@
       }
     },
     {
+      "displayName": "Poczta Polska",
+      "id": "pocztapolska-4d399f",
+      "locationSet": {"include": ["pl"]},
+      "matchNames": [
+        "poczta",
+        "poczta polska sa"
+      ],
+      "tags": {
+        "amenity": "post_office",
+        "brand": "Poczta Polska",
+        "brand:wikidata": "Q168833"
+      }
+    },
+    {
       "displayName": "Post Office (UK)",
       "id": "postoffice-a028f7",
       "locationSet": {"include": ["gb"]},

--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -979,20 +979,6 @@
       }
     },
     {
-      "displayName": "Poczta Polska",
-      "id": "pocztapolska-504b8a",
-      "locationSet": {"include": ["pl"]},
-      "matchNames": [
-        "poczta",
-        "poczta polska sa"
-      ],
-      "tags": {
-        "amenity": "post_office",
-        "operator": "Poczta Polska",
-        "operator:wikidata": "Q168833"
-      }
-    },
-    {
       "displayName": "Pos Indonesia",
       "id": "posindonesia-ab1265",
       "locationSet": {"include": ["id"]},


### PR DESCRIPTION
fixes #10028

Poland has no USPS/USPO dychotomy