### PR TITLE
Drop Target shop=department_store

### DIFF
--- a/data/brands/shop/department_store.json
+++ b/data/brands/shop/department_store.json
@@ -1452,17 +1452,6 @@
       }
     },
     {
-      "displayName": "Target (USA)",
-      "id": "target-592fe0",
-      "locationSet": {"include": ["us"]},
-      "tags": {
-        "brand": "Target",
-        "brand:wikidata": "Q1046951",
-        "name": "Target",
-        "shop": "department_store"
-      }
-    },
-    {
       "displayName": "The Warehouse",
       "id": "thewarehouse-98a4a8",
       "locationSet": {"include": ["nz"]},


### PR DESCRIPTION
I'm not super confidant on this, I've never been to the US, never been in a Target.

I am confidant the vast majority in OSM are miss tagged:

> Target (only stores that do not carry a full selection of groceries; stores that sell groceries should be [shop](https://wiki.openstreetmap.org/wiki/Key:shop)=[supermarket](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dsupermarket))

https://wiki.openstreetmap.org/wiki/Tag:shop%3Ddepartment_store

Briefly discussed on [OSM US slack](https://osmus.slack.com/archives/CDJ4LKA2Y/p1736382081486899), they basically all offer food nowadays. And a lot of the `shop=department_store` in OSM may have been encouraged because that was in NSI first.

> basically all

I don't know. And the website doesn’t differentiate.