### PR TITLE
Add RNV  Transit Ticket vending machines in Germany

### DIFF
--- a/data/operators/amenity/vending_machine.json
+++ b/data/operators/amenity/vending_machine.json
@@ -289,6 +289,21 @@
         "recycling:plastic_bottles": "yes",
         "vending": "bottle_return"
       }
+    },
+    {
+      "displayName": "Rhein-Neckar-Verkehr",
+      "locationSet": {"include": ["de-bw.geojson", "de-he.geojson", "de-rp.geojson"]},
+      "matchNames": ["rnv", "vrn"],
+      "tags": {
+        "amenity": "vending_machine",
+        "operator": "Rhein-Neckar-Verkehr GmbH",
+        "operator:wikidata": "Q1650863",
+        "currency:EUR": "yes",
+        "payment:cash": "yes",
+        "payment:credit_cards": "yes",
+        "payment:debit_cards": "yes",
+        "vending": "public_transport_tickets"
+      }
     }
   ]
 }


### PR DESCRIPTION
More info: https://en.wikipedia.org/wiki/Rhein-Neckar-Verkehr - Large transit operator in the Rhine-Main area with surely hundreds of machines.

All machines are consistent, so payment tags are correct. Should be ready to merge.