### PR TITLE
[shop/telecommunication] change Wikidata QID for Bell

### DIFF
--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -135,7 +135,7 @@
       ],
       "tags": {
         "brand": "Bell",
-        "brand:wikidata": "Q2894594",
+        "brand:wikidata": "Q815694",
         "name": "Bell",
         "shop": "telecommunication"
       }


### PR DESCRIPTION
Update Bell (Bell Canada) to the correct Wikidata page.

https://www.wikidata.org/wiki/Q815694