### PR TITLE
[shop/car][Daihatsu] add worldwide entry

### DIFF
--- a/data/brands/shop/car.json
+++ b/data/brands/shop/car.json
@@ -1432,6 +1432,16 @@
       }
     },
     {
+      "displayName": "Daihatsu",
+      "locationSet": {"include": ["001"], "exclude": ["jp"]},
+      "tags": {
+        "brand": "Daihatsu",
+        "brand:wikidata": "Q27511",
+        "name": "Daihatsu",
+        "shop": "car"
+      }
+    },
+    {
       "displayName": "トヨタ",
       "id": "toyota-27c9bc",
       "locationSet": {"include": ["jp"]},


### PR DESCRIPTION
Daihatsu's dealerships and car repairs still exist, so I think it's ok to add world entry.
- https://www.daihatsu.com/networks/index.html
- https://overpass-turbo.eu/s/1UJY