### PR TITLE
Update cafe.json (move all Dunkin' (Q847743) from fast_food.json)

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -42,6 +42,115 @@
   },
   "items": [
     {
+      "displayName": "Dunkin'",
+      "locationSet": {
+        "include": ["001"],
+        "exclude": [
+          "ae",
+          "bh",
+          "cn",
+          "eg",
+          "es",
+          "kw",
+          "lb",
+          "om",
+          "qa",
+          "sa"
+        ]
+      },
+      "matchNames": ["dunkin doughnuts"],
+      "tags": {
+        "alt_name": "Dunkin' Donuts",
+        "amenity": "cafe",
+        "brand": "Dunkin'",
+        "brand:wikidata": "Q847743",
+        "cuisine": "donut;coffee_shop",
+        "name": "Dunkin'",
+        "takeaway": "yes"
+      }
+    },
+        {
+      "displayName": "Dunkin' Coffee",
+      "locationSet": {"include": ["es"]},
+      "matchNames": [
+        "dunkin doughnuts",
+        "dunkin' donuts"
+      ],
+      "tags": {
+        "amenity": "cafe",
+        "brand": "Dunkin' Coffee",
+        "brand:wikidata": "Q847743",
+        "cuisine": "donut;coffee_shop",
+        "name": "Dunkin' Coffee",
+        "takeaway": "yes"
+      }
+    },
+        {
+      "displayName": "DUNKIN唐恩都乐'",
+      "locationSet": {"include": ["cn"]},
+      "matchNames": [
+        "dunkin'",
+        "dunkin's",
+        "dunkin唐恩都可"
+      ],
+      "tags": {
+        "amenity": "cafe",
+        "brand": "DUNKIN唐恩都乐",
+        "brand:en": "Dunkin' Donuts",
+        "brand:wikidata": "Q847743",
+        "brand:zh": "唐恩都乐",
+        "cuisine": "donut;coffee_shop",
+        "name": "DUNKIN唐恩都乐",
+        "name:en": "Dunkin' Donuts",
+        "name:zh": "唐恩都乐",
+        "takeaway": "yes"
+      }
+    },
+        {
+      "displayName": "დანკინ დონათსი",
+      "locationSet": {"include": ["ge"]},
+      "tags": {
+        "amenity": "cafe",
+        "brand": "დანკინ დონათსი",
+        "brand:ka": "დანკინ დონათსი",
+        "brand:wikidata": "Q847743",
+        "cuisine": "donut;coffee_shop",
+        "delivery": "yes",
+        "name": "დანკინ დონათსი",
+        "name:en": "Dunkin' Donuts",
+        "name:ka": "დანკინ დონათსი",
+        "takeaway": "yes"
+      }
+    },
+        {
+      "displayName": "دانكن دونتس",
+      "locationSet": {
+        "include": [
+          "ae",
+          "bh",
+          "eg",
+          "kw",
+          "lb",
+          "om",
+          "qa",
+          "sa"
+        ]
+      },
+      "matchNames": ["dunkin's"],
+      "tags": {
+        "amenity": "cafe",
+        "brand": "دانكن",
+        "brand:ar": "دانكن",
+        "brand:en": "Dunkin'",
+        "brand:wikidata": "Q847743",
+        "cuisine": "donut;coffee_shop",
+        "name": "دانكن دونتس",
+        "name:ar": "دانكن دونتس",
+        "name:en": "Dunkin' Donuts",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "% Arabica",
       "id": "arabica-e1ef51",
       "locationSet": {"include": ["001"]},

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -2808,74 +2808,6 @@
       }
     },
     {
-      "displayName": "Dunkin'",
-      "id": "dunkin-e46fb5",
-      "locationSet": {
-        "include": ["001"],
-        "exclude": [
-          "ae",
-          "bh",
-          "cn",
-          "eg",
-          "es",
-          "kw",
-          "lb",
-          "om",
-          "qa",
-          "sa"
-        ]
-      },
-      "matchNames": ["dunkin doughnuts"],
-      "tags": {
-        "alt_name": "Dunkin' Donuts",
-        "amenity": "fast_food",
-        "brand": "Dunkin'",
-        "brand:wikidata": "Q847743",
-        "cuisine": "donut;coffee_shop",
-        "name": "Dunkin'",
-        "takeaway": "yes"
-      }
-    },
-    {
-      "displayName": "Dunkin' Coffee",
-      "id": "dunkincoffee-34e6e8",
-      "locationSet": {"include": ["es"]},
-      "matchNames": [
-        "dunkin doughnuts",
-        "dunkin' donuts"
-      ],
-      "tags": {
-        "amenity": "fast_food",
-        "brand": "Dunkin' Coffee",
-        "brand:wikidata": "Q847743",
-        "cuisine": "donut;coffee_shop",
-        "name": "Dunkin' Coffee",
-        "takeaway": "yes"
-      }
-    },
-    {
-      "displayName": "DUNKIN唐恩都乐'",
-      "id": "dunkindonuts-65b4e8",
-      "locationSet": {"include": ["cn"]},
-      "matchNames": [
-        "dunkin'",
-        "dunkin's",
-        "dunkin唐恩都可"
-      ],
-      "tags": {
-        "amenity": "fast_food",
-        "brand": "DUNKIN唐恩都乐",
-        "brand:en": "Dunkin' Donuts",
-        "brand:wikidata": "Q847743",
-        "brand:zh": "唐恩都乐",
-        "cuisine": "donut;coffee_shop",
-        "name": "DUNKIN唐恩都乐",
-        "name:en": "Dunkin' Donuts",
-        "name:zh": "唐恩都乐",
-        "takeaway": "yes"
-      }
-    },
-    {
       "displayName": "East of Chicago Pizza",
       "id": "eastofchicagopizza-4d2ff4",
       "locationSet": {"include": ["us"]},
@@ -11968,23 +11900,6 @@
       }
     },
     {
-      "displayName": "დანკინ დონათსი",
-      "id": "dunkindonuts-90e404",
-      "locationSet": {"include": ["ge"]},
-      "tags": {
-        "amenity": "fast_food",
-        "brand": "დანკინ დონათსი",
-        "brand:ka": "დანკინ დონათსი",
-        "brand:wikidata": "Q847743",
-        "cuisine": "donut;bagel;pizza;hot_dog;burger",
-        "delivery": "yes",
-        "name": "დანკინ დონათსი",
-        "name:en": "Dunkin' Donuts",
-        "name:ka": "დანკინ დონათსი",
-        "takeaway": "yes"
-      }
-    },
-    {
       "displayName": "დეგუსტო",
       "id": "degusto-90e404",
       "locationSet": {"include": ["ge"]},
@@ -12283,35 +12198,6 @@
         "name": "الطازج",
         "name:ar": "الطازج",
         "name:en": "Al Tazaj",
-        "takeaway": "yes"
-      }
-    },
-    {
-      "displayName": "دانكن دونتس",
-      "id": "dunkindonuts-07d3e5",
-      "locationSet": {
-        "include": [
-          "ae",
-          "bh",
-          "eg",
-          "kw",
-          "lb",
-          "om",
-          "qa",
-          "sa"
-        ]
-      },
-      "matchNames": ["dunkin's"],
-      "tags": {
-        "amenity": "fast_food",
-        "brand": "دانكن",
-        "brand:ar": "دانكن",
-        "brand:en": "Dunkin'",
-        "brand:wikidata": "Q847743",
-        "cuisine": "donut;coffee_shop",
-        "name": "دانكن دونتس",
-        "name:ar": "دانكن دونتس",
-        "name:en": "Dunkin' Donuts",
         "takeaway": "yes"
       }
     },


### PR DESCRIPTION
Dunkin' is no longer considered fast food.   It is branded more as a coffee shop/cafe.  
https://intelligence.coffee/2023/04/dunkin-became-global-coffee-giant/