### PR TITLE
Add IPIC movie theaters

### DIFF
--- a/data/brands/amenity/cinema.json
+++ b/data/brands/amenity/cinema.json
@@ -542,6 +542,17 @@
       }
     },
     {
+      "displayName": "IPIC Theaters",
+      "id": "ipic-40491",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "amenity": "cinema",
+        "brand": "IPIC Theaters",
+        "brand:wikidata": "Q133939347",
+        "name": "IPIC Theaters"
+      }
+    },
+    {
       "displayName": "Irish Multiplex Cinemas",
       "id": "imc-668c40",
       "locationSet": {"include": ["ie"]},


### PR DESCRIPTION
Movie theater brand with locations in Texas, Georgia, Florida, Maryland, California, New York, New Jersey, and Washington

Wikidata entry created here:
https://www.wikidata.org/wiki/Q42299303

You can find them here:
https://www.ipic.com/

![Screenshot_2025-04-19_17-56-30](https://github.com/user-attachments/assets/c4dded6f-85fd-46d3-b67c-e18c664917d5)