### PR TITLE
Added Ametller Origen

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -420,6 +420,19 @@
       }
     },
     {
+      "displayName": "Ametller Origen",
+      "id": "",
+      "locationSet": {
+        "include": ["es", "ad"]
+      },
+      "tags": {
+        "brand": "Ametller Origen",
+        "brand:wikidata": "Q20106290",
+        "name": "Ametller Origen",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Amigo",
       "id": "amigo-dde59d",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Supermarket chain found in Catalonia (I used `es` in case of expansion) and Andorra, with more than 130 stores.