### PR TITLE
Add brand or franchise mentioned in #10323 (添加 #10323 提到的機構)

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -4573,23 +4573,15 @@
       }
     },
     {
-      "displayName": "YouBike 微笑單車",
-      "id": "youbike-1bb859",
+      "displayName": "Moovo",
       "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "bicycle_rental",
         "bicycle_rental": "docking_station",
-        "brand": "YouBike 微笑單車",
-        "brand:en": "YouBike",
-        "brand:wikidata": "Q20687952",
-        "brand:zh": "微笑單車",
-        "network": "YouBike 微笑單車",
-        "network:en": "YouBike",
-        "network:wikidata": "Q20687952",
-        "network:zh": "微笑單車",
-        "operator": "Giant",
-        "operator:type": "private",
-        "operator:wikidata": "Q703557"
+        "brand": "Moovo",
+        "brand:wikidata": "Q17370530",
+        "network": "Moovo",
+        "network:wikidata": "Q17370530"
       }
     },
     {

--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -6353,6 +6353,23 @@
       }
     },
     {
+      "displayName": "多那之咖啡",
+      "id": "komedacoffeeshop-7d270d",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "amenity": "cafe",
+        "brand": "多那之咖啡",
+        "brand:en": "Donutes Coffee",
+        "brand:wikidata": "Q132010304",
+        "brand:zh": "多那之咖啡",
+        "cuisine": "coffee_shop",
+        "name": "多那之咖啡",
+        "name:en": "Donutes Coffee",
+        "name:zh": "多那之咖啡",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "幸福堂",
       "id": "xingfutang-7d270d",
       "locationSet": {"include": ["tw"]},

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -12519,6 +12519,46 @@
       }
     },
     {
+      "displayName": "胖老爹美式炸雞",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "",
+        "brand:en": "Fat Daddy American Fried Chicken",
+        "brand:wikidata": "Q66768745",
+        "brand:zh": "胖老爹美式炸雞",
+        "cuisine": "chicken",
+        "name": "胖老爹美式炸雞",
+        "name:en": "Fat Daddy American Fried Chicken",
+        "name:zh": "胖老爹美式炸雞",
+        "takeaway": "only"
+      }
+    },
+    {
+      "displayName": "21風味館",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "21世紀西式健康快速餐廳",
+        "21世紀風味館",
+        "二十一世紀生活事業股份有限公司",
+        "21 Century"
+      ],
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "21風味館",
+        "brand:en": "21Plus",
+        "brand:wikidata": "Q28416350",
+        "brand:zh": "21Plus",
+        "cuisine": "chicken",
+        "name": "21風味館",
+        "name:en": "21Plus",
+        "name:zh": "21風味館",
+        "operator": "統一超商",
+        "operator:wikidata": "Q4642867",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "唐記包點 Tong Kee Bao Dim",
       "id": "tongkeebaodim-9f9722",
       "locationSet": {"include": ["hk"]},
@@ -12797,6 +12837,19 @@
         "name:en": "Hong Ya Hambuger",
         "name:zh": "弘爺漢堡",
         "operator": "弘爺國際企業股份有限公司",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "Qburger",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Qburger",
+        "brand:wikidata": "Q131858964",
+        "cuisine": "american;breakfast",
+        "name": "Qburger",
+        "operator": "饗樂餐飲實業股份有限公司",
         "takeaway": "yes"
       }
     },

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -12523,7 +12523,7 @@
       "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "fast_food",
-        "brand": "",
+        "brand": "胖老爹美式炸雞",
         "brand:en": "Fat Daddy American Fried Chicken",
         "brand:wikidata": "Q66768745",
         "brand:zh": "胖老爹美式炸雞",

--- a/data/brands/amenity/parking.json
+++ b/data/brands/amenity/parking.json
@@ -32,6 +32,37 @@
       }
     },
     {
+      "displayName": "俥亭停車",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": ["日月亭", "俥亭"],
+      "tags": {
+        "amenity": "parking",
+        "brand": "俥亭停車",
+        "brand:en": "youparking",
+        "brand:zh": "俥亭停車",
+        "brand:wikidata": "Q132009628",
+        "fee": "yes",
+        "name": "俥亭停車",
+        "name:en": "youparking",
+        "name:ja": "俥亭停車"
+      }
+    },
+    {
+      "displayName": "和雲行動",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "amenity": "parking",
+        "brand": "和雲行動",
+        "brand:en": "Hi parking",
+        "brand:zh": "和雲行動",
+        "brand:wikidata": "Q132008893",
+        "fee": "yes",
+        "name": "和雲行動",
+        "name:en": "Hi parking",
+        "name:ja": "和雲行動"
+      }
+    },
+    {
       "displayName": "JustPark",
       "id": "justpark-aa7823",
       "locationSet": {"include": ["gb"]},

--- a/data/brands/amenity/prep_school.json
+++ b/data/brands/amenity/prep_school.json
@@ -350,7 +350,18 @@
       "tags": {
         "amenity": "prep_school",
         "brand": "明光義塾",
-        "name": "明光義塾"
+        "name": "明光義塾",
+        "brand:wikidata": "Q11512003"
+      }
+    },
+    {
+      "displayName": "明光義塾 (臺灣)",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "明光義塾",
+        "name": "明光義塾",
+        "brand:wikidata": "Q11512003"
       }
     },
     {
@@ -445,6 +456,27 @@
         "name": "滝川練成会",
         "name:en": "Takikawa Renseikai",
         "name:ja": "滝川練成会"
+      }
+    },
+    {
+      "displayName": "佳音英語",
+      "locationSet": {"include": ["tw"]},
+      "matchTags":[
+        "amenity/language_school",
+        "office/educational_institution"
+      ],
+      "matchNames": [
+        "Joy Education"
+      ],
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "佳音英語",
+        "brand:en": "Joy English",
+        "brand:ja": "佳音英語",
+        "brand:wikidata": "Q10887049",
+        "name": "佳音英語",
+        "name:en": "Joy English",
+        "name:ja": "佳音英語"
       }
     },
     {

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -9800,6 +9800,21 @@
       }
     },
     {
+      "displayName": "甘泉魚麵",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "甘泉魚麵",
+        "brand:en": "Fishnoodle",
+        "brand:wikidata": "Q132360457",
+        "brand:zh": "甘泉魚麵",
+        "cuisine": "noodle",
+        "name": "甘泉魚麵",
+        "name:en": "Fishnoodle",
+        "name:zh": "甘泉魚麵"
+      }
+    },
+    {
       "displayName": "田老师红烧肉",
       "id": "785320-0a8e9b",
       "locationSet": {"include": ["cn"]},

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -9509,6 +9509,9 @@
         "cuisine": "hotpot",
         "name": "石二鍋",
         "name:en": "Shi Erguo",
+        "operator": "王品集團",
+        "operator:en": "Wowprime Group",
+        "operator:wikidata": "Q15905144",
         "name:zh": "石二鍋"
       }
     },

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -9494,6 +9494,44 @@
       }
     },
     {
+      "displayName": "",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "12 Hot Pot",
+        "12 Sabu"
+      ],
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "石二鍋",
+        "brand:en": "Shi Erguo",
+        "brand:wikidata": "Q108056247",
+        "brand:zh": "石二鍋",
+        "cuisine": "hotpot",
+        "name": "石二鍋",
+        "name:en": "Shi Erguo",
+        "name:zh": "石二鍋"
+      }
+    },
+    {
+      "displayName": "千葉火鍋",
+      "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "Chien Yen Hot Pot",
+        "CY"
+      ],
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "千葉火鍋",
+        "brand:en": "Chien Yen Shabu Shabu",
+        "brand:wikidata": "Q67936077",
+        "brand:zh": "千葉火鍋",
+        "cuisine": "japanese;hotpot",
+        "name": "千葉火鍋",
+        "name:en": "Chien Yen Shabu Shabu",
+        "name:zh": "千葉火鍋"
+      }
+    },
+    {
       "displayName": "海底撈火鍋 Haidilao Hot Pot",
       "id": "haidilaohotpot-edf541",
       "locationSet": {"include": ["hk", "mo"]},

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -9494,7 +9494,7 @@
       }
     },
     {
-      "displayName": "",
+      "displayName": "石二鍋",
       "locationSet": {"include": ["tw"]},
       "matchNames": [
         "12 Hot Pot",

--- a/data/brands/shop/beauty.json
+++ b/data/brands/shop/beauty.json
@@ -700,6 +700,21 @@
       }
     },
     {
+      "displayName": "詩威特",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "beauty": "cosmetics",
+        "brand": "詩威特",
+        "brand:en": "Switer",
+        "brand:wikidata": "Q132360529",
+        "brand:zh": "詩威特",
+        "name": "詩威特",
+        "name:en": "Switer",
+        "name:zh": "詩威特",
+        "shop": "beauty"
+      }
+    },
+    {
       "displayName": "葉露芝 Yves Rocher",
       "id": "yvesrocher-1744e8",
       "locationSet": {"include": ["hk"]},

--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -10509,6 +10509,12 @@
       "displayName": "Triumph",
       "id": "triumph-3937bd",
       "locationSet": {"include": ["001"]},
+      "matchNames":[
+        "AMO'S STYLE",
+        "トリンプ",
+        "트라이엄프 인터내셔널",
+        "黛安芬"
+      ],
       "tags": {
         "brand": "Triumph",
         "brand:wikidata": "Q671216",

--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -11048,6 +11048,11 @@
     {
       "displayName": "Wacoal",
       "id": "wacoal-3937bd",
+      "matchNames":[
+        "華歌爾",
+        "ワコール",
+        "와코루"
+      ],
       "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "Wacoal",

--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -7244,6 +7244,20 @@
       }
     },
     {
+      "displayName": "伊蕾名店",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "伊蕾名店",
+        "brand:en": "ILEYED",
+        "brand:zh": "伊蕾名店",
+        "brand:wikidata": "Q132360513",
+        "name": "伊蕾名店",
+        "name:en": "ILEYED",
+        "name:zh": "伊蕾名店",
+        "shop": "clothes"
+      }
+    },
+    {
       "displayName": "New Look",
       "id": "newlook-f337da",
       "locationSet": {
@@ -11065,6 +11079,21 @@
         "brand:wikidata": "Q909522",
         "clothes": "underwear",
         "name": "Wacoal",
+        "shop": "clothes"
+      }
+    },
+    {
+      "displayName": "emon依夢",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "emon依夢",
+        "brand:en": "emon",
+        "brand:zh": "依夢",
+        "brand:wikidata": "Q132360486",
+        "clothes": "underwear",
+        "name": "emon依夢",
+        "name:en": "emon",
+        "name:zh": "依夢",
         "shop": "clothes"
       }
     },

--- a/data/brands/shop/optician.json
+++ b/data/brands/shop/optician.json
@@ -1663,6 +1663,34 @@
       }
     },
     {
+      "displayName": "大倉酷眼鏡",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "大倉酷眼鏡",
+        "brand:en": "dcool",
+        "brand:wikidata": "Q132360433",
+        "brand:zh": "大倉酷眼鏡",
+        "name": "大倉酷眼鏡",
+        "name:en": "dcool",
+        "name:zh": "大倉酷眼鏡",
+        "shop": "optician"
+      }
+    },
+    {
+      "displayName": "年青人眼鏡",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "年青人眼鏡",
+        "brand:en": "Younman",
+        "brand:wikidata": "Q132360432",
+        "brand:zh": "年青人眼鏡",
+        "name": "年青人眼鏡",
+        "name:en": "Younman",
+        "name:zh": "年青人眼鏡",
+        "shop": "optician"
+      }
+    },
+    {
       "displayName": "小林眼鏡",
       "id": "kobayashioptical-b2cb2d",
       "locationSet": {"include": ["tw"]},

--- a/data/brands/shop/outdoor.json
+++ b/data/brands/shop/outdoor.json
@@ -539,6 +539,34 @@
       }
     },
     {
+      "displayName": "城市綠洲",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "城市綠洲",
+        "brand:en": "Metro Oasis",
+        "brand:zh": "城市綠洲",
+        "brand:wikidata": "Q132360408",
+        "name": "城市綠洲",
+        "name:en": "Metro Oasis",
+        "name:zh": "城市綠洲",
+        "shop": "outdoor"
+      }
+    },
+    {
+      "displayName": "歐都納",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "歐都納",
+        "brand:en": "Atunas",
+        "brand:zh": "歐都納",
+        "brand:wikidata": "Q132360419",
+        "name": "歐都納",
+        "name:en": "Atunas",
+        "name:zh": "歐都納",
+        "shop": "outdoor"
+      }
+    },
+    {
       "displayName": "上州屋",
       "id": "johshuya-c097b7",
       "locationSet": {"include": ["jp"]},

--- a/data/brands/shop/shoes.json
+++ b/data/brands/shop/shoes.json
@@ -2742,7 +2742,11 @@
         "name": "鞋全家福",
         "name:en": "familyshoes",
         "name:zh": "鞋全家福",
-        "shop": "shoes"
+        "shop": "shoes",
+        "operator": "三商企業集團",
+        "operator:en": "Mercuries Group",
+        "operator:wikidata": "Q10865578",
+        "operator:zh": "三商企業集團"
       }
     },
     {

--- a/data/brands/shop/shoes.json
+++ b/data/brands/shop/shoes.json
@@ -2732,6 +2732,20 @@
       }
     },
     {
+      "displayName": "鞋全家福",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "鞋全家福",
+        "brand:en": "familyshoes",
+        "brand:wikidata": "Q132359984",
+        "brand:zh": "鞋全家福",
+        "name": "鞋全家福",
+        "name:en": "familyshoes",
+        "name:zh": "鞋全家福",
+        "shop": "shoes"
+      }
+    },
+    {
       "displayName": "靴専科",
       "id": "kutsusenka-53e098",
       "locationSet": {"include": ["jp"]},

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -944,6 +944,10 @@
       "displayName": "中華電信",
       "id": "chunghwatelecom-4f600a",
       "locationSet": {"include": ["tw"]},
+      "matchNames": [
+        "神腦國際",
+        "Senao International"
+      ],
       "tags": {
         "brand": "中華電信",
         "brand:en": "Chunghwa Telecom",

--- a/data/operators/amenity/community_centre.json
+++ b/data/operators/amenity/community_centre.json
@@ -657,6 +657,26 @@
       }
     },
     {
+      "displayName": "中國青年救國團",
+      "locationSet": {"include": ["tw"]},
+      "matchTags": [
+        "amenity/social_facility",
+        "office/ngo"
+      ],
+      "matchNames":[
+        "救國團",
+        "中國青年反共救國團",
+        "China Youth Corps",
+        "CYC"
+      ],
+      "tags": {
+        "amenity": "community_centre",
+        "operator": "中國青年救國團",
+        "operator:type": "ngo",
+        "operator:wikidata": "Q700615"
+      }
+    },
+    {
       "displayName": "ГБУ \"Талисман\"",
       "id": "3e975b-67abd2",
       "locationSet": {"include": ["ru"]},

--- a/data/operators/amenity/community_centre.json
+++ b/data/operators/amenity/community_centre.json
@@ -665,7 +665,6 @@
       ],
       "matchNames":[
         "救國團",
-        "中國青年反共救國團",
         "China Youth Corps",
         "CYC"
       ],


### PR DESCRIPTION
Add the following brands that have existed on Wikidata or OSM:

|中文|English|Wikidata|Type|
|--------------------|--------------------|--------------------|--------------------|
|明光義塾|Meikō Gijuku|Q11512003|amenity=prep_school|
|佳音英語|Joy English|Q10887049|amenity=prep_school, amenity=language_school, office=educational_institution|
|Qburger|Qburger|Q131858964|amenity=fast_food|
|千葉火鍋|Chien Yen Shabu Shabu|Q67936077|amenity=fast_food|
|千葉火鍋|Chien Yen Shabu Shabu|Q67936077|amenity=fast_food|
|石二鍋|Shi Erguo|Q108056247|amenity=restaurant|
|21世紀風味館|21Plus|Q28416350|amenity=fast_food|
|胖老爹|Fat Daddy American Fried Chicken|Q66768745|amenity=fast_food|
|中國青年救國團|China Youth Corps|Q700615|amenity=community_centre|

In addition, I have created Chinese, Japanese, and Korean aliases (`matchNames` in the NSI sense) for Wacoal, Triumph, and Chunghwa Telecom because not everyone knows their official name (for example, Wacoal is known as "華歌爾" rather than Wacoal for many Taiwanese people). The aliases don't change their `brand` or `name` prop since I just add `matchNames`.