### PR TITLE
Add some Axfood (Sweden) convenience store brands

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -2466,6 +2466,19 @@
       }
     },
     {
+      "displayName": "Handlar'n",
+      "locationSet": {"include": ["se"]},
+      "matchNames": ["Handlarn"],
+      "matchTags": ["shop/supermarket"],
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Handlar'n",
+        "brand:wikidata": "Q10517161",
+        "name": "Handlar'n",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "Hasty Market",
       "id": "hastymarket-eea72f",
       "locationSet": {"include": ["ca"]},
@@ -3447,6 +3460,18 @@
         "name": "masymas basic",
         "operator": "Juan Fornés Fornés S.A.",
         "operator:wikidata": "Q6135987",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "Matöppet",
+      "locationSet": {"include": ["se"]},
+      "matchTags": ["shop/supermarket"],
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Matöppet",
+        "brand:wikidata": "Q10578618",
+        "name": "Matöppet",
         "shop": "convenience"
       }
     },
@@ -5318,7 +5343,7 @@
       }
     },
     {
-      "displayName": "Tempo",
+      "displayName": "Tempo (Česko)",
       "id": "tempo-a7773e",
       "locationSet": {"include": ["cz"]},
       "matchNames": [
@@ -5331,6 +5356,18 @@
       "tags": {
         "brand": "Tempo",
         "brand:wikidata": "Q52851660",
+        "name": "Tempo",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "Tempo (Sverige)",
+      "locationSet": {"include": ["se"]},
+      "matchTags": ["shop/supermarket"],
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Tempo",
+        "brand:wikidata": "Q10692628",
         "name": "Tempo",
         "shop": "convenience"
       }


### PR DESCRIPTION
Changes:
* Add Axfood-owned Swedish convenience store brands Handlar'n, Matöppet and Tempo