### PR TITLE
Update SouthState bank name and footprint

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -12247,23 +12247,25 @@
       }
     },
     {
-      "displayName": "South State Bank",
+      "displayName": "SouthState Bank",
       "id": "southstatebank-7bc186",
       "locationSet": {
         "include": [
           "us-al.geojson",
+          "us-co.geojson",
           "us-fl.geojson",
           "us-ga.geojson",
           "us-nc.geojson",
           "us-sc.geojson",
+          "us-tx.geojson",
           "us-va.geojson"
         ]
       },
       "tags": {
         "amenity": "bank",
-        "brand": "South State Bank",
+        "brand": "SouthState Bank",
         "brand:wikidata": "Q55633597",
-        "name": "South State Bank"
+        "name": "SouthState Bank"
       }
     },
     {


### PR DESCRIPTION
SouthState Bank now has a number of locations in Colorado and Texas, so those states should be added to its entry in the NSI.

Additionally, while the entity is currently listed as "South State Bank" has been officially known as "SouthState Bank" (no space between "South" and "State") since November 2021. (Among other sources, see [FDIC BankFind](https://banks.data.fdic.gov/bankfind-suite/bankfind/details/33555?bankfindLevelThreeView=History&branchOffices=true&pageNumber=1&resultLimit=25), Transaction ID 202124497 - as shown below because deep-linking into the database does not appear to be possible.)

![image](https://github.com/user-attachments/assets/d5fbbaef-3714-4286-ae00-633e1e3366b0)
