### PR TITLE
Add more Swedish shop brands

### DIFF
--- a/data/brands/shop/craft.json
+++ b/data/brands/shop/craft.json
@@ -99,6 +99,21 @@
       }
     },
     {
+      "displayName": "Panduro",
+      "locationSet": {"include": ["dk", "no", "se"]},
+      "matchNames": ["panduro hobby"],
+      "matchTags": [
+        "shop/doityourself",
+        "shop/hobby"
+      ],
+      "tags": {
+        "brand": "Panduro",
+        "brand:wikidata": "Q265941",
+        "name": "Panduro",
+        "shop": "craft"
+      }
+    },
+    {
       "displayName": "pipoos",
       "id": "pipoos-d918ce",
       "locationSet": {"include": ["be", "nl"]},

--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -794,7 +794,9 @@
     {
       "displayName": "jem & fix",
       "id": "jemandfix-27539e",
-      "locationSet": {"include": ["dk"]},
+      "locationSet": {
+        "include": ["dk", "no", "se"]
+      },
       "matchNames": ["jem fix"],
       "tags": {
         "brand": "jem & fix",

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -1253,7 +1253,7 @@
     {
       "displayName": "NetOnNet",
       "id": "netonnet-09807a",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {"include": ["no", "se"]},
       "tags": {
         "brand": "NetOnNet",
         "brand:wikidata": "Q10599837",

--- a/data/brands/shop/jewelry.json
+++ b/data/brands/shop/jewelry.json
@@ -1187,6 +1187,16 @@
       }
     },
     {
+      "displayName": "Ur&Penn",
+      "locationSet": {"include": ["fi", "se"]},
+      "tags": {
+        "brand": "Ur&Penn",
+        "brand:wikidata": "Q10710340",
+        "name": "Ur&Penn",
+        "shop": "jewelry"
+      }
+    },
+    {
       "displayName": "Tous",
       "id": "tous-a038d2",
       "locationSet": {"include": ["001"]},

--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -35,6 +35,17 @@
       }
     },
     {
+      "displayName": "3Butiken (Sweden)",
+      "locationSet": {"include": ["se"]},
+      "matchNames": ["3", "tre"],
+      "tags": {
+        "brand": "3Butiken",
+        "brand:wikidata": "Q10523825",
+        "name": "3Butiken",
+        "shop": "mobile_phone"
+      }
+    },
+    {
       "displayName": "A1 prodajno mesto",
       "id": "a1prodajnomesto-6945ea",
       "locationSet": {"include": ["rs"]},

--- a/data/brands/shop/pet.json
+++ b/data/brands/shop/pet.json
@@ -123,6 +123,17 @@
       }
     },
     {
+      "displayName": "Dogman",
+      "locationSet": {"include": ["fi", "no", "se"]},
+      "matchNames": ["dogman and friends"],
+      "tags": {
+        "brand": "Dogman",
+        "brand:wikidata": "Q132752615",
+        "name": "Dogman",
+        "shop": "pet"
+      }
+    },
+    {
       "displayName": "EarthWise Pet",
       "id": "earthwisepet-81a22d",
       "locationSet": {"include": ["us"]},

--- a/data/brands/shop/sports.json
+++ b/data/brands/shop/sports.json
@@ -428,14 +428,17 @@
       }
     },
     {
-      "displayName": "Hööks Hästsport",
-      "id": "hookshastsport-b82ac0",
-      "locationSet": {"include": ["se"]},
+      "displayName": "Hööks",
+      "locationSet": {
+        "include": ["dk", "fi", "no", "se"]
+      },
+      "matchNames": ["hööks hästsport"],
       "tags": {
-        "brand": "Hööks Hästsport",
+        "brand": "Hööks",
         "brand:wikidata": "Q10532686",
-        "name": "Hööks Hästsport",
-        "shop": "sports"
+        "name": "Hööks",
+        "shop": "sports",
+        "sport": "equestrian"
       }
     },
     {
@@ -572,6 +575,18 @@
         "brand:wikidata": "Q6545495",
         "name": "Life Style Sports",
         "shop": "sports"
+      }
+    },
+    {
+      "displayName": "Löplabbet",
+      "locationSet": {"include": ["no", "se"]},
+      "matchTags": ["shop/clothes", "shop/shoes"],
+      "tags": {
+        "brand": "Löplabbet",
+        "brand:wikidata": "Q10572886",
+        "name": "Löplabbet",
+        "shop": "sports",
+        "sport": "running"
       }
     },
     {
@@ -1043,6 +1058,16 @@
         "brand": "Stadium",
         "brand:wikidata": "Q4993863",
         "name": "Stadium",
+        "shop": "sports"
+      }
+    },
+    {
+      "displayName": "Team Sportia",
+      "locationSet": {"include": ["se"]},
+      "tags": {
+        "brand": "Team Sportia",
+        "brand:wikidata": "Q10691628",
+        "name": "Team Sportia",
         "shop": "sports"
       }
     },


### PR DESCRIPTION
Changes:
* Add shop brands 3Butiken, Dogman, Löplabbet, Panduro (formerly Panduro Hobby), Team Sportia, Ur&Penn.
* Add Sweden and Norway to jem&fix location set.
* Add Norway to NetOnNet location set.
* Update name of Hööks (formerly Hööks Hästsport) and add Denmark, Finland and Norway to location set.