### PR TITLE
amenity/bicycle_rental: Nibelungen Bike rebranded to VELOLEO

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -2763,16 +2763,17 @@
       }
     },
     {
-      "displayName": "Nibelungen-Bike",
+      "displayName": "VELOLEO",
       "id": "nibelungenbike-497979",
       "locationSet": {
         "include": [[10.52, 52.26, 10]]
       },
+      "matchNames": ["nibelungen bike"],
       "tags": {
         "amenity": "bicycle_rental",
-        "brand": "Nibelungen-Bike",
+        "brand": "VELOLEO",
         "brand:wikidata": "Q117301923",
-        "network": "Nibelungen-Bike",
+        "network": "VELOLEO",
         "network:wikidata": "Q117301923",
         "operator": "Nextbike",
         "operator:type": "private",


### PR DESCRIPTION
See the [announcement](https://www.braunschweig.de/politik_verwaltung/nachrichten/veloleo.php) (in German)

Not sure if the ID should change too, but I guess it should stay for backwards compatibility…?

I've already updated the Wikidata item accordingly.