### PR TITLE
[Renault Trucks] move from shop/car to shop/truck

### DIFF
--- a/data/brands/shop/car.json
+++ b/data/brands/shop/car.json
@@ -1148,17 +1148,6 @@
       }
     },
     {
-      "displayName": "Renault Trucks",
-      "id": "renaulttrucks-13eeb7",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "brand": "Renault Trucks",
-        "brand:wikidata": "Q840045",
-        "name": "Renault Trucks",
-        "shop": "car"
-      }
-    },
-    {
       "displayName": "Rimac",
       "id": "rimac-0f1e04",
       "locationSet": {

--- a/data/brands/shop/truck.json
+++ b/data/brands/shop/truck.json
@@ -116,6 +116,16 @@
       }
     },
     {
+      "displayName": "Renault Trucks",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "Renault Trucks",
+        "brand:wikidata": "Q840045",
+        "name": "Renault Trucks",
+        "shop": "truck"
+      }
+    },
+    {
       "displayName": "Volvo Trucks",
       "id": "volvotrucks-bb8fb2",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Renault Trucks sells trucks not regular cars: https://www.renault-trucks.com/en
[In OSM](https://overpass-turbo.eu/s/24SH) only 54 POIs with this brand and `shop=car` or `shop=car_repair`, so I don't think this PR is a radical change.

Typical Renault Trucks dealer:
<img width="462" alt="image" src="https://github.com/user-attachments/assets/b40b2267-cbf0-4985-93ae-729bd4bff08d" />
