### PR TITLE
Change the Wikidata item for A+ Glass

### DIFF
--- a/data/brands/shop/car_repair.json
+++ b/data/brands/shop/car_repair.json
@@ -88,13 +88,13 @@
       }
     },
     {
-      "displayName": "A+ Glass",
+      "displayName": "A+Glass",
       "id": "aglass-98e3a2",
       "locationSet": {"include": ["fr"]},
       "tags": {
-        "brand": "A+ Glass",
+        "brand": "A+Glass",
         "brand:wikidata": "Q116688243",
-        "name": "A+ Glass",
+        "name": "A+Glass",
         "service:vehicle:glass": "yes",
         "shop": "car_repair"
       }

--- a/data/brands/shop/car_repair.json
+++ b/data/brands/shop/car_repair.json
@@ -93,7 +93,7 @@
       "locationSet": {"include": ["fr"]},
       "tags": {
         "brand": "A+ Glass",
-        "brand:wikidata": "Q123409768",
+        "brand:wikidata": "Q116688243",
         "name": "A+ Glass",
         "service:vehicle:glass": "yes",
         "shop": "car_repair"


### PR DESCRIPTION
Wikidata item [Q123409768](https://www.wikidata.org/wiki/Q123409768) is for a different shop named "Active Green + Ross", located in Canada. The item is [already linked to the correct brand in NSI](https://nsi.guide/?t=brands&k=shop&v=car_repair&tt=Active%20Green%20%2B%20Ross#activegreenross-9c9847), with ID activegreenross-9c9847.

I could not find a matching Wikidata item for A+ Glass.