### PR TITLE
Update Walmart Neighborhood Market

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -9016,9 +9016,10 @@
       "displayName": "Walmart Neighborhood Market",
       "id": "walmartneighborhoodmarket-dde59d",
       "locationSet": {"include": ["us"]},
+      "preserveTags": ["^name"],
       "tags": {
         "brand": "Walmart",
-        "brand:wikidata": "Q483551",
+        "brand:wikidata": "Q7963529",
         "name": "Walmart Neighborhood Market",
         "shop": "supermarket"
       }


### PR DESCRIPTION
Walmart Neighborhood Market now has its own Wikidata item. Also, some individual store locations apparently have their own names, [prominently signposted](https://commons.wikimedia.org/wiki/File:Walmart_Harvey_Market,_Harvey,_Louisiana.jpg). I haven’t figured out if that’s a regional practice or a new thing.