### PR TITLE
Remove Flowbird as a brand

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -10,6 +10,7 @@
         "^(自動)?[券販]売機$",
         "^automat na jizdenky$",
         "^casa dell'acqua$",
+        "^flowbird$",
         "^horodateur$",
         "^máquina de tickets$",
         "^milchtankstelle$",

--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -546,21 +546,6 @@
       }
     },
     {
-      "displayName": "Flowbird",
-      "id": "flowbird-5c6913",
-      "locationSet": {
-        "include": ["001"],
-        "exclude": ["cn", "jp", "kp", "kr"]
-      },
-      "tags": {
-        "amenity": "vending_machine",
-        "brand": "Flowbird",
-        "brand:wikidata": "Q3365450",
-        "name": "Flowbird",
-        "vending": "parking_tickets"
-      }
-    },
-    {
       "displayName": "FuelRod",
       "id": "fuelrod-7e3927",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
[Flowbird](https://www.flowbird.com/) is an app for the parking tickets payment. That was included in the NSI long time ago as a brand for `amenity=vending_machine` with no `locationSet`. After that, some excludes were appended.

The point is Flowbird is NOT an actual brand, as we understand in the NSI, but a payment method. There's a `payment:flowbird=*` key indeed. Flowbird does not provide a vending machine itself (just do a google search: _flowbird vending machine_), that's something the local administration sets. Neither has a so-called name Flowbird.

That's why this brand should be removed from NSI, it should never be suggested when a user introduces a new vending machine.

Wiki: https://wiki.openstreetmap.org/wiki/DE:Tag:vending%3Dparking_tickets [DE]
Community: https://community.openstreetmap.org/t/parquimetros-con-name-flowbird/123573 [ES]