### PR TITLE
Allpoint ATMs are now in New Zealand too.

### DIFF
--- a/data/brands/amenity/atm.json
+++ b/data/brands/amenity/atm.json
@@ -21,7 +21,7 @@
       "displayName": "Allpoint",
       "id": "allpoint-a81297",
       "locationSet": {
-        "include": ["au", "ca", "gb", "mx", "us"]
+        "include": ["au", "ca", "gb", "mx", "nz", "us"]
       },
       "tags": {
         "amenity": "atm",


### PR DESCRIPTION
As per https://www.kiwibank.co.nz/banking-with-us/banking-in-person/atms/