### PR TITLE
Add One NZ, A New Zealand cell phone company

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -13,7 +13,7 @@
       "displayName": "One NZ",
       "id": "",
       "locationSet": {"include": ["nz"]},
-      "matchNames": ["one nz, vodafone"],
+      "matchNames": ["one nz", "vodafone"],
       "preserveTags": ["^name"],
       "tags": {
         "brand": "One NZ",

--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -14,7 +14,6 @@
       "id": "",
       "locationSet": {"include": ["nz"]},
       "matchNames": ["one nz", "vodafone"],
-      "preserveTags": ["^name"],
       "tags": {
         "brand": "One NZ",
         "brand:wikidata": "Q7939291",

--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -10,6 +10,19 @@
   },
   "items": [
     {
+      "displayName": "One NZ",
+      "id": "",
+      "locationSet": {"include": ["nz"]},
+      "matchNames": ["one nz, vodafone"],
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "One NZ",
+        "brand:wikidata": "Q7939291",
+        "name": "One NZ",
+        "shop": "mobile_phone"
+      }
+    },
+    {
       "displayName": "2degrees",
       "id": "2degrees-5219b0",
       "locationSet": {"include": ["nz"]},


### PR DESCRIPTION
Vodafone sold their NZ division off in 2023 and then they rebranded to One NZ. I'm not sure if i should also include vodafone in the match names as it is the name many people still know them by, please leave a comment if not. Thanks <3