### PR TITLE
Update chemist.json for Poland new brand

### DIFF
--- a/data/brands/shop/chemist.json
+++ b/data/brands/shop/chemist.json
@@ -895,6 +895,19 @@
         "name:zh-Hant": "萬寧",
         "shop": "chemist"
       }
-    }
+    },{
+   "displayName": "Drogerie Polskie",
+   "locationSet": {
+       "include": [
+           "pl"
+       ]
+   },
+   "tags": {
+       "brand": "Drogerie Polskie",
+       "brand:wikidata": "Q133373948",
+       "name": "Drogerie Polskie",
+       "shop": "chemist"
+   }
+}
   ]
 }


### PR DESCRIPTION
Adding new brand for shop=chemist in Poland called Drogerie Polskie

https://www.wikidata.org/wiki/Q133373948
https://drogeriepolskie.pl/