### PR TITLE
Make Fix Price available in LV

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -2942,6 +2942,7 @@
       },
       "tags": {
         "brand": "Fix Price",
+        "brand:wikidata": "Q4038791",
         "name": "Fix Price",
         "shop": "supermarket"
       }


### PR DESCRIPTION
Fix Price is operating also in Latvia. Here is the website: https://lv.fix-price.com/