### PR TITLE
Add Appalachian Trail club operators

### DIFF
--- a/data/operators/trail.json
+++ b/data/operators/trail.json
@@ -1,0 +1,394 @@
+{
+  "items": [
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Green Mountain Club",
+        "operator:type": "private",
+        "operator:short": "GMC",
+        "operator:wikidata": "Q16994469"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Blue Mountain Eagle Climbing Club",
+        "operator:type": "private",
+        "operator:short": "BMECC",
+        "operator:wikidata": "Q131316451"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Georgia Appalachian Trail Club",
+        "operator:type": "private",
+        "operator:short": "GATC",
+        "operator:wikidata": "Q5547337"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Smoky Mountain Hiking Club",
+        "operator:type": "private",
+        "operator:short": "SMHC",
+        "operator:wikidata": "Q131309078"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Appalachian Mountain Club",
+        "operator:type": "private",
+        "operator:short": "AMC",
+        "operator:wikidata": "Q2858593"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Tennessee Eastman Hiking and Canoeing Club",
+        "operator:type": "private",
+        "operator:short": "TEHCC",
+        "operator:wikidata": "Q131309091"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Roanoke Appalachian Trail Club",
+        "operator:type": "private",
+        "operator:short": "RATC",
+        "operator:wikidata": "Q131316249"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "New York-New Jersey Trail Conference",
+        "operator:type": "private",
+        "operator:short": "NYNJTC",
+        "operator:wikidata": "Q17083031"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Maine Appalachian Trail Club",
+        "operator:type": "private",
+        "operator:short": "MATC",
+        "operator:wikidata": "Q6736310"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Potomac Appalachian Trail Club",
+        "operator:type": "private",
+        "operator:short": "PATC",
+        "operator:wikidata": "Q7235036"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Appalachian Mountain Club Western Massachusetts Chapter",
+        "operator:type": "private",
+        "operator:short": "AMC-WMA",
+        "operator:wikidata": "Q131309030"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Appalachian Mountain Club Connecticut Chapter",
+        "operator:type": "private",
+        "operator:short": "CT AMC",
+        "operator:wikidata": "Q131309025"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Dartmouth Outing Club",
+        "operator:type": "private",
+        "operator:short": "DOC",
+        "operator:wikidata": "Q5225718"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Nantahala Hiking Club",
+        "operator:type": "private",
+        "operator:short": "NHC",
+        "operator:wikidata": "Q131309055"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Carolina Mountain Club",
+        "operator:type": "private",
+        "operator:short": "CMC",
+        "operator:wikidata": "Q131309085"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Randolph Mountain Club",
+        "operator:type": "private",
+        "operator:short": "RMC",
+        "operator:wikidata": "Q131309101"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Piedmont Appalachian Trail Hikers",
+        "operator:type": "private",
+        "operator:short": "PATH",
+        "operator:wikidata": "Q131311677"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Mount Rogers Appalachian Trail Club",
+        "operator:type": "private",
+        "operator:short": "MRATC",
+        "operator:wikidata": "Q131311682"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Old Dominion Appalachian Trail Club",
+        "operator:type": "private",
+        "operator:short": "ODATC",
+        "operator:wikidata": "Q131311954"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Tidewater Appalachian Trail Club",
+        "operator:type": "private",
+        "operator:short": "TATC",
+        "operator:wikidata": "Q131311942"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Natural Bridge Appalachian Trail Club",
+        "operator:type": "private",
+        "operator:short": "NBATC",
+        "operator:wikidata": "Q131311920"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Outdoor Club at Virginia Tech",
+        "operator:type": "private",
+        "operator:short": "OCVT",
+        "operator:wikidata": "Q131316233"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Mountain Club of Maryland",
+        "operator:type": "private",
+        "operator:short": "MCM",
+        "operator:wikidata": "Q131316360"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Cumberland Valley Appalachian Trail Club",
+        "operator:type": "private",
+        "operator:short": "CVATC",
+        "operator:wikidata": "Q131316387"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "York Hiking Club",
+        "operator:type": "private",
+        "operator:short": "YHC",
+        "operator:wikidata": "Q131316417"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Batona Hiking Club",
+        "operator:type": "private",
+        "operator:short": "BHC",
+        "operator:wikidata": "Q131316475"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Susquehanna Appalachian Trail Club",
+        "operator:type": "private",
+        "operator:short": "SATC",
+        "operator:wikidata": "Q131316447"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Allentown Hiking Club",
+        "operator:type": "private",
+        "operator:short": "AHC",
+        "operator:wikidata": "Q131316453"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Keystone Trails Association",
+        "operator:type": "private",
+        "operator:short": "KTA",
+        "operator:wikidata": "Q131316456"
+      }
+    },
+    {
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "operator": "Appalachian Mountain Club Delaware Valley Chapter",
+        "operator:type": "private",
+        "operator:short": "AMC DV",
+        "operator:wikidata": "Q131316468"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This is a draft PR to help illustrate and open up discussion around #10865. The data format would need to be better defined, but this is a start. The data is for the 30 member clubs that maintain the Appalachian Trail ([relation/156553](https://www.openstreetmap.org/relation/156553)), all mapped in OSM and linked to Wikidata.