### PR TITLE
Add Naïma Italian perfumery chain

### DIFF
--- a/data/brands/shop/perfumery.json
+++ b/data/brands/shop/perfumery.json
@@ -201,6 +201,16 @@
       }
     },
     {
+      "displayName": "Naïma",
+      "locationSet": {"include": ["it"]},
+      "tags": {
+        "brand": "Naïma",
+        "brand:wikidata": "Q128205270",
+        "name": "Naïma",
+        "shop": "perfumery"
+      }
+    },
+    {
       "displayName": "O Boticário",
       "id": "oboticario-40d28a",
       "locationSet": {


### PR DESCRIPTION
Naïma it's an Italian perfumery chain in Italy with more than 300 stores.

Wikidata item: Q128205270 [https://www.wikidata.org/wiki/Q128205270](url)