### PR TITLE
[nz] remove `operator:type` from DOC

### DIFF
--- a/data/operators/boundary/protected_area.json
+++ b/data/operators/boundary/protected_area.json
@@ -537,7 +537,6 @@
       "tags": {
         "boundary": "protected_area",
         "operator": "Department of Conservation",
-        "operator:type": "government",
         "operator:wikidata": "Q1191417"
       }
     },

--- a/data/operators/leisure/park.json
+++ b/data/operators/leisure/park.json
@@ -3470,7 +3470,6 @@
       "tags": {
         "leisure": "park",
         "operator": "Department of Conservation",
-        "operator:type": "government",
         "operator:wikidata": "Q1191417"
       }
     },


### PR DESCRIPTION
There have been some counterproductive changes to DOC presets recently... 

1.  NSI suggests adding `operator:type=government` to thousands of protected areas & parks, which isn't helpful and just creates noise
2. there are some equally unhelpful "upgrades" which actually destroy the data when people blindly accept these suggestions:

<img width="380" alt="image" src="https://github.com/user-attachments/assets/1c8e1d74-a1c5-499f-a378-a5c7a39cb9d5" />

<img width="379" alt="image" src="https://github.com/user-attachments/assets/171c9a30-825c-40bc-bae6-860fa56665be" />
