### PR TITLE
[brand/shop/jewelry][585 zolotoy] add wikidata and english name

### DIFF
--- a/data/brands/shop/jewelry.json
+++ b/data/brands/shop/jewelry.json
@@ -13,6 +13,7 @@
       "displayName": "585 Gold",
       "id": "585gold-a038d2",
       "locationSet": {"include": ["001"]},
+      "note": "This brand is different from brand 585 Zolotoy",
       "tags": {
         "brand": "585 Gold",
         "brand:wikidata": "Q125730875",
@@ -24,6 +25,7 @@
       "displayName": "585 Золотой",
       "id": "79c341-ee45ea",
       "locationSet": {"include": ["ru"]},
+      "note": "This brand is different from brand 585 Gold",
       "tags": {
         "brand": "585 Золотой",
         "brand:ru": "585 Золотой",

--- a/data/brands/shop/jewelry.json
+++ b/data/brands/shop/jewelry.json
@@ -26,7 +26,12 @@
       "locationSet": {"include": ["ru"]},
       "tags": {
         "brand": "585 Золотой",
+        "brand:ru": "585 Золотой",
+        "brand:en": "585 Zolotoy",
+        "brand:wikidata": "Q4031865",
         "name": "585 Золотой",
+        "name:ru": "585 Золотой",
+        "name:en": "585 Zolotoy",
         "shop": "jewelry"
       }
     },


### PR DESCRIPTION
Also updated [585 Zolotoy wikidata](https://www.wikidata.org/wiki/Q4031865) and [585 Gold wikidata](https://www.wikidata.org/wiki/Q125730875), which is a different chain (might confuse natives).