### PR TITLE
Add DeinFach parcel locker

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -239,6 +239,16 @@
       }
     },
     {
+      "displayName": "DeinFach",
+      "id": "deinfach-83cc4d",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "DeinFach",
+        "brand:wikidata": "Q134622119"
+      }
+    },
+    {
       "displayName": "Deutsche Post",
       "id": "deutschepost-83cc4d",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
This adds the new [DeinFach](https://www.deinfach.de/de) parcel lockers. They are a [super recent](https://www.deinfach.de/de/uber-uns/pressebereich.html) addition, but one has already popped up in the neighborhood near me and some are already tagged in OSM.

I'm not sure what NSI's policy is with new brands popping up but as they are partnering with DHL and others I think it's quite likely they are going to stay.