### PR TITLE
Match O² to O2

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -667,6 +667,7 @@
       "locationSet": {
         "include": ["cz", "de", "gb", "ie", "sk"]
       },
+      "matchNames": ["o²"],
       "tags": {
         "brand": "O2",
         "brand:wikidata": "Q1759255",


### PR DESCRIPTION
This extends the matching rule for O2 to also match O² (like tagged [here](https://www.openstreetmap.org/node/5851165744) for example)