### PR TITLE
Change Mr. Tire to Auto Service Center from Car Parts store

### DIFF
--- a/data/brands/shop/car_parts.json
+++ b/data/brands/shop/car_parts.json
@@ -388,17 +388,6 @@
       }
     },
     {
-      "displayName": "Mr. Tire",
-      "id": "mrtire-bb9baa",
-      "locationSet": {"include": ["us"]},
-      "tags": {
-        "brand": "Mr. Tire",
-        "brand:wikidata": "Q6929249",
-        "name": "Mr. Tire",
-        "shop": "car_parts"
-      }
-    },
-    {
       "displayName": "NAPA Auto Parts",
       "id": "napaautoparts-808aac",
       "locationSet": {

--- a/data/brands/shop/car_repair.json
+++ b/data/brands/shop/car_repair.json
@@ -898,6 +898,17 @@
         "shop": "car_repair"
       }
     },
+     {
+      "displayName": "Mr. Tire",
+      "id": "mrtire-bb9baa",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "brand": "Mr. Tire",
+        "brand:wikidata": "Q6929249",
+        "name": "Mr. Tire",
+        "shop": "car_repair"
+      }
+    },
     {
       "displayName": "mycar Tyre & Auto",
       "id": "mycartyreandauto-c3960a",


### PR DESCRIPTION
Mr. Tire is wrongly marked as a Car Parts store. This company is a car service center and in this PR, I've moved the data from `car_parts.json` to `car_repair.json`.

Additionally, updated some of the information on Wikidata.