### PR TITLE
Update PL Bank BPS

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -2281,11 +2281,11 @@
       "displayName": "Bank BPS",
       "id": "bankbps-68054b",
       "locationSet": {"include": ["pl"]},
+      "matchNames": ["spółdzielczy"],
       "tags": {
         "amenity": "bank",
         "brand": "Bank Polskiej Spółdzielczości",
-        "brand:wikidata": "Q9165001",
-        "name": "Bank BPS"
+        "brand:wikidata": "Q9165001"
       }
     },
     {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -2278,14 +2278,13 @@
       }
     },
     {
-      "displayName": "Bank BPS",
-      "id": "bankbps-68054b",
+      "displayName": "Banki spółdzielcze Grupa BPS",
       "locationSet": {"include": ["pl"]},
-      "matchNames": ["spółdzielczy"],
+      "matchNames": ["Bank BPS", "spółdzielczy"],
       "tags": {
         "amenity": "bank",
-        "brand": "Bank Polskiej Spółdzielczości",
-        "brand:wikidata": "Q9165001"
+	    "network": "Grupa BPS",
+	    "network:wikidata": "Q86673022"
       }
     },
     {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -2278,13 +2278,14 @@
       }
     },
     {
-      "displayName": "Banki spółdzielcze Grupa BPS",
+      "displayName": "Bank BPS",
+      "id": "bankbps-68054b",
       "locationSet": {"include": ["pl"]},
       "matchNames": ["Bank BPS", "spółdzielczy"],
       "tags": {
         "amenity": "bank",
-	    "network": "Grupa BPS",
-	    "network:wikidata": "Q86673022"
+        "brand": "Bank Polskiej Spółdzielczości",
+        "brand:wikidata": "Q9165001"
       }
     },
     {


### PR DESCRIPTION
Remove `name` from Bank BPS.

Bank BPS is more likely a parent organization that unites local banks.
Each local bank in the BPS group has its own name, typically formatted as "Bank Spółdzielczy in [area]", and manages its own branches in the surrounding areas.

The main bank, currently named Bank BPS, operates only [12 branches](https://www.bankbps.pl/znajdz-placowke). In contrast, there are over [300 local banks with more than 2,300 branches](https://www.bankbps.pl/aktualnosci/zrzeszenie-bps-rosnie-w-sile).