### PR TITLE
add europtica to opticians

### DIFF
--- a/data/brands/shop/optician.json
+++ b/data/brands/shop/optician.json
@@ -285,6 +285,17 @@
       }
     },
     {
+      "displayName": "Europtica",
+      "locationSet": {"include": ["ar"]},
+      "tags": {
+        "brand": "Europtica",
+        "brand:wikidata": "Q131418760",
+        "name": "Europtica",
+        "shop": "optician",
+	"healthcare": "optometrist"
+      }
+    },
+    {
       "displayName": "Eye Wish",
       "id": "eyewish-719c83",
       "locationSet": {"include": ["nl"]},


### PR DESCRIPTION
This PR adds the Argentinian chain of _Europtica_ opticians to the index. 

[According to their brand website](https://europtica.com.ar/nuestros-locales/), they currently have 38+ locations across 5 provinces, so the notability should be met I think :slightly_smiling_face: 