### PR TITLE
Update ticket_validator.json - change to WSW mobil GmbH

### DIFF
--- a/data/operators/amenity/ticket_validator.json
+++ b/data/operators/amenity/ticket_validator.json
@@ -296,13 +296,13 @@
       }
     },
     {
-      "displayName": "WSW mobil",
+      "displayName": "WSW mobil GmbH",
       "id": "wswmobil-f980d0",
       "locationSet": {"include": ["de"]},
-      "matchNames": ["wsw mobil gmbh"],
+      "matchNames": ["wsw mobil"],
       "tags": {
         "amenity": "ticket_validator",
-        "operator": "WSW mobil",
+        "operator": "WSW mobil GmbH",
         "operator:wikidata": "Q44880072"
       }
     },


### PR DESCRIPTION
The WSW operator should be written as WSW mobil GmbH, as it is also so for other German ticket validator operators like DB Vetrieb GmbH and Transdev Vertrieb GmbH.