### PR TITLE
[shop/hairdresser] change name/brand values of First Choice Haircutters

### DIFF
--- a/data/brands/shop/hairdresser.json
+++ b/data/brands/shop/hairdresser.json
@@ -263,13 +263,13 @@
       }
     },
     {
-      "displayName": "First Choice Haircutters",
+      "displayName": "First Choice Hair",
       "id": "firstchoicehaircutters-7e5a14",
       "locationSet": {"include": ["ca"]},
       "tags": {
-        "brand": "First Choice Haircutters",
+        "brand": "First Choice Hair",
         "brand:wikidata": "Q5452622",
-        "name": "First Choice Haircutters",
+        "name": "First Choice Hair",
         "shop": "hairdresser"
       }
     },

--- a/data/brands/shop/hairdresser.json
+++ b/data/brands/shop/hairdresser.json
@@ -266,6 +266,7 @@
       "displayName": "First Choice Hair",
       "id": "firstchoicehaircutters-7e5a14",
       "locationSet": {"include": ["ca"]},
+      "matchNames": ["First Choice Haircutters"],
       "tags": {
         "brand": "First Choice Hair",
         "brand:wikidata": "Q5452622",


### PR DESCRIPTION
Updated brand name to First Choice Hair to match Wikidata and official website.

https://www.wikidata.org/wiki/Q5452622
https://www.firstchoice.com/