### PR TITLE
Remove name tag from Little Free Library

### DIFF
--- a/data/brands/amenity/public_bookcase.json
+++ b/data/brands/amenity/public_bookcase.json
@@ -150,8 +150,7 @@
       "tags": {
         "amenity": "public_bookcase",
         "brand": "Little Free Library",
-        "brand:wikidata": "Q6650101",
-        "name": "Little Free Library"
+        "brand:wikidata": "Q6650101"
       }
     },
     {


### PR DESCRIPTION
"Little Free Library" is a brand but these are commonly signed with more specific names by their operators. Even if there isn't a proper name, these may be designated by a non-English label, such as "Petite Bibliothèque". If you browse the map it won't take long to see some name examples: https://littlefreelibrary.org/map/