### PR TITLE
Delete Accor

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -71,17 +71,6 @@
       }
     },
     {
-      "displayName": "Accor",
-      "id": "accor-779ccb",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "brand": "Accor",
-        "brand:wikidata": "Q212599",
-        "name": "Accor",
-        "tourism": "hotel"
-      }
-    },
-    {
       "displayName": "Adagio",
       "id": "adagio-779ccb",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Accor is not a brand. It is a hospitality company that owns many hotel brands. It is on a couple of their buildings, but it is not on the list of brands it owns. Thus, I think it should be deleted from brands.