### PR TITLE
fix wrong symbol latinici i (unicode 105) by cyrillic і (unicode 1110)

### DIFF
--- a/data/brands/shop/books.json
+++ b/data/brands/shop/books.json
@@ -1166,17 +1166,17 @@
       }
     },
     {
-      "displayName": "Белкнига",
+      "displayName": "Белкніга",
       "id": "belkniga-9972c8",
       "locationSet": {"include": ["by"]},
       "tags": {
-        "brand": "Белкнiга",
-        "brand:be": "Белкнiга",
+        "brand": "Белкніга",
+        "brand:be": "Белкніга",
         "brand:en": "Belkniga",
         "brand:ru": "Белкнига",
         "brand:wikidata": "Q60793563",
-        "name": "Белкнiга",
-        "name:be": "Белкнiга",
+        "name": "Белкніга",
+        "name:be": "Белкніга",
         "name:en": "Belkniga",
         "name:ru": "Белкнига",
         "shop": "books"


### PR DESCRIPTION
using Belarusian letter for Belarusian name (was English symbol)