### PR TITLE
Update insurance name to GRAWE

### DIFF
--- a/data/brands/office/insurance.json
+++ b/data/brands/office/insurance.json
@@ -1313,7 +1313,7 @@
       }
     },
     {
-      "displayName": "Grawe",
+      "displayName": "GRAWE",
       "id": "grawe-49851b",
       "locationSet": {
         "include": [
@@ -1337,9 +1337,9 @@
         "grazer wechselseitige versicherung ag"
       ],
       "tags": {
-        "brand": "Grawe",
+        "brand": "GRAWE",
         "brand:wikidata": "Q877006",
-        "name": "Grawe",
+        "name": "GRAWE",
         "office": "insurance"
       }
     },


### PR DESCRIPTION
The company's official website https://www.grawe.at ([here the latest archived version because somehow it's not really loading…](https://web.archive.org/web/20250510120138/https://www.grawe.at/)) only uses capitalized GRAWE.

Also, what to do with all the existing tags that use 'Grawe'? Will they be automatically changed after merge, or should I do that?