### PR TITLE
Mixed upper and lower case brand names for supermarkets

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -257,7 +257,7 @@
       }
     },
     {
-      "displayName": "ALDI (ALDI Nord group)",
+      "displayName": "Aldi (Aldi Nord group)",
       "id": "aldi-3a2eb7",
       "locationSet": {
         "include": [
@@ -272,16 +272,16 @@
         ]
       },
       "matchNames": ["aldi france", "aldi nord"],
-      "note": "countries in which ALDI Nord group is active",
+      "note": "countries in which Aldi Nord group is active",
       "tags": {
-        "brand": "ALDI",
+        "brand": "Aldi",
         "brand:wikidata": "Q41171373",
-        "name": "ALDI",
+        "name": "Aldi",
         "shop": "supermarket"
       }
     },
     {
-      "displayName": "ALDI (ALDI Süd group)",
+      "displayName": "Aldi (Aldi Süd group)",
       "id": "aldi-68f0e3",
       "locationSet": {
         "include": [
@@ -303,39 +303,39 @@
         "aldi uk",
         "aldi usa"
       ],
-      "note": "countries in which ALDI Süd group is active",
+      "note": "countries in which Aldi Süd group is active",
       "tags": {
-        "brand": "ALDI",
+        "brand": "Aldi",
         "brand:wikidata": "Q41171672",
-        "name": "ALDI",
+        "name": "Aldi",
         "shop": "supermarket"
       }
     },
     {
-      "displayName": "ALDI Nord (Deutschland)",
+      "displayName": "Aldi Nord (Deutschland)",
       "id": "aldi-813759",
       "locationSet": {
         "include": ["de"],
         "exclude": ["aldi-sued.geojson"]
       },
-      "note": "German ALDI Nord branding",
+      "note": "German Aldi Nord branding",
       "tags": {
-        "brand": "ALDI Nord",
+        "brand": "Aldi Nord",
         "brand:wikidata": "Q41171373",
         "name": "Aldi",
         "shop": "supermarket"
       }
     },
     {
-      "displayName": "ALDI Süd (Deutschland)",
+      "displayName": "Aldi Süd (Deutschland)",
       "id": "aldisud-e4a24f",
       "locationSet": {
         "include": ["aldi-sued.geojson"]
       },
       "matchNames": ["aldi"],
-      "note": "German ALDI Süd branding",
+      "note": "German Aldi Süd branding",
       "tags": {
-        "brand": "ALDI Süd",
+        "brand": "Aldi Süd",
         "brand:wikidata": "Q41171672",
         "name": "Aldi Süd",
         "shop": "supermarket"
@@ -2412,7 +2412,7 @@
       "locationSet": {"include": ["de"]},
       "preserveTags": ["^name"],
       "tags": {
-        "brand": "EDEKA",
+        "brand": "Edeka",
         "brand:wikidata": "Q701755",
         "name": "E-Center",
         "shop": "supermarket"
@@ -2533,7 +2533,7 @@
       }
     },
     {
-      "displayName": "EDEKA",
+      "displayName": "Edeka",
       "id": "edeka-0a839e",
       "locationSet": {"include": ["de"]},
       "matchNames": [
@@ -2542,32 +2542,32 @@
       ],
       "preserveTags": ["^name"],
       "tags": {
-        "brand": "EDEKA",
+        "brand": "Edeka",
         "brand:wikidata": "Q701755",
-        "name": "EDEKA",
+        "name": "Edeka",
         "shop": "supermarket"
       }
     },
     {
-      "displayName": "EDEKA aktiv markt",
+      "displayName": "Edeka aktiv markt",
       "id": "edekaaktivmarkt-0a839e",
       "locationSet": {"include": ["de"]},
       "preserveTags": ["^name"],
       "tags": {
-        "brand": "EDEKA",
+        "brand": "Edeka",
         "brand:wikidata": "Q701755",
-        "name": "EDEKA aktiv markt",
+        "name": "Edeka aktiv markt",
         "shop": "supermarket"
       }
     },
     {
-      "displayName": "EDEKA xpress",
+      "displayName": "Edeka xpress",
       "id": "edekaxpress-0a839e",
       "locationSet": {"include": ["de"]},
       "tags": {
-        "brand": "EDEKA",
+        "brand": "Edeka",
         "brand:wikidata": "Q701755",
-        "name": "EDEKA xpress",
+        "name": "Edeka xpress",
         "shop": "supermarket"
       }
     },
@@ -5862,7 +5862,7 @@
       "matchNames": ["nah & gut"],
       "preserveTags": ["^name"],
       "tags": {
-        "brand": "EDEKA",
+        "brand": "Edeka",
         "brand:wikidata": "Q701755",
         "name": "nah und gut",
         "shop": "supermarket"
@@ -6086,15 +6086,15 @@
       }
     },
     {
-      "displayName": "NORMA",
+      "displayName": "Norma",
       "id": "norma-c1eeeb",
       "locationSet": {
         "include": ["at", "cz", "de", "fr"]
       },
       "tags": {
-        "brand": "NORMA",
+        "brand": "Norma",
         "brand:wikidata": "Q450180",
-        "name": "NORMA",
+        "name": "Norma",
         "shop": "supermarket"
       }
     },
@@ -6929,26 +6929,26 @@
       }
     },
     {
-      "displayName": "REWE",
+      "displayName": "Rewe",
       "id": "rewe-0a839e",
       "locationSet": {"include": ["de"]},
       "preserveTags": ["^name"],
       "tags": {
-        "brand": "REWE",
+        "brand": "Rewe",
         "brand:wikidata": "Q16968817",
-        "name": "REWE",
+        "name": "Rewe",
         "shop": "supermarket"
       }
     },
     {
-      "displayName": "REWE City",
+      "displayName": "Rewe City",
       "id": "rewecity-0a839e",
       "locationSet": {"include": ["de"]},
       "preserveTags": ["^name"],
       "tags": {
-        "brand": "REWE",
+        "brand": "Rewe",
         "brand:wikidata": "Q16968817",
-        "name": "REWE City",
+        "name": "Rewe City",
         "shop": "supermarket"
       }
     },
@@ -7256,7 +7256,7 @@
       "id": "scheckincenter-0a839e",
       "locationSet": {"include": ["de"]},
       "tags": {
-        "brand": "EDEKA",
+        "brand": "Edeka",
         "brand:wikidata": "Q701755",
         "name": "Scheck-In Center",
         "operator": "Scheck-In",


### PR DESCRIPTION
Changed the brand names of Aldi, Edeka, Norma and Rewe to user mixed upper and lower case instead of upper case only. The change is similar to the change for _Penny_ in #9337.

This makes `name` and `brand` more consistent with other brands.