### PR TITLE
 Special Civil Courts (JECs) in Brazil

### DIFF
--- a/data/operators/amenity/courthouse.json
+++ b/data/operators/amenity/courthouse.json
@@ -158,6 +158,16 @@
       }
     },
     {
+      "displayName": "Juizados Especiais Cíveis (JECs)",
+      "id": "poderjudiciário-3a5e8d",
+      "locationSet": {"include": ["br"]},
+      "tags": {
+        "amenity": "courthouse",
+        "operator": "Poder Judiciário",
+        "operator:wikidata": "Q10312802"
+      }
+    },
+    {
       "displayName": "Ministério da Justiça (Brasil)",
       "id": "ministeriodajustica-e063cd",
       "locationSet": {"include": ["br"]},


### PR DESCRIPTION
 Special Civil Courts (JECs) are bodies of the State Common Justice System, part of the Judiciary that operates in all Brazilian states.

History of the Special Civil Courts (JECs) https://pt.wikipedia.org/wiki/Juizado_Especial_C%C3%ADvel and their foundation.