### PR TITLE
Remove any related multilingual keys from templates

### DIFF
--- a/lib/file_tree.js
+++ b/lib/file_tree.js
@@ -391,7 +391,7 @@ expandTemplates: (cache, loco) => {
           } else {
             delete tags[osmkey];
             // remove any related multilingual keys
-            const multilingual_keys = ['name', 'alt_name', 'official_name', 'short_name'];
+            const multilingual_keys = ['name', 'alt_name', 'official_name', 'short_name', 'full_name'];
             if (multilingual_keys.includes(osmkey)) {
               Object.keys(tags).forEach (key => {
                 if (key.startsWith(osmkey + ':')) {

--- a/lib/file_tree.js
+++ b/lib/file_tree.js
@@ -390,6 +390,15 @@ expandTemplates: (cache, loco) => {
             tags[osmkey] = tagValue;
           } else {
             delete tags[osmkey];
+            // remove any related multilingual keys
+            const multilingual_keys = ['name', 'alt_name', 'official_name', 'short_name'];
+            if (multilingual_keys.includes(osmkey)) {
+              Object.keys(tags).forEach (key => {
+                if (key.startsWith(osmkey + ':')) {
+                  delete tags[key];
+                }
+              });
+            }
           }
         });
 


### PR DESCRIPTION
Resolves #7236
Resolves #9260

I might've missed or overlooked something so please test this change. Other than that it seems to produce correct results.

P.S. Quite a few banks have `official_name`, `alt_name` or `short_name`. If we are removing `name` from ATMs, we should remove the above mentioned tags as well.