### PR TITLE
Copy preschool entry for Rīgas pašvaldība to school entry to fix incorrect iD amenity value replacement

### DIFF
--- a/data/operators/amenity/school.json
+++ b/data/operators/amenity/school.json
@@ -37578,6 +37578,16 @@
       }
     },
     {
+      "displayName": "Rīgas pašvaldība",
+      "locationSet": {"include": ["lv"]},
+      "tags": {
+        "amenity": "school",
+        "operator": "Rīgas pašvaldība",
+        "operator:type": "government",
+        "operator:wikidata": "Q2089528"
+      }
+    },
+    {
       "displayName": "Ringerike kommune",
       "id": "ringerikekommune-ee5f1f",
       "locationSet": {"include": ["no"]},


### PR DESCRIPTION
iD is attempting to replace `amenity=school` with `amenity=kindergarten` when `operator=Rīgas pašvaldība` is set via [this entry](https://nsi.guide/index.html?t=operators&k=amenity&v=kindergarten#rigaspasvaldiba-e433d7):

![school replace](https://github.com/user-attachments/assets/eb621f3d-681e-426d-ab0c-52b1cc04632b)

This is presumably because NSI has a "school" value match group that includes both values. This is incorrect in this case (and I'm not entirely sure when this is ever correct? (in fact, it even matches generic `amenity=yes`, which seems extremely optimistic.)) So this PR adds a school entry so iD at least doesn't attempt an incorrect `amenity` value replacement.