### PR TITLE
Add 'name' preserveTags to pharmacies

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -526,6 +526,7 @@
         "benu aptieka",
         "benu vaistinė"
       ],
+      "preserveTags": ["^name"],
       "tags": {
         "amenity": "pharmacy",
         "brand": "Benu",

--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -189,6 +189,7 @@
       "displayName": "Alma Gyógyszertár",
       "id": "almagyogyszertar-3674c9",
       "locationSet": {"include": ["hu"]},
+      "preserveTags": ["^name"],
       "tags": {
         "amenity": "pharmacy",
         "brand": "Alma Gyógyszertár",


### PR DESCRIPTION
- Benu pharmacies sometimes have a unique name. See an example here: https://www.openstreetmap.org/node/3097302629
- Alma Gyógyszertár pharmacies sometimes have a unique name. See an example here: https://www.openstreetmap.org/node/6545104545