### PR TITLE
Update operator and network tags of tram routes in Lodz and add similar one item to buses

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -9184,6 +9184,15 @@
       }
     },
     {
+      "displayName": "Lokalny Transport Zbiorowy w Łodzi",
+      "locationSet": {"include": ["pl"]},
+      "tags": {
+        "network": "Lokalny Transport Zbiorowy w Łodzi",
+        "network:wikidata": "Q133202246",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "London Buses",
       "id": "londonbuses-3a83f8",
       "locationSet": {

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -9186,6 +9186,7 @@
     {
       "displayName": "Lokalny Transport Zbiorowy w Łodzi",
       "locationSet": {"include": ["pl"]},
+      "matchNames": ["LTZ Łódź"],
       "tags": {
         "network": "Lokalny Transport Zbiorowy w Łodzi",
         "network:wikidata": "Q133202246",
@@ -9328,15 +9329,6 @@
       "tags": {
         "network": "LTFRB PUJ",
         "network:wikidata": "Q6483998",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "LTZ Łódź",
-      "id": "ltzlodz-9340cc",
-      "locationSet": {"include": ["pl"]},
-      "tags": {
-        "network": "LTZ Łódź",
         "route": "bus"
       }
     },

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -345,13 +345,13 @@
       }
     },
     {
-      "displayName": "LTZ Łódź",
+      "displayName": "Lokalny Transport Zbiorowy w Łodzi",
       "id": "ltzlodz-ba1938",
       "locationSet": {"include": ["pl"]},
       "tags": {
-        "network": "LTZ Łódź",
-        "network:wikidata": "Q1149987",
-        "operator": "MPK Łódź",
+        "network": "Lokalny Transport Zbiorowy w Łodzi",
+        "network:wikidata": "Q133202246",
+        "operator": "MPK-Łódź",
         "operator:wikidata": "Q11780295",
         "route": "tram"
       }

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -348,6 +348,7 @@
       "displayName": "Lokalny Transport Zbiorowy w Łodzi",
       "id": "ltzlodz-ba1938",
       "locationSet": {"include": ["pl"]},
+      "matchNames": ["LTZ Łódź"],
       "tags": {
         "network": "Lokalny Transport Zbiorowy w Łodzi",
         "network:wikidata": "Q133202246",


### PR DESCRIPTION
**1. trams**

Changed _network_ name from "LTZ Łódź" to "Lokalny Transport Zbiorowy w Łodzi", aligning with official terminology. Wherever this name appears, it is given in full words. When you google this abbreviation, results refer to "ŁTŻ Łódź" (motorcycle speedway club) rather than mass transit service.

Updated _network:wikidata_ tag to link to the correct Wikidata item representing the transit network.

Fixed _operator_ name from "MPK Łódź" to "MPK-Łódź", matching the official spelling. The company consistently uses a hyphen instead of blank space in its name.


**2. buses**

Created a separate entry for "Lokalny Transport Zbiorowy w Łodzi" with _route=bus_ as an equivalent to existing _route=tram_ entry.