### PR TITLE
Update Civibank names to correct legal name

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -1217,15 +1217,15 @@
       }
     },
     {
-      "displayName": "Banca Popolare di Cividale",
+      "displayName": "CiviBank",
       "id": "bancapopolaredicividale-7b36b5",
       "locationSet": {"include": ["it"]},
-      "matchNames": ["civibank"],
+      "matchNames": ["banca popolare di cividale"],
       "tags": {
         "amenity": "bank",
-        "brand": "Banca Popolare di Cividale",
+        "brand": "CiviBank",
         "brand:wikidata": "Q15639942",
-        "name": "Banca Popolare di Cividale"
+        "name": "CiviBank"
       }
     },
     {


### PR DESCRIPTION
They rebranded and changed their legal name to CiviBank 
https://civib.wordpress.com/about/
https://www.civibank.it/ - CiviBank is everywhere, but Cividale is sparse only in About section.