### PR TITLE
Remove `preserveTags: ["^name"]` from ATMs

### DIFF
--- a/data/brands/amenity/atm.json
+++ b/data/brands/amenity/atm.json
@@ -2,7 +2,6 @@
   "properties": {
     "path": "brands/amenity/atm",
     "skipCollection": true,
-    "preserveTags": ["^name"],
     "exclude": {"generic": ["^atm$"]}
   },
   "items": [


### PR DESCRIPTION
Since #10378 and https://github.com/osmlab/name-suggestion-index/commit/91ed2e449273afe3db415b2eef082724cfa197f6 we are no longer in the `name` business of ATMs. 

NSI is generating a preset for it's ATMs that includes a `name` field. This field now stays empty on the top of the list in iD which is likely unwanted. The bug seems to be caused by https://github.com/osmlab/name-suggestion-index/blob/main/scripts/dist_files.js#L368-L372. iD's preset seems to include all necessary tags so it should work fine in theory (see https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/amenity/atm.json).

I'm not sure if making this change would break anything on iD's side... Is there any way to test it?

|Branded | Unbranded|
|--|--|
|![image](https://github.com/user-attachments/assets/b7dc747d-5d28-4f04-bb42-1eb9d6cb3267)|![image](https://github.com/user-attachments/assets/20ba004e-81aa-407b-bda1-b241b374eb9a)|