### PR TITLE
Add WSW mobil GmbH as a public transport ticket vending machine operator

### DIFF
--- a/data/operators/amenity/vending_machine.json
+++ b/data/operators/amenity/vending_machine.json
@@ -190,6 +190,21 @@
         "vending": "public_transport_tickets"
       }
     },
+        {
+      "displayName": "WSW mobil GmbH",
+      "id": "wswmobil-b39441",
+      "locationSet": {"include":["de-nw.geojson"]},
+      "matchNames": [
+        "wsw",
+        "wsw mobil"
+      ],
+      "tags": {
+        "amenity": "vending_machine",
+        "operator": "WSW mobil GmbH",
+        "operator:wikidata": "Q44880072",
+        "vending": "public_transport_tickets"
+      }
+    },
     {
       "displayName": "БГ Тол",
       "id": "bgtoll-c8e53b",


### PR DESCRIPTION
Hi,

the operator WSW mobil GmbH does not only operates ticket validators, but also ticket vending machines. Until now it was not part in the NSI. Thank you.