### PR TITLE
Update bank.json for Poland new brand

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -19639,6 +19639,19 @@
         "name:en": "Kagoshima Bank",
         "name:ja": "鹿児島銀行"
       }
-    }
+    },{
+   "displayName": "Plus Bank",
+   "locationSet": {
+       "include": [
+           "pl"
+       ]
+   },
+   "tags": {
+       "brand": "Plus Bank",
+       "brand:wikidata": "Q11713529",
+       "name": "Plus Bank",
+       "amenity": "bank"
+   }
+}
   ]
 }


### PR DESCRIPTION
Adding new brand for amenity=bank in Poland called Plus Bank

https://www.wikidata.org/wiki/Q11713529
https://plusbank.pl/