### PR TITLE
Mixed upper and lower case brand names for Edeka and Rewe beverage shops

### DIFF
--- a/data/brands/shop/beverages.json
+++ b/data/brands/shop/beverages.json
@@ -40,14 +40,14 @@
       }
     },
     {
-      "displayName": "EDEKA Getränkemarkt",
+      "displayName": "Edeka Getränkemarkt",
       "id": "edekagetrankemarkt-c4cb62",
       "locationSet": {"include": ["de"]},
       "preserveTags": ["^name"],
       "tags": {
-        "brand": "EDEKA",
+        "brand": "Edeka",
         "brand:wikidata": "Q57450576",
-        "name": "EDEKA Getränkemarkt",
+        "name": "Edeka Getränkemarkt",
         "shop": "beverages"
       }
     },
@@ -259,13 +259,13 @@
       }
     },
     {
-      "displayName": "REWE Getränkemarkt",
+      "displayName": "Rewe Getränkemarkt",
       "id": "rewegetrankemarkt-c4cb62",
       "locationSet": {"include": ["de"]},
       "tags": {
-        "brand": "REWE Getränkemarkt",
+        "brand": "Rewe Getränkemarkt",
         "brand:wikidata": "Q57519344",
-        "name": "REWE Getränkemarkt",
+        "name": "Rewe Getränkemarkt",
         "shop": "beverages"
       }
     },


### PR DESCRIPTION
Changed the brand names of Edeka and Rewe beverage shops to use mixed upper and lower case instead of upper case only. The change is a follow up of the change for supermarkets of the same brands in #10738.

This makes `name` and `brand` more consistent with other brands.