### PR TITLE
Add/split SmartPosti parcel locker entry for Latvia from now-renamed Smartpost (Itella)

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -1067,13 +1067,25 @@
       "displayName": "Smartpost Itella",
       "id": "smartpost-b4a3f3",
       "locationSet": {
-        "include": ["ee", "lt", "lv"]
+        "include": ["ee", "lt"]
       },
       "tags": {
         "amenity": "parcel_locker",
         "brand": "Smartpost",
         "brand:wikidata": "Q7543889",
         "operator": "Itella",
+        "parcel_mail_in": "yes",
+        "parcel_pickup": "yes"
+      }
+    },
+    {
+      "displayName": "SmartPosti",
+      "locationSet": { "include": ["lv"] },
+      "tags": {
+        "amenity": "parcel_locker",
+        "name": "SmartPosti",
+        "brand": "SmartPosti",
+        "brand:wikidata": "Q132157239",
         "parcel_mail_in": "yes",
         "parcel_pickup": "yes"
       }


### PR DESCRIPTION
Finnish Posti Group logistics daughter companies in Baltic States (Latvia, Lithuania, Estonia) [have rebranded](https://www.smartposti.lv/en/latest-news/all-news/smartpost-itella-transitions-to-the-smart-posti-brand) to a common name/company/brand "**SmartPosti**". This PR splits the parcel locker entry for Latvia to use the new branding. The other two countries still need to rename/fix theirs (but also need to adjust/add Wikidata entries first).