### PR TITLE
Add bicycle_repair_station.json with "RadKULTUR" entry

### DIFF
--- a/data/brands/amenity/bicycle_repair_station.json
+++ b/data/brands/amenity/bicycle_repair_station.json
@@ -11,17 +11,7 @@
       "tags": {
         "amenity": "bicycle_repair_station",
         "brand": "RadKULTUR",
-        "brand:wikidata": "Q132562116",
-        "name": "RadService-Punkt",
-        "manometer": "yes",
-        "manual": "yes",
-        "service:bicycle:chain_tool": "no",
-        "service:bicycle:diy": "yes",
-        "service:bicycle:pump": "yes",
-        "service:bicycle:screwdriver": "yes",
-        "service:bicycle:stand": "yes",
-        "service:bicycle:tools": "yes",
-        "valves": "dunlop;schrader;sclaverand"
+        "brand:wikidata": "Q132562116"
       }
     }
   ]


### PR DESCRIPTION
I would like to add the “RadService-Punkt” bicycle repair stations of the “RadKULTUR” brand/initiative. These are limited to the federal state of Baden-Württemberg in Germany. There are currently over 600 stations and the number is constantly increasing due to an ongoing funding program. The stations all have the same properties, even if the manufacturer of the station alternates.

Since there was no file for bike repair stations yet, I'd be grateful for any feedback on this!