### PR TITLE
Add TRAFIKON

### DIFF
--- a/data/brands/shop/tobacco.json
+++ b/data/brands/shop/tobacco.json
@@ -101,6 +101,22 @@
       }
     },
     {
+      "displayName": "TRAFICON",
+      "id": "traficon-56156e",
+      "locationSet": {"include": ["cz"]},
+      "matchNames": ["tabák traficon"],
+      "matchTags": [
+        "shop/kiosk",
+        "shop/newsagent"
+      ],
+      "tags": {
+        "brand": "TRAFICON",
+        "brand:wikidata": "Q67807570",
+        "name": "TRAFICON",
+        "shop": "tobacco"
+      }
+    },
+    {
       "displayName": "Wolsdorff",
       "id": "wolsdorff-7d79b1",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
Add TRAFIKON, Czech Tobacco stand chain (198 branches).