### PR TITLE
Adding/updated hostels associated with Hostelling International

### DIFF
--- a/data/brands/tourism/hostel.json
+++ b/data/brands/tourism/hostel.json
@@ -136,7 +136,7 @@
       "id": "yha-99878c",
       "locationSet": {"include": ["gb-eng", "gb-wls"]},
       "matchTags": ["tourism/hotel"],
-      "matchName": ["Hostelling International"],
+      "matchNames": ["Hostelling International"],
       "tags": {
         "brand": "Youth Hostels Association",
         "brand:wikidata": "Q8059214",
@@ -190,7 +190,7 @@
       "displayName": "Youth Hostels Association of India",
       "locationSet": {"include": ["in"]},
       "matchTags": ["tourism/hotel"],
-      "matchName": ["Hostelling International"],
+      "matchNames": ["Hostelling International"],
       "tags": {
         "brand": "Youth Hostels Association of India",
         "brand:wikidata": "Q8059217",
@@ -203,7 +203,7 @@
       "displayName": "Youth Hostels Association (Australia)",
       "locationSet": {"include": ["au"]},
       "matchTags": ["tourism/hotel"],
-      "matchName": ["Hostelling International"],
+      "matchNames": ["Hostelling International"],
       "tags": {
         "brand": "Youth Hostels Association",
         "brand:wikidata": "Q8045885",
@@ -216,7 +216,7 @@
       "displayName": "Hostelling Scotland",
       "locationSet": {"include": ["gb-sct"]},
       "matchTags": ["tourism/hotel"],
-      "matchName": ["Scottish Youth Hostels Association","SYHA Hostelling Scotland","Hostelling International"],
+      "matchNames": ["Scottish Youth Hostels Association","SYHA Hostelling Scotland","Hostelling International"],
       "tags": {
         "brand": "Hostelling Scotland",
         "brand:wikidata": "Q7438052",

--- a/data/brands/tourism/hostel.json
+++ b/data/brands/tourism/hostel.json
@@ -132,14 +132,16 @@
       }
     },
     {
-      "displayName": "YHA",
+      "displayName": "Youth Hostels Association (England & Wales)",
       "id": "yha-99878c",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {"include": ["gb-eng", "gb-wls"]},
       "matchTags": ["tourism/hotel"],
+      "matchName": ["Hostelling International"]
       "tags": {
-        "brand": "YHA",
+        "brand": "Youth Hostels Association",
         "brand:wikidata": "Q8059214",
-        "name": "YHA",
+        "name": "Youth Hostels Association",
+        "short_name": "YHA",
         "tourism": "hostel"
       }
     },
@@ -158,6 +160,69 @@
         "name:en": "9h nine hours",
         "name:ja": "ナインアワーズ",
         "tourism": "hostel"
+      }
+    },
+    {
+      "displayName": "Hostelling International (Canada)",
+      "locationSet": {"include": ["ca"]},
+      "matchTags": ["tourism/hotel"],
+      "tags": {
+        "brand": "Hostelling International",
+        "brand:wikidata": "Q16984941",
+        "name": "Hostelling International",
+        "short_name": "HI",
+        "shop": "hostel"
+      }
+    },
+    {
+      "displayName": "Hostelling International (USA)",
+      "locationSet": {"include": ["us"]},
+      "matchTags": ["tourism/hotel"],
+      "tags": {
+        "brand": "Hostelling International",
+        "brand:wikidata": "Q16980401",
+        "name": "Hostelling International",
+        "short_name": "HI",
+        "shop": "hostel"
+      }
+    },
+    {
+      "displayName": "Youth Hostels Association of India",
+      "locationSet": {"include": ["in"]},
+      "matchTags": ["tourism/hotel"],
+      "matchName": ["Hostelling International"].
+      "tags": {
+        "brand": "Youth Hostels Association of India",
+        "brand:wikidata": "Q8059217",
+        "name": "Youth Hostels Association of India",
+        "short_name": "YHA India",
+        "shop": "hostel"
+      }
+    },
+    {
+      "displayName": "Youth Hostels Association (Australia)",
+      "locationSet": {"include": ["au"]},
+      "matchTags": ["tourism/hotel"],
+      "matchName": ["Hostelling International"],
+      "tags": {
+        "brand": "Youth Hostels Association",
+        "brand:wikidata": "Q8045885",
+        "name": "Youth Hostels Association",
+        "short_name": "YHA Australia",
+        "shop": "hostel"
+      }
+    },
+    {
+      "displayName": "Hostelling Scotland",
+      "locationSet": {"include": ["gb-sct"]},
+      "matchTags": ["tourism/hotel"],
+      "matchName": ["Scottish Youth Hostels Association","SYHA Hostelling Scotland","Hostelling International"],
+      "tags": {
+        "brand": "Hostelling Scotland",
+        "brand:wikidata": "Q7438052",
+        "name": "Hostelling Scotland",
+        "short_name": "HS",
+        "shop": "hostel"
       }
     }
   ]

--- a/data/brands/tourism/hostel.json
+++ b/data/brands/tourism/hostel.json
@@ -136,7 +136,7 @@
       "id": "yha-99878c",
       "locationSet": {"include": ["gb-eng", "gb-wls"]},
       "matchTags": ["tourism/hotel"],
-      "matchName": ["Hostelling International"]
+      "matchName": ["Hostelling International"],
       "tags": {
         "brand": "Youth Hostels Association",
         "brand:wikidata": "Q8059214",
@@ -190,7 +190,7 @@
       "displayName": "Youth Hostels Association of India",
       "locationSet": {"include": ["in"]},
       "matchTags": ["tourism/hotel"],
-      "matchName": ["Hostelling International"].
+      "matchName": ["Hostelling International"],
       "tags": {
         "brand": "Youth Hostels Association of India",
         "brand:wikidata": "Q8059217",

--- a/data/brands/tourism/hostel.json
+++ b/data/brands/tourism/hostel.json
@@ -139,9 +139,9 @@
       "matchNames": ["Hostelling International"],
       "tags": {
         "brand": "Youth Hostels Association",
+        "brand:short": "YHA",
         "brand:wikidata": "Q8059214",
         "name": "Youth Hostels Association",
-        "short_name": "YHA",
         "tourism": "hostel"
       }
     },
@@ -168,10 +168,10 @@
       "matchTags": ["tourism/hotel"],
       "tags": {
         "brand": "Hostelling International",
+        "brand:short": "HI",
         "brand:wikidata": "Q16984941",
         "name": "Hostelling International",
-        "short_name": "HI",
-        "shop": "hostel"
+        "tourism": "hostel"
       }
     },
     {
@@ -180,10 +180,10 @@
       "matchTags": ["tourism/hotel"],
       "tags": {
         "brand": "Hostelling International",
+        "brand:short": "HI",
         "brand:wikidata": "Q16980401",
         "name": "Hostelling International",
-        "short_name": "HI",
-        "shop": "hostel"
+        "tourism": "hostel"
       }
     },
     {
@@ -193,10 +193,10 @@
       "matchNames": ["Hostelling International"],
       "tags": {
         "brand": "Youth Hostels Association of India",
+        "brand:short": "YHA India",
         "brand:wikidata": "Q8059217",
         "name": "Youth Hostels Association of India",
-        "short_name": "YHA India",
-        "shop": "hostel"
+        "tourism": "hostel"
       }
     },
     {
@@ -206,10 +206,10 @@
       "matchNames": ["Hostelling International"],
       "tags": {
         "brand": "Youth Hostels Association",
+        "brand:short": "YHA Australia",
         "brand:wikidata": "Q8045885",
         "name": "Youth Hostels Association",
-        "short_name": "YHA Australia",
-        "shop": "hostel"
+        "tourism": "hostel"
       }
     },
     {
@@ -219,10 +219,10 @@
       "matchNames": ["Scottish Youth Hostels Association","SYHA Hostelling Scotland","Hostelling International"],
       "tags": {
         "brand": "Hostelling Scotland",
+        "brand:short": "HS",
         "brand:wikidata": "Q7438052",
         "name": "Hostelling Scotland",
-        "short_name": "HS",
-        "shop": "hostel"
+        "tourism": "hostel"
       }
     }
   ]


### PR DESCRIPTION
Adding/updating the hostelling organizations in England, Wales, Scotland, Canada, USA, India, and Australia that are associated with Hostelling International

This is an incomplete list but captures many of the largest national organizations.