### PR TITLE
Add PH to Starbucks Reserve location set

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -3698,7 +3698,7 @@
       "displayName": "Starbucks Reserve",
       "id": "starbucksreserve-6e0560",
       "locationSet": {
-        "include": ["it", "jp", "us"]
+        "include": ["it", "jp", "ph", "us"]
       },
       "tags": {
         "amenity": "cafe",


### PR DESCRIPTION
Starbucks has opened up branches under its Reserve sub-brand here in the Philippines. As the OpenStreetMap mapping addicts would say:

**Source:** `local knowledge`

An example of an SBR branch in `PH` would be [this one](https://www.google.com/maps/place/Starbucks+Reserve+Hiraya/@14.1024129,120.9517885,19.75z/data=!4m6!3m5!1s0x33bd772aec0e931d:0x81913c29d43a16cb!8m2!3d14.1026279!4d120.9517044!16s%252Fg%252F11v3kmqkh0) in my home province. *(Admittedly, I went looking for it on OSM only to find out it hasn't been added yet.)*

For example: | City | Province
----|----|----
[Starbucks Reserve Hiraya](https://www.google.com/maps/place/Starbucks+Reserve+Hiraya/@14.1024129,120.9517885,19.75z/data=!4m6!3m5!1s0x33bd772aec0e931d:0x81913c29d43a16cb!8m2!3d14.1026279!4d120.9517044!16s%252Fg%252F11v3kmqkh0) | Tagaytay | Cavite