### PR TITLE
Remove invalid operator:type=private for BKK

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -2601,7 +2601,6 @@
         "network": "MOL Bubi",
         "network:wikidata": "Q16971969",
         "operator": "BKK",
-        "operator:type": "private",
         "operator:wikidata": "Q608917"
       }
     },


### PR DESCRIPTION
BKK (BKK Budapesti Közlekedési Központ Zrt.) is a public company owned by the local government of Budapest: https://bkk.hu/rolunk/bemutatkozas/kik-vagyunk/#:~:text=A%20BKK%20100%20sz%C3%A1zal%C3%A9kban%20f%C5%91v%C3%A1rosi%20tulajdon%C3%BA%20k%C3%B6zszolg%C3%A1ltat%C3%B3%20t%C3%A1rsas%C3%A1g

Also, operator:* keys are generally not allowed in the NSI: https://github.com/osmlab/name-suggestion-index/wiki/Judge-Case#adding-specific-keys