### PR TITLE
add Petmark, Italian pet shop chain (ex Maxi Zoo)

### DIFF
--- a/data/brands/shop/pet.json
+++ b/data/brands/shop/pet.json
@@ -561,6 +561,16 @@
         "shop": "pet"
       }
     },
+   {
+      "displayName": "Petmark",
+      "locationSet": { "include": ["it"]},
+      "tags": {
+        "brand": "Petmark",
+        "brand:wikidata": "Q133849688",
+        "name": "Petmark",
+        "shop": "pet"
+      }
+    },
     {
       "displayName": "PetPeople",
       "id": "petpeople-81a22d",


### PR DESCRIPTION
This new Italian retail chain is supposed to consist entirely of former Maxi zoo shops.

A few of these shops have already been mapped on OSM: https://overpass-turbo.eu/s/226Q