### PR TITLE
[brands/office/government] rename Câmara de Vereadores to Câmara Municipal

### DIFF
--- a/data/brands/office/government.json
+++ b/data/brands/office/government.json
@@ -37,12 +37,14 @@
       }
     },
     {
-      "displayName": "Câmara de Vereadores",
-      "id": "camaradevereadores-efb6ac",
+      "displayName": "Câmara Municipal",
+      "id": "camaramunicipal-efb6ac",
       "locationSet": {"include": ["br"]},
       "tags": {
-        "brand": "Câmara de Vereadores",
-        "name": "Câmara de Vereadores",
+        "brand:br": "Câmara de Vereadores",
+        "brand": "Câmara Municipal",
+        "brand:wikidata": "Q25550691",
+        "name": "Câmara Municipal",
         "office": "government"
       }
     },


### PR DESCRIPTION
city council, known in Brazil as the chamber of councilors.  https://www.wikidata.org/wiki/Q25550691

In Brazil, the city council is the legislative body of each municipality, acting as the assembly of representatives of the citizens residing there.  https://pt.wikipedia.org/wiki/C%C3%A2mara_municipal_(Brasil)