### PR TITLE
Correct entry for PubliBike network "Velo Bern"

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -4279,15 +4279,15 @@
       }
     },
     {
-      "displayName": "Velohauptstadt",
+      "displayName": "PubliBike (Velo Bern)",
       "id": "velohauptstadt-a8de7e",
       "locationSet": {
         "include": [[7.45, 46.95, 10]]
       },
-      "matchNames": ["velo bern"],
       "tags": {
         "amenity": "bicycle_rental",
-        "brand": "Velohauptstadt",
+        "brand": "PubliBike",
+        "brand:wikidata": "Q3555363"
         "network": "Velo Bern",
         "operator": "PubliBike",
         "operator:type": "private",

--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -4287,7 +4287,7 @@
       "tags": {
         "amenity": "bicycle_rental",
         "brand": "PubliBike",
-        "brand:wikidata": "Q3555363"
+        "brand:wikidata": "Q3555363",
         "network": "Velo Bern",
         "operator": "PubliBike",
         "operator:type": "private",


### PR DESCRIPTION
Correct entry for PubliBike network _Velo Bern_.

NB: The company _PubliBike AG_ has two brands: _PubliBike_ itself and _Velospot_ (formerly an independent company that was taken over by PubliBike AG). The network in Bern and in the surrounding municipalities is called _Velo Bern_.

_[Velohauptstadt](https://www.bern.ch/velohauptstadt)_ (English: "bicycle capital") is a slogan that the municipality of Bern uses for its measures to promote cycling. It is therefore only written on the PubliBike stations in the city of Bern.