### PR TITLE
Correct brand:wikidata reference for Michael Kors clothing brand

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -7063,7 +7063,7 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "Michael Kors",
-        "brand:wikidata": "Q19572998",
+        "brand:wikidata": "Q134612138",
         "name": "Michael Kors",
         "shop": "clothes"
       }


### PR DESCRIPTION
It seems that the original wd item has morphed into representing "Capri Holdings" the parent company of the Michael Kors brand. So I've created a new wd item for the brand itself. NSI should switch to that item.