### PR TITLE
Remove `short`, `alt`, `official` and `full` names from ATMs

### DIFF
--- a/data/brands/amenity/atm.json
+++ b/data/brands/amenity/atm.json
@@ -13,6 +13,9 @@
       "templateTags": {
         "amenity": "atm",
         "name": "",
+        "short_name": "",
+        "alt_name": "",
+        "official_name": "",
         "operator": "{source.tags.brand}",
         "operator:wikidata": "{source.tags.brand:wikidata}"
       }

--- a/data/brands/amenity/atm.json
+++ b/data/brands/amenity/atm.json
@@ -16,6 +16,7 @@
         "short_name": "",
         "alt_name": "",
         "official_name": "",
+        "full_name": "",
         "operator": "{source.tags.brand}",
         "operator:wikidata": "{source.tags.brand:wikidata}"
       }


### PR DESCRIPTION
Quite a few banks have `official_name`, `alt_name`, `short_name` or `full_name`. If we are removing `name` from ATMs, we should remove the above mentioned tags as well.

~~Blocked by #10378~~