### PR TITLE
Fix operator:type tag for Better/GLL

### DIFF
--- a/data/brands/leisure/sports_centre.json
+++ b/data/brands/leisure/sports_centre.json
@@ -107,7 +107,7 @@
         "fee": "yes",
         "leisure": "sports_centre",
         "operator": "Greenwich Leisure Limited",
-        "operator:type": "private",
+        "operator:type": "cooperative",
         "operator:wikidata": "Q5604859"
       }
     },


### PR DESCRIPTION
Better/GLL is a worker-owned cooperative.

Reference:
* https://www.gll.org/b2b/pages/vision-culture
* https://community.openstreetmap.org/t/i-think-gll-better-shouldnt-be-operator-type-private-what-should-it-be/130736