### PR TITLE
add wikidata for "Gradska ljekarna Zagreb"

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -1890,6 +1890,7 @@
       "tags": {
         "amenity": "pharmacy",
         "brand": "Gradska ljekarna Zagreb",
+        "brand:wikidata": "Q132529253",
         "healthcare": "pharmacy",
         "name": "Gradska ljekarna Zagreb"
       }


### PR DESCRIPTION
(also created https://www.wikidata.org/wiki/Q132529253)