### PR TITLE
Fix "France Travail" vs "Pôle Emploi"

### DIFF
--- a/data/brands/office/employment_agency.json
+++ b/data/brands/office/employment_agency.json
@@ -117,19 +117,6 @@
       }
     },
     {
-      "displayName": "France Travail",
-      "id": "francetravail-9e0ae6",
-      "locationSet": {"include": ["fr"]},
-      "matchNames": ["pôle emploi"],
-      "matchTags": ["office/government"],
-      "tags": {
-        "brand": "France Travail",
-        "brand:wikidata": "Q8901192",
-        "name": "France Travail",
-        "office": "employment_agency"
-      }
-    },
-    {
       "displayName": "Interaction",
       "id": "interaction-e5fc42",
       "locationSet": {"include": ["fx"]},

--- a/data/brands/office/government.json
+++ b/data/brands/office/government.json
@@ -111,7 +111,6 @@
         "brand": "France Travail",
         "brand:wikidata": "Q8901192",
         "name": "France Travail",
-        "old_name": "Pôle Emploi",
         "office": "government",
         "government": "employment_agency"
       }

--- a/data/brands/office/government.json
+++ b/data/brands/office/government.json
@@ -102,6 +102,21 @@
       }
     },
     {
+      "displayName": "France Travail",
+      "id": "francetravail-9e0ae6",
+      "locationSet": {"include": ["fr"]},
+      "matchNames": ["pôle emploi"],
+      "matchTags": ["office/employment_agency"],
+      "tags": {
+        "brand": "France Travail",
+        "brand:wikidata": "Q8901192",
+        "name": "France Travail",
+        "old_name": "Pôle Emploi",
+        "office": "government",
+        "government": "employment_agency"
+      }
+    },
+    {
       "displayName": "Gesundheitsamt",
       "id": "gesundheitsamt-70633b",
       "locationSet": {"include": ["at", "de"]},
@@ -212,16 +227,6 @@
       "tags": {
         "brand": "PARCOURS GC",
         "name": "PARCOURS GC",
-        "office": "government"
-      }
-    },
-    {
-      "displayName": "Pôle Emploi",
-      "id": "poleemploi-f941ae",
-      "locationSet": {"include": ["fr"]},
-      "tags": {
-        "brand": "Pôle Emploi",
-        "name": "Pôle Emploi",
         "office": "government"
       }
     },


### PR DESCRIPTION
"Pôle Emploi" brand does not exist anymore, it has been replaced by "France Travail" (since 2024-01-01).

And it is a public service, not an employment agency.

Sources:
- https://wiki.openstreetmap.org/wiki/France/Services_Publics#France_Travail_/_P%C3%B4le_Emploi
- https://forum.openstreetmap.fr/t/de-pole-emploi-a-france-travail/20397