### PR TITLE
Add Holy See flag

### DIFF
--- a/data/flags/man_made/flagpole.json
+++ b/data/flags/man_made/flagpole.json
@@ -2690,6 +2690,20 @@
       }
     },
     {
+      "displayName": "Holy See",
+      "id": "holysee-e5dc93",
+      "locationSet": {"include": ["001"]},
+      "matchNames": ["vatican"],
+      "tags": {
+        "flag:name": "Holy See",
+        "flag:type": "religious",
+        "flag:wikidata": "Q79198",
+        "man_made": "flagpole",
+        "subject": "Holy See",
+        "subject:wikidata": "Q159583"
+      }
+    },
+    {
       "displayName": "HR - Croatia",
       "id": "croatia-e5dc93",
       "locationSet": {"include": ["001"]},
@@ -6022,6 +6036,7 @@
       "displayName": "VA - Vatican City",
       "id": "vaticancity-e5dc93",
       "locationSet": {"include": ["001"]},
+      "matchNames": ["holy see"],
       "tags": {
         "country": "VA",
         "flag:name": "Vatican City",


### PR DESCRIPTION
The flag of the Vatican City also serves as the flag of the Holy See. Churches, schools, and cemeteries that fly this flag are flying an ecclesiastical flag, not a national flag.