### PR TITLE
remove duplicate entry for sigo bike sharing

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -3438,6 +3438,7 @@
       "displayName": "sigo E-Lastenrad Sharing",
       "id": "sigo-937152",
       "locationSet": {"include": ["de"]},
+      "matchNames": ["sigo E-Lastenrad Standort"],
       "tags": {
         "amenity": "bicycle_rental",
         "brand": "sigo",

--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -3448,16 +3448,6 @@
       }
     },
     {
-      "displayName": "sigo E-Lastenrad Standort",
-      "id": "sigoelastenradstandort-937152",
-      "locationSet": {"include": ["de"]},
-      "tags": {
-        "amenity": "bicycle_rental",
-        "brand": "sigo E-Lastenrad Standort",
-        "name": "sigo E-Lastenrad Standort"
-      }
-    },
-    {
       "displayName": "SiPedala",
       "id": "sipedala-aab06d",
       "locationSet": {


### PR DESCRIPTION
Removed a duplicated entry for sigo in favour of the previous entry, which already has a wikidata entry.