### PR TITLE
Added Cramo

### DIFF
--- a/data/brands/shop/tool_hire.json
+++ b/data/brands/shop/tool_hire.json
@@ -65,6 +65,25 @@
         "shop": "tool_hire"
       }
     },
+	{
+      "displayName": "Cramo",
+      "locationSet": {
+        "include": [
+          "ee",
+          "fi",
+          "lt",
+          "lv",
+          "no",
+          "se"
+        ]
+      },
+      "tags": {
+        "brand": "Cramo",
+        "brand:wikidata": "Q10460958",
+        "name": "Cramo",
+        "shop": "tool_hire"
+      }
+    },
     {
       "displayName": "Hirebase",
       "id": "hirebase-92549b",


### PR DESCRIPTION
Boels Group's subsidiary Cramo operates in Baltic States and Scandinavia.

https://www.cramogroup.com/
https://group.boels.com/en/about-cramo/