### PR TITLE
Denny's should be global (except localization for Japan)

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -2032,7 +2032,10 @@
     {
       "displayName": "Denny's",
       "id": "dennys-96af40",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {
+        "include": ["001"],
+        "exclude": ["jp"]
+      },
       "tags": {
         "amenity": "restaurant",
         "brand": "Denny's",


### PR DESCRIPTION
Denny's should be set to global, with exception for Japan (which has a localized preset). The chain has already gone global since around late 10s, but the main entry remains US-only until now in NSI.