### PR TITLE
Honest Greens in Paris and London

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -3068,7 +3068,14 @@
     {
       "displayName": "Honest Greens",
       "id": "honestgreens-1d6b00",
-      "locationSet": {"include": ["es", "pt"]},
+      "locationSet": {
+        "include": [
+          "es",
+          "fr-idf.geojson",
+          "gb-lon.geojson",
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "restaurant",
         "brand": "Honest Greens",


### PR DESCRIPTION
Honest Greens is opening locations in Paris and London according to https://www.honestgreens.com/en/#restaurants