### PR TITLE
Add operator:wikidata for Tyskie Linie Trolejbusowe

### DIFF
--- a/data/transit/route/trolleybus.json
+++ b/data/transit/route/trolleybus.json
@@ -675,6 +675,7 @@
         "network": "Zarząd Transportu Metropolitalnego",
         "network:wikidata": "Q48862619",
         "operator": "Tyskie Linie Trolejbusowe",
+        "operator:wikidata": "Q130340846",
         "route": "trolleybus"
       }
     },


### PR DESCRIPTION
Add `operator:wikidata` for Tyskie Linie Trolejbusowe ([Q130340846](https://www.wikidata.org/wiki/Q130340846))