### PR TITLE
Add two fast food chain

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -1894,6 +1894,35 @@
       }
     },
     {
+      "displayName": "Çiğköftem",
+      "id": "cigkoftem-7c8ccc",
+      "locationSet": {
+        "include": [
+          "at",
+          "be",
+          "bg",
+          "de",
+          "es",
+          "fr",
+          "gb",
+          "hu",
+          "nl",
+          "pl",
+          "tr"
+        ]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Çiğköftem",
+        "brand:wikidata": "Q106597459",
+        "cuisine": "turkish",
+        "diet:vegan": "yes",
+        "diet:vegetarian": "only",
+        "name": "Çiğköftem",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Cinnabon",
       "id": "cinnabon-9b2018",
       "locationSet": {
@@ -3490,6 +3519,19 @@
         "brand:wikidata": "Q5515791",
         "cuisine": "pizza",
         "name": "Gabriel Pizza",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "Gagawa",
+      "id": "gagawa-f6eb08",
+      "locationSet": {"include": ["es", "pt"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Gagawa",
+        "brand:wikidata": "Q132156132",
+        "cuisine": "chicken",
+        "name": "Gagawa",
         "takeaway": "yes"
       }
     },


### PR DESCRIPTION
* Çiğköftem: a turkish vegetarian chain operating in many european countries 
* Gagawa: a turkish chain operating in Spain and Portugal (the european filiale of Tavuk Dünyası)