### PR TITLE
add viewport meta tag for mobile

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Name Suggestion Index</title>
 <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
# Desktop

(no change)
| Before | After |
|--------|-------|
| ![Screenshot 2024-10-29 at 18-12-25 Name Suggestion Index - brands_](https://github.com/user-attachments/assets/a3d590b2-0784-4d7d-8a1d-9f77049ba74c) | ![Screenshot 2024-10-29 at 18-13-37 Name Suggestion Index - brands_](https://github.com/user-attachments/assets/50d38658-cd5d-4e95-be72-8d13c260a4f6) |

# Mobile

| Before | After |
|--------|-------|
| ![Screenshot 2024-10-29 at 18-13-01 Name Suggestion Index - brands_](https://github.com/user-attachments/assets/f45e7c62-7335-4374-946e-088909be08c4) | ![Screenshot 2024-10-29 at 18-13-50 Name Suggestion Index - brands_](https://github.com/user-attachments/assets/28b06c92-409e-471d-a7fa-42c6a5c4b2d5) |


Related to (but not closing): 
https://github.com/osmlab/name-suggestion-index/issues/10043