### PR TITLE
Deleted Michelin and Pirelli

### DIFF
--- a/data/brands/shop/tyres.json
+++ b/data/brands/shop/tyres.json
@@ -3,6 +3,7 @@
     "path": "brands/shop/tyres",
     "exclude": {
       "generic": [
+        "^(michelin|pirelli)$",
         "^(tyres|wulkanizacja|vulcanizare)$",
         "^(вулканизация|шиномонтаж)$",
         "^borrachar[ií]a$",

--- a/data/brands/shop/tyres.json
+++ b/data/brands/shop/tyres.json
@@ -370,20 +370,6 @@
       }
     },
     {
-      "displayName": "Michelin",
-      "id": "michelin-c3bb11",
-      "locationSet": {
-        "include": ["001"],
-        "exclude": ["fr", "gb"]
-      },
-      "tags": {
-        "brand": "Michelin",
-        "brand:wikidata": "Q151107",
-        "name": "Michelin",
-        "shop": "tyres"
-      }
-    },
-    {
       "displayName": "OK Tire",
       "id": "oktire-20a245",
       "locationSet": {"include": ["ca"]},
@@ -391,17 +377,6 @@
         "brand": "OK Tire",
         "brand:wikidata": "Q118368331",
         "name": "OK Tire",
-        "shop": "tyres"
-      }
-    },
-    {
-      "displayName": "Pirelli",
-      "id": "pirelli-1d5291",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "brand": "Pirelli",
-        "brand:wikidata": "Q207770",
-        "name": "Pirelli",
         "shop": "tyres"
       }
     },


### PR DESCRIPTION
Both of these brands do not have physical locations. Thus, I am wondering if it even makes sense to have them in NSI. Yes they are brands, but the point of NSI is to have common brand names for Places. Then POIs in OSM will have matching common names if they are the same company stores. Am I thinking about this correctly?