### PR TITLE
Add Trans Jogja and Trans Semarang

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -18984,12 +18984,30 @@
       }
     },
     {
+      "displayName": "Trans Jogja",
+      "locationSet": {"include": ["id-jw"]},
+      "tags": {
+        "network": "Trans Jogja",
+        "network:wikidata": "Q4263106",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "Trans Metro Bandung",
       "id": "transmetrobandung-462599",
       "locationSet": {"include": ["id-jw"]},
       "tags": {
         "network": "Trans Metro Bandung",
         "network:wikidata": "Q12522252",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Trans Semarang",
+      "locationSet": {"include": ["id-jw"]},
+      "tags": {
+        "network": "Trans Semarang",
+        "network:wikidata": "Q12522247",
         "route": "bus"
       }
     },


### PR DESCRIPTION
Please add Trans Jogja and Trans Semarang, city bus network in the island of Java, Indonesia.