### PR TITLE
Merge Market Place by Jasons into Market Place

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -5040,25 +5040,13 @@
       "displayName": "Market Place",
       "id": "marketplace-745f9c",
       "locationSet": {"include": ["hk"]},
+      "matchNames": ["market place by jasons"],
       "tags": {
         "brand": "Market Place",
         "brand:en": "Market Place",
         "brand:wikidata": "Q10851178",
         "name": "Market Place",
         "name:en": "Market Place",
-        "shop": "supermarket"
-      }
-    },
-    {
-      "displayName": "Market Place by Jasons",
-      "id": "marketplacebyjasons-745f9c",
-      "locationSet": {"include": ["hk"]},
-      "tags": {
-        "brand": "Market Place by Jasons",
-        "brand:en": "Market Place by Jasons",
-        "brand:wikidata": "Q6770713",
-        "name": "Market Place by Jasons",
-        "name:en": "Market Place by Jasons",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/issues/10949#issuecomment-2869954634

According to [Wikipedia](https://en.wikipedia.org/wiki/Market_Place_(supermarket)), this is clear that "Market Place by Jasons" was rebranded to "Market Place". I imagine the Wikidata entry will be merged at some point too, I'm not sure which ID they'll keep.