### PR TITLE
Change Canada Post post_office to brand, not operator

### DIFF
--- a/data/brands/amenity/post_office.json
+++ b/data/brands/amenity/post_office.json
@@ -38,6 +38,20 @@
       }
     },
     {
+      "displayName": "Canada Post",
+      "id": "canadapost-17c815",
+      "locationSet": {
+        "include": ["ca"],
+        "exclude": ["ca-qc.geojson"]
+      },
+      "matchNames": ["canada post", "canada post/ poste canada"],
+      "tags": {
+        "amenity": "post_office",
+        "brand": "Canada Post",
+        "brand:wikidata": "Q1032001"
+      }
+    },
+    {
       "displayName": "City Express (Србија)",
       "id": "cityexpress-59a7c7",
       "locationSet": {"include": ["rs"]},
@@ -330,6 +344,23 @@
         "amenity": "post_office",
         "brand": "Posten",
         "brand:wikidata": "Q1815701"
+      }
+    },
+    {
+      "displayName": "Postes Canada",
+      "id": "postescanada-525cac",
+      "locationSet": {
+        "include": ["ca-qc.geojson"]
+      },
+      "matchNames": [
+        "canada post/ poste canada",
+        "poste canada",
+        "postes canada"
+      ],
+      "tags": {
+        "amenity": "post_office",
+        "brand": "Postes Canada",
+        "brand:wikidata": "Q1032001"
       }
     },
     {

--- a/data/operators/amenity/post_office.json
+++ b/data/operators/amenity/post_office.json
@@ -185,20 +185,6 @@
       }
     },
     {
-      "displayName": "Canada Post",
-      "id": "canadapost-17c815",
-      "locationSet": {
-        "include": ["ca"],
-        "exclude": ["ca-qc.geojson"]
-      },
-      "matchNames": ["canada post/ poste canada"],
-      "tags": {
-        "amenity": "post_office",
-        "operator": "Canada Post",
-        "operator:wikidata": "Q1032001"
-      }
-    },
-    {
       "displayName": "Cargus",
       "id": "cargus-08dfb1",
       "locationSet": {"include": ["ro"]},
@@ -1163,22 +1149,6 @@
         "amenity": "post_office",
         "operator": "Pošte Srpske",
         "operator:wikidata": "Q5245881"
-      }
-    },
-    {
-      "displayName": "Postes Canada",
-      "id": "postescanada-525cac",
-      "locationSet": {
-        "include": ["ca-qc.geojson"]
-      },
-      "matchNames": [
-        "canada post/ poste canada",
-        "poste canada"
-      ],
-      "tags": {
-        "amenity": "post_office",
-        "operator": "Postes Canada",
-        "operator:wikidata": "Q1032001"
       }
     },
     {


### PR DESCRIPTION
Similar to #7100 and #10076: at least some Canada Post outlets are not operated by Canada Post (possibly most), however they are prominently branded as Canada Post.

See https://community.openstreetmap.org/t/canada-post-outlets-not-operated-by-canada-post/129748 for discussion and a picture. See also https://wiki.openstreetmap.org/wiki/Canada_Post for a project where many post offices were added or amended.

Draft PR while I wait for further comments on the forum.

Sorry for making this two commits, the repo is huge to clone and I couldn't figure out how to edit two files in one commit in the Github web interface. Please squash when merging.