### PR TITLE
Update bank.json bank brand in Egypt

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -6470,7 +6470,7 @@
     {
       "displayName": "First Abu Dhabi Bank",
       "id": "firstabudhabibank-d9ce9c",
-      "locationSet": {"include": ["ae"]},
+      "locationSet": {"include": ["ae","eg"]},
       "tags": {
         "amenity": "bank",
         "brand": "First Abu Dhabi Bank",


### PR DESCRIPTION
Adding Egypt country to bank brand : First Abu Dhabi Bank   https://www.fabmisr.com.eg/en/personal-banking
and https://www.wikidata.org/wiki/Q29124183