### PR TITLE
Add operators and Wikidata references to transit routes

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -87,6 +87,8 @@
       "tags": {
         "network": "Achterhoek-Rivierenland",
         "network:wikidata": "Q108716027",
+        "operator": "Arriva",
+        "operator:wikidata": "Q2581356",
         "route": "bus"
       }
     },
@@ -928,6 +930,8 @@
       "tags": {
         "network": "Arnhem-Nijmegen",
         "network:wikidata": "Q108716067",
+        "operator": "Hermes",
+        "operator:wikidata": "Q1030145",
         "route": "bus"
       }
     },
@@ -2634,6 +2638,8 @@
       "tags": {
         "network": "Busvervoer Almere",
         "network:wikidata": "Q108716136",
+        "operator": "Keolis",
+        "operator:wikidata": "Q365126",
         "route": "bus"
       }
     },
@@ -6218,6 +6224,8 @@
       "tags": {
         "network": "Fryslân",
         "network:wikidata": "Q115122762",
+        "operator": "Qbuzz",
+        "operator:wikidata": "Q3146926",
         "route": "bus"
       }
     },
@@ -6905,6 +6913,8 @@
       "tags": {
         "network": "Haarlem-IJmond",
         "network:wikidata": "Q66991285",
+        "operator": "Connexxion",
+        "operator:wikidata": "Q591484",
         "route": "bus"
       }
     },
@@ -7170,6 +7180,8 @@
       "tags": {
         "network": "Hoeksche Waard - Goeree-Overflakkee",
         "network:wikidata": "Q108721362",
+        "operator": "Connexxion",
+        "operator:wikidata": "Q591484",
         "route": "bus"
       }
     },
@@ -11854,6 +11866,8 @@
       "tags": {
         "network": "Noord-Holland Noord",
         "network:wikidata": "Q2271893",
+        "operator": "Connexxion",
+        "operator:wikidata": "Q591484",
         "route": "bus"
       }
     },
@@ -12126,6 +12140,8 @@
       "tags": {
         "network": "Oost-Brabant",
         "network:wikidata": "Q108712935",
+        "operator": "Arriva",
+        "operator:wikidata": "Q2581356",
         "route": "bus"
       }
     },
@@ -13173,6 +13189,8 @@
       "tags": {
         "network": "Provincie Utrecht",
         "network:wikidata": "Q108742249",
+        "operator": "Keolis",
+        "operator:wikidata": "Q365126",
         "route": "bus"
       }
     },
@@ -13686,6 +13704,8 @@
       "tags": {
         "network": "Regio Utrecht",
         "network:wikidata": "Q108742251",
+        "operator": "Qbuzz",
+        "operator:wikidata": "Q3146926",
         "route": "bus"
       }
     },
@@ -20004,6 +20024,8 @@
       "tags": {
         "network": "Veluwe-Zuid",
         "network:wikidata": "Q115122855",
+        "operator": "Hermes",
+        "operator:wikidata": "Q1030145",
         "route": "bus"
       }
     },
@@ -20972,6 +20994,8 @@
       "tags": {
         "network": "Voorne-Putten en Rozenburg",
         "network:wikidata": "Q108718063",
+        "operator": "EBS",
+        "operator:wikidata": "Q2107949",
         "route": "bus"
       }
     },
@@ -21867,6 +21891,8 @@
       "tags": {
         "network": "Zeeland",
         "network:wikidata": "Q108718030",
+        "operator": "Connexxion",
+        "operator:wikidata": "Q591484",
         "route": "bus"
       }
     },
@@ -22075,6 +22101,8 @@
       "tags": {
         "network": "Zuid-Holland Noord",
         "network:wikidata": "Q130404809",
+        "operator": "Qbuzz",
+        "operator:wikidata": "Q3146926",
         "route": "bus"
       }
     },
@@ -22086,7 +22114,7 @@
         "network": "Zuidoost-Brabant",
         "network:wikidata": "Q108710205",
         "operator": "Hermes",
-        "operator:wikidata": "Q2107948",
+        "operator:wikidata": "Q1030145",
         "route": "bus"
       }
     },

--- a/data/transit/route/ferry.json
+++ b/data/transit/route/ferry.json
@@ -183,6 +183,7 @@
         "network": "Concessie Personenvervoer over water in Rotterdam en Schiedam",
         "network:wikidata": "Q130404610",
         "operator": "Watertaxi Rotterdam",
+        "operator:wikidata": "Q130707437",
         "route": "ferry"
       }
     },
@@ -230,6 +231,7 @@
         "network": "Fast Ferry Vlissingen - Breskens",
         "network:wikidata": "Q130404377",
         "operator": "Westerschelde Ferry BV",
+        "operator:wikidata": "Q28567814",
         "route": "ferry"
       }
     },
@@ -266,6 +268,30 @@
       "tags": {
         "network": "IJ- en Noordzeekanaalveren",
         "network:wikidata": "Q108720424",
+        "operator": "GVB",
+        "operator:wikidata": "Q1808041",
+        "route": "ferry"
+      }
+    },
+    {
+      "displayName": "Friese Waddenveren West",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "network": "Friese Waddenveren West",
+        "network:wikidata": "Q131622501",
+        "operator": "Rederij Doeksen",
+        "operator:wikidata": "Q2222805",
+        "route": "ferry"
+      }
+    },
+    {
+      "displayName": "Friese Waddenveren Oost",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "network": "Friese Waddenveren Oost",
+        "network:wikidata": "Q131622541",
+        "operator": "Wagenborg",
+        "operator:wikidata": "Q1614910",
         "route": "ferry"
       }
     },

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -41,6 +41,8 @@
       "tags": {
         "network": "Achterhoek-Rivierenland",
         "network:wikidata": "Q108716027",
+        "operator": "Arriva",
+        "operator:wikidata": "Q2581356",
         "route": "train"
       }
     },
@@ -87,7 +89,8 @@
       "tags": {
         "network": "Arnhem-Nijmegen",
         "network:wikidata": "Q108716067",
-        "operator": "Breng",
+        "operator": "Hermes",
+        "operator:wikidata": "Q1030145",
         "route": "train"
       }
     },

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -611,6 +611,8 @@
       "tags": {
         "network": "Regio Utrecht",
         "network:wikidata": "Q108742251",
+        "operator": "Qbuzz",
+        "operator:wikidata": "Q3146926",
         "route": "tram"
       }
     },


### PR DESCRIPTION
Added wikidata tag to public transport concessions.

all sourced from https://wiki.ovinnederland.nl/wiki/Hoofdpagina