### PR TITLE
Add Alhelli supermarket brand in Bahrain

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -352,8 +352,9 @@
       },
       "tags": {
         "brand": "Alhelli",
+        "brand:wikidata": "Q134521158",
         "name": "Alhelli",
-        "name:ar": "الحلي",
+        "name:ar": "أسواق الحلي",
         "shop": "supermarket"
       }
     },

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -345,6 +345,19 @@
       }
     },
     {
+      "displayName": "Alhelli",
+      "id": "alhelli-bh",
+      "locationSet": {
+        "include": ["bh"]
+      },
+      "tags": {
+        "brand": "Alhelli",
+        "name": "Alhelli",
+        "name:ar": "الحلي",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Alimerka",
       "id": "alimerka-0513f1",
       "locationSet": {"include": ["es"]},


### PR DESCRIPTION
This PR adds the "Alhelli" supermarket brand in Bahrain to the Name Suggestion Index.

- Brand name: Alhelli
- Location: Bahrain (ISO code: bh)
- Tags include: 
  - shop=supermarket
  - brand=Alhelli
  - name=Alhelli
  - name:ar=أسواق الحلي

This entry will help improve tagging consistency for "Alhelli" locations in Bahrain.
