### PR TITLE
Update RTC Bike Share and add state for Indego

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -1815,8 +1815,10 @@
     },
     {
       "displayName": "Indego",
-      "id": "indego-97ea79",
-      "locationSet": {"include": ["us"]},
+      "id": "indego-d5d8a9",
+      "locationSet": {
+        "include": ["us-pa.geojson"]
+      },
       "tags": {
         "amenity": "bicycle_rental",
         "brand": "Indego",
@@ -3108,16 +3110,19 @@
       }
     },
     {
-      "displayName": "RTC of Southern Nevada",
-      "id": "rtcofsouthernnevada-91e721",
+      "displayName": "RTC Bike Share",
+      "id": "rtcbikeshare-91e721",
       "locationSet": {
         "include": ["us-nv.geojson"]
       },
       "tags": {
         "amenity": "bicycle_rental",
-        "brand": "RTC of Southern Nevada",
-        "name": "RTC of Southern Nevada",
-        "operator": "BCycle"
+        "brand": "RTC Bike Share",
+        "brand:wikidata": "Q104727968",
+        "network": "RTC Bike Share",
+        "network:wikidata": "Q104727968",
+        "operator": "Bicycle Transit Systems",
+        "operator:wikidata": "Q104005517"
       }
     },
     {


### PR DESCRIPTION
The bike share system in Las Vegas is branded as "RTC Bike Share". RTC of Southern Nevada is the name of the transit agency that owns it. RTC Bike Share is operated by Bicycle Transit Systems. BCycle is just the supplier. (BCycle is actually being acquired by BTS but it's not clear if they will rebrand).