### PR TITLE
Added Romanain RetuRO bottle return points

### DIFF
--- a/data/operators/amenity/vending_machine.json
+++ b/data/operators/amenity/vending_machine.json
@@ -114,6 +114,18 @@
       }
     },
     {
+      "displayName": "RetuRO",
+      "locationSet": {"include": ["ro"]},
+      "tags": {
+        "amenity": "vending_machine",
+        "operator": "RetuRO",
+        "operator:wikidata": "Q123704028",
+        "payment:token": "yes",
+        "recycling:refund_bottles": "yes",
+        "vending": "bottle_return"
+      }
+    },
+    {
       "displayName": "Rīgas Satiksme",
       "id": "rigassatiksme-3c36b4",
       "locationSet": {"include": ["lv"]},


### PR DESCRIPTION
In Romania, since 1st January 2024 there is a bottle return system with various points, mostly in every supermarkets and some minimarkets.

I hope this preset will help to map them correctly.

More info here: https://returosgr.ro/en

Wikidata item: https://www.wikidata.org/wiki/Q123704028

This tagging was discussed with the Romaian OSM community.