### PR TITLE
Add AlSater Market supermarket brand in Bahrain

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -389,6 +389,7 @@
         "brand": "AlSater Market",
         "brand:wikidata": "Q134521185",
         "name": "AlSater Market",
+        "name:en": "AlSater Market",
         "name:ar": "أسواق الساتر",
         "shop": "supermarket"
       }

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -380,6 +380,19 @@
       }
     },
     {
+      "displayName": "AlSater Market",
+      "id": "alsater-market-bh",
+      "locationSet": {
+        "include": ["bh"]
+      },
+      "tags": {
+        "brand": "AlSater Market",
+        "name": "AlSater Market",
+        "name:ar": "أسواق الساتر",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Alvo",
       "id": "alvo-f276cb",
       "locationSet": {"include": ["be", "lu"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -387,6 +387,7 @@
       },
       "tags": {
         "brand": "AlSater Market",
+        "brand:wikidata": "Q134521185",
         "name": "AlSater Market",
         "name:ar": "أسواق الساتر",
         "shop": "supermarket"


### PR DESCRIPTION
This PR adds the "AlSater Market" supermarket brand in Bahrain to the Name Suggestion Index.

- Brand name: AlSater Market
- Location: Bahrain (ISO code: bh)
- Tags include: 
  - shop=supermarket
  - brand=AlSater Market
  - name=AlSater Market
  - name:ar=أسواق الساتر
  
This entry will help improve tagging consistency for "AlSater Market" locations in Bahrain.
