### PR TITLE
Remove Coles Express fuel

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -5559,14 +5559,16 @@
         "exclude": ["jp"]
       },
       "matchNames": [
+        "coles",
+        "coles express",
         "posto shell",
+        "shell australia",
         "shell gas station",
         "shell oil",
         "shell petrol station",
         "shell service station",
         "shell station",
-        "station shell",
-        "coles express"
+        "station shell"
       ],
       "tags": {
         "amenity": "fuel",

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -1483,25 +1483,6 @@
       }
     },
     {
-      "displayName": "Coles Express",
-      "id": "colesexpress-9ed9c0",
-      "issues": [8392],
-      "locationSet": {"include": ["au"]},
-      "matchNames": [
-        "coles",
-        "shell",
-        "shell australia"
-      ],
-      "tags": {
-        "amenity": "fuel",
-        "brand": "Coles Express",
-        "brand:wikidata": "Q5144653",
-        "name": "Coles Express",
-        "operator": "Coles Group",
-        "operator:wikidata": "Q131937428"
-      }
-    },
-    {
       "displayName": "Compass",
       "id": "compass-fdaf22",
       "locationSet": {"include": ["gh"]},
@@ -5584,7 +5565,8 @@
         "shell petrol station",
         "shell service station",
         "shell station",
-        "station shell"
+        "station shell",
+        "coles express"
       ],
       "tags": {
         "amenity": "fuel",

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -4551,7 +4551,7 @@
       "displayName": "Reddy Express",
       "id": "reddyexpress-0b0ae9",
       "locationSet": {"include": ["au"]},
-      "matchNames": ["Coles Express"],
+      "matchNames": ["coles express"],
       "tags": {
         "brand": "Reddy Express",
         "brand:wikidata": "Q5144653",

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1401,19 +1401,6 @@
       }
     },
     {
-      "displayName": "Coles Express",
-      "id": "colesexpress-0b0ae9",
-      "locationSet": {"include": ["au"]},
-      "tags": {
-        "brand": "Coles Express",
-        "brand:wikidata": "Q5144653",
-        "name": "Coles Express",
-        "operator": "Coles Group",
-        "operator:wikidata": "Q131937428",
-        "shop": "convenience"
-      }
-    },
-    {
       "displayName": "Conoco",
       "id": "conoco-f1e40b",
       "locationSet": {"include": ["us"]},
@@ -4557,6 +4544,18 @@
         "brand": "Red Apple Food Mart",
         "brand:wikidata": "Q114343337",
         "name": "Red Apple Food Mart",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "Reddy Express",
+      "id": "reddyexpress-0b0ae9",
+      "locationSet": {"include": ["au"]},
+      "matchNames": ["Coles Express"],
+      "tags": {
+        "brand": "Reddy Express",
+        "brand:wikidata": "Q5144653",
+        "name": "Reddy Express",
         "shop": "convenience"
       }
     },


### PR DESCRIPTION
Remove the amenity=fuel entry for Coles Express.    With the new ownership, they are Shell branded stations with the shop being Reddy Express or possibly OTR in future.