### PR TITLE
Add entries for Sépaq

### DIFF
--- a/data/operators/boundary/national_park.json
+++ b/data/operators/boundary/national_park.json
@@ -257,6 +257,20 @@
       }
     },
     {
+      "displayName": "Sépaq",
+      "id": "societedesetablissementsdepleinairduquebec-77ca76",
+      "locationSet": {
+        "include": ["ca-qc.geojson"]
+      },
+      "tags": {
+        "boundary": "national_park",
+        "operator": "Société des établissements de plein air du Québec",
+        "operator:short": "Sépaq",
+        "operator:type": "government",
+        "operator:wikidata": "Q3488215"
+      }
+    },
+    {
       "displayName": "Servicio Nacional de Áreas Protegidas (Bolivia)",
       "id": "servicionacionaldeareasprotegidas-3c2a1d",
       "locationSet": {"include": ["bo"]},

--- a/data/operators/boundary/protected_area.json
+++ b/data/operators/boundary/protected_area.json
@@ -3205,6 +3205,20 @@
       }
     },
     {
+      "displayName": "Sépaq",
+      "id": "societedesetablissementsdepleinairduquebec-214176",
+      "locationSet": {
+        "include": ["ca-qc.geojson"]
+      },
+      "tags": {
+        "boundary": "protected_area",
+        "operator": "Société des établissements de plein air du Québec",
+        "operator:short": "Sépaq",
+        "operator:type": "government",
+        "operator:wikidata": "Q3488215"
+      }
+    },
+    {
       "displayName": "Servicio Nacional de Áreas Naturales Protegidas por el Estado",
       "id": "servicionacionaldeareasnaturalesprotegidasporelestado-2c37fa",
       "locationSet": {"include": ["pe"]},

--- a/data/operators/leisure/nature_reserve.json
+++ b/data/operators/leisure/nature_reserve.json
@@ -173,6 +173,20 @@
       }
     },
     {
+      "displayName": "Sépaq",
+      "id": "societedesetablissementsdepleinairduquebec-9bd80d",
+      "locationSet": {
+        "include": ["ca-qc.geojson"]
+      },
+      "tags": {
+        "leisure": "nature_reserve",
+        "operator": "Société des établissements de plein air du Québec",
+        "operator:short": "Sépaq",
+        "operator:type": "government",
+        "operator:wikidata": "Q3488215"
+      }
+    },
+    {
       "displayName": "The Nature Conservancy",
       "id": "thenatureconservancy-0d1563",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Add 3 entries for Sépaq, a Quebec government agency that operates the provincial parks and nature reserves.

* Adds an entry into `leisure=nature_reserve`
* Add an entry for `boundary=national_park`
* Adds an entry for `boundary=protected_area`

In many cases, more than one preset would apply at the same time, as all national parks are also tagged as `leisure=nature_reserve`, and all nature reserves are also tagged `boundary=protected_area`.

Example Nature Reserve: https://www.openstreetmap.org/relation/8008866
```
boundary=protected_area
leisure=nature_reserve
name=Réserve faunique de Portneuf
operator=Sépaq
operator:wikidata=Q3488215
operator:type=government
```
Example National Park: https://www.openstreetmap.org/relation/15421717
```
boundary=national_park
leisure=nature_reserve
name=Parc national de la Jacques-Cartier
operator=Sépaq
operator:type=government
operator:wikidata=Q3488215
```

Would this cause any issues downstream in editors?