### PR TITLE
Extend Interspar `locationSet` to `hu` & `si`

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -3979,7 +3979,7 @@
     {
       "displayName": "Interspar",
       "id": "interspar-287015",
-      "locationSet": {"include": ["at", "hu", "hr"]},
+      "locationSet": {"include": ["at", "hu", "hr", "si"]},
       "tags": {
         "brand": "Interspar",
         "brand:wikidata": "Q15820339",

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -3979,7 +3979,7 @@
     {
       "displayName": "Interspar",
       "id": "interspar-287015",
-      "locationSet": {"include": ["at", "hr"]},
+      "locationSet": {"include": ["at", "hu", "hr"]},
       "tags": {
         "brand": "Interspar",
         "brand:wikidata": "Q15820339",


### PR DESCRIPTION
Sources:
- https://en.wikipedia.org/wiki/Spar_(retailer)#:~:text=There%20are%20some%20international%20naming%20variants
- https://matrix.to/#/!gAwUAKJoCAuYnIoNeV:grin.hu/$K4PjT3crTLts4tau83UKTGnxHus7QX2IRqukcxta_vc?via=grin.hu&via=matrix.org&via=cwt.grin.hu