### PR TITLE
add NBN Co street cabinet operator

### DIFF
--- a/data/operators/man_made/street_cabinet.json
+++ b/data/operators/man_made/street_cabinet.json
@@ -34,6 +34,19 @@
       }
     },
     {
+      "displayName": "NBN Co",
+      "locationSet": {
+        "include": ["au"]
+      },
+      "matchNames": ["nbn"],
+      "tags": {
+        "man_made": "street_cabinet",
+        "operator": "NBN Co",
+        "operator:wikidata": "Q6952833",
+        "utility": "telecom"
+      }
+    },
+    {
       "displayName": "Openreach",
       "id": "openreach-9ac957",
       "locationSet": {"include": ["gb"]},


### PR DESCRIPTION
Per https://wiki.openstreetmap.org/wiki/Australian_Tagging_Guidelines/Utilities_and_infrastructure#NBN_Co