### PR TITLE
add `doc_url` property to the generated taginfo file

### DIFF
--- a/dist/taginfo.json
+++ b/dist/taginfo.json
@@ -15,11 +15,31 @@
     {"key": "access", "value": "permit"},
     {"key": "access", "value": "private"},
     {"key": "access", "value": "yes"},
-    {"key": "advertising", "value": "billboard"},
-    {"key": "advertising", "value": "column"},
-    {"key": "advertising", "value": "poster_box"},
-    {"key": "advertising", "value": "screen"},
-    {"key": "advertising", "value": "totem"},
+    {
+      "key": "advertising",
+      "value": "billboard",
+      "doc_url": "https://nsi.guide/?t=operators&k=advertising&v=billboard"
+    },
+    {
+      "key": "advertising",
+      "value": "column",
+      "doc_url": "https://nsi.guide/?t=operators&k=advertising&v=column"
+    },
+    {
+      "key": "advertising",
+      "value": "poster_box",
+      "doc_url": "https://nsi.guide/?t=operators&k=advertising&v=poster_box"
+    },
+    {
+      "key": "advertising",
+      "value": "screen",
+      "doc_url": "https://nsi.guide/?t=operators&k=advertising&v=screen"
+    },
+    {
+      "key": "advertising",
+      "value": "totem",
+      "doc_url": "https://nsi.guide/?t=brands&k=advertising&v=totem"
+    },
     {"key": "after_school", "value": "yes"},
     {"key": "agrarian", "value": "machine_parts"},
     {"key": "agrarian", "value": "seed;feed;tools"},
@@ -43,86 +63,362 @@
     {"key": "alt_name:vi"},
     {"key": "alt_name:zh"},
     {"key": "alt_name"},
-    {"key": "amenity", "value": "animal_boarding"},
-    {"key": "amenity", "value": "animal_shelter"},
-    {"key": "amenity", "value": "atm"},
-    {"key": "amenity", "value": "bank"},
-    {"key": "amenity", "value": "bar"},
-    {"key": "amenity", "value": "bicycle_parking"},
-    {"key": "amenity", "value": "bicycle_rental"},
-    {"key": "amenity", "value": "bureau_de_change"},
-    {"key": "amenity", "value": "cafe"},
-    {"key": "amenity", "value": "car_rental"},
-    {"key": "amenity", "value": "car_sharing"},
-    {"key": "amenity", "value": "car_wash"},
-    {"key": "amenity", "value": "casino"},
-    {"key": "amenity", "value": "charging_station"},
-    {"key": "amenity", "value": "childcare"},
-    {"key": "amenity", "value": "cinema"},
-    {"key": "amenity", "value": "clinic"},
-    {"key": "amenity", "value": "college"},
-    {"key": "amenity", "value": "community_centre"},
-    {"key": "amenity", "value": "conference_centre"},
-    {"key": "amenity", "value": "courthouse"},
-    {"key": "amenity", "value": "dentist"},
-    {"key": "amenity", "value": "doctors"},
-    {"key": "amenity", "value": "drinking_water"},
-    {"key": "amenity", "value": "driving_school"},
-    {"key": "amenity", "value": "fast_food"},
-    {"key": "amenity", "value": "ferry_terminal"},
-    {"key": "amenity", "value": "fire_station"},
-    {"key": "amenity", "value": "food_sharing"},
-    {"key": "amenity", "value": "fuel"},
-    {"key": "amenity", "value": "gambling"},
-    {"key": "amenity", "value": "hospital"},
-    {"key": "amenity", "value": "ice_cream"},
-    {"key": "amenity", "value": "internet_cafe"},
-    {"key": "amenity", "value": "karaoke_box"},
-    {"key": "amenity", "value": "kindergarten"},
-    {"key": "amenity", "value": "language_school"},
-    {"key": "amenity", "value": "library"},
-    {"key": "amenity", "value": "marketplace"},
-    {"key": "amenity", "value": "money_transfer"},
-    {"key": "amenity", "value": "mortuary"},
-    {"key": "amenity", "value": "motorcycle_rental"},
-    {"key": "amenity", "value": "music_school"},
-    {"key": "amenity", "value": "parcel_locker"},
-    {"key": "amenity", "value": "parking"},
-    {"key": "amenity", "value": "payment_centre"},
-    {"key": "amenity", "value": "payment_terminal"},
-    {"key": "amenity", "value": "pharmacy"},
-    {"key": "amenity", "value": "photo_booth"},
-    {"key": "amenity", "value": "police"},
-    {"key": "amenity", "value": "post_box"},
-    {"key": "amenity", "value": "post_depot"},
-    {"key": "amenity", "value": "post_office"},
-    {"key": "amenity", "value": "prep_school"},
-    {"key": "amenity", "value": "prison"},
-    {"key": "amenity", "value": "pub"},
-    {"key": "amenity", "value": "public_bookcase"},
-    {"key": "amenity", "value": "recycling"},
-    {"key": "amenity", "value": "restaurant"},
-    {"key": "amenity", "value": "school"},
-    {"key": "amenity", "value": "social_centre"},
-    {"key": "amenity", "value": "social_facility"},
-    {"key": "amenity", "value": "telephone"},
-    {"key": "amenity", "value": "ticket_validator"},
-    {"key": "amenity", "value": "toilets"},
-    {"key": "amenity", "value": "townhall"},
-    {"key": "amenity", "value": "training"},
-    {"key": "amenity", "value": "trolley_bay"},
-    {"key": "amenity", "value": "university"},
-    {"key": "amenity", "value": "vehicle_inspection"},
-    {"key": "amenity", "value": "vending_machine"},
-    {"key": "amenity", "value": "veterinary"},
-    {"key": "amenity", "value": "waste_basket"},
-    {"key": "amenity", "value": "weighbridge"},
+    {
+      "key": "amenity",
+      "value": "animal_boarding",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=animal_boarding"
+    },
+    {
+      "key": "amenity",
+      "value": "animal_shelter",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=animal_shelter"
+    },
+    {"key": "amenity", "value": "atm", "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=atm"},
+    {"key": "amenity", "value": "bank", "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=bank"},
+    {"key": "amenity", "value": "bar", "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=bar"},
+    {
+      "key": "amenity",
+      "value": "bicycle_parking",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=bicycle_parking"
+    },
+    {
+      "key": "amenity",
+      "value": "bicycle_rental",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=bicycle_rental"
+    },
+    {
+      "key": "amenity",
+      "value": "bureau_de_change",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=bureau_de_change"
+    },
+    {"key": "amenity", "value": "cafe", "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=cafe"},
+    {
+      "key": "amenity",
+      "value": "car_rental",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=car_rental"
+    },
+    {
+      "key": "amenity",
+      "value": "car_sharing",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=car_sharing"
+    },
+    {
+      "key": "amenity",
+      "value": "car_wash",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=car_wash"
+    },
+    {
+      "key": "amenity",
+      "value": "casino",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=casino"
+    },
+    {
+      "key": "amenity",
+      "value": "charging_station",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=charging_station"
+    },
+    {
+      "key": "amenity",
+      "value": "childcare",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=childcare"
+    },
+    {
+      "key": "amenity",
+      "value": "cinema",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=cinema"
+    },
+    {
+      "key": "amenity",
+      "value": "clinic",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=clinic"
+    },
+    {
+      "key": "amenity",
+      "value": "college",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=college"
+    },
+    {
+      "key": "amenity",
+      "value": "community_centre",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=community_centre"
+    },
+    {
+      "key": "amenity",
+      "value": "conference_centre",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=conference_centre"
+    },
+    {
+      "key": "amenity",
+      "value": "courthouse",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=courthouse"
+    },
+    {
+      "key": "amenity",
+      "value": "dentist",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=dentist"
+    },
+    {
+      "key": "amenity",
+      "value": "doctors",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=doctors"
+    },
+    {
+      "key": "amenity",
+      "value": "drinking_water",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=drinking_water"
+    },
+    {
+      "key": "amenity",
+      "value": "driving_school",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=driving_school"
+    },
+    {
+      "key": "amenity",
+      "value": "fast_food",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=fast_food"
+    },
+    {
+      "key": "amenity",
+      "value": "ferry_terminal",
+      "doc_url": "https://nsi.guide/?t=transit&k=amenity&v=ferry_terminal"
+    },
+    {
+      "key": "amenity",
+      "value": "fire_station",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=fire_station"
+    },
+    {
+      "key": "amenity",
+      "value": "food_sharing",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=food_sharing"
+    },
+    {"key": "amenity", "value": "fuel", "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=fuel"},
+    {
+      "key": "amenity",
+      "value": "gambling",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=gambling"
+    },
+    {
+      "key": "amenity",
+      "value": "hospital",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=hospital"
+    },
+    {
+      "key": "amenity",
+      "value": "ice_cream",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=ice_cream"
+    },
+    {
+      "key": "amenity",
+      "value": "internet_cafe",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=internet_cafe"
+    },
+    {
+      "key": "amenity",
+      "value": "karaoke_box",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=karaoke_box"
+    },
+    {
+      "key": "amenity",
+      "value": "kindergarten",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=kindergarten"
+    },
+    {
+      "key": "amenity",
+      "value": "language_school",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=language_school"
+    },
+    {
+      "key": "amenity",
+      "value": "library",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=library"
+    },
+    {
+      "key": "amenity",
+      "value": "marketplace",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=marketplace"
+    },
+    {
+      "key": "amenity",
+      "value": "money_transfer",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=money_transfer"
+    },
+    {
+      "key": "amenity",
+      "value": "mortuary",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=mortuary"
+    },
+    {
+      "key": "amenity",
+      "value": "motorcycle_rental",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=motorcycle_rental"
+    },
+    {
+      "key": "amenity",
+      "value": "music_school",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=music_school"
+    },
+    {
+      "key": "amenity",
+      "value": "parcel_locker",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=parcel_locker"
+    },
+    {
+      "key": "amenity",
+      "value": "parking",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=parking"
+    },
+    {
+      "key": "amenity",
+      "value": "payment_centre",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=payment_centre"
+    },
+    {
+      "key": "amenity",
+      "value": "payment_terminal",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=payment_terminal"
+    },
+    {
+      "key": "amenity",
+      "value": "pharmacy",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=pharmacy"
+    },
+    {
+      "key": "amenity",
+      "value": "photo_booth",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=photo_booth"
+    },
+    {
+      "key": "amenity",
+      "value": "police",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=police"
+    },
+    {
+      "key": "amenity",
+      "value": "post_box",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=post_box"
+    },
+    {
+      "key": "amenity",
+      "value": "post_depot",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=post_depot"
+    },
+    {
+      "key": "amenity",
+      "value": "post_office",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=post_office"
+    },
+    {
+      "key": "amenity",
+      "value": "prep_school",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=prep_school"
+    },
+    {
+      "key": "amenity",
+      "value": "prison",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=prison"
+    },
+    {"key": "amenity", "value": "pub", "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=pub"},
+    {
+      "key": "amenity",
+      "value": "public_bookcase",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=public_bookcase"
+    },
+    {
+      "key": "amenity",
+      "value": "recycling",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=recycling"
+    },
+    {
+      "key": "amenity",
+      "value": "restaurant",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=restaurant"
+    },
+    {
+      "key": "amenity",
+      "value": "school",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=school"
+    },
+    {
+      "key": "amenity",
+      "value": "social_centre",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=social_centre"
+    },
+    {
+      "key": "amenity",
+      "value": "social_facility",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=social_facility"
+    },
+    {
+      "key": "amenity",
+      "value": "telephone",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=telephone"
+    },
+    {
+      "key": "amenity",
+      "value": "ticket_validator",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=ticket_validator"
+    },
+    {
+      "key": "amenity",
+      "value": "toilets",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=toilets"
+    },
+    {
+      "key": "amenity",
+      "value": "townhall",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=townhall"
+    },
+    {
+      "key": "amenity",
+      "value": "training",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=training"
+    },
+    {
+      "key": "amenity",
+      "value": "trolley_bay",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=trolley_bay"
+    },
+    {
+      "key": "amenity",
+      "value": "university",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=university"
+    },
+    {
+      "key": "amenity",
+      "value": "vehicle_inspection",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=vehicle_inspection"
+    },
+    {
+      "key": "amenity",
+      "value": "vending_machine",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=vending_machine"
+    },
+    {
+      "key": "amenity",
+      "value": "veterinary",
+      "doc_url": "https://nsi.guide/?t=operators&k=amenity&v=veterinary"
+    },
+    {
+      "key": "amenity",
+      "value": "waste_basket",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=waste_basket"
+    },
+    {
+      "key": "amenity",
+      "value": "weighbridge",
+      "doc_url": "https://nsi.guide/?t=brands&k=amenity&v=weighbridge"
+    },
     {"key": "animal_boarding", "value": "dog"},
     {"key": "animal_boarding", "value": "dog;cat"},
     {"key": "authentication:app", "value": "true"},
     {"key": "authentication:app", "value": "yes"},
     {"key": "bar", "value": "yes"},
-    {"key": "barrier", "value": "toll_booth"},
+    {
+      "key": "barrier",
+      "value": "toll_booth",
+      "doc_url": "https://nsi.guide/?t=operators&k=barrier&v=toll_booth"
+    },
     {"key": "beauty", "value": "aesthetic"},
     {"key": "beauty", "value": "aesthetic;hair_removal"},
     {"key": "beauty", "value": "cosmetics"},
@@ -159,9 +455,21 @@
     {"key": "books", "value": "comic"},
     {"key": "books", "value": "comic;manga"},
     {"key": "books", "value": "religion"},
-    {"key": "boundary", "value": "aboriginal_lands"},
-    {"key": "boundary", "value": "national_park"},
-    {"key": "boundary", "value": "protected_area"},
+    {
+      "key": "boundary",
+      "value": "aboriginal_lands",
+      "doc_url": "https://nsi.guide/?t=operators&k=boundary&v=aboriginal_lands"
+    },
+    {
+      "key": "boundary",
+      "value": "national_park",
+      "doc_url": "https://nsi.guide/?t=operators&k=boundary&v=national_park"
+    },
+    {
+      "key": "boundary",
+      "value": "protected_area",
+      "doc_url": "https://nsi.guide/?t=operators&k=boundary&v=protected_area"
+    },
     {"key": "brand_wikidata"},
     {"key": "brand:ar"},
     {"key": "brand:be-tarask"},
@@ -280,8 +588,12 @@
     {"key": "clothes", "value": "women;underwear;swimwear;men;children"},
     {"key": "clothes", "value": "workwear"},
     {"key": "clothes", "value": "yes"},
-    {"key": "club", "value": "freemasonry"},
-    {"key": "club", "value": "scout"},
+    {
+      "key": "club",
+      "value": "freemasonry",
+      "doc_url": "https://nsi.guide/?t=brands&k=club&v=freemasonry"
+    },
+    {"key": "club", "value": "scout", "doc_url": "https://nsi.guide/?t=brands&k=club&v=scout"},
     {"key": "club", "value": "sport"},
     {"key": "cocktails", "value": "yes"},
     {"key": "coffee:brand"},
@@ -293,14 +605,46 @@
     {"key": "country"},
     {"key": "covered", "value": "yes"},
     {"key": "craft", "value": "bakery"},
-    {"key": "craft", "value": "carpenter"},
-    {"key": "craft", "value": "cleaning"},
-    {"key": "craft", "value": "electrician"},
-    {"key": "craft", "value": "electronics_repair"},
-    {"key": "craft", "value": "glaziery"},
-    {"key": "craft", "value": "plumber"},
-    {"key": "craft", "value": "signmaker"},
-    {"key": "craft", "value": "window_construction"},
+    {
+      "key": "craft",
+      "value": "carpenter",
+      "doc_url": "https://nsi.guide/?t=brands&k=craft&v=carpenter"
+    },
+    {
+      "key": "craft",
+      "value": "cleaning",
+      "doc_url": "https://nsi.guide/?t=brands&k=craft&v=cleaning"
+    },
+    {
+      "key": "craft",
+      "value": "electrician",
+      "doc_url": "https://nsi.guide/?t=brands&k=craft&v=electrician"
+    },
+    {
+      "key": "craft",
+      "value": "electronics_repair",
+      "doc_url": "https://nsi.guide/?t=brands&k=craft&v=electronics_repair"
+    },
+    {
+      "key": "craft",
+      "value": "glaziery",
+      "doc_url": "https://nsi.guide/?t=brands&k=craft&v=glaziery"
+    },
+    {
+      "key": "craft",
+      "value": "plumber",
+      "doc_url": "https://nsi.guide/?t=brands&k=craft&v=plumber"
+    },
+    {
+      "key": "craft",
+      "value": "signmaker",
+      "doc_url": "https://nsi.guide/?t=brands&k=craft&v=signmaker"
+    },
+    {
+      "key": "craft",
+      "value": "window_construction",
+      "doc_url": "https://nsi.guide/?t=brands&k=craft&v=window_construction"
+    },
     {"key": "cuisine", "value": "açaí"},
     {"key": "cuisine", "value": "african;chicken;portuguese"},
     {"key": "cuisine", "value": "american"},
@@ -671,12 +1015,36 @@
     {"key": "electronics_repair", "value": "computer;appliance;phone"},
     {"key": "electronics_repair", "value": "computer;phone"},
     {"key": "electronics_repair", "value": "phone"},
-    {"key": "emergency", "value": "ambulance_station"},
-    {"key": "emergency", "value": "disaster_response"},
-    {"key": "emergency", "value": "lifeguard"},
-    {"key": "emergency", "value": "phone"},
-    {"key": "emergency", "value": "siren"},
-    {"key": "emergency", "value": "water_rescue"},
+    {
+      "key": "emergency",
+      "value": "ambulance_station",
+      "doc_url": "https://nsi.guide/?t=operators&k=emergency&v=ambulance_station"
+    },
+    {
+      "key": "emergency",
+      "value": "disaster_response",
+      "doc_url": "https://nsi.guide/?t=operators&k=emergency&v=disaster_response"
+    },
+    {
+      "key": "emergency",
+      "value": "lifeguard",
+      "doc_url": "https://nsi.guide/?t=operators&k=emergency&v=lifeguard"
+    },
+    {
+      "key": "emergency",
+      "value": "phone",
+      "doc_url": "https://nsi.guide/?t=operators&k=emergency&v=phone"
+    },
+    {
+      "key": "emergency",
+      "value": "siren",
+      "doc_url": "https://nsi.guide/?t=operators&k=emergency&v=siren"
+    },
+    {
+      "key": "emergency",
+      "value": "water_rescue",
+      "doc_url": "https://nsi.guide/?t=operators&k=emergency&v=water_rescue"
+    },
     {"key": "fair_trade", "value": "only"},
     {"key": "fast_food", "value": "cafeteria"},
     {"key": "fee", "value": "no"},
@@ -763,26 +1131,70 @@
     {"key": "healthcare:speciality", "value": "surgery"},
     {"key": "healthcare:speciality", "value": "urgent"},
     {"key": "healthcare:speciality", "value": "weight_loss"},
-    {"key": "healthcare", "value": "alternative"},
-    {"key": "healthcare", "value": "audiologist"},
-    {"key": "healthcare", "value": "blood_donation"},
+    {
+      "key": "healthcare",
+      "value": "alternative",
+      "doc_url": "https://nsi.guide/?t=brands&k=healthcare&v=alternative"
+    },
+    {
+      "key": "healthcare",
+      "value": "audiologist",
+      "doc_url": "https://nsi.guide/?t=brands&k=healthcare&v=audiologist"
+    },
+    {
+      "key": "healthcare",
+      "value": "blood_donation",
+      "doc_url": "https://nsi.guide/?t=brands&k=healthcare&v=blood_donation"
+    },
     {"key": "healthcare", "value": "clinic"},
-    {"key": "healthcare", "value": "counselling"},
+    {
+      "key": "healthcare",
+      "value": "counselling",
+      "doc_url": "https://nsi.guide/?t=brands&k=healthcare&v=counselling"
+    },
     {"key": "healthcare", "value": "dentist"},
     {"key": "healthcare", "value": "dialysis"},
     {"key": "healthcare", "value": "doctor"},
     {"key": "healthcare", "value": "hospital"},
-    {"key": "healthcare", "value": "laboratory"},
+    {
+      "key": "healthcare",
+      "value": "laboratory",
+      "doc_url": "https://nsi.guide/?t=brands&k=healthcare&v=laboratory"
+    },
     {"key": "healthcare", "value": "optometrist"},
     {"key": "healthcare", "value": "pharmacy"},
-    {"key": "healthcare", "value": "physiotherapist"},
-    {"key": "healthcare", "value": "sample_collection"},
+    {
+      "key": "healthcare",
+      "value": "physiotherapist",
+      "doc_url": "https://nsi.guide/?t=brands&k=healthcare&v=physiotherapist"
+    },
+    {
+      "key": "healthcare",
+      "value": "sample_collection",
+      "doc_url": "https://nsi.guide/?t=brands&k=healthcare&v=sample_collection"
+    },
     {"key": "hgv", "value": "only"},
     {"key": "hgv", "value": "yes"},
-    {"key": "highway", "value": "bus_stop"},
-    {"key": "highway", "value": "services"},
-    {"key": "highway", "value": "street_lamp"},
-    {"key": "highway", "value": "toll_gantry"},
+    {
+      "key": "highway",
+      "value": "bus_stop",
+      "doc_url": "https://nsi.guide/?t=transit&k=highway&v=bus_stop"
+    },
+    {
+      "key": "highway",
+      "value": "services",
+      "doc_url": "https://nsi.guide/?t=operators&k=highway&v=services"
+    },
+    {
+      "key": "highway",
+      "value": "street_lamp",
+      "doc_url": "https://nsi.guide/?t=operators&k=highway&v=street_lamp"
+    },
+    {
+      "key": "highway",
+      "value": "toll_gantry",
+      "doc_url": "https://nsi.guide/?t=operators&k=highway&v=toll_gantry"
+    },
     {"key": "indoor", "value": "yes"},
     {"key": "industrial", "value": "concrete_plant"},
     {"key": "industrial", "value": "depot"},
@@ -797,51 +1209,191 @@
     {"key": "internet_access:fee", "value": "yes"},
     {"key": "internet_access:operator"},
     {"key": "internet_access:ssid"},
-    {"key": "internet_access", "value": "wlan"},
+    {
+      "key": "internet_access",
+      "value": "wlan",
+      "doc_url": "https://nsi.guide/?t=operators&k=internet_access&v=wlan"
+    },
     {"key": "isced:level", "value": "0"},
-    {"key": "landuse", "value": "industrial"},
-    {"key": "landuse", "value": "quarry"},
-    {"key": "landuse", "value": "residential"},
-    {"key": "landuse", "value": "retail"},
+    {
+      "key": "landuse",
+      "value": "industrial",
+      "doc_url": "https://nsi.guide/?t=operators&k=landuse&v=industrial"
+    },
+    {
+      "key": "landuse",
+      "value": "quarry",
+      "doc_url": "https://nsi.guide/?t=operators&k=landuse&v=quarry"
+    },
+    {
+      "key": "landuse",
+      "value": "residential",
+      "doc_url": "https://nsi.guide/?t=operators&k=landuse&v=residential"
+    },
+    {
+      "key": "landuse",
+      "value": "retail",
+      "doc_url": "https://nsi.guide/?t=operators&k=landuse&v=retail"
+    },
     {"key": "language:en", "value": "main"},
     {"key": "language:en", "value": "yes"},
     {"key": "language:es", "value": "yes"},
     {"key": "language:ja", "value": "main"},
     {"key": "language:ja", "value": "yes"},
     {"key": "language:ko", "value": "yes"},
-    {"key": "leisure", "value": "adult_gaming_centre"},
-    {"key": "leisure", "value": "amusement_arcade"},
-    {"key": "leisure", "value": "bowling_alley"},
-    {"key": "leisure", "value": "dance"},
-    {"key": "leisure", "value": "dog_park"},
-    {"key": "leisure", "value": "escape_game"},
-    {"key": "leisure", "value": "fitness_centre"},
-    {"key": "leisure", "value": "fitness_station"},
-    {"key": "leisure", "value": "indoor_play"},
-    {"key": "leisure", "value": "miniature_golf"},
-    {"key": "leisure", "value": "nature_reserve"},
-    {"key": "leisure", "value": "park"},
-    {"key": "leisure", "value": "pitch"},
-    {"key": "leisure", "value": "playground"},
-    {"key": "leisure", "value": "sports_centre"},
-    {"key": "leisure", "value": "trampoline_park"},
+    {
+      "key": "leisure",
+      "value": "adult_gaming_centre",
+      "doc_url": "https://nsi.guide/?t=brands&k=leisure&v=adult_gaming_centre"
+    },
+    {
+      "key": "leisure",
+      "value": "amusement_arcade",
+      "doc_url": "https://nsi.guide/?t=brands&k=leisure&v=amusement_arcade"
+    },
+    {
+      "key": "leisure",
+      "value": "bowling_alley",
+      "doc_url": "https://nsi.guide/?t=brands&k=leisure&v=bowling_alley"
+    },
+    {
+      "key": "leisure",
+      "value": "dance",
+      "doc_url": "https://nsi.guide/?t=brands&k=leisure&v=dance"
+    },
+    {
+      "key": "leisure",
+      "value": "dog_park",
+      "doc_url": "https://nsi.guide/?t=brands&k=leisure&v=dog_park"
+    },
+    {
+      "key": "leisure",
+      "value": "escape_game",
+      "doc_url": "https://nsi.guide/?t=brands&k=leisure&v=escape_game"
+    },
+    {
+      "key": "leisure",
+      "value": "fitness_centre",
+      "doc_url": "https://nsi.guide/?t=brands&k=leisure&v=fitness_centre"
+    },
+    {
+      "key": "leisure",
+      "value": "fitness_station",
+      "doc_url": "https://nsi.guide/?t=brands&k=leisure&v=fitness_station"
+    },
+    {
+      "key": "leisure",
+      "value": "indoor_play",
+      "doc_url": "https://nsi.guide/?t=brands&k=leisure&v=indoor_play"
+    },
+    {
+      "key": "leisure",
+      "value": "miniature_golf",
+      "doc_url": "https://nsi.guide/?t=brands&k=leisure&v=miniature_golf"
+    },
+    {
+      "key": "leisure",
+      "value": "nature_reserve",
+      "doc_url": "https://nsi.guide/?t=operators&k=leisure&v=nature_reserve"
+    },
+    {
+      "key": "leisure",
+      "value": "park",
+      "doc_url": "https://nsi.guide/?t=operators&k=leisure&v=park"
+    },
+    {
+      "key": "leisure",
+      "value": "pitch",
+      "doc_url": "https://nsi.guide/?t=operators&k=leisure&v=pitch"
+    },
+    {
+      "key": "leisure",
+      "value": "playground",
+      "doc_url": "https://nsi.guide/?t=brands&k=leisure&v=playground"
+    },
+    {
+      "key": "leisure",
+      "value": "sports_centre",
+      "doc_url": "https://nsi.guide/?t=brands&k=leisure&v=sports_centre"
+    },
+    {
+      "key": "leisure",
+      "value": "trampoline_park",
+      "doc_url": "https://nsi.guide/?t=brands&k=leisure&v=trampoline_park"
+    },
     {"key": "light_rail", "value": "yes"},
     {"key": "live_music", "value": "yes"},
     {"key": "male", "value": "yes"},
-    {"key": "man_made", "value": "charge_point"},
-    {"key": "man_made", "value": "flagpole"},
-    {"key": "man_made", "value": "mast"},
-    {"key": "man_made", "value": "monitoring_station"},
-    {"key": "man_made", "value": "pipeline"},
-    {"key": "man_made", "value": "pumping_station"},
-    {"key": "man_made", "value": "street_cabinet"},
-    {"key": "man_made", "value": "surveillance"},
-    {"key": "man_made", "value": "survey_point"},
-    {"key": "man_made", "value": "tower"},
-    {"key": "man_made", "value": "wastewater_plant"},
-    {"key": "man_made", "value": "water_tower"},
-    {"key": "man_made", "value": "water_works"},
-    {"key": "man_made", "value": "works"},
+    {
+      "key": "man_made",
+      "value": "charge_point",
+      "doc_url": "https://nsi.guide/?t=operators&k=man_made&v=charge_point"
+    },
+    {
+      "key": "man_made",
+      "value": "flagpole",
+      "doc_url": "https://nsi.guide/?t=flags&k=man_made&v=flagpole"
+    },
+    {
+      "key": "man_made",
+      "value": "mast",
+      "doc_url": "https://nsi.guide/?t=operators&k=man_made&v=mast"
+    },
+    {
+      "key": "man_made",
+      "value": "monitoring_station",
+      "doc_url": "https://nsi.guide/?t=operators&k=man_made&v=monitoring_station"
+    },
+    {
+      "key": "man_made",
+      "value": "pipeline",
+      "doc_url": "https://nsi.guide/?t=operators&k=man_made&v=pipeline"
+    },
+    {
+      "key": "man_made",
+      "value": "pumping_station",
+      "doc_url": "https://nsi.guide/?t=operators&k=man_made&v=pumping_station"
+    },
+    {
+      "key": "man_made",
+      "value": "street_cabinet",
+      "doc_url": "https://nsi.guide/?t=operators&k=man_made&v=street_cabinet"
+    },
+    {
+      "key": "man_made",
+      "value": "surveillance",
+      "doc_url": "https://nsi.guide/?t=operators&k=man_made&v=surveillance"
+    },
+    {
+      "key": "man_made",
+      "value": "survey_point",
+      "doc_url": "https://nsi.guide/?t=operators&k=man_made&v=survey_point"
+    },
+    {
+      "key": "man_made",
+      "value": "tower",
+      "doc_url": "https://nsi.guide/?t=operators&k=man_made&v=tower"
+    },
+    {
+      "key": "man_made",
+      "value": "wastewater_plant",
+      "doc_url": "https://nsi.guide/?t=operators&k=man_made&v=wastewater_plant"
+    },
+    {
+      "key": "man_made",
+      "value": "water_tower",
+      "doc_url": "https://nsi.guide/?t=operators&k=man_made&v=water_tower"
+    },
+    {
+      "key": "man_made",
+      "value": "water_works",
+      "doc_url": "https://nsi.guide/?t=operators&k=man_made&v=water_works"
+    },
+    {
+      "key": "man_made",
+      "value": "works",
+      "doc_url": "https://nsi.guide/?t=operators&k=man_made&v=works"
+    },
     {"key": "map_size", "value": "local"},
     {"key": "map_type", "value": "street"},
     {"key": "max_age"},
@@ -922,7 +1474,11 @@
     {"key": "name:zh-Hant"},
     {"key": "name:zh"},
     {"key": "name"},
-    {"key": "natural", "value": "water"},
+    {
+      "key": "natural",
+      "value": "water",
+      "doc_url": "https://nsi.guide/?t=operators&k=natural&v=water"
+    },
     {"key": "network:de"},
     {"key": "network:el"},
     {"key": "network:en"},
@@ -957,32 +1513,124 @@
     {"key": "network:zh"},
     {"key": "network"},
     {"key": "nursery", "value": "yes"},
-    {"key": "office", "value": "association"},
-    {"key": "office", "value": "bail_bond_agent"},
-    {"key": "office", "value": "company"},
-    {"key": "office", "value": "consulting"},
-    {"key": "office", "value": "coworking"},
-    {"key": "office", "value": "employment_agency"},
-    {"key": "office", "value": "energy_supplier"},
-    {"key": "office", "value": "engineer"},
-    {"key": "office", "value": "estate_agent"},
-    {"key": "office", "value": "financial"},
-    {"key": "office", "value": "financial_advisor"},
-    {"key": "office", "value": "government"},
-    {"key": "office", "value": "insurance"},
-    {"key": "office", "value": "insurance_adjuster"},
-    {"key": "office", "value": "it"},
-    {"key": "office", "value": "lawyer"},
-    {"key": "office", "value": "logistics"},
-    {"key": "office", "value": "mortgage"},
-    {"key": "office", "value": "moving_company"},
-    {"key": "office", "value": "political_party"},
-    {"key": "office", "value": "security"},
-    {"key": "office", "value": "tax_advisor"},
-    {"key": "office", "value": "telecommunication"},
-    {"key": "office", "value": "union"},
-    {"key": "office", "value": "visa"},
-    {"key": "office", "value": "water_utility"},
+    {
+      "key": "office",
+      "value": "association",
+      "doc_url": "https://nsi.guide/?t=operators&k=office&v=association"
+    },
+    {
+      "key": "office",
+      "value": "bail_bond_agent",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=bail_bond_agent"
+    },
+    {
+      "key": "office",
+      "value": "company",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=company"
+    },
+    {
+      "key": "office",
+      "value": "consulting",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=consulting"
+    },
+    {
+      "key": "office",
+      "value": "coworking",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=coworking"
+    },
+    {
+      "key": "office",
+      "value": "employment_agency",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=employment_agency"
+    },
+    {
+      "key": "office",
+      "value": "energy_supplier",
+      "doc_url": "https://nsi.guide/?t=operators&k=office&v=energy_supplier"
+    },
+    {
+      "key": "office",
+      "value": "engineer",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=engineer"
+    },
+    {
+      "key": "office",
+      "value": "estate_agent",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=estate_agent"
+    },
+    {
+      "key": "office",
+      "value": "financial",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=financial"
+    },
+    {
+      "key": "office",
+      "value": "financial_advisor",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=financial_advisor"
+    },
+    {
+      "key": "office",
+      "value": "government",
+      "doc_url": "https://nsi.guide/?t=operators&k=office&v=government"
+    },
+    {
+      "key": "office",
+      "value": "insurance",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=insurance"
+    },
+    {
+      "key": "office",
+      "value": "insurance_adjuster",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=insurance_adjuster"
+    },
+    {"key": "office", "value": "it", "doc_url": "https://nsi.guide/?t=brands&k=office&v=it"},
+    {
+      "key": "office",
+      "value": "lawyer",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=lawyer"
+    },
+    {
+      "key": "office",
+      "value": "logistics",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=logistics"
+    },
+    {
+      "key": "office",
+      "value": "mortgage",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=mortgage"
+    },
+    {
+      "key": "office",
+      "value": "moving_company",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=moving_company"
+    },
+    {
+      "key": "office",
+      "value": "political_party",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=political_party"
+    },
+    {
+      "key": "office",
+      "value": "security",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=security"
+    },
+    {
+      "key": "office",
+      "value": "tax_advisor",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=tax_advisor"
+    },
+    {
+      "key": "office",
+      "value": "telecommunication",
+      "doc_url": "https://nsi.guide/?t=brands&k=office&v=telecommunication"
+    },
+    {"key": "office", "value": "union", "doc_url": "https://nsi.guide/?t=brands&k=office&v=union"},
+    {"key": "office", "value": "visa", "doc_url": "https://nsi.guide/?t=operators&k=office&v=visa"},
+    {
+      "key": "office",
+      "value": "water_utility",
+      "doc_url": "https://nsi.guide/?t=operators&k=office&v=water_utility"
+    },
     {"key": "official_name:ar"},
     {"key": "official_name:de"},
     {"key": "official_name:en"},
@@ -1143,16 +1791,40 @@
     {"key": "payment:visa_electron", "value": "yes"},
     {"key": "payment:visa", "value": "yes"},
     {"key": "pet", "value": "fish"},
-    {"key": "pipeline", "value": "substation"},
-    {"key": "power", "value": "catenary_mast"},
-    {"key": "power", "value": "generator"},
-    {"key": "power", "value": "line"},
-    {"key": "power", "value": "minor_line"},
-    {"key": "power", "value": "plant"},
-    {"key": "power", "value": "pole"},
-    {"key": "power", "value": "substation"},
-    {"key": "power", "value": "tower"},
-    {"key": "power", "value": "transformer"},
+    {
+      "key": "pipeline",
+      "value": "substation",
+      "doc_url": "https://nsi.guide/?t=operators&k=pipeline&v=substation"
+    },
+    {
+      "key": "power",
+      "value": "catenary_mast",
+      "doc_url": "https://nsi.guide/?t=operators&k=power&v=catenary_mast"
+    },
+    {
+      "key": "power",
+      "value": "generator",
+      "doc_url": "https://nsi.guide/?t=operators&k=power&v=generator"
+    },
+    {"key": "power", "value": "line", "doc_url": "https://nsi.guide/?t=operators&k=power&v=line"},
+    {
+      "key": "power",
+      "value": "minor_line",
+      "doc_url": "https://nsi.guide/?t=operators&k=power&v=minor_line"
+    },
+    {"key": "power", "value": "plant", "doc_url": "https://nsi.guide/?t=operators&k=power&v=plant"},
+    {"key": "power", "value": "pole", "doc_url": "https://nsi.guide/?t=operators&k=power&v=pole"},
+    {
+      "key": "power",
+      "value": "substation",
+      "doc_url": "https://nsi.guide/?t=operators&k=power&v=substation"
+    },
+    {"key": "power", "value": "tower", "doc_url": "https://nsi.guide/?t=operators&k=power&v=tower"},
+    {
+      "key": "power",
+      "value": "transformer",
+      "doc_url": "https://nsi.guide/?t=operators&k=power&v=transformer"
+    },
     {"key": "preschool", "value": "yes"},
     {"key": "product", "value": "concrete"},
     {"key": "protected", "value": "perpetuity"},
@@ -1166,8 +1838,16 @@
     {"key": "railway:network:wikidata"},
     {"key": "railway:network:zh"},
     {"key": "railway:network"},
-    {"key": "railway", "value": "station"},
-    {"key": "railway", "value": "tram_stop"},
+    {
+      "key": "railway",
+      "value": "station",
+      "doc_url": "https://nsi.guide/?t=transit&k=railway&v=station"
+    },
+    {
+      "key": "railway",
+      "value": "tram_stop",
+      "doc_url": "https://nsi.guide/?t=transit&k=railway&v=tram_stop"
+    },
     {"key": "recycling_type", "value": "centre"},
     {"key": "recycling_type", "value": "container"},
     {"key": "recycling_type", "value": "vending_machine"},
@@ -1199,18 +1879,42 @@
     {"key": "reservation", "value": "yes"},
     {"key": "residential", "value": "apartments"},
     {"key": "residential", "value": "trailer_park"},
-    {"key": "route", "value": "aerialway"},
-    {"key": "route", "value": "bus"},
-    {"key": "route", "value": "ferry"},
-    {"key": "route", "value": "light_rail"},
-    {"key": "route", "value": "power"},
-    {"key": "route", "value": "railway"},
-    {"key": "route", "value": "subway"},
-    {"key": "route", "value": "tracks"},
-    {"key": "route", "value": "train"},
-    {"key": "route", "value": "tram"},
-    {"key": "route", "value": "trolleybus"},
-    {"key": "route", "value": "walking_bus"},
+    {
+      "key": "route",
+      "value": "aerialway",
+      "doc_url": "https://nsi.guide/?t=transit&k=route&v=aerialway"
+    },
+    {"key": "route", "value": "bus", "doc_url": "https://nsi.guide/?t=transit&k=route&v=bus"},
+    {"key": "route", "value": "ferry", "doc_url": "https://nsi.guide/?t=transit&k=route&v=ferry"},
+    {
+      "key": "route",
+      "value": "light_rail",
+      "doc_url": "https://nsi.guide/?t=transit&k=route&v=light_rail"
+    },
+    {"key": "route", "value": "power", "doc_url": "https://nsi.guide/?t=operators&k=route&v=power"},
+    {
+      "key": "route",
+      "value": "railway",
+      "doc_url": "https://nsi.guide/?t=operators&k=route&v=railway"
+    },
+    {"key": "route", "value": "subway", "doc_url": "https://nsi.guide/?t=transit&k=route&v=subway"},
+    {
+      "key": "route",
+      "value": "tracks",
+      "doc_url": "https://nsi.guide/?t=operators&k=route&v=tracks"
+    },
+    {"key": "route", "value": "train", "doc_url": "https://nsi.guide/?t=transit&k=route&v=train"},
+    {"key": "route", "value": "tram", "doc_url": "https://nsi.guide/?t=transit&k=route&v=tram"},
+    {
+      "key": "route",
+      "value": "trolleybus",
+      "doc_url": "https://nsi.guide/?t=transit&k=route&v=trolleybus"
+    },
+    {
+      "key": "route",
+      "value": "walking_bus",
+      "doc_url": "https://nsi.guide/?t=transit&k=route&v=walking_bus"
+    },
     {"key": "seamark:small_craft_facility:category", "value": "chandler"},
     {"key": "seamark:type", "value": "small_craft_facility"},
     {"key": "second_hand", "value": "only"},
@@ -1235,154 +1939,450 @@
     {"key": "shoes", "value": "orthopaedic"},
     {"key": "shoes", "value": "sport"},
     {"key": "shoes", "value": "women"},
-    {"key": "shop", "value": "agrarian"},
-    {"key": "shop", "value": "alcohol"},
-    {"key": "shop", "value": "anime"},
-    {"key": "shop", "value": "appliance"},
-    {"key": "shop", "value": "art"},
-    {"key": "shop", "value": "baby_goods"},
-    {"key": "shop", "value": "bag"},
-    {"key": "shop", "value": "bakery"},
-    {"key": "shop", "value": "bathroom_furnishing"},
-    {"key": "shop", "value": "bbq"},
-    {"key": "shop", "value": "beauty"},
-    {"key": "shop", "value": "bed"},
-    {"key": "shop", "value": "beverages"},
-    {"key": "shop", "value": "bicycle"},
-    {"key": "shop", "value": "boat"},
-    {"key": "shop", "value": "bookmaker"},
-    {"key": "shop", "value": "books"},
-    {"key": "shop", "value": "butcher"},
-    {"key": "shop", "value": "camera"},
-    {"key": "shop", "value": "candles"},
-    {"key": "shop", "value": "cannabis"},
-    {"key": "shop", "value": "car"},
-    {"key": "shop", "value": "car_parts"},
-    {"key": "shop", "value": "car_repair"},
-    {"key": "shop", "value": "caravan"},
-    {"key": "shop", "value": "carpet"},
-    {"key": "shop", "value": "catalogue"},
-    {"key": "shop", "value": "charity"},
-    {"key": "shop", "value": "cheese"},
-    {"key": "shop", "value": "chemist"},
-    {"key": "shop", "value": "chocolate"},
-    {"key": "shop", "value": "clothes"},
-    {"key": "shop", "value": "coffee"},
-    {"key": "shop", "value": "computer"},
-    {"key": "shop", "value": "confectionery"},
-    {"key": "shop", "value": "convenience"},
-    {"key": "shop", "value": "copyshop"},
-    {"key": "shop", "value": "cosmetics"},
-    {"key": "shop", "value": "country_store"},
-    {"key": "shop", "value": "craft"},
-    {"key": "shop", "value": "curtain"},
-    {"key": "shop", "value": "dairy"},
-    {"key": "shop", "value": "deli"},
-    {"key": "shop", "value": "department_store"},
-    {"key": "shop", "value": "doityourself"},
-    {"key": "shop", "value": "doors"},
-    {"key": "shop", "value": "dry_cleaning"},
-    {"key": "shop", "value": "e-cigarette"},
-    {"key": "shop", "value": "electrical"},
-    {"key": "shop", "value": "electronics"},
-    {"key": "shop", "value": "erotic"},
-    {"key": "shop", "value": "fabric"},
-    {"key": "shop", "value": "fashion_accessories"},
-    {"key": "shop", "value": "fishing"},
-    {"key": "shop", "value": "flooring"},
-    {"key": "shop", "value": "florist"},
-    {"key": "shop", "value": "frame"},
-    {"key": "shop", "value": "frozen_food"},
-    {"key": "shop", "value": "funeral_directors"},
-    {"key": "shop", "value": "furniture"},
-    {"key": "shop", "value": "games"},
-    {"key": "shop", "value": "garden_centre"},
-    {"key": "shop", "value": "gas"},
-    {"key": "shop", "value": "general"},
-    {"key": "shop", "value": "gift"},
-    {"key": "shop", "value": "gold_buyer"},
-    {"key": "shop", "value": "greengrocer"},
-    {"key": "shop", "value": "hairdresser"},
-    {"key": "shop", "value": "hairdresser_supply"},
-    {"key": "shop", "value": "hardware"},
-    {"key": "shop", "value": "health_food"},
-    {"key": "shop", "value": "hearing_aids"},
-    {"key": "shop", "value": "herbalist"},
-    {"key": "shop", "value": "hifi"},
-    {"key": "shop", "value": "household_linen"},
-    {"key": "shop", "value": "houseware"},
-    {"key": "shop", "value": "interior_decoration"},
-    {"key": "shop", "value": "jewelry"},
-    {"key": "shop", "value": "kiosk"},
-    {"key": "shop", "value": "kitchen"},
-    {"key": "shop", "value": "laundry"},
-    {"key": "shop", "value": "leather"},
-    {"key": "shop", "value": "lighting"},
-    {"key": "shop", "value": "locksmith"},
-    {"key": "shop", "value": "lottery"},
-    {"key": "shop", "value": "mall"},
-    {"key": "shop", "value": "massage"},
-    {"key": "shop", "value": "medical_supply"},
-    {"key": "shop", "value": "mobile_phone"},
-    {"key": "shop", "value": "mobile_phone_accessories"},
-    {"key": "shop", "value": "model"},
-    {"key": "shop", "value": "money_lender"},
-    {"key": "shop", "value": "motorcycle"},
-    {"key": "shop", "value": "motorcycle_repair"},
-    {"key": "shop", "value": "music"},
-    {"key": "shop", "value": "musical_instrument"},
-    {"key": "shop", "value": "newsagent"},
-    {"key": "shop", "value": "nutrition_supplements"},
-    {"key": "shop", "value": "nuts"},
-    {"key": "shop", "value": "optician"},
-    {"key": "shop", "value": "outdoor"},
-    {"key": "shop", "value": "outpost"},
-    {"key": "shop", "value": "paint"},
-    {"key": "shop", "value": "party"},
-    {"key": "shop", "value": "pastry"},
-    {"key": "shop", "value": "pawnbroker"},
-    {"key": "shop", "value": "perfumery"},
-    {"key": "shop", "value": "pest_control"},
-    {"key": "shop", "value": "pet"},
-    {"key": "shop", "value": "photo"},
-    {"key": "shop", "value": "plant_hire"},
-    {"key": "shop", "value": "pottery"},
-    {"key": "shop", "value": "power_tools"},
-    {"key": "shop", "value": "printer_ink"},
-    {"key": "shop", "value": "pyrotechnics"},
-    {"key": "shop", "value": "rental"},
-    {"key": "shop", "value": "repair"},
-    {"key": "shop", "value": "seafood"},
-    {"key": "shop", "value": "second_hand"},
-    {"key": "shop", "value": "shoes"},
-    {"key": "shop", "value": "spices"},
-    {"key": "shop", "value": "sports"},
-    {"key": "shop", "value": "stationery"},
-    {"key": "shop", "value": "storage_rental"},
-    {"key": "shop", "value": "supermarket"},
-    {"key": "shop", "value": "swimming_pool"},
-    {"key": "shop", "value": "tailor"},
-    {"key": "shop", "value": "tattoo"},
-    {"key": "shop", "value": "tea"},
-    {"key": "shop", "value": "telecommunication"},
-    {"key": "shop", "value": "ticket"},
-    {"key": "shop", "value": "tiles"},
-    {"key": "shop", "value": "tobacco"},
-    {"key": "shop", "value": "tool_hire"},
-    {"key": "shop", "value": "toys"},
-    {"key": "shop", "value": "trade"},
-    {"key": "shop", "value": "travel_agency"},
-    {"key": "shop", "value": "truck"},
-    {"key": "shop", "value": "truck_repair"},
-    {"key": "shop", "value": "tyres"},
-    {"key": "shop", "value": "vacuum_cleaner"},
-    {"key": "shop", "value": "variety_store"},
-    {"key": "shop", "value": "video"},
-    {"key": "shop", "value": "video_games"},
-    {"key": "shop", "value": "watches"},
-    {"key": "shop", "value": "wholesale"},
-    {"key": "shop", "value": "window_blind"},
-    {"key": "shop", "value": "wine"},
+    {
+      "key": "shop",
+      "value": "agrarian",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=agrarian"
+    },
+    {"key": "shop", "value": "alcohol", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=alcohol"},
+    {"key": "shop", "value": "anime", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=anime"},
+    {
+      "key": "shop",
+      "value": "appliance",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=appliance"
+    },
+    {"key": "shop", "value": "art", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=art"},
+    {
+      "key": "shop",
+      "value": "baby_goods",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=baby_goods"
+    },
+    {"key": "shop", "value": "bag", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=bag"},
+    {"key": "shop", "value": "bakery", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=bakery"},
+    {
+      "key": "shop",
+      "value": "bathroom_furnishing",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=bathroom_furnishing"
+    },
+    {"key": "shop", "value": "bbq", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=bbq"},
+    {"key": "shop", "value": "beauty", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=beauty"},
+    {"key": "shop", "value": "bed", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=bed"},
+    {
+      "key": "shop",
+      "value": "beverages",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=beverages"
+    },
+    {"key": "shop", "value": "bicycle", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=bicycle"},
+    {"key": "shop", "value": "boat", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=boat"},
+    {
+      "key": "shop",
+      "value": "bookmaker",
+      "doc_url": "https://nsi.guide/?t=operators&k=shop&v=bookmaker"
+    },
+    {"key": "shop", "value": "books", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=books"},
+    {"key": "shop", "value": "butcher", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=butcher"},
+    {"key": "shop", "value": "camera", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=camera"},
+    {"key": "shop", "value": "candles", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=candles"},
+    {
+      "key": "shop",
+      "value": "cannabis",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=cannabis"
+    },
+    {"key": "shop", "value": "car", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=car"},
+    {
+      "key": "shop",
+      "value": "car_parts",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=car_parts"
+    },
+    {
+      "key": "shop",
+      "value": "car_repair",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=car_repair"
+    },
+    {"key": "shop", "value": "caravan", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=caravan"},
+    {"key": "shop", "value": "carpet", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=carpet"},
+    {
+      "key": "shop",
+      "value": "catalogue",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=catalogue"
+    },
+    {
+      "key": "shop",
+      "value": "charity",
+      "doc_url": "https://nsi.guide/?t=operators&k=shop&v=charity"
+    },
+    {"key": "shop", "value": "cheese", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=cheese"},
+    {"key": "shop", "value": "chemist", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=chemist"},
+    {
+      "key": "shop",
+      "value": "chocolate",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=chocolate"
+    },
+    {"key": "shop", "value": "clothes", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=clothes"},
+    {"key": "shop", "value": "coffee", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=coffee"},
+    {
+      "key": "shop",
+      "value": "computer",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=computer"
+    },
+    {
+      "key": "shop",
+      "value": "confectionery",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=confectionery"
+    },
+    {
+      "key": "shop",
+      "value": "convenience",
+      "doc_url": "https://nsi.guide/?t=operators&k=shop&v=convenience"
+    },
+    {
+      "key": "shop",
+      "value": "copyshop",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=copyshop"
+    },
+    {
+      "key": "shop",
+      "value": "cosmetics",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=cosmetics"
+    },
+    {
+      "key": "shop",
+      "value": "country_store",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=country_store"
+    },
+    {"key": "shop", "value": "craft", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=craft"},
+    {"key": "shop", "value": "curtain", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=curtain"},
+    {"key": "shop", "value": "dairy", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=dairy"},
+    {"key": "shop", "value": "deli", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=deli"},
+    {
+      "key": "shop",
+      "value": "department_store",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=department_store"
+    },
+    {
+      "key": "shop",
+      "value": "doityourself",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=doityourself"
+    },
+    {"key": "shop", "value": "doors", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=doors"},
+    {
+      "key": "shop",
+      "value": "dry_cleaning",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=dry_cleaning"
+    },
+    {
+      "key": "shop",
+      "value": "e-cigarette",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=e-cigarette"
+    },
+    {
+      "key": "shop",
+      "value": "electrical",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=electrical"
+    },
+    {
+      "key": "shop",
+      "value": "electronics",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=electronics"
+    },
+    {"key": "shop", "value": "erotic", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=erotic"},
+    {"key": "shop", "value": "fabric", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=fabric"},
+    {
+      "key": "shop",
+      "value": "fashion_accessories",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=fashion_accessories"
+    },
+    {"key": "shop", "value": "fishing", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=fishing"},
+    {
+      "key": "shop",
+      "value": "flooring",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=flooring"
+    },
+    {"key": "shop", "value": "florist", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=florist"},
+    {"key": "shop", "value": "frame", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=frame"},
+    {
+      "key": "shop",
+      "value": "frozen_food",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=frozen_food"
+    },
+    {
+      "key": "shop",
+      "value": "funeral_directors",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=funeral_directors"
+    },
+    {
+      "key": "shop",
+      "value": "furniture",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=furniture"
+    },
+    {"key": "shop", "value": "games", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=games"},
+    {
+      "key": "shop",
+      "value": "garden_centre",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=garden_centre"
+    },
+    {"key": "shop", "value": "gas", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=gas"},
+    {"key": "shop", "value": "general", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=general"},
+    {"key": "shop", "value": "gift", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=gift"},
+    {
+      "key": "shop",
+      "value": "gold_buyer",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=gold_buyer"
+    },
+    {
+      "key": "shop",
+      "value": "greengrocer",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=greengrocer"
+    },
+    {
+      "key": "shop",
+      "value": "hairdresser",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=hairdresser"
+    },
+    {
+      "key": "shop",
+      "value": "hairdresser_supply",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=hairdresser_supply"
+    },
+    {
+      "key": "shop",
+      "value": "hardware",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=hardware"
+    },
+    {
+      "key": "shop",
+      "value": "health_food",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=health_food"
+    },
+    {
+      "key": "shop",
+      "value": "hearing_aids",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=hearing_aids"
+    },
+    {
+      "key": "shop",
+      "value": "herbalist",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=herbalist"
+    },
+    {"key": "shop", "value": "hifi", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=hifi"},
+    {
+      "key": "shop",
+      "value": "household_linen",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=household_linen"
+    },
+    {
+      "key": "shop",
+      "value": "houseware",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=houseware"
+    },
+    {
+      "key": "shop",
+      "value": "interior_decoration",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=interior_decoration"
+    },
+    {"key": "shop", "value": "jewelry", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=jewelry"},
+    {"key": "shop", "value": "kiosk", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=kiosk"},
+    {"key": "shop", "value": "kitchen", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=kitchen"},
+    {"key": "shop", "value": "laundry", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=laundry"},
+    {"key": "shop", "value": "leather", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=leather"},
+    {
+      "key": "shop",
+      "value": "lighting",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=lighting"
+    },
+    {
+      "key": "shop",
+      "value": "locksmith",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=locksmith"
+    },
+    {"key": "shop", "value": "lottery", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=lottery"},
+    {"key": "shop", "value": "mall", "doc_url": "https://nsi.guide/?t=operators&k=shop&v=mall"},
+    {"key": "shop", "value": "massage", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=massage"},
+    {
+      "key": "shop",
+      "value": "medical_supply",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=medical_supply"
+    },
+    {
+      "key": "shop",
+      "value": "mobile_phone",
+      "doc_url": "https://nsi.guide/?t=operators&k=shop&v=mobile_phone"
+    },
+    {
+      "key": "shop",
+      "value": "mobile_phone_accessories",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=mobile_phone_accessories"
+    },
+    {"key": "shop", "value": "model", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=model"},
+    {
+      "key": "shop",
+      "value": "money_lender",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=money_lender"
+    },
+    {
+      "key": "shop",
+      "value": "motorcycle",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=motorcycle"
+    },
+    {
+      "key": "shop",
+      "value": "motorcycle_repair",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=motorcycle_repair"
+    },
+    {"key": "shop", "value": "music", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=music"},
+    {
+      "key": "shop",
+      "value": "musical_instrument",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=musical_instrument"
+    },
+    {
+      "key": "shop",
+      "value": "newsagent",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=newsagent"
+    },
+    {
+      "key": "shop",
+      "value": "nutrition_supplements",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=nutrition_supplements"
+    },
+    {"key": "shop", "value": "nuts", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=nuts"},
+    {
+      "key": "shop",
+      "value": "optician",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=optician"
+    },
+    {"key": "shop", "value": "outdoor", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=outdoor"},
+    {"key": "shop", "value": "outpost", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=outpost"},
+    {"key": "shop", "value": "paint", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=paint"},
+    {"key": "shop", "value": "party", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=party"},
+    {"key": "shop", "value": "pastry", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=pastry"},
+    {
+      "key": "shop",
+      "value": "pawnbroker",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=pawnbroker"
+    },
+    {
+      "key": "shop",
+      "value": "perfumery",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=perfumery"
+    },
+    {
+      "key": "shop",
+      "value": "pest_control",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=pest_control"
+    },
+    {"key": "shop", "value": "pet", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=pet"},
+    {"key": "shop", "value": "photo", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=photo"},
+    {
+      "key": "shop",
+      "value": "plant_hire",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=plant_hire"
+    },
+    {"key": "shop", "value": "pottery", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=pottery"},
+    {
+      "key": "shop",
+      "value": "power_tools",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=power_tools"
+    },
+    {
+      "key": "shop",
+      "value": "printer_ink",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=printer_ink"
+    },
+    {
+      "key": "shop",
+      "value": "pyrotechnics",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=pyrotechnics"
+    },
+    {"key": "shop", "value": "rental", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=rental"},
+    {"key": "shop", "value": "repair", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=repair"},
+    {"key": "shop", "value": "seafood", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=seafood"},
+    {
+      "key": "shop",
+      "value": "second_hand",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=second_hand"
+    },
+    {"key": "shop", "value": "shoes", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=shoes"},
+    {"key": "shop", "value": "spices", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=spices"},
+    {"key": "shop", "value": "sports", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=sports"},
+    {
+      "key": "shop",
+      "value": "stationery",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=stationery"
+    },
+    {
+      "key": "shop",
+      "value": "storage_rental",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=storage_rental"
+    },
+    {
+      "key": "shop",
+      "value": "supermarket",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=supermarket"
+    },
+    {
+      "key": "shop",
+      "value": "swimming_pool",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=swimming_pool"
+    },
+    {"key": "shop", "value": "tailor", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=tailor"},
+    {"key": "shop", "value": "tattoo", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=tattoo"},
+    {"key": "shop", "value": "tea", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=tea"},
+    {
+      "key": "shop",
+      "value": "telecommunication",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=telecommunication"
+    },
+    {"key": "shop", "value": "ticket", "doc_url": "https://nsi.guide/?t=operators&k=shop&v=ticket"},
+    {"key": "shop", "value": "tiles", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=tiles"},
+    {"key": "shop", "value": "tobacco", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=tobacco"},
+    {
+      "key": "shop",
+      "value": "tool_hire",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=tool_hire"
+    },
+    {"key": "shop", "value": "toys", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=toys"},
+    {"key": "shop", "value": "trade", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=trade"},
+    {
+      "key": "shop",
+      "value": "travel_agency",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=travel_agency"
+    },
+    {"key": "shop", "value": "truck", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=truck"},
+    {
+      "key": "shop",
+      "value": "truck_repair",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=truck_repair"
+    },
+    {"key": "shop", "value": "tyres", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=tyres"},
+    {
+      "key": "shop",
+      "value": "vacuum_cleaner",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=vacuum_cleaner"
+    },
+    {
+      "key": "shop",
+      "value": "variety_store",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=variety_store"
+    },
+    {"key": "shop", "value": "video", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=video"},
+    {
+      "key": "shop",
+      "value": "video_games",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=video_games"
+    },
+    {"key": "shop", "value": "watches", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=watches"},
+    {
+      "key": "shop",
+      "value": "wholesale",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=wholesale"
+    },
+    {
+      "key": "shop",
+      "value": "window_blind",
+      "doc_url": "https://nsi.guide/?t=brands&k=shop&v=window_blind"
+    },
+    {"key": "shop", "value": "wine", "doc_url": "https://nsi.guide/?t=brands&k=shop&v=wine"},
     {"key": "short_name:bg"},
     {"key": "short_name:de"},
     {"key": "short_name:el"},
@@ -1453,20 +2453,60 @@
     {"key": "supervised", "value": "yes"},
     {"key": "takeaway", "value": "only"},
     {"key": "takeaway", "value": "yes"},
-    {"key": "telecom", "value": "data_center"},
-    {"key": "telecom", "value": "exchange"},
+    {
+      "key": "telecom",
+      "value": "data_center",
+      "doc_url": "https://nsi.guide/?t=operators&k=telecom&v=data_center"
+    },
+    {
+      "key": "telecom",
+      "value": "exchange",
+      "doc_url": "https://nsi.guide/?t=operators&k=telecom&v=exchange"
+    },
     {"key": "theme", "value": "irish"},
     {"key": "tickets:public_transport", "value": "only"},
     {"key": "tobacco", "value": "yes"},
     {"key": "toilets:disposal", "value": "flush"},
-    {"key": "tourism", "value": "camp_site"},
-    {"key": "tourism", "value": "caravan_site"},
-    {"key": "tourism", "value": "hostel"},
-    {"key": "tourism", "value": "hotel"},
-    {"key": "tourism", "value": "information"},
-    {"key": "tourism", "value": "motel"},
-    {"key": "tourism", "value": "theme_park"},
-    {"key": "tourism", "value": "wilderness_hut"},
+    {
+      "key": "tourism",
+      "value": "camp_site",
+      "doc_url": "https://nsi.guide/?t=operators&k=tourism&v=camp_site"
+    },
+    {
+      "key": "tourism",
+      "value": "caravan_site",
+      "doc_url": "https://nsi.guide/?t=brands&k=tourism&v=caravan_site"
+    },
+    {
+      "key": "tourism",
+      "value": "hostel",
+      "doc_url": "https://nsi.guide/?t=brands&k=tourism&v=hostel"
+    },
+    {
+      "key": "tourism",
+      "value": "hotel",
+      "doc_url": "https://nsi.guide/?t=brands&k=tourism&v=hotel"
+    },
+    {
+      "key": "tourism",
+      "value": "information",
+      "doc_url": "https://nsi.guide/?t=brands&k=tourism&v=information"
+    },
+    {
+      "key": "tourism",
+      "value": "motel",
+      "doc_url": "https://nsi.guide/?t=brands&k=tourism&v=motel"
+    },
+    {
+      "key": "tourism",
+      "value": "theme_park",
+      "doc_url": "https://nsi.guide/?t=brands&k=tourism&v=theme_park"
+    },
+    {
+      "key": "tourism",
+      "value": "wilderness_hut",
+      "doc_url": "https://nsi.guide/?t=operators&k=tourism&v=wilderness_hut"
+    },
     {"key": "tower:construction", "value": "freestanding"},
     {"key": "tower:type", "value": "communication"},
     {"key": "tower:type", "value": "lighting"},
@@ -1532,7 +2572,11 @@
     {"key": "walk-in", "value": "yes"},
     {"key": "waste", "value": "dog_excrement"},
     {"key": "water", "value": "reservoir"},
-    {"key": "waterway", "value": "fuel"},
+    {
+      "key": "waterway",
+      "value": "fuel",
+      "doc_url": "https://nsi.guide/?t=brands&k=waterway&v=fuel"
+    },
     {"key": "wheelchair", "value": "yes"},
     {"key": "wholesale", "value": "food"},
     {"key": "zero_waste", "value": "only"}

--- a/scripts/dist_files.js
+++ b/scripts/dist_files.js
@@ -504,7 +504,7 @@ function buildTaginfo() {
       'description': 'Canonical features for OpenStreetMap',
       'project_url': 'https://github.com/osmlab/name-suggestion-index',
       'doc_url': 'https://github.com/osmlab/name-suggestion-index/blob/main/README.md',
-      'icon_url': 'https://cdn.jsdelivr.net/npm/@mapbox/maki@6/icons/fastr-food-15.svg',
+      'icon_url': 'https://cdn.jsdelivr.net/npm/@mapbox/maki@6/icons/fast-food-15.svg',
       'contact_name': 'Bryan Housel',
       'contact_email': 'bhousel@gmail.com'
     }
@@ -512,24 +512,30 @@ function buildTaginfo() {
 
   // collect all tag pairs
   let tagPairs = {};
-  _cache.id.forEach(item => {
-    for (const k in item.tags) {
-      let v = item.tags[k];
+  for (const path in _cache.path) {
+    for (const item of _cache.path[path].items) {
+      for (const k in item.tags) {
+        let v = item.tags[k];
 
-      // Don't export every value for many tags this project uses..
-      // ('tag matches any of these')(?!('not followed by :type'))
-      if (/(bic|brand|brewery|country|flag|internet_access:ssid|max_age|min_age|name|network|operator|owner|ref|subject)(?!(:type))/.test(k)) {
-        v = '*';
-      }
+        // Don't export every value for many tags this project uses..
+        // ('tag matches any of these')(?!('not followed by :type'))
+        if (/(bic|brand|brewery|country|flag|internet_access:ssid|max_age|min_age|name|network|operator|owner|ref|subject)(?!(:type))/.test(k)) {
+          v = '*';
+        }
 
-      const kv = `${k}/${v}`;
-      tagPairs[kv] = { key: k };
+        const kv = `${k}/${v}`;
+        tagPairs[kv] ||= { key: k };
 
-      if (v !== '*') {
-        tagPairs[kv].value = v;
+        if (v !== '*') {
+          tagPairs[kv].value = v;
+          const [t, kPreset, vPreset] = path.split('/');
+          if (k === kPreset && v === vPreset) {
+            tagPairs[kv].doc_url = `${packageJSON.homepage}/?t=${t}&k=${k}&v=${v}`;
+          }
+        }
       }
     }
-  });
+  }
 
   taginfo.tags = Object.keys(tagPairs).sort(withLocale).map(kv => tagPairs[kv]);
   fs.writeFileSync('dist/taginfo.json', stringify(taginfo, { maxLength: 100 }) + '\n');


### PR DESCRIPTION
This allows people to go from taginfo directly to the NSI website to see how exactly the tag is used. I've committed the changes to `dist/taginfo.json` to show the impact of this change. 

Also fixed a broken URL for the project icon.