### PR TITLE
Change Total/Total Access to TotalEnergies for convenience and kiosk shops

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5571,27 +5571,21 @@
       }
     },
     {
-      "displayName": "Total",
-      "id": "total-bd0db4",
+      "displayName": "TotalEnergies",
       "locationSet": {
         "include": ["001"],
         "exclude": ["us"]
       },
+      "matchNames": [
+        "total",
+        "total access",
+        "totalenergies access"
+      ],
+      "note": "Total is/has rebranded to TotalEnergies, We still have total and station total in matchNames if there are any lingering fuel stations left. Same with Total Access"
       "tags": {
-        "brand": "Total",
+        "brand": "TotalEnergies",
         "brand:wikidata": "Q154037",
-        "name": "Total",
-        "shop": "convenience"
-      }
-    },
-    {
-      "displayName": "Total Access",
-      "id": "totalaccess-bf3eb4",
-      "locationSet": {"include": ["fr"]},
-      "tags": {
-        "brand": "Total Access",
-        "brand:wikidata": "Q154037",
-        "name": "Total Access",
+        "name": "TotalEnergies",
         "shop": "convenience"
       }
     },

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5581,7 +5581,7 @@
         "total access",
         "totalenergies access"
       ],
-      "note": "Total is/has rebranded to TotalEnergies, We still have total and station total in matchNames if there are any lingering conveience stores left. Same with Total Access"
+      "note": "Total is/has rebranded to TotalEnergies, We still have total and station total in matchNames if there are any lingering conveience stores left. Same with Total Access",
       "tags": {
         "brand": "TotalEnergies",
         "brand:wikidata": "Q154037",

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5581,7 +5581,7 @@
         "total access",
         "totalenergies access"
       ],
-      "note": "Total is/has rebranded to TotalEnergies, We still have total and station total in matchNames if there are any lingering fuel stations left. Same with Total Access"
+      "note": "Total is/has rebranded to TotalEnergies, We still have total and station total in matchNames if there are any lingering conveience stores left. Same with Total Access"
       "tags": {
         "brand": "TotalEnergies",
         "brand:wikidata": "Q154037",

--- a/data/brands/shop/kiosk.json
+++ b/data/brands/shop/kiosk.json
@@ -197,16 +197,17 @@
       }
     },
     {
-      "displayName": "Total",
-      "id": "total-5fe041",
+      "displayName": "TotalEnergies",
       "locationSet": {
         "include": ["001"],
         "exclude": ["us"]
       },
+      "matchNames": ["total"],
+      "note": "Total is/has rebranded to TotalEnergies, We still have total and station total in matchNames if there are any lingering kiosks left",
       "tags": {
-        "brand": "Total",
+        "brand": "TotalEnergies",
         "brand:wikidata": "Q154037",
-        "name": "Total",
+        "name": "TotalEnergies",
         "shop": "kiosk"
       }
     },


### PR DESCRIPTION
Total and Total Access have rebranded to the greater TotalEnergies Brand