### PR TITLE
[operators/man_made/surveillance] add France to main McDonalds entry

### DIFF
--- a/data/operators/man_made/surveillance.json
+++ b/data/operators/man_made/surveillance.json
@@ -3914,7 +3914,6 @@
           "by",
           "cn",
           "eg",
-          "fr",
           "iq",
           "jo",
           "jp",
@@ -3933,17 +3932,6 @@
           "tw"
         ]
       },
-      "tags": {
-        "man_made": "surveillance",
-        "operator": "McDonald's",
-        "operator:wikidata": "Q38076"
-      }
-    },
-    {
-      "displayName": "McDonald's (France)",
-      "id": "mcdonalds-e10d05",
-      "locationSet": {"include": ["fr"]},
-      "matchNames": ["mac donald"],
       "tags": {
         "man_made": "surveillance",
         "operator": "McDonald's",

--- a/data/operators/man_made/surveillance.json
+++ b/data/operators/man_made/surveillance.json
@@ -3947,7 +3947,7 @@
       "tags": {
         "man_made": "surveillance",
         "operator": "McDonald's",
-        "operator:wikidata": "Q60766811"
+        "operator:wikidata": "Q38076"
       }
     },
     {


### PR DESCRIPTION
rel to: https://github.com/osmlab/name-suggestion-index/commit/10af0856a3ee6dcdde63d035a8adb1d18fe41c2d

[Q60766811](https://www.wikidata.org/w/index.php?title=Q60766811) has zero usages in OSM

- https://taginfo.geofabrik.de/europe:france/search?q=brand%3Awikidata%3DQ60766811
- https://taginfo.geofabrik.de/europe:france/search?q=operator%3Awikidata%3DQ60766811

seems France uses Q38076 for both brands and operators:

- https://taginfo.geofabrik.de/europe:france/search?q=operator%3Awikidata%3DQ38076
- https://taginfo.geofabrik.de/europe:france/search?q=brand%3Awikidata%3DQ38076

