### PR TITLE
Copy Despar to `shop=convenience` with an extended `locationSet`; unify Spar `brand`s

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1775,6 +1775,16 @@
       }
     },
     {
+      "displayName": "Despar",
+      "locationSet": {"include": ["hu", "it"]},
+      "tags": {
+        "brand": "Spar",
+        "brand:wikidata": "Q610492",
+        "name": "Despar",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "Dia & Go",
       "id": "diaandgo-dd9aae",
       "locationSet": {"include": ["es"]},

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1778,8 +1778,8 @@
       "displayName": "Despar",
       "locationSet": {"include": ["hu", "it"]},
       "tags": {
-        "brand": "Despar",
-        "brand:wikidata": "Q131344742",
+        "brand": "Spar",
+        "brand:wikidata": "Q610492",
         "name": "Despar",
         "shop": "convenience"
       }

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1778,8 +1778,8 @@
       "displayName": "Despar",
       "locationSet": {"include": ["hu", "it"]},
       "tags": {
-        "brand": "Spar",
-        "brand:wikidata": "Q610492",
+        "brand": "Despar",
+        "brand:wikidata": "Q131344742",
         "name": "Despar",
         "shop": "convenience"
       }

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -2179,7 +2179,7 @@
     {
       "displayName": "Despar",
       "id": "despar-0cb133",
-      "locationSet": {"include": ["hu", "it"]},
+      "locationSet": {"include": ["it"]},
       "tags": {
         "brand": "Spar",
         "brand:wikidata": "Q610492",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -2181,8 +2181,8 @@
       "id": "despar-0cb133",
       "locationSet": {"include": ["it"]},
       "tags": {
-        "brand": "Spar",
-        "brand:wikidata": "Q610492",
+        "brand": "Despar",
+        "brand:wikidata": "Q131344742",
         "name": "Despar",
         "shop": "supermarket"
       }

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -2179,7 +2179,7 @@
     {
       "displayName": "Despar",
       "id": "despar-0cb133",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {"include": ["hu", "it"]},
       "tags": {
         "brand": "Spar",
         "brand:wikidata": "Q610492",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -2181,8 +2181,8 @@
       "id": "despar-0cb133",
       "locationSet": {"include": ["it"]},
       "tags": {
-        "brand": "Despar",
-        "brand:wikidata": "Q131344742",
+        "brand": "Spar",
+        "brand:wikidata": "Q610492",
         "name": "Despar",
         "shop": "supermarket"
       }
@@ -2726,8 +2726,8 @@
       "id": "eurospar-4b5e11",
       "locationSet": {"include": ["150"]},
       "tags": {
-        "brand": "Eurospar",
-        "brand:wikidata": "Q12309283",
+        "brand": "Spar",
+        "brand:wikidata": "Q610492",
         "name": "Eurospar",
         "shop": "supermarket"
       }
@@ -3981,8 +3981,8 @@
       "id": "interspar-287015",
       "locationSet": {"include": ["at", "hr"]},
       "tags": {
-        "brand": "Interspar",
-        "brand:wikidata": "Q15820339",
+        "brand": "Spar",
+        "brand:wikidata": "Q610492",
         "name": "Interspar",
         "shop": "supermarket"
       }
@@ -7684,7 +7684,7 @@
       "id": "spargourmet-1eef1d",
       "locationSet": {"include": ["at"]},
       "tags": {
-        "brand": "SPAR Gourmet",
+        "brand": "Spar",
         "brand:wikidata": "Q610492",
         "name": "SPAR Gourmet",
         "shop": "supermarket"
@@ -8187,7 +8187,7 @@
       "id": "superspar-5f0ef1",
       "locationSet": {"include": ["es", "za"]},
       "tags": {
-        "brand": "Superspar",
+        "brand": "Spar",
         "brand:wikidata": "Q610492",
         "name": "Superspar",
         "shop": "supermarket"


### PR DESCRIPTION
Despar currently only has a `shop=supermarket` entry for Italy. But the chain also has `shop=convenience` stores both in [Italy](https://maps.app.goo.gl/cPzksuHyikvxazE28) and [Hungary](https://www.openstreetmap.org/node/4054231644).

See https://en.wikipedia.org/wiki/Spar_(retailer)#:~:text=There%20are%20some%20international%20naming%20variants for more info.