### PR TITLE
Update Access Bank locationSet and remove Ghana version

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -191,12 +191,21 @@
       "id": "accessbank-193d4e",
       "locationSet": {
         "include": [
+          "ao",
+          "bw",
           "cd",
+          "cm",
           "gb",
+          "gh",
           "gm",
+          "gn",
+          "ke",
           "mz",
+          "ng",
           "rw",
           "sl",
+          "tz",
+          "za",
           "zm"
         ]
       },
@@ -205,21 +214,10 @@
         "amenity": "bank",
         "brand": "Access Bank",
         "brand:wikidata": "Q4672418",
-        "name": "Access Bank"
-      }
-    },
-    {
-      "displayName": "Access Bank (Ghana)",
-      "id": "accessbank-9d35ea",
-      "locationSet": {"include": ["gh"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Access Bank",
-        "brand:wikidata": "Q4672420",
         "name": "Access Bank",
-        "operator": "Access Bank Ghana Plc",
+        "operator": "Access Bank plc",
         "operator:type": "public",
-        "operator:wikidata": "Q24915128"
+        "operator:wikidata": "Q4672420"
       }
     },
     {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -214,10 +214,7 @@
         "amenity": "bank",
         "brand": "Access Bank",
         "brand:wikidata": "Q4672418",
-        "name": "Access Bank",
-        "operator": "Access Bank plc",
-        "operator:type": "public",
-        "operator:wikidata": "Q4672420"
+        "name": "Access Bank"
       }
     },
     {


### PR DESCRIPTION
I updated the location set of Access Bank based on the country locations on their [website](https://www.accessbankplc.com/), and removed Access Bank (Ghana).