### PR TITLE
Add Brunei, the Philippines and Singapore as ZUS Coffee branch locations

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -4565,7 +4565,7 @@
     {
       "displayName": "ZUS Coffee",
       "id": "zuscoffee-2aa1ef",
-      "locationSet": {"include": ["my"]},
+      "locationSet": {"include": ["bn", "my", "ph", "sg"]},
       "tags": {
         "amenity": "cafe",
         "brand": "ZUS Coffee",


### PR DESCRIPTION
The Malaysian coffee shop chain ZUS Coffee has expanded to nearby countries here in Southeast Asia, such as Brunei, the Philippines and Singapore.

In fact, a branch just opened up a few weeks ago in my hometown mall here in southern Greater Manila Area.

### See also

- https://en.wikipedia.org/wiki/Zus_Coffee