### PR TITLE
[shop/stationery] add Calendar Club

### DIFF
--- a/data/brands/shop/stationery.json
+++ b/data/brands/shop/stationery.json
@@ -452,6 +452,16 @@
         "name:zh": "金玉堂",
         "shop": "stationery"
       }
+    },
+    {
+      "displayName": "Calendar Club",
+      "locationSet": {"include": ["ca"]},
+      "tags": {
+        "brand": "Calendar Club",
+        "brand:wikidata": "Q132798539",
+        "name": "Calendar Club",
+        "shop": "stationery"
+      }
     }
   ]
 }


### PR DESCRIPTION
Adding a new brand for "shop": "stationery" in Canada.

https://www.wikidata.org/wiki/Q132798539
https://www.calendarclub.ca/