### PR TITLE
Update Walmart Neighborhood Market brand

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -9115,7 +9115,7 @@
       "locationSet": {"include": ["us"]},
       "preserveTags": ["^name"],
       "tags": {
-        "brand": "Walmart",
+        "brand": "Walmart Neighborhood Market",
         "brand:wikidata": "Q7963529",
         "name": "Walmart Neighborhood Market",
         "shop": "supermarket"


### PR DESCRIPTION
[In OSMUS Slack](https://osmus.slack.com/archives/C2VJAJCS0/p1743527750151379?thread_ts=1743521359.334469&cid=C2VJAJCS0), @petercooperjr kindly pointed out to me that I neglected to update the `brand=*` tag in #10694 when distinguishing Walmart Neighborhood Market’s separate QID.