### PR TITLE
Add METRO GASTRO

### DIFF
--- a/data/brands/shop/wholesale.json
+++ b/data/brands/shop/wholesale.json
@@ -240,6 +240,17 @@
       }
     },
     {
+      "displayName": "METRO GASTRO",
+      "id": "metrogastro-ad6aeb",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "brand": "METRO",
+        "brand:wikidata": "Q13610282",
+        "name": "METRO GASTRO",
+        "shop": "wholesale"
+      }
+    },
+    {
       "displayName": "S&R Membership Shopping",
       "id": "sandrmembershipshopping-fc4d00",
       "locationSet": {"include": ["ph"]},

--- a/data/brands/shop/wholesale.json
+++ b/data/brands/shop/wholesale.json
@@ -243,6 +243,7 @@
       "displayName": "METRO GASTRO",
       "id": "metrogastro-ad6aeb",
       "locationSet": {"include": ["de"]},
+      "matchNames": ["c+c schaper"],
       "tags": {
         "brand": "METRO",
         "brand:wikidata": "Q13610282",


### PR DESCRIPTION
Add [METRO GASTRO](https://www.metro.de/unternehmen/metro-gastro) (formerly "C+C Schaper") as a part of the METRO brand, as it's often being mistagged as `branch=Gastro`.

From my research it looks like these only exist in Germany, there, however, they make up a big chunk of the METRO lineup ([47 out of all 102 stores](https://www.metro.de/standorte)).