### PR TITLE
Change operator of CATA (Michigan) in bus.json

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -3181,7 +3181,7 @@
       "tags": {
         "network": "CATA",
         "network:wikidata": "Q5035474",
-        "operator": "Capital Area Transit Authority",
+        "operator": "Capital Area Transportation Authority",
         "route": "bus"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -3178,6 +3178,7 @@
       "locationSet": {
         "include": ["us-mi.geojson"]
       },
+      "matchNames": ["capital area transit authority"],
       "tags": {
         "network": "CATA",
         "network:wikidata": "Q5035474",


### PR DESCRIPTION
Changed from Capital Area Transit Authority from Capital Area Transportation Authority