### PR TITLE
Add preserveTags to Bike Totaal entry in bicycle.json

### DIFF
--- a/data/brands/shop/bicycle.json
+++ b/data/brands/shop/bicycle.json
@@ -64,6 +64,7 @@
       "displayName": "Bike Totaal",
       "id": "biketotaal-a0a74d",
       "locationSet": {"include": ["nl"]},
+      "preserveTags": ["^name"],
       "tags": {
         "brand": "Bike Totaal",
         "brand:wikidata": "Q123536506",


### PR DESCRIPTION
Based on the feedback received here: <https://community.openstreetmap.org/t/nsi-feedback-topic/131133/5>

The bike total always has the name of the franchise in the name.