### PR TITLE
Remove reference to Eight Way and consolidate Bafang Dumpling entry

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -13526,29 +13526,9 @@
       }
     },
     {
-      "displayName": "八方雲集",
-      "id": "eightway-70aa35",
-      "locationSet": {
-        "include": ["cn", "tw"],
-        "exclude": ["hk", "mo"]
-      },
-      "tags": {
-        "amenity": "fast_food",
-        "brand": "八方雲集",
-        "brand:en": "Eight Way",
-        "brand:wikidata": "Q28417381",
-        "brand:zh": "八方雲集",
-        "cuisine": "dumplings",
-        "name": "八方雲集",
-        "name:en": "Eight Way",
-        "name:zh": "八方雲集",
-        "takeaway": "yes"
-      }
-    },
-    {
       "displayName": "八方雲集 Bafang Dumpling",
       "id": "bafangdumpling-17dd9a",
-      "locationSet": {"include": ["hk", "mo"]},
+      "locationSet": {"include": ["cn", "hk", "mo", "tw"]},
       "tags": {
         "amenity": "fast_food",
         "brand": "八方雲集 Bafang Dumpling",
@@ -14517,7 +14497,7 @@
         "name:en": "FJ Veggie",
         "name:zh": "芳珍蔬食",
         "operator": "八方雲集",
-        "operator:en": "Eight Way",
+        "operator:en": "Bafang Dumpling",
         "operator:wikidata": "Q28417381",
         "operator:zh": "八方雲集",
         "takeaway": "yes"


### PR DESCRIPTION
There is no need to have a separate entry for China and Taiwan with the English brand name of "Eight Way" as the company does not use that brand name in any of their English language material. The only reference to the term "Eight Way" is the domain name of their [official website](https://www.8way.com.tw). We can consolidate the China and Taiwan entry into the existing entry used in Hong Kong and Macau.

Also corrected the FJ Veggie operator's English name to "Bafang Dumpling".