### PR TITLE
[brands/amenity/vending_machine.json] Add "Falomat"

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -547,6 +547,18 @@
       }
     },
     {
+      "displayName": "Falomat",
+      "locationSet": {"include": ["pl"]},
+      "tags": {
+        "amenity": "vending_machine",
+        "brand": "Falomat",
+        "brand:wikidata": "Q134171522",
+        "operator": "System Fala",
+        "vending": "public_transport_tickets",
+        "payment:contactless": "yes"
+      }
+    },
+    {
       "displayName": "FastKey",
       "id": "fastkey-7e3927",
       "locationSet": {"include": ["us"]},

--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -552,6 +552,7 @@
       "tags": {
         "amenity": "vending_machine",
         "brand": "Falomat",
+        "brand:wikidata": "Q134171522",
         "operator": "System Fala",
         "vending": "public_transport_tickets",
         "payment:contactless": "yes"

--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -552,7 +552,6 @@
       "tags": {
         "amenity": "vending_machine",
         "brand": "Falomat",
-        "brand:wikidata": "Q134171522",
         "operator": "System Fala",
         "vending": "public_transport_tickets",
         "payment:contactless": "yes"


### PR DESCRIPTION
Add "Falomat". A machine vending public transport tickets in the Pomeranian Voivodeship, Poland: https://www.wikidata.org/wiki/Q134171522

Operated by "System Fala": https://systemfala.pl/