### PR TITLE
feat: Add PostNord parcel locker

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -943,6 +943,18 @@
       }
     },
     {
+      "displayName": "PostNord",
+      "id": "postnord-aa986b",
+      "locationSet": {"include": ["se"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "PostNord",
+        "brand:wikidata": "Q3181430",
+        "name": "PostNord",
+        "parcel_pickup": "yes"
+      }
+    },
+    {
       "displayName": "PPL",
       "id": "ppl-6a219a",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Similar to Instabox or Budbee parcel lockers in Sweden, there are PostNord parcel lockers.

E.g.
https://www.openstreetmap.org/node/12341092142

![image](https://westnordost.de/p/250937.jpg)