### PR TITLE
Add RD Electronics

### DIFF
--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -1409,6 +1409,16 @@
       }
     },
     {
+      "displayName": "RD Electronics",
+      "locationSet": {"include": ["lv"]},
+      "tags": {
+        "brand": "RD Electronics",
+        "brand:wikidata": "Q124607006",
+        "name": "RD Electronics",
+        "shop": "electronics"
+      }
+    }, 
+    {
       "displayName": "re:Store",
       "id": "restore-71b2fd",
       "locationSet": {"include": ["ru"]},


### PR DESCRIPTION
RD Electronics is an electronics store chain operating in Latvia. The company itself is called MK Trade.