### PR TITLE
Fix fees on indoor play

### DIFF
--- a/data/brands/leisure/indoor_play.json
+++ b/data/brands/leisure/indoor_play.json
@@ -64,7 +64,8 @@
         "brand": "Kids Empire",
         "brand:wikidata": "Q134489648",
         "leisure": "indoor_play",
-        "name": "Kids Empire"
+        "name": "Kids Empire",
+        "fee": "yes"
       }
     },
     {
@@ -76,7 +77,8 @@
         "brand:wikidata": "Q6945604",
         "leisure": "indoor_play",
         "name": "My Gym",
-        "official_name": "My Gym Children's Fitness Center"
+        "official_name": "My Gym Children's Fitness Center",
+        "fee": "yes"
       }
     },
     {
@@ -87,7 +89,8 @@
         "brand": "The Little Gym",
         "brand:wikidata": "Q7747618",
         "leisure": "indoor_play",
-        "name": "The Little Gym"
+        "name": "The Little Gym",
+        "fee": "yes"
       }
     },
     {
@@ -98,7 +101,8 @@
         "brand": "Wacky Warehouse",
         "brand:wikidata": "Q104215014",
         "leisure": "indoor_play",
-        "name": "Wacky Warehouse"
+        "name": "Wacky Warehouse",
+        "fee": "yes"
       }
     }
   ]


### PR DESCRIPTION
The wiki documents two different types of indoor_play

* play that's free without a fee
* centers for indoor play that require a fee.

We have both on this list. The IKEA play centers do not require a fee, as far as I can see. The others clearly do. This is in line with the wiki proposal.