### PR TITLE
Add Bright Store

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -994,6 +994,17 @@
       }
     },
     {
+      "displayName": "Bright Store",
+      "locationSet": {"include": ["id"]},
+      "matchNames": ["bright"],
+      "tags": {
+        "brand": "Bright Store",
+        "brand:wikidata": "Q130389269",
+        "name": "Bright Store",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "Brněnka",
       "id": "brnenka-a7773e",
       "locationSet": {"include": ["cz"]},


### PR DESCRIPTION
Please add Bright Store, a convenience store brand owned by Pertamina, often place in Pertamina fuel stations