### PR TITLE
Remove London from Honest Greens locations

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -3314,7 +3314,6 @@
         "include": [
           "es",
           "fr-idf.geojson",
-          "gb-lon.geojson",
           "pt"
         ]
       },


### PR DESCRIPTION
Remove London from Honest Greens locations as it operates under different name of Hg