### PR TITLE
Add "Company" to Pacific Gas and Electric Company operator value

### DIFF
--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -6334,7 +6334,7 @@
         "pacific gas and electric company"
       ],
       "tags": {
-        "operator": "Pacific Gas and Electric",
+        "operator": "Pacific Gas and Electric Company",
         "operator:short": "PG&E",
         "operator:wikidata": "Q1815011",
         "power": "line"


### PR DESCRIPTION
Added the word "Company" to the value of the operator tag. This is how the company calls itself on its company profile.

https://www.pge.com/en/about/company-information/company-profile.html