### PR TITLE
Add Rennie Grove Peace charity shops

### DIFF
--- a/data/brands/shop/charity.json
+++ b/data/brands/shop/charity.json
@@ -40,6 +40,16 @@
       }
     },
     {
+      "displayName": "Rennie Grove Peace",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "Rennie Grove Peace",
+        "brand:wikidata": "Q131599401",
+        "name": "Rennie Grove Peace",
+        "shop": "charity"
+      }
+    },
+    {
       "displayName": "Barnardo's",
       "id": "barnardos-f84d6b",
       "locationSet": {"include": ["gb", "ie"]},


### PR DESCRIPTION
There are about 33 shops north west of London.