### PR TITLE
[office/telecommunication] Add Telkom Indonesia

### DIFF
--- a/data/brands/office/telecommunication.json
+++ b/data/brands/office/telecommunication.json
@@ -272,6 +272,17 @@
       }
     },
     {
+      "displayName": "Telkom Indonesia",
+      "locationSet": {"include": ["id"]},
+      "matchNames": ["telkom"],
+      "tags": {
+        "brand": "Telkom Indonesia",
+        "brand:wikidata": "Q2305438",
+        "name": "Telkom Indonesia",
+        "office": "telecommunication"
+      }
+    },
+    {
       "displayName": "Telkomsel",
       "id": "telkomsel-89d943",
       "locationSet": {"include": ["id"]},


### PR DESCRIPTION
Please add Telkom Indonesia, a state-owned telecommunication company in Indonesia. It is the parent company of Telkomsel, which sometimes share office with Telkom Indonesia, but not always.