### PR TITLE
Delete Total brand fuel station entry

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6346,19 +6346,6 @@
       }
     },
     {
-      "displayName": "Total",
-      "id": "total-b3d110",
-      "locationSet": {"include": ["001"]},
-      "matchNames": ["station total"],
-      "note": "Total is/has rebranded to TotalEnergies, this should probably be removed or offered in less countries in the future. https://en.wikipedia.org/wiki/TotalEnergies#2021%E2%80%93present:_Rebranding_to_TotalEnergies",
-      "tags": {
-        "amenity": "fuel",
-        "brand": "Total",
-        "brand:wikidata": "Q154037",
-        "name": "Total"
-      }
-    },
-    {
       "displayName": "Total Access",
       "id": "totalaccess-3772a0",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6399,6 +6399,8 @@
       "displayName": "TotalEnergies",
       "id": "totalenergies-b3d110",
       "locationSet": {"include": ["001"]},
+      "matchNames": ["station total", "total"],
+      "note": "Total is/has rebranded to TotalEnergies, We still have total and station total in matchNames if there are any linguring fuel stations left.",
       "tags": {
         "amenity": "fuel",
         "brand": "TotalEnergies",

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6385,7 +6385,7 @@
     {
       "displayName": "TotalEnergies",
       "id": "totalenergies-b3d110",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["001"], "exclude": ["us"]},
       "matchNames": ["station total", "total"],
       "note": "Total is/has rebranded to TotalEnergies, We still have total and station total in matchNames if there are any linguring fuel stations left.",
       "tags": {


### PR DESCRIPTION
I think we can delete this entry from NSI as most places have been rebranded by this point. For any that are left we can add total to the matchNames of TotalEnergies (as well as "station total"). 