### PR TITLE
Change Humana to second-hand clothes shop.

### DIFF
--- a/data/brands/shop/charity.json
+++ b/data/brands/shop/charity.json
@@ -256,18 +256,6 @@
       }
     },
     {
-      "displayName": "Humana",
-      "id": "humana-bf05c1",
-      "locationSet": {"include": ["001"]},
-      "matchNames": ["humana people to people"],
-      "tags": {
-        "brand": "Humana",
-        "brand:wikidata": "Q1636581",
-        "name": "Humana",
-        "shop": "charity"
-      }
-    },
-    {
       "displayName": "Kirkens Korshær Genbrug",
       "id": "kirkenskorshaergenbrug-40689c",
       "locationSet": {"include": ["dk"]},

--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -4854,6 +4854,19 @@
       }
     },
     {
+      "displayName": "Humana",
+      "id": "humana-bf05c1",
+      "locationSet": {"include": ["001"]},
+      "matchNames": ["humana people to people"],
+      "tags": {
+        "brand": "Humana",
+        "brand:wikidata": "Q1636581",
+        "name": "Humana",
+        "shop": "clothes",
+        "second_hand": "only"
+      }
+    },
+    {
       "displayName": "Hunkemöller",
       "id": "hunkemoller-4950a4",
       "locationSet": {


### PR DESCRIPTION
Humana is second-hand clothes shop only. This conflicts with current tagging "shop=charity" which implies that the shop sells all kinds of things donated to the shop.