### PR TITLE
fix names for books shop Belkniga in BY

### DIFF
--- a/data/brands/shop/books.json
+++ b/data/brands/shop/books.json
@@ -1170,12 +1170,14 @@
       "id": "belkniga-9972c8",
       "locationSet": {"include": ["by"]},
       "tags": {
-        "brand": "Белкнига",
-        "brand:be": "Белкнига",
+        "brand": "Белкнiга",
+        "brand:be": "Белкнiга",
+        "brand:ru": "Белкнига",
         "brand:en": "Belkniga",
         "brand:wikidata": "Q60793563",
-        "name": "Белкнига",
-        "name:be": "Белкнига",
+        "name": "Белкнiга",
+        "name:be": "Белкнiга",
+        "name:ru": "Белкнига",
         "name:en": "Belkniga",
         "shop": "books"
       }


### PR DESCRIPTION
Now  in Belarus default names are in "be", not in "ru"