### PR TITLE
Update bank.json - Deleted Banca Intesa

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -1192,17 +1192,6 @@
       }
     },
     {
-      "displayName": "Banca Intesa",
-      "id": "bancaintesa-4a6838",
-      "locationSet": {"include": ["it", "rs"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Banca Intesa",
-        "brand:wikidata": "Q647092",
-        "name": "Banca Intesa"
-      }
-    },
-    {
       "displayName": "Banca March",
       "id": "bancamarch-ce59ab",
       "locationSet": {"include": ["es"]},
@@ -8064,6 +8053,7 @@
         "exclude": ["ua"]
       },
       "matchNames": [
+        "banca intesa",
         "banca popolare di vicenza",
         "banco di napoli",
         "cassa di risparmio del veneto",


### PR DESCRIPTION
As Banca Intesa was merged with Sanpaolo IMI in 2007 to create Intesa Sanpaolo.