### PR TITLE
Preserve `name=*` tags of CBA & Reál convenience stores

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1093,13 +1093,26 @@
       "displayName": "CBA",
       "id": "cba-a1e3fb",
       "locationSet": {
-        "include": ["bg", "hu", "ro", "sk"]
+        "include": ["hu", "ro", "sk"]
       },
       "preserveTags": ["^name"],
       "tags": {
         "brand": "CBA",
         "brand:wikidata": "Q779845",
         "name": "CBA",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "CBA (България)",
+      "locationSet": {"include": ["bg"]},
+      "tags": {
+        "brand": "CBA",
+        "brand:bg": "ЦБА",
+        "brand:wikidata": "Q779845",
+        "name": "CBA",
+        "name:bg": "ЦБА",
+        "operator": "ЦБА България",
         "shop": "convenience"
       }
     },

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1095,6 +1095,7 @@
       "locationSet": {
         "include": ["bg", "hu", "ro", "sk"]
       },
+      "preserveTags": ["^name"],
       "tags": {
         "brand": "CBA",
         "brand:wikidata": "Q779845",
@@ -4424,6 +4425,7 @@
         "reál hungária élelmiszer kereskedelmi kft.",
         "reál pont"
       ],
+      "preserveTags": ["^name"],
       "tags": {
         "brand": "Reál",
         "brand:wikidata": "Q100741414",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1266,6 +1266,7 @@
       "locationSet": {
         "include": ["hu", "ro", "sk"]
       },
+      "preserveTags": "^name",
       "tags": {
         "brand": "CBA",
         "brand:wikidata": "Q779845",
@@ -6824,6 +6825,7 @@
         "reál hungária élelmiszer kereskedelmi kft.",
         "reál pont"
       ],
+      "preserveTags": "^name",
       "tags": {
         "brand": "Reál",
         "brand:wikidata": "Q100741414",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1266,7 +1266,6 @@
       "locationSet": {
         "include": ["hu", "ro", "sk"]
       },
-      "preserveTags": ["^name"],
       "tags": {
         "brand": "CBA",
         "brand:wikidata": "Q779845",
@@ -6825,7 +6824,6 @@
         "reál hungária élelmiszer kereskedelmi kft.",
         "reál pont"
       ],
-      "preserveTags": ["^name"],
       "tags": {
         "brand": "Reál",
         "brand:wikidata": "Q100741414",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -1266,7 +1266,7 @@
       "locationSet": {
         "include": ["hu", "ro", "sk"]
       },
-      "preserveTags": "^name",
+      "preserveTags": ["^name"],
       "tags": {
         "brand": "CBA",
         "brand:wikidata": "Q779845",
@@ -6825,7 +6825,7 @@
         "reál hungária élelmiszer kereskedelmi kft.",
         "reál pont"
       ],
-      "preserveTags": "^name",
+      "preserveTags": ["^name"],
       "tags": {
         "brand": "Reál",
         "brand:wikidata": "Q100741414",


### PR DESCRIPTION
The `name=*` tags of _CBA_ & _Reál_ convenience stores should be preserved, as these shops usually have a unique name by which they are commonly known.