### PR TITLE
Reduce United Community Bank to their service area

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -12963,7 +12963,16 @@
     {
       "displayName": "United Community Bank",
       "id": "unitedcommunitybank-ea2e2d",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {
+        "include": [
+          "us-al.geojson",
+          "us-fl.geojson",
+          "us-ga.geojson",
+          "us-nc.geojson",
+          "us-sc.geojson",
+          "us-tn.geojson"
+        ]
+      },
       "tags": {
         "amenity": "bank",
         "brand": "United Community Bank",


### PR DESCRIPTION
More specific locationSet for United Community Bank in the southeast US instead of being nationwide