### PR TITLE
Added Wikidata item for InCoop and moved from supermarket to convenience

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -2569,6 +2569,17 @@
       }
     },
     {
+      "displayName": "InCoop",
+      "id": "incoop-0cb133",
+      "locationSet": {"include": ["it"]},
+      "tags": {
+        "brand": "InCoop",
+        "brand:wikidata": "Q131934414",
+        "name": "InCoop",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "Indomaret",
       "id": "indomaret-bb8a09",
       "locationSet": {"include": ["id"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -3912,16 +3912,6 @@
       }
     },
     {
-      "displayName": "Incoop",
-      "id": "incoop-0cb133",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "brand": "Incoop",
-        "name": "Incoop",
-        "shop": "supermarket"
-      }
-    },
-    {
       "displayName": "Ingles",
       "id": "ingles-dde59d",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
InCoop it's the brand for small stores of Coop brand with mostly food and less than 1.000sq space. You definitely can't use a shopping cart there.