### PR TITLE
Add Orange City Fire Dept

### DIFF
--- a/data/operators/amenity/fire_station.json
+++ b/data/operators/amenity/fire_station.json
@@ -4983,6 +4983,20 @@
         "operator": "高雄市政府消防局",
         "operator:wikidata": "Q15920569"
       }
+    },
+    {
+      "displayName": "Orange City Fire Department",
+      "id": "",
+      "locationSet": {
+        "include": ["us-ca-orange_county.geojson"]
+      },
+      "matchNames": ["city of orange fire"],
+      "note": "This is not the 'county' fire dept.",
+      "tags": {
+        "amenity": "fire_station",
+        "operator": "Orange City Fire Department",
+        "operator:wikidata": "Q7099617"
+      }
     }
   ]
 }


### PR DESCRIPTION
Added Orange City Fire Department. Not to be confused with Orange County Fire Authority.