### PR TITLE
Update bus.json

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -6368,12 +6368,13 @@
       }
     },
     {
-      "displayName": "IDELIS",
+      "displayName": "Idelis",
       "id": "idelis-add5eb",
       "locationSet": {"include": ["fx"]},
       "tags": {
-        "network": "IDELIS",
+        "network": "Idelis",
         "network:wikidata": "Q3147798",
+        "operator": "STAP",
         "route": "bus"
       }
     },
@@ -7960,44 +7961,18 @@
       "displayName": "liO",
       "id": "lio-add5eb",
       "locationSet": {"include": ["fx"]},
-      "tags": {"network": "liO", "route": "bus"}
-    },
-    {
-      "displayName": "liO Arc-en-Ciel",
-      "id": "lioarcenciel-add5eb",
-      "locationSet": {"include": ["fx"]},
+      "matchNames": [
+        "lio arc-en-ciel",
+        "lio hérault transport",
+        "lio30",
+        "lio34",
+        "lio66",
+      ],
       "tags": {
-        "network": "liO Arc-en-Ciel",
-        "network:wikidata": "Q3456528",
+        "network": "liO",
+        "network:wikidata": "Q55597931",
         "route": "bus"
       }
-    },
-    {
-      "displayName": "liO Hérault Transport",
-      "id": "lioheraulttransport-add5eb",
-      "locationSet": {"include": ["fx"]},
-      "tags": {
-        "network": "liO Hérault Transport",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "liO30",
-      "id": "lio30-add5eb",
-      "locationSet": {"include": ["fx"]},
-      "tags": {"network": "liO30", "route": "bus"}
-    },
-    {
-      "displayName": "liO34",
-      "id": "lio34-add5eb",
-      "locationSet": {"include": ["fx"]},
-      "tags": {"network": "liO34", "route": "bus"}
-    },
-    {
-      "displayName": "liO66",
-      "id": "lio66-add5eb",
-      "locationSet": {"include": ["fx"]},
-      "tags": {"network": "liO66", "route": "bus"}
     },
     {
       "displayName": "Livo",


### PR DESCRIPTION
All liO variants merged between 2020 and 2022 to simply liO + added details here and there in Occitanie and Nouvelle-Aquitaine