### PR TITLE
Update fuel.json [amenity/fuel] Add Egypt country to Mobil fuel brand

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -4024,7 +4024,7 @@
       "id": "mobil-00679c",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["jp"]
+        "exclude": ["jp","eg"]
       },
       "matchNames": ["mobile"],
       "note": "This wikidata isn't Q3088656",


### PR DESCRIPTION
Add Egypt country to Mobil fuel brand 
https://www.wikidata.org/wiki/Q109676002
And 
https://www.mobil.com/en