### PR TITLE
Update bank.json - Deleted Banco di Sicilia

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -1659,17 +1659,6 @@
       }
     },
     {
-      "displayName": "Banco di Sicilia",
-      "id": "bancodisicilia-7b36b5",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Banco di Sicilia",
-        "brand:wikidata": "Q3633842",
-        "name": "Banco di Sicilia"
-      }
-    },
-    {
       "displayName": "Banco do Brasil",
       "id": "bancodobrasil-0ed44d",
       "locationSet": {"include": ["br"]},
@@ -12844,6 +12833,7 @@
         ]
       },
       "matchNames": [
+        "banco di sicilia",
         "unicredit",
         "unicredit banca",
         "unicredit s.p.a."


### PR DESCRIPTION
In 2010 UniCredit Banca, Banco di Sicilia and Banca di Roma were absorbed into the parent company UniCredit.