### PR TITLE
Move Banca Carige to BPER Banca

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -1160,17 +1160,6 @@
       }
     },
     {
-      "displayName": "Banca Carige",
-      "id": "bancacarige-7b36b5",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Banca Carige",
-        "brand:wikidata": "Q3633695",
-        "name": "Banca Carige"
-      }
-    },
-    {
       "displayName": "Banca di Asti",
       "id": "bancadiasti-7b36b5",
       "locationSet": {"include": ["it"]},
@@ -4060,7 +4049,8 @@
         "banca pop emilia romagna",
         "bper",
         "unipol",
-        "unipol banca"
+        "unipol banca",
+        "banca carige"
       ],
       "tags": {
         "amenity": "bank",

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -4050,7 +4050,8 @@
         "bper",
         "unipol",
         "unipol banca",
-        "banca carige"
+        "banca carige",
+        "carige"
       ],
       "tags": {
         "amenity": "bank",
@@ -4621,17 +4622,6 @@
         "brand": "Capitec Bank",
         "brand:wikidata": "Q5035822",
         "name": "Capitec Bank"
-      }
-    },
-    {
-      "displayName": "Carige",
-      "id": "carige-7b36b5",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Carige",
-        "brand:wikidata": "Q3633695",
-        "name": "Carige"
       }
     },
     {


### PR DESCRIPTION
It has been over 2 years since Banca Carige has been sold to BPER Banca. Thus, I think we can delete the entry.