### PR TITLE
Deleted Punto Simply and Simply Market Entries

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -569,6 +569,10 @@
       "displayName": "Auchan Supermarché",
       "id": "auchansupermarche-c16b1c",
       "locationSet": {"include": ["fr"]},
+      "matchNames": [
+        "simply",
+        "simply market"
+      ],
       "tags": {
         "brand": "Auchan Supermarché",
         "brand:wikidata": "Q105857776",
@@ -6755,17 +6759,6 @@
       }
     },
     {
-      "displayName": "Punto Simply",
-      "id": "puntosimply-0cb133",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "brand": "Punto Simply",
-        "brand:wikidata": "Q3484790",
-        "name": "Punto Simply",
-        "shop": "supermarket"
-      }
-    },
-    {
       "displayName": "Puregold",
       "id": "puregold-49e134",
       "locationSet": {"include": ["ph"]},
@@ -7477,18 +7470,6 @@
         "brand": "Sigma",
         "brand:wikidata": "Q3977979",
         "name": "Sigma",
-        "shop": "supermarket"
-      }
-    },
-    {
-      "displayName": "Simply Market",
-      "id": "simplymarket-986a24",
-      "locationSet": {"include": ["001"]},
-      "matchNames": ["simply"],
-      "tags": {
-        "brand": "Simply Market",
-        "brand:wikidata": "Q3484790",
-        "name": "Simply Market",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
Simply Market Rebranded from 2016-2019 to Auchan Supermarche. Punto Simply merged into Simply Market.