### PR TITLE
Add Exploren charging network

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -3019,6 +3019,15 @@
       }
     },
     {
+      "displayName": "Exploren",
+      "locationSet": {"include": ["au"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Exploren",
+        "operator:wikidata": "Q130278349"
+      }
+    },
+    {
       "displayName": "EZE",
       "id": "eze-1299a8",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
Have purchased a significant number of chargers that are currently on the Chargefox network.