### PR TITLE
Fixed Queensland Rail being listed as a private operator

### DIFF
--- a/data/operators/amenity/parking.json
+++ b/data/operators/amenity/parking.json
@@ -759,7 +759,7 @@
         "fee": "no",
         "name": "Queensland Rail park 'n' ride",
         "operator": "Queensland Rail",
-        "operator:type": "private",
+        "operator:type": "public",
         "operator:wikidata": "Q379439",
         "park_ride": "yes",
         "supervised": "no"


### PR DESCRIPTION
Queensland Rail is a company owned by the Queensland Government.

Not `operator:type=government` because:

- Has their own corporate and governance structure (https://www.queenslandrail.com.au/aboutus/governance) including a board of directors (https://www.queenslandrail.com.au/aboutus/governance/board), thus not operated directly by the Queensland Government
- ABN not listed as a government department (https://abr.business.gov.au/ABN/View?id=71132181090), opposed to, for examples, the Department of Transport and Main Roads in Queensland (https://abr.business.gov.au/ABN/View?abn=39407690291)