### PR TITLE
fix(totalenergies): exclude specific countries from locationSet

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5749,7 +5749,7 @@
       "id": "totalenergies-bd0db4",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["us"]
+        "exclude": ["us", "id", "tr", "mx", "br", "de"]
       },
       "matchNames": [
         "total",


### PR DESCRIPTION
This pull request updates the locationSet for the TotalEnergies brand entry. Specifically, it excludes Indonesia (id), Turkey (tr), Mexico (mx), Brazil (br), and Germany (de) from the locationSet.​

Reasoning:

In these countries, TotalEnergies operates primarily as fuel stations (amenity=fuel) rather than convenience stores (shop=convenience). This adjustment ensures that the NSI accurately reflects the brand's operations in these regions. Each of these countries has different convenience stores operating at the facility, IDN/TUR/BRA and MEX has bonjour for example While place in DEU has Circle K
![image](https://github.com/user-attachments/assets/99e52fff-ea35-4d37-a4f0-7545827a503d)

This trend could extend to other locations across the world.
These 5 countries above confirmed.