### PR TITLE
Update bank.json - Exclude MX in citibank

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -5066,7 +5066,7 @@
       "id": "citibank-4bddfc",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["hk"]
+        "exclude": ["hk", "mx"]
       },
       "matchNames": [
         "citibank brazil",


### PR DESCRIPTION
As citibank switched to Banamex in Mexico we can exclude it.