### PR TITLE
Updated KFC entry with alt_name:vi as 'Gà Rán Kentucky

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -13607,6 +13607,23 @@
         "name:zh": "齊柏林熱狗",
         "takeaway": "yes"
       }
-    }
+    },
+    {
+      "displayName": "KFC",
+      "id": "kfc-vn",
+      "locationSet": {
+        "include": ["vn"]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "KFC",
+        "brand:vi": "KFC",
+        "brand:wikidata": "Q524757",
+        "cuisine": "fried_chicken",
+        "name": "KFC",
+        "alt_name:vi": "Gà Rán Kentucky",
+        "takeaway": "yes"
+      }
+    }       
   ]
 }

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -4716,7 +4716,8 @@
           "sy",
           "tn",
           "tw",
-          "ye"
+          "ye",
+          "vn"
         ]
       },
       "tags": {
@@ -13609,7 +13610,7 @@
       }
     },
     {
-      "displayName": "KFC",
+      "displayName": "KFC (Vietnam)",
       "id": "kfc-vn",
       "locationSet": {
         "include": ["vn"]
@@ -13617,13 +13618,12 @@
       "tags": {
         "amenity": "fast_food",
         "brand": "KFC",
-        "brand:vi": "KFC",
         "brand:wikidata": "Q524757",
         "cuisine": "fried_chicken",
         "name": "KFC",
         "alt_name:vi": "Gà Rán Kentucky",
         "takeaway": "yes"
       }
-    }       
+    }           
   ]
 }


### PR DESCRIPTION
- Updated KFC entry in `fast_food.json`
- Added `alt_name:vi` as "Gà Rán Kentucky" while keeping `name:vi` as "KFC"
- This follows the localization guidelines and maintains consistency with branding
- Related to Issue #10553