### PR TITLE
Add Taiwanese brands (新增臺灣的品牌): 日藥本舖, 六扇門, ecoco

### DIFF
--- a/data/brands/amenity/recycling.json
+++ b/data/brands/amenity/recycling.json
@@ -429,6 +429,25 @@
         "owner:zh-Hant": "環境保護署",
         "recycling_type": "centre"
       }
+    },
+    {
+      "displayName": "ecoco",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "amenity": "recycling",
+        "name": "ecoco",
+        "name:en": "ecoco",
+        "name:wikidata": "Q131689024",
+        "name:zh": "宜可可",
+        "brand": "ecoco",
+        "brand:en": "ecoco",
+        "brand:wikidata": "Q131689024",
+        "brand:zh": "宜可可",
+        "owner": "凡立橙股份有限公司",
+        "owner:en": "Fun Lead Chabge Co., Ltd",
+        "owner:zh": "凡立橙股份有限公司",
+        "recycling_type": "container"
+      }
     }
   ]
 }

--- a/data/brands/amenity/recycling.json
+++ b/data/brands/amenity/recycling.json
@@ -443,9 +443,9 @@
         "brand:en": "ecoco",
         "brand:wikidata": "Q131689024",
         "brand:zh": "宜可可",
-        "owner": "凡立橙股份有限公司",
-        "owner:en": "Fun Lead Chabge Co., Ltd",
-        "owner:zh": "凡立橙股份有限公司",
+        "operator": "凡立橙股份有限公司",
+        "operator:en": "Fun Lead Chabge Co., Ltd",
+        "operator:zh": "凡立橙股份有限公司",
         "recycling_type": "container"
       }
     }

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -9462,6 +9462,25 @@
       }
     },
     {
+      "displayName": "六扇門時尚湯鍋",
+      "locationSet": {"include": ["tw"]},
+      "matchNames":["6owldoor"],
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "六扇門時尚湯鍋",
+        "brand:en": "6owl door",
+        "brand:wikidata": "Q131688921",
+        "brand:zh": "六扇門時尚湯鍋",
+        "cuisine": "hotpot",
+        "name": "六扇門時尚湯鍋",
+        "name:en": "6owl door",
+        "name:zh": "六扇門時尚湯鍋",
+        "owner": "六扇門有限公司",
+        "owner:en": "Liu, Shan-Men Ltd.",
+        "owner:zh": "六扇門有限公司"
+      }
+    },
+    {
       "displayName": "海底撈火鍋 Haidilao Hot Pot",
       "id": "haidilaohotpot-edf541",
       "locationSet": {"include": ["hk", "mo"]},

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -9477,7 +9477,8 @@
         "name:zh": "六扇門時尚湯鍋",
         "owner": "六扇門有限公司",
         "owner:en": "Liu, Shan-Men Ltd.",
-        "owner:zh": "六扇門有限公司"
+        "owner:zh": "六扇門有限公司",
+        "diet:vegetarian": "yes"
       }
     },
     {

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -9475,9 +9475,9 @@
         "name": "六扇門時尚湯鍋",
         "name:en": "6owl door",
         "name:zh": "六扇門時尚湯鍋",
-        "owner": "六扇門有限公司",
-        "owner:en": "Liu, Shan-Men Ltd.",
-        "owner:zh": "六扇門有限公司",
+        "operator": "六扇門有限公司",
+        "operator:en": "Liu, Shan-Men Ltd.",
+        "operator:zh": "六扇門有限公司",
         "diet:vegetarian": "yes"
       }
     },

--- a/data/brands/shop/chemist.json
+++ b/data/brands/shop/chemist.json
@@ -846,6 +846,28 @@
       }
     },
     {
+      "displayName": "日藥本舖",
+      "locationSet": {"include": ["tw"]},
+      "matchNames":[
+        "JPMED",
+        "jp.medical",
+        "Japan Medical"
+      ],
+      "tags": {
+        "brand": "日藥本舖",
+        "brand:en": "jp medical",
+        "brand:wikidata": "Q131688453",
+        "brand:zh": "日藥本舖",
+        "name": "日藥本舖",
+        "name:en": "jp medical",
+        "name:zh": "日藥本舖",
+        "owner": "日藥本舖股份有限公司",
+        "owner:en": "Japan Medical Co., Ltd.",
+        "owner:zh": "日藥本舖股份有限公司",
+        "shop": "chemist"
+      }
+    },
+    {
       "displayName": "萬寧 Mannings",
       "id": "mannings-d89f96",
       "locationSet": {"include": ["hk", "mo"]},

--- a/data/brands/shop/chemist.json
+++ b/data/brands/shop/chemist.json
@@ -861,9 +861,9 @@
         "name": "日藥本舖",
         "name:en": "jp medical",
         "name:zh": "日藥本舖",
-        "owner": "日藥本舖股份有限公司",
-        "owner:en": "Japan Medical Co., Ltd.",
-        "owner:zh": "日藥本舖股份有限公司",
+        "operator": "日藥本舖股份有限公司",
+        "operator:en": "Japan Medical Co., Ltd.",
+        "operator:zh": "日藥本舖股份有限公司",
         "shop": "chemist"
       }
     },


### PR DESCRIPTION
Add the following brands:
|中文|English|Wikidata|Type|
|-------------|----------------|----------|----------|
|日藥本舖|jp.medical|[Q131688453](https://www.wikidata.org/wiki/Q131688453)|shop=chemist|
|六扇門|6owl door|[Q131688921](https://www.wikidata.org/wiki/Q131688921)|amenity=restaurant|
|ecoco (宜可可)|ecoco|[Q131689024](https://www.wikidata.org/wiki/Q131689024)|amenity=recycling|

By the way, Ecoco operates a recycling business and their recycling stands look like this: 
![20190926-0928_台灣創新技術博覽會_台灣國際循環經濟展-03.jpg](https://www.ecocogroup.com/wp-content/uploads/2020/06/20190926-0928_%E5%8F%B0%E7%81%A3%E5%89%B5%E6%96%B0%E6%8A%80%E8%A1%93%E5%8D%9A%E8%A6%BD%E6%9C%83_%E5%8F%B0%E7%81%A3%E5%9C%8B%E9%9A%9B%E5%BE%AA%E7%92%B0%E7%B6%93%E6%BF%9F%E5%B1%95-03.jpg)

That's why I tag it as `recycling_type=container`