### PR TITLE
Adding new countries for EuroSpin supermarket brand

### DIFF
--- a/brands/shop/supermarket.json
+++ b/brands/shop/supermarket.json
@@ -1952,7 +1952,7 @@
     {
       "displayName": "EuroSpin",
       "id": "eurospin-a66db7",
-      "locationSet": {"include": ["it", "si"]},
+      "locationSet": {"include": ["hr", "it", "mt", "si", "sr"]},
       "oldid": "shop/supermarket|EuroSpin",
       "tags": {
         "brand": "EuroSpin",


### PR DESCRIPTION
Addded Croatia, Malta and Serbia. EuroSpin is still not in Serbia, but coming very soon.