### PR TITLE
Update furniture.json for Poland new brand

### DIFF
--- a/data/brands/shop/furniture.json
+++ b/data/brands/shop/furniture.json
@@ -2463,6 +2463,19 @@
         "name:ja": "ニトリ",
         "shop": "furniture"
       }
-    }
+    },{
+   "displayName": "Komfort",
+   "locationSet": {
+       "include": [
+           "pl"
+       ]
+   },
+   "tags": {
+       "brand": "Komfort",
+       "brand:wikidata": "Q127275164",
+       "name": "Komfort",
+       "shop": "furniture"
+   }
+}
   ]
 }


### PR DESCRIPTION
Adding new brand for shop=furniture in Poland called Komfort

https://www.wikidata.org/wiki/Q127275164
https://komfort.pl/