### PR TITLE
change operator name of ÜSTRA in GVH to be the currently used one

### DIFF
--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -209,7 +209,7 @@
         "network": "Großraum-Verkehr Hannover",
         "network:short": "GVH",
         "network:wikidata": "Q1549516",
-        "operator": "Überlandwerke und Straßenbahnen Hannover",
+        "operator": "ÜSTRA Hannoversche Verkehrsbetriebe Aktiengesellschaft",
         "operator:short": "ÜSTRA",
         "operator:wikidata": "Q265625",
         "route": "tram"

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -209,8 +209,7 @@
         "network": "Großraum-Verkehr Hannover",
         "network:short": "GVH",
         "network:wikidata": "Q1549516",
-        "operator": "ÜSTRA Hannoversche Verkehrsbetriebe Aktiengesellschaft",
-        "operator:short": "ÜSTRA",
+        "operator": "ÜSTRA",
         "operator:wikidata": "Q265625",
         "route": "tram"
       }


### PR DESCRIPTION
ÜSTRA does not call herself "Überlandwerke und Straßenbahn Hannover" anymore since 1960.
Source: https://de.wikipedia.org/wiki/%C3%9Cstra_Hannoversche_Verkehrsbetriebe