### PR TITLE
Spain rail transport: New services and names

### DIFF
--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -230,7 +230,7 @@
         "network": "Cercanías León",
         "network:wikidata": "Q107428854",
         "operator": "Renfe Cercanías AM",
-        "operator:wikidata": "Q1054739",
+        "operator:wikidata": "Q1143007",
         "route": "train"
       }
     },
@@ -250,7 +250,7 @@
         "network": "Cercanías Ferrol",
         "network:wikidata": "Q107428536",
         "operator": "Renfe Cercanías AM",
-        "operator:wikidata": "Q1054739",
+        "operator:wikidata": "Q1143007",
         "route": "train"
       }
     },
@@ -268,7 +268,7 @@
       "tags": {
         "network": "Cercanías Cartagena",
         "operator": "Renfe Cercanías AM",
-        "operator:wikidata": "Q1054739",
+        "operator:wikidata": "Q1143007",
         "route": "train"
       }
     },

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -148,6 +148,23 @@
       }
     },
     {
+      "displayName": "Arabako Aldiriak / Cercanías Álava",
+      "id": "arabakoaldiriakcercaniasalava",
+      "locationSet": {
+        "include": ["es-vi.geojson"]
+      },
+      "note": "around Q31913753",
+      "tags": {
+        "network": "Arabako Aldiriak / Cercanías Álava",
+        "network:es": "Cercanías Álava",
+        "network:eu": "Arabako Aldiriak",
+        "network:wikidata": "Q134617299",
+        "operator": "Renfe",
+        "operator:wikidata": "Q2476154",
+        "route": "train"
+      }
+    },
+    {
       "displayName": "Bilboko Aldiriak / Cercanías Bilbao",
       "id": "bilbokoaldiriakcercaniasbilbao-a4f257",
       "locationSet": {
@@ -193,6 +210,65 @@
       "tags": {
         "network": "Caltrain",
         "network:wikidata": "Q166817",
+        "route": "train"
+      }
+    },
+	{
+      "displayName": "Cercanías León",
+      "id": "cercaniasleon",
+      "locationSet": {
+        "include": [
+			"es-le.geojson",
+			"es-p.geojson",		
+		]
+      },
+      "matchNames": [
+        "feve",
+        "renfe feve",
+      ],
+      "tags": {
+        "network": "Cercanías León",
+        "network:wikidata": "Q107428854",
+        "operator": "Renfe Cercanías AM",
+        "operator:wikidata": "Q1054739",
+        "route": "train"
+      }
+    },
+	{
+      "displayName": "Cercanías Ferrol",
+      "id": "cercaniasferrol",
+      "locationSet": {
+        "include": ["es-c.geojson"]
+      },
+      "matchNames": [
+        "feve",
+        "renfe feve",
+		"proximidades",
+		"cercanías galicia"
+      ],
+      "tags": {
+        "network": "Cercanías Ferrol",
+        "network:wikidata": "Q107428536",
+        "operator": "Renfe Cercanías AM",
+        "operator:wikidata": "Q1054739",
+        "route": "train"
+      }
+    },
+	{
+      "displayName": "Cercanías Cartagena",
+      "id": "cercaniascartagena",
+      "locationSet": {
+        "include": ["es-mu.geojson"]
+      },
+      "matchNames": [
+        "feve",
+        "renfe feve",
+		"cercanías cartagena",
+      ],
+      "tags": {
+        "network": "Cercanías Cartagena",
+        "operator": "Renfe Cercanías AM",
+        "operator:wikidata": "Q1054739",
         "route": "train"
       }
     },
@@ -276,13 +352,16 @@
       }
     },
     {
-      "displayName": "Cercanías Santander",
+      "displayName": "Cercanías Cantabria",
       "id": "cercaniassantander-f28461",
       "locationSet": {
         "include": ["es-s.geojson"]
       },
+      "matchNames": [
+        "cercanías santander",
+      ],
       "tags": {
-        "network": "Cercanías Santander",
+        "network": "Cercanías Cantabria",
         "network:wikidata": "Q1054773",
         "operator": "Renfe",
         "operator:wikidata": "Q2476154",

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -267,6 +267,7 @@
       ],
       "tags": {
         "network": "Cercanías Cartagena",
+	"network:wikidata": "Q28181968",
         "operator": "Renfe Cercanías AM",
         "operator:wikidata": "Q1143007",
         "route": "train"

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -153,7 +153,7 @@
       "locationSet": {
         "include": ["es-vi.geojson"]
       },
-      "note": "around Q31913753",
+      "note": "around Q14318",
       "tags": {
         "network": "Arabako Aldiriak / Cercanías Álava",
         "network:es": "Cercanías Álava",


### PR DESCRIPTION
- Cercanías Santander was renamed to Cantabria in 2019.
- Old FEVE services now operate under Renfe Cercanías AM
- Araba got a new commuter service.

Some of the changes I missed in my previous pull request. Thanks.