### PR TITLE
MPL parcel locker: sync tags with Wiki

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -602,10 +602,8 @@
       ],
       "tags": {
         "amenity": "parcel_locker",
-        "brand": "Magyar Posta Logisztika",
-        "brand:short": "MPL",
-        "name": "Magyar Posta Logisztika",
-        "short_name": "MPL"
+        "brand": "MPL",
+        "brand:wikidata": "Q131431491"
       }
     },
     {

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -594,11 +594,11 @@
       }
     },
     {
-      "displayName": "Magyar Posta Logisztika",
+      "displayName": "Magyar Posta Logisztika (MPL)",
       "id": "magyarpostalogisztika-68603c",
       "locationSet": {"include": ["hu"]},
       "matchNames": [
-        "magyar posta logisztika (mpl)"
+        "magyar posta logisztika (mpl)","Magyar Posta Logisztika"
       ],
       "tags": {
         "amenity": "parcel_locker",

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -594,11 +594,12 @@
       }
     },
     {
-      "displayName": "Magyar Posta Logisztika (MPL)",
+      "displayName": "MPL (Magyar Posta Logisztika)",
       "id": "magyarpostalogisztika-68603c",
       "locationSet": {"include": ["hu"]},
       "matchNames": [
-        "magyar posta logisztika (mpl)","Magyar Posta Logisztika"
+        "magyar posta logisztika (mpl)",
+        "Magyar Posta Logisztika"
       ],
       "tags": {
         "amenity": "parcel_locker",


### PR DESCRIPTION
Sync tags of _MPL_ parcel locker with https://wiki.openstreetmap.org/wiki/Hungary/Jelölési_példák#Csomagautomata and remove tags that are out of the NSI's scope.

- Remove `brand:short=*`, `name=*`, `short_name=*`
- Correct `brand` value
- Add `brand:wikidata=Q131431491`