### PR TITLE
Deleted Total Access

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6366,18 +6366,6 @@
       }
     },
     {
-      "displayName": "Total Access",
-      "id": "totalaccess-3772a0",
-      "locationSet": {"include": ["fr"]},
-      "matchNames": ["totalenergies access"],
-      "tags": {
-        "amenity": "fuel",
-        "brand": "Total Access",
-        "brand:wikidata": "Q154037",
-        "name": "Total Access"
-      }
-    },
-    {
       "displayName": "Total Contact",
       "id": "totalcontact-acec89",
       "locationSet": {"include": ["fx"]},
@@ -6409,8 +6397,8 @@
         "include": ["001"],
         "exclude": ["us"]
       },
-      "matchNames": ["station total", "total"],
-      "note": "Total is/has rebranded to TotalEnergies, We still have total and station total in matchNames if there are any lingering fuel stations left.",
+      "matchNames": ["station total", "total", "total access"],
+      "note": "Total is/has rebranded to TotalEnergies, We still have total and station total in matchNames if there are any lingering fuel stations left. Same with Total Access",
       "tags": {
         "amenity": "fuel",
         "brand": "TotalEnergies",

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6397,7 +6397,7 @@
         "include": ["001"],
         "exclude": ["us"]
       },
-      "matchNames": ["station total", "total", "total access"],
+      "matchNames": ["station total", "total", "total access", "totalenergies access"],
       "note": "Total is/has rebranded to TotalEnergies, We still have total and station total in matchNames if there are any lingering fuel stations left. Same with Total Access",
       "tags": {
         "amenity": "fuel",


### PR DESCRIPTION
Total Access is rebranding to TotalEnergies as with the larger "Total" company rebrand. I added it to the match names of Total Energies as I did with regular Total.