### PR TITLE
Please extend locationset for Electra charging stations with BE and NL

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -1948,7 +1948,7 @@
     {
       "displayName": "Electra",
       "id": "electra-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {"include": ["fx", "be", "nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Electra",


### PR DESCRIPTION
Hello,

Due to a strategic partnership with AholdDelhaize (the parent company of the supermarket chains Albert Heijn and Delhaize), it is installing charging points on the premises of those supermarkets.

Since these are located in Belgium and Netherlands but the locationset didn't include that, I'm extending this with BE and NL.
Please merge with main tree.