### PR TITLE
Update Hardware/DIY stores for quebec

### DIFF
--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -1231,17 +1231,18 @@
     },
     {
       "displayName": "Rona+",
-      "id": "rona-33a285",
+      "id": "rona-381944",
       "locationSet": {
         "include": [
           "ca-ab.geojson",
           "ca-bc.geojson",
           "ca-mb.geojson",
           "ca-on.geojson",
+          "ca-qc.geojson",
           "ca-sk.geojson"
         ]
       },
-      "matchNames": ["lowes"],
+      "matchNames": ["lowes", "réno-dépôt"],
       "tags": {
         "brand": "Rona+",
         "brand:wikidata": "Q123688669",

--- a/data/brands/shop/hardware.json
+++ b/data/brands/shop/hardware.json
@@ -69,6 +69,23 @@
       }
     },
     {
+      "displayName": "Canac",
+      "id": "canac-f34a8a",
+      "locationSet": {
+        "include": ["ca-qc.geojson"]
+      },
+      "matchNames": [
+        "canac marquis",
+        "canac marquis grenier"
+      ],
+      "tags": {
+        "brand": "Canac",
+        "brand:wikidata": "Q2935743",
+        "name": "Canac",
+        "shop": "hardware"
+      }
+    },
+    {
       "displayName": "Carters",
       "id": "carters-10910e",
       "locationSet": {"include": ["nz"]},


### PR DESCRIPTION
Rona discontinued the Reno-Depot brand and is rebranding to Rona+
Adds a Quebec hardware store chain