### PR TITLE
Correct `parcel_locker`s and add `hu` versions

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -272,9 +272,18 @@
         "amenity": "parcel_locker",
         "brand": "DHL BOX 24/7",
         "brand:wikidata": "Q115568785",
-        "operator": "DHL",
-        "operator:wikidata": "Q489815",
         "parcel_mail_in": "yes"
+      }
+    },
+    {
+      "displayName": "DHL csomagautomata",
+      "locationSet": {"include": ["hu"]},
+      "matchNames": ["dhl"],
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "DHL",
+        "brand:wikidata": "Q1766703",
+        "parcel_mail_in": "no"
       }
     },
     {
@@ -286,8 +295,6 @@
         "amenity": "parcel_locker",
         "brand": "DHL Packstation",
         "brand:wikidata": "Q1766703",
-        "operator": "DHL",
-        "operator:wikidata": "Q489815",
         "parcel_mail_in": "yes"
       }
     },
@@ -300,8 +307,6 @@
         "brand": "Paketbox",
         "brand:wikidata": "Q2046604",
         "name": "DHL Paketbox",
-        "operator": "DHL",
-        "operator:wikidata": "Q489815",
         "parcel_mail_in": "yes"
       }
     },
@@ -312,9 +317,7 @@
       "tags": {
         "amenity": "parcel_locker",
         "brand": "DHL",
-        "brand:wikidata": "Q489815",
         "name": "DHL Pakketautomaat",
-        "operator": "DHL Parcel",
         "operator:wikidata": "Q489815",
         "parcel_mail_in": "yes",
         "parcel_pickup": "yes"
@@ -329,8 +332,6 @@
         "amenity": "parcel_locker",
         "brand": "DHL Poststation",
         "brand:wikidata": "Q123120984",
-        "operator": "DHL",
-        "operator:wikidata": "Q489815",
         "parcel_mail_in": "yes"
       }
     },

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -320,7 +320,6 @@
         "brand": "DHL",
         "brand:wikidata": "Q132858576",
         "name": "DHL Pakketautomaat",
-        "operator:wikidata": "Q489815",
         "parcel_mail_in": "yes",
         "parcel_pickup": "yes"
       }

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -386,8 +386,7 @@
         "amenity": "parcel_locker",
         "brand": "DPD Pickup Station",
         "brand:wikidata": "Q114273730",
-        "operator": "DPD",
-        "operator:wikidata": "Q541030",
+        "parcel_mail_in": "no",
         "parcel_pickup": "yes"
       }
     },

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -284,8 +284,7 @@
       "tags": {
         "amenity": "parcel_locker",
         "brand": "DHL",
-        "brand:wikidata": "Q1766703",
-        "parcel_mail_in": "no"
+        "brand:wikidata": "Q1766703"
       }
     },
     {

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -318,6 +318,7 @@
       "tags": {
         "amenity": "parcel_locker",
         "brand": "DHL",
+        "brand:wikidata": "Q132858576",
         "name": "DHL Pakketautomaat",
         "operator:wikidata": "Q489815",
         "parcel_mail_in": "yes",

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -480,7 +480,9 @@
       "tags": {
         "amenity": "parcel_locker",
         "brand": "GLS",
-        "brand:wikidata": "Q366182"
+        "brand:wikidata": "Q366182",
+        "parcel_mail_in": "yes",
+        "parcel_pickup": "yes"
       }
     },
     {

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -39,7 +39,8 @@
         "brand:wikidata": "Q115254158",
         "operator": "Alza",
         "operator:wikidata": "Q10786832",
-        "parcel_mail_in": "yes"
+        "parcel_mail_in": "yes",
+        "parcel_pickup": "yes"
       }
     },
     {

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -665,7 +665,9 @@
       "tags": {
         "amenity": "parcel_locker",
         "brand": "MPL",
-        "brand:wikidata": "Q131431491"
+        "brand:wikidata": "Q131431491",
+        "parcel_mail_in": "yes",
+        "parcel_pickup": "yes"
       }
     },
     {

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -765,7 +765,9 @@
         "amenity": "parcel_locker",
         "brand": "Packeta",
         "brand:wikidata": "Q67809905",
-        "name": "Z-Box"
+        "name": "Z-Box",
+        "parcel_mail_in": "yes",
+        "parcel_pickup": "yes"
       }
     },
     {

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -284,7 +284,7 @@
       "tags": {
         "amenity": "parcel_locker",
         "brand": "DHL",
-        "brand:wikidata": "Q1766703"
+        "brand:wikidata": "Q131712019"
       }
     },
     {

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -438,6 +438,18 @@
       }
     },
     {
+      "displayName": "Express One csomagpont",
+      "locationSet": {"include": ["hu"]},
+      "matchNames": ["express one"],
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "Express One",
+        "brand:wikidata": "Q131629851",
+        "parcel_mail_in": "returns_only",
+        "parcel_pickup": "yes"
+      }
+    },
+    {
       "displayName": "FANbox",
       "id": "fanbox-ba4d23",
       "locationSet": {"include": ["ro"]},

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -509,6 +509,17 @@
       }
     },
     {
+      "displayName": "IKEA csomagpont",
+      "locationSet": {"include": ["hu"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "IKEA",
+        "brand:wikidata": "Q131629951",
+        "parcel_mail_in": "no",
+        "parcel_pickup": "yes"
+      }
+    },
+    {
       "displayName": "InPost",
       "id": "inpost-6b37ec",
       "locationSet": {

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -38,7 +38,8 @@
         "brand": "AlzaBox",
         "brand:wikidata": "Q115254158",
         "operator": "Alza",
-        "operator:wikidata": "Q10786832"
+        "operator:wikidata": "Q10786832",
+        "parcel_mail_in": "yes"
       }
     },
     {


### PR DESCRIPTION
## DHL

- Remove out-of-scope tags (`operator` and `operator:wikidata`) after linking them to the `brand:wikidata` value on Wikidata
- Correct a Wikidata tag (its value was the same as `operator:wikidata`'s)
- Add 'DHL csomagautomata' for `hu`. Sources: https://wiki.openstreetmap.org/wiki/Hungary/Jelölési_példák#Csomagautomata and https://dhlexpress.hu/hu/


## AlzaBox

- Add `parcel_mail_in=yes`. Source: https://dhlexpress.hu/hu/alzabox/
- Add `parcel_pickup=yes`


## DPD Pickup Station

- Remove out-of-scope tags (`operator` and `operator:wikidata`) because the operator is linked to the `brand:wikidata` item on Wikidata
- Add `parcel_mail_in=no`. Source: https://www.dpd.com/hu/hu/visszakuldes/


## Express One

- Add 'Express One csomagpont'. Source: https://expressone.hu/csomagpont


## GLS

- Add `parcel_mail_in=yes` & `parcel_pickup=yes`. Source: https://matrix.to/#/!gAwUAKJoCAuYnIoNeV:grin.hu/$dxwb8-1loFrzP38KeuvodWb0Xdmo4hIHK34AOyi7ahQ?via=grin.hu&via=matrix.org&via=cwt.grin.hu


## IKEA

- Add 'IKEA csomagpont'. Source: https://www.ikea.com/hu/hu/customer-service/services/kattints-es-vedd-at-csomagpontok-puba9241fe7/


## MPL

- Add `parcel_mail_in=yes` & `parcel_pickup=yes`. Source: https://matrix.to/#/!gAwUAKJoCAuYnIoNeV:grin.hu/$dxwb8-1loFrzP38KeuvodWb0Xdmo4hIHK34AOyi7ahQ?via=grin.hu&via=matrix.org&via=cwt.grin.hu


## Packeta

- Add `parcel_mail_in=yes` & `parcel_pickup=yes`. Source: https://matrix.to/#/!gAwUAKJoCAuYnIoNeV:grin.hu/$dxwb8-1loFrzP38KeuvodWb0Xdmo4hIHK34AOyi7ahQ?via=grin.hu&via=matrix.org&via=cwt.grin.hu