### PR TITLE
Add Taiwanese brands (新增臺灣的品牌): 能量小姐, 三顧茅廬, 八曜和茶

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -6603,6 +6603,30 @@
       }
     },
     {
+      "displayName": "八曜和茶",
+      "locationSet": {"include": ["tw"]},
+      "matchTags": ["shop/beverages"],
+      "matchNames": [
+        "8 yo tea",
+        "8yo tea",
+        "8yotea"
+      ],
+      "tags": {
+        "amenity": "cafe",
+        "brand": "八曜和茶",
+        "brand:en": "Hachiyo Tea",
+        "brand:wikidata": "Q130360667",
+        "brand:ja": "ハチヨウワチヤ",
+        "brand:zh": "八曜和茶",
+        "cuisine": "bubble_tea",
+        "name": "八曜和茶",
+        "name:en": "Hachiyo Tea",
+        "name:ja": "ハチヨウワチヤ",
+        "name:zh": "八曜和茶",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "珈琲館",
       "id": "kohikan-0cf217",
       "locationSet": {"include": ["jp"]},

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -9120,10 +9120,43 @@
         "brand:en": "Johnnybro",
         "brand:wikidata": "Q127692591",
         "brand:zh": "強尼兄弟",
-        "cuisine": "hot_dog",
         "name": "強尼兄弟",
         "name:en": "Johnnybro",
         "name:zh": "強尼兄弟",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "能量小姐",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "能量小姐",
+        "brand:en": "Miss Energy",
+        "brand:wikidata": "Q131554250",
+        "brand:zh": "能量小姐",
+        "name": "能量小姐",
+        "name:en": "Miss Energy",
+        "name:zh": "能量小姐",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "三顧茅廬",
+      "locationSet": {"include": ["tw"]},
+      "matchNames":[
+        "3good"
+      ],
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "三顧茅廬",
+        "brand:en": "San Gu Mao Lu",
+        "brand:wikidata": "Q131554286",
+        "brand:zh": "三顧茅廬",
+        "cuisine": "chinese;loumei",
+        "name": "三顧茅廬",
+        "name:en": "San Gu Mao Lu",
+        "name:zh": "三顧茅廬",
         "takeaway": "yes"
       }
     },

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -9136,6 +9136,8 @@
         "brand:wikidata": "Q131554250",
         "brand:zh": "能量小姐",
         "name": "能量小姐",
+        "cuisine": "health_food;bento",
+
         "name:en": "Miss Energy",
         "name:zh": "能量小姐",
         "takeaway": "yes"


### PR DESCRIPTION
Add the following brands:
|中文|English|Wikidata|Type|
|-------------|----------------|----------|----------|
|八曜和茶|Hachiyo Tea|[Q130360667](https://www.wikidata.org/wiki/Q130360667)|amenity=cafe|
|能量小姐|Miss Energy|[Q131554250](https://www.wikidata.org/wiki/Q131554250)|amenity=restaurant|
|三顧茅廬|San Gu Mao Lu|[Q131554286](https://www.wikidata.org/wiki/Q131554286)|amenity=restaurant|

A minor question here: what `cuisine` should [Miss Energy](https://www.missenergy.com.tw/product.php?lang=tw&tb=2) be? `health_food`? `bento`? I don't know.
小問題：[能量小姐](https://www.missenergy.com.tw/product.php?lang=tw&tb=2)的 `cuisine` 要算什麼？ `health_food`? `bento`? 我不知道。