### PR TITLE
[brands/amenity/car_sharing] add Zipcar

### DIFF
--- a/data/brands/amenity/car_sharing.json
+++ b/data/brands/amenity/car_sharing.json
@@ -187,6 +187,16 @@
         "operator:type": "private",
         "operator:wikidata": "Q55931"
       }
+    },
+    {
+      "displayName": "Zipcar",
+      "locationSet": {"include": ["ca","us"]},
+      "tags": {
+        "brand": "Zipcar",
+        "name": "Zipcar",
+        "brand:wikidata": "Q1069924",
+        "amenity": "car_sharing"
+      }
     }
   ]
 }


### PR DESCRIPTION
Adding a new brand for amenity=car_sharing in Canada and USA.

https://www.wikidata.org/wiki/Q1069924
https://www.zipcar.com/en-ca