### PR TITLE
Update hospital.json - NHS trusts are operator:type=public, not private

### DIFF
--- a/data/operators/amenity/hospital.json
+++ b/data/operators/amenity/hospital.json
@@ -344,7 +344,7 @@
         "amenity": "hospital",
         "healthcare": "hospital",
         "operator": "Avon and Wiltshire Mental Health Partnership NHS Trust",
-        "operator:type": "private",
+        "operator:type": "public",
         "operator:wikidata": "Q4829257"
       }
     },
@@ -658,7 +658,7 @@
         "amenity": "hospital",
         "healthcare": "hospital",
         "operator": "Cornwall Partnership NHS Foundation Trust",
-        "operator:type": "private",
+        "operator:type": "public",
         "operator:wikidata": "Q16988175"
       }
     },
@@ -819,7 +819,7 @@
         "amenity": "hospital",
         "healthcare": "hospital",
         "operator": "Devon Partnership NHS Trust",
-        "operator:type": "private",
+        "operator:type": "public",
         "operator:wikidata": "Q16988718"
       }
     },
@@ -851,7 +851,7 @@
         "amenity": "hospital",
         "healthcare": "hospital",
         "operator": "Dorset HealthCare University NHS Foundation Trust",
-        "operator:type": "private",
+        "operator:type": "public",
         "operator:wikidata": "Q16988978"
       }
     },
@@ -1114,7 +1114,7 @@
         "amenity": "hospital",
         "healthcare": "hospital",
         "operator": "Great Ormond Street Hospital for Children NHS Foundation Trust",
-        "operator:type": "private",
+        "operator:type": "public",
         "operator:wikidata": "Q19873658"
       }
     },
@@ -1131,7 +1131,7 @@
         "amenity": "hospital",
         "healthcare": "hospital",
         "operator": "Greater Manchester Mental Health NHS Foundation Trust",
-        "operator:type": "private",
+        "operator:type": "public",
         "operator:wikidata": "Q16993309"
       }
     },
@@ -1247,7 +1247,7 @@
         "amenity": "hospital",
         "healthcare": "hospital",
         "operator": "Imperial College Healthcare NHS Trust",
-        "operator:type": "private",
+        "operator:type": "public",
         "operator:wikidata": "Q14956770"
       }
     },
@@ -1560,7 +1560,7 @@
         "amenity": "hospital",
         "healthcare": "hospital",
         "operator": "Maidstone and Tunbridge Wells NHS Trust",
-        "operator:type": "private",
+        "operator:type": "public",
         "operator:wikidata": "Q16997207"
       }
     },
@@ -2958,7 +2958,7 @@
         "amenity": "hospital",
         "healthcare": "hospital",
         "operator": "Somerset NHS Foundation Trust",
-        "operator:type": "private",
+        "operator:type": "public",
         "operator:wikidata": "Q96405998"
       }
     },
@@ -3206,7 +3206,7 @@
         "amenity": "hospital",
         "healthcare": "hospital",
         "operator": "University Hospitals Dorset NHS Foundation Trust",
-        "operator:type": "private",
+        "operator:type": "public",
         "operator:wikidata": "Q99964922"
       }
     },


### PR DESCRIPTION
NHS trusts in the UK are publicly owned, so should be operator:type=public, not private. The wiki seems fairly unambiguous on this.

https://wiki.openstreetmap.org/wiki/Key:operator:type

This has resulted in mis-tagging by inexperienced users who unquestioningly accept iD's suggestions for tag upgrades.