### PR TITLE
Update of Catalana Occidente due to rebranding to Occident

### DIFF
--- a/data/brands/office/insurance.json
+++ b/data/brands/office/insurance.json
@@ -728,13 +728,14 @@
       }
     },
     {
-      "displayName": "Catalana Occidente",
+      "displayName": "Occident",
       "id": "catalanaoccidente-38d127",
       "locationSet": {"include": ["es"]},
+      "matchNames": ["Catalana Occidente", "Catalana Occident", "Seguros Bilbao", "Plus Ultra", "Norte Hispania"],
       "tags": {
-        "brand": "Catalana Occidente",
-        "brand:wikidata": "Q5936881",
-        "name": "Catalana Occidente",
+        "brand": "Occident",
+        "brand:wikidata": "Q124218333",
+        "name": "Occident",
         "office": "insurance"
       }
     },


### PR DESCRIPTION
Catalana Occidente has fusionante all its insurance brands and named as "Occident". Additionally, the Wikidata reference is updated from Q5936881 to Q124218333. Q5936881 makes reference to the parent company and Q124218333 only to occident as an insurance company.

Sources: 
https://www.occident.com/
https://brandemia.org/catalana-occidente-cambia-nombre-occident

@Robot8A 