### PR TITLE
Add "Era Immobilier" for France

### DIFF
--- a/data/brands/office/estate_agent.json
+++ b/data/brands/office/estate_agent.json
@@ -408,9 +408,9 @@
       "id": "era",
       "locationSet": {"include": ["fx", "mq"]},
       "tags": {
-        "brand": "Era",
+        "brand": "ERA",
         "brand:wikidata": "Q121496901",
-        "name": "Era Immobilier",
+        "name": "ERA Immobilier",
         "office": "estate_agent"
       }
     },

--- a/data/brands/office/estate_agent.json
+++ b/data/brands/office/estate_agent.json
@@ -404,6 +404,17 @@
       }
     },
     {
+      "displayName": "ERA Immobilier",
+      "id": "era",
+      "locationSet": {"include": ["fx", "mq"]},
+      "tags": {
+        "brand": "Era",
+        "brand:wikidata": "Q121496901",
+        "name": "Era Immobilier",
+        "office": "estate_agent"
+      }
+    },
+    {
       "displayName": "FALC Immobilien",
       "id": "falcimmobilien-2b2e07",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
World group : Era Real Estate
France : Era Immobilier

On nsi, there is an entry for Era only in Bulgaria. The is the same world group