### PR TITLE
[shop/variety_store][gifi] add more countries to locationSet

### DIFF
--- a/data/brands/shop/variety_store.json
+++ b/data/brands/shop/variety_store.json
@@ -460,7 +460,7 @@
     {
       "displayName": "GiFi",
       "id": "gifi-4bad18",
-      "locationSet": {"include": ["fr"]},
+      "locationSet": {"include": ["fr", "es", "it", "ch"]},
       "tags": {
         "brand": "GiFi",
         "brand:wikidata": "Q3105439",


### PR DESCRIPTION
Rel to https://github.com/alltheplaces/alltheplaces/pull/11505. There is also info on [https://fr.wikipedia.org/wiki/Gifi](https://fr.wikipedia.org/wiki/Gifi#:~:text=L%27enseigne%20est%20majoritairement%20pr%C3%A9sente%20sur%20l%27ensemble%20du%20territoire%20fran%C3%A7ais%20avec%20plus%20de%20600%20magasins%20en%2020233.%20Elle%20est%20%C3%A9galement%20pr%C3%A9sente%20en%20Suisse%2C%20Espagne%2C%20Italie%20ainsi%20qu%27en%20C%C3%B4te%20d%27Ivoire.).