### PR TITLE
[man_made/wastewater_plant] add England to Welsh Water locationSet

### DIFF
--- a/data/operators/man_made/wastewater_plant.json
+++ b/data/operators/man_made/wastewater_plant.json
@@ -343,7 +343,7 @@
     {
       "displayName": "Dŵr Cymru - Welsh Water",
       "id": "dwrcymruwelshwater-6a6be4",
-      "locationSet": {"include": ["gb-wls"]},
+      "locationSet": {"include": ["gb-wls","gb-eng"]},
       "tags": {
         "man_made": "wastewater_plant",
         "operator": "Dŵr Cymru - Welsh Water",


### PR DESCRIPTION
Dŵr Cymru Welsh Water's service area extends into parts of England along the border, so let it suggest that there too.