### PR TITLE
Added Ramirent

### DIFF
--- a/data/brands/shop/tool_hire.json
+++ b/data/brands/shop/tool_hire.json
@@ -126,30 +126,21 @@
           "br",
           "ch",
           "co",
-          "cz",
           "de",
           "dk",
-          "ee",
           "es",
-          "fi",
           "fr",
           "gb",
           "ie",
           "it",
           "kw",
-          "lt",
           "lu",
-          "lv",
           "ma",
           "nl",
-          "no",
           "om",
-          "pl",
           "pt",
           "qa",
-          "sa",
-          "se",
-          "sk"
+          "sa"
         ]
       },
       "tags": {
@@ -159,6 +150,28 @@
         "shop": "tool_hire"
       }
     },
+    {
+      "displayName": "Ramirent",
+      "locationSet": {
+        "include": [
+          "lv",
+          "lt",
+          "ee",
+          "no",
+          "fi",
+          "se",
+          "pl",
+          "cz",
+          "sk"
+        ]
+      },
+      "tags": {
+        "brand": "Ramirent",
+        "brand:wikidata": "Q11890005",
+        "name": "Ramirent",
+        "shop": "tool_hire"
+      }
+    },	
     {
       "displayName": "Rentas",
       "id": "rentas-6e38b5",


### PR DESCRIPTION
Loxam operates as Ramirent in some countries. See https://www.ramirent.com/ for more info.

All currently mapped Ramirent shops: https://overpass-turbo.eu/s/22Y9
All currently mapped Loxam shops: https://overpass-turbo.eu/s/22Yb