### PR TITLE
Delete Banca Popolare di Novara/Verona to Banco BPM

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -1229,17 +1229,6 @@
       }
     },
     {
-      "displayName": "Banca Popolare di Novara",
-      "id": "bancapopolaredinovara-7b36b5",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Banca Popolare di Novara",
-        "brand:wikidata": "Q3633742",
-        "name": "Banca Popolare di Novara"
-      }
-    },
-    {
       "displayName": "Banca Popolare di Sondrio",
       "id": "bancapopolaredisondrio-7b36b5",
       "locationSet": {"include": ["it"]},
@@ -1248,17 +1237,6 @@
         "brand": "Banca Popolare di Sondrio",
         "brand:wikidata": "Q686176",
         "name": "Banca Popolare di Sondrio"
-      }
-    },
-    {
-      "displayName": "Banca Popolare di Verona",
-      "id": "bancapopolarediverona-7b36b5",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Banca Popolare di Verona",
-        "brand:wikidata": "Q3167468",
-        "name": "Banca Popolare di Verona"
       }
     },
     {
@@ -1436,7 +1414,9 @@
         "banca bpm",
         "banca popolare di milano",
         "banco bpm s.p.a.",
-        "bpm"
+        "bpm",
+        "banca popolare di verona",
+        "banca popolare di novara"
       ],
       "tags": {
         "amenity": "bank",


### PR DESCRIPTION
Both of these have been dissolved and were absorbed into its parent Banco Popolare and then merged with Banca Popolare di Milano to from Banco BPM. Thus, I think we can add them to match names of Banco BPM and delete the others.