### PR TITLE
Added Credito Artigiano/Valtellinese to Crédit Agricole Italia

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -5468,7 +5468,11 @@
       "locationSet": {
         "include": ["eg", "fr", "pl", "ua"]
       },
-      "matchNames": ["crédit agricole bank"],
+      "matchNames": [
+        "crédit agricole bank", 
+        "credito artigiano", 
+        "credito valtellinese"
+      ],
       "tags": {
         "amenity": "bank",
         "brand": "Crédit Agricole",
@@ -5594,28 +5598,6 @@
         "brand": "Crédito Agrícola",
         "brand:wikidata": "Q10262017",
         "name": "Crédito Agrícola"
-      }
-    },
-    {
-      "displayName": "Credito Artigiano",
-      "id": "creditoartigiano-7b36b5",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Credito Artigiano",
-        "brand:wikidata": "Q3696876",
-        "name": "Credito Artigiano"
-      }
-    },
-    {
-      "displayName": "Credito Valtellinese",
-      "id": "creditovaltellinese-7b36b5",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Credito Valtellinese",
-        "brand:wikidata": "Q3696888",
-        "name": "Credito Valtellinese"
       }
     },
     {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -5468,11 +5468,7 @@
       "locationSet": {
         "include": ["eg", "fr", "pl", "ua"]
       },
-      "matchNames": [
-        "crédit agricole bank", 
-        "credito artigiano", 
-        "credito valtellinese"
-      ],
+      "matchNames": ["crédit agricole bank"],
       "tags": {
         "amenity": "bank",
         "brand": "Crédit Agricole",
@@ -5500,7 +5496,11 @@
       "displayName": "Crédit Agricole Italia",
       "id": "creditagricole-7b36b5",
       "locationSet": {"include": ["it"]},
-      "matchNames": ["cariparma"],
+      "matchNames": [
+        "cariparma", 
+        "credito artigiano", 
+        "credito valtellinese"
+      ],
       "tags": {
         "amenity": "bank",
         "brand": "Crédit Agricole",


### PR DESCRIPTION
Credito Artigiano was merged into Credito Valtellinese, which then had all of its ownership bought out by Crédit Agricole Group in 2021. Thus, the merging of of Valtellinese into Credit Agricole Italia commenced.