### PR TITLE
Add LKQ Pick Your Part to operator/landuse/industrial

### DIFF
--- a/data/brands/landuse/industrial.json
+++ b/data/brands/landuse/industrial.json
@@ -1,0 +1,23 @@
+{
+  "properties": {
+    "path": "brands/landuse/industrial",
+    "preserveTags": ["^name"],
+    "exclude": {"generic": ["^industrial$"]}
+  },
+  "items": [
+    {
+      "displayName": "LKQ Pick Your Part",
+      "locationSet": {"include": ["us"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Pick Your Part",
+        "brand:short_name": "PYP",
+        "brand:wikidata": "Q133309706",
+        "industrial": "auto_wrecker",
+        "landuse": "industrial",
+        "name": "Pick Your Part",
+        "official_name": "LKQ Pick Your Part",
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Only added LKQ Pick Your Part. This is a salvage yard in the USA with 63 yards.

The branch name is wrong. Doesn't matter. Caught it. This should be in operators not brands.

For one such location, https://www.openstreetmap.org/way/1368619252