### PR TITLE
fix wrong suggestion

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -398,7 +398,6 @@
         "amenity": "parcel_locker",
         "brand": "DPD Pickup Station",
         "brand:wikidata": "Q114273730",
-        "parcel_mail_in": "no",
         "parcel_pickup": "yes"
       }
     },


### PR DESCRIPTION
@gy-mate - fixes (maybe part of) #10306

as reported by Polish mapper this is not always true (picture below advertises point-to-point delivery)

![screen04](https://github.com/user-attachments/assets/49f0b8fc-8ea4-46a5-b313-c6b7b2e2cdd2)

in general I would be really careful with `parcel_mail_in=no` as it changes dynamically