### PR TITLE
Bike Share Toronto does not need default name -- stations have unique names

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -560,7 +560,6 @@
         "bicycle_rental": "docking_station",
         "brand": "Bike Share Toronto",
         "brand:wikidata": "Q17018523",
-        "name": "Bike Share Toronto",
         "operator": "Toronto Parking Authority",
         "operator:wikidata": "Q7826466"
       }


### PR DESCRIPTION
Hi! Just want to suggest removing default name from preset since there are real names for each station. People surveying can write them down in name tag, better leave it empty