### PR TITLE
Replace Coles Express with Reddy Express

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1401,19 +1401,6 @@
       }
     },
     {
-      "displayName": "Coles Express",
-      "id": "colesexpress-0b0ae9",
-      "locationSet": {"include": ["au"]},
-      "tags": {
-        "brand": "Coles Express",
-        "brand:wikidata": "Q5144653",
-        "name": "Coles Express",
-        "operator": "Coles Group",
-        "operator:wikidata": "Q131937428",
-        "shop": "convenience"
-      }
-    },
-    {
       "displayName": "Conoco",
       "id": "conoco-f1e40b",
       "locationSet": {"include": ["us"]},
@@ -4557,6 +4544,18 @@
         "brand": "Red Apple Food Mart",
         "brand:wikidata": "Q114343337",
         "name": "Red Apple Food Mart",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "Reddy Express",
+      "id": "reddyexpress-0b0ae9",
+      "locationSet": {"include": ["au"]},
+      "matchNames": ["Coles Express"],
+      "tags": {
+        "brand": "Reddy Express",
+        "brand:wikidata": "Q5144653",
+        "name": "Reddy Express",
         "shop": "convenience"
       }
     },


### PR DESCRIPTION
Replace Coles Express convenience store with Reddy Express.

Reddy Express is the convenience store brand while Shell is the main fuel station brand since Viva bought the servos from Coles. 
Wiki has been renamed previously. 