### PR TITLE
Remove Hydro-Quebec from street lamp operators

### DIFF
--- a/data/operators/highway/street_lamp.json
+++ b/data/operators/highway/street_lamp.json
@@ -88,18 +88,6 @@
       }
     },
     {
-      "displayName": "Hydro-Québec",
-      "id": "hydroquebec-0ef919",
-      "locationSet": {
-        "include": ["ca-qc.geojson"]
-      },
-      "tags": {
-        "highway": "street_lamp",
-        "operator": "Hydro-Québec",
-        "operator:wikidata": "Q167840"
-      }
-    },
-    {
       "displayName": "Kansas City BPU",
       "id": "kansascityboardofpublicutilities-26592d",
       "locationSet": {


### PR DESCRIPTION
Hydro-Quebec doesn't operate street lamps, that would be the transportation ministry, or the local municipality.

The reason it was being automatically added to the data is because certain power poles have street lamps and are tagged with
```
power=pole
highway=street_lamp
```

Ex: https://www.openstreetmap.org/node/9649669706
Relvant wiki entry: https://wiki.openstreetmap.org/wiki/Tag:power%3Dpole#Examples (See example from New Jersey, USA)