### PR TITLE
Change brand of payment terminals by Oppa

### DIFF
--- a/data/brands/amenity/payment_terminal.json
+++ b/data/brands/amenity/payment_terminal.json
@@ -641,6 +641,7 @@
         "brand": "ფეიბოქსი",
         "brand:en": "PayBox",
         "brand:ka": "ფეიბოქსი",
+        "brand:wikidata": "Q132183551",
         "operator": "ოპპა",
         "operator:en": "Oppa",
         "operator:ka": "ოპპა",

--- a/data/brands/amenity/payment_terminal.json
+++ b/data/brands/amenity/payment_terminal.json
@@ -633,14 +633,14 @@
       }
     },
     {
-      "displayName": "ოპპა",
+      "displayName": "ფეიბოქსი",
       "id": "oppa-ebda91",
       "locationSet": {"include": ["ge"]},
       "tags": {
         "amenity": "payment_terminal",
-        "brand": "ოპპა",
-        "brand:en": "Oppa",
-        "brand:ka": "ოპპა",
+        "brand": "ფეიბოქსი",
+        "brand:en": "PayBox",
+        "brand:ka": "ფეიბოქსი",
         "operator": "ოპპა",
         "operator:en": "Oppa",
         "operator:ka": "ოპპა",


### PR DESCRIPTION
Actually, all payment termninals operated by Oppa are branded as PayBox, see [https://paybox.ge/en](https://paybox.ge/en). Also, I added wikidata for this brand