### PR TITLE
Charging_station cleanup

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -2,31 +2,18 @@
   "properties": {
     "path": "brands/amenity/charging_station",
     "skipCollection": true,
-    "preserveTags": [
-      "^name"
-    ],
+    "preserveTags": ["^name"],
     "exclude": {
-      "generic": [
-        "^charging station$"
-      ],
-      "named": [
-        "^tesla, inc.$"
-      ]
+      "generic": ["^charging station$"],
+      "named": ["^tesla, inc.$"]
     }
   },
   "items": [
     {
       "displayName": "7-Eleven",
-      "id": "7eleven-994ed4",
-      "locationSet": {
-        "include": [
-          "us"
-        ]
-      },
-      "matchNames": [
-        "7-11",
-        "seven eleven"
-      ],
+      "id": "7eleven-5598dd",
+      "locationSet": {"include": ["us"]},
+      "matchNames": ["7-11", "seven eleven"],
       "tags": {
         "amenity": "charging_station",
         "brand": "7-Eleven",
@@ -38,13 +25,9 @@
     },
     {
       "displayName": "Applegreen Electric",
-      "id": "applegreenelectric-f6fe0b",
+      "id": "applegreenelectric-731cc1",
       "locationSet": {
-        "include": [
-          "gb",
-          "ie",
-          "us"
-        ]
+        "include": ["gb", "ie", "us"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -56,13 +39,8 @@
     },
     {
       "displayName": "Aral pulse",
-      "id": "aral-2d0940",
-      "locationSet": {
-        "include": [
-          "de",
-          "lu"
-        ]
-      },
+      "id": "aralpulse-e59580",
+      "locationSet": {"include": ["de", "lu"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Aral pulse",
@@ -72,12 +50,8 @@
     },
     {
       "displayName": "Be.EV",
-      "id": "iduna-3c1cb1",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "id": "beev-cc3397",
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Be.EV",
@@ -88,15 +62,8 @@
     {
       "displayName": "Believ",
       "id": "believ-cc3397",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
-      "matchNames": [
-        "believe",
-        "liberty charge"
-      ],
+      "locationSet": {"include": ["gb"]},
+      "matchNames": ["believe", "liberty charge"],
       "tags": {
         "amenity": "charging_station",
         "brand": "Believ",
@@ -106,7 +73,7 @@
     },
     {
       "displayName": "bike-energy",
-      "id": "bikeenergy-ff2890",
+      "id": "bikeenergy-b97cbe",
       "locationSet": {
         "include": [
           "at",
@@ -117,9 +84,7 @@
           "lu"
         ]
       },
-      "matchNames": [
-        "bike-energy ladestation"
-      ],
+      "matchNames": ["bike-energy ladestation"],
       "tags": {
         "amenity": "charging_station",
         "brand": "bike-energy",
@@ -131,13 +96,8 @@
     },
     {
       "displayName": "Blink",
-      "id": "blink-74901a",
-      "locationSet": {
-        "include": [
-          "gb",
-          "us"
-        ]
-      },
+      "id": "blink-f1151b",
+      "locationSet": {"include": ["gb", "us"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Blink",
@@ -149,15 +109,12 @@
     },
     {
       "displayName": "Bosch eBike Systems",
-      "id": "boschebikesystems-28ff7e",
+      "id": "boschebikesystems-67e574",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "no"
-        ]
+        "include": ["001"],
+        "exclude": ["no"]
       },
+      "matchNames": ["robert bosch gmbh"],
       "tags": {
         "amenity": "charging_station",
         "brand": "Bosch eBike Systems",
@@ -168,14 +125,9 @@
     },
     {
       "displayName": "BP Pulse",
-      "id": "bppulse-ed9b3b",
+      "id": "bppulse-36ec13",
       "locationSet": {
-        "include": [
-          "au",
-          "gb",
-          "nz",
-          "us"
-        ]
+        "include": ["au", "gb", "nz", "us"]
       },
       "matchNames": [
         "bp chargemaster",
@@ -192,11 +144,7 @@
     {
       "displayName": "char.gy",
       "id": "chargy-cc3397",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "char.gy",
@@ -206,11 +154,7 @@
     {
       "displayName": "Charge365",
       "id": "charge365-054d0f",
-      "locationSet": {
-        "include": [
-          "no"
-        ]
-      },
+      "locationSet": {"include": ["no"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Charge365"
@@ -218,14 +162,10 @@
     },
     {
       "displayName": "ChargePoint",
-      "id": "chargepoint-28ff7e",
+      "id": "chargepoint-67e574",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "no"
-        ]
+        "include": ["001"],
+        "exclude": ["no"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -238,11 +178,9 @@
     },
     {
       "displayName": "Charging the Regions",
-      "id": "centralvictoriangreenhousealliance-6c573b",
+      "id": "chargingtheregions-604e55",
       "locationSet": {
-        "include": [
-          "au-vic.geojson"
-        ]
+        "include": ["au-vic.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -255,11 +193,7 @@
     {
       "displayName": "Chargy",
       "id": "chargy-e87a7c",
-      "locationSet": {
-        "include": [
-          "lu"
-        ]
-      },
+      "locationSet": {"include": ["lu"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Chargy",
@@ -271,12 +205,8 @@
     },
     {
       "displayName": "Circle K",
-      "id": "circlek-c22d3a",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
+      "id": "circlek-4bd82e",
+      "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Circle K",
@@ -288,15 +218,9 @@
     },
     {
       "displayName": "Circuit électrique",
-      "id": "circuitelectrique-67089a",
-      "locationSet": {
-        "include": [
-          "ca"
-        ]
-      },
-      "matchNames": [
-        "le circuit électrique"
-      ],
+      "id": "circuitelectrique-1f220b",
+      "locationSet": {"include": ["ca"]},
+      "matchNames": ["le circuit électrique"],
       "tags": {
         "amenity": "charging_station",
         "brand": "Circuit électrique",
@@ -314,12 +238,8 @@
     },
     {
       "displayName": "E-WALD",
-      "id": "ewald-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "id": "ewald-190c99",
+      "locationSet": {"include": ["de"]},
       "matchNames": [
         "e-wald gmbh",
         "e-wald ladestation"
@@ -335,15 +255,9 @@
     },
     {
       "displayName": "E.ON Drive",
-      "id": "eon-7f623e",
-      "locationSet": {
-        "include": [
-          "150"
-        ]
-      },
-      "matchNames": [
-        "e-on drive"
-      ],
+      "id": "eondrive-b625d6",
+      "locationSet": {"include": ["150"]},
+      "matchNames": ["e.on danmark"],
       "tags": {
         "amenity": "charging_station",
         "brand": "E.ON Drive",
@@ -353,13 +267,9 @@
     },
     {
       "displayName": "Electra",
-      "id": "electra-1b5132",
+      "id": "electra-86df4c",
       "locationSet": {
-        "include": [
-          "be",
-          "fx",
-          "nl"
-        ]
+        "include": ["be", "fx", "nl"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -371,12 +281,8 @@
     },
     {
       "displayName": "Electrify America",
-      "id": "electrifyamerica-994ed4",
-      "locationSet": {
-        "include": [
-          "us"
-        ]
-      },
+      "id": "electrifyamerica-5598dd",
+      "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Electrify America",
@@ -388,11 +294,7 @@
     {
       "displayName": "Electrocharge",
       "id": "electrocharge-59a92d",
-      "locationSet": {
-        "include": [
-          "bg"
-        ]
-      },
+      "locationSet": {"include": ["bg"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Electrocharge",
@@ -401,12 +303,8 @@
     },
     {
       "displayName": "Enel",
-      "id": "enel-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "id": "enel-0532c0",
+      "locationSet": {"include": ["it"]},
       "matchNames": [
         "enel - stazione di ricarica"
       ],
@@ -421,17 +319,11 @@
     },
     {
       "displayName": "Enel X",
-      "id": "enelx-bdf07e",
+      "id": "enelx-01e016",
       "locationSet": {
-        "include": [
-          "cl",
-          "it",
-          "ro"
-        ]
+        "include": ["cl", "it", "ro"]
       },
-      "matchNames": [
-        "enel x metbus"
-      ],
+      "matchNames": ["enel x metbus"],
       "tags": {
         "amenity": "charging_station",
         "brand": "Enel X",
@@ -443,12 +335,9 @@
     },
     {
       "displayName": "ESB ecars",
-      "id": "esbgroup-881c56",
+      "id": "ecars-e9c107",
       "locationSet": {
-        "include": [
-          "gb-nir",
-          "ie"
-        ]
+        "include": ["gb-nir", "ie"]
       },
       "matchNames": [
         "ecarni",
@@ -464,12 +353,8 @@
     },
     {
       "displayName": "EV Connect",
-      "id": "evconnect-994ed4",
-      "locationSet": {
-        "include": [
-          "us"
-        ]
-      },
+      "id": "evconnect-5598dd",
+      "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "EV Connect",
@@ -480,12 +365,8 @@
     },
     {
       "displayName": "EVgo",
-      "id": "evgo-994ed4",
-      "locationSet": {
-        "include": [
-          "us"
-        ]
-      },
+      "id": "evgo-5598dd",
+      "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "EVgo",
@@ -498,11 +379,7 @@
     {
       "displayName": "Eviny",
       "id": "eviny-054d0f",
-      "locationSet": {
-        "include": [
-          "no"
-        ]
-      },
+      "locationSet": {"include": ["no"]},
       "matchNames": [
         "bkk",
         "bkk nett as for hordaland fylkeskommune",
@@ -517,12 +394,8 @@
     },
     {
       "displayName": "evyve",
-      "id": "evyve-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "id": "evyve-cc3397",
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "evyve",
@@ -533,14 +406,9 @@
     },
     {
       "displayName": "Fastned",
-      "id": "fastned-17c03e",
+      "id": "fastned-b69337",
       "locationSet": {
-        "include": [
-          "be",
-          "de",
-          "gb",
-          "nl"
-        ]
+        "include": ["be", "de", "gb", "nl"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -552,13 +420,8 @@
     },
     {
       "displayName": "FLO",
-      "id": "flo-78626b",
-      "locationSet": {
-        "include": [
-          "ca",
-          "us"
-        ]
-      },
+      "id": "flo-d2b245",
+      "locationSet": {"include": ["ca", "us"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "FLO",
@@ -570,12 +433,8 @@
     },
     {
       "displayName": "GeniePoint",
-      "id": "geniepoint-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "id": "geniepoint-cc3397",
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "GeniePoint",
@@ -586,14 +445,10 @@
     },
     {
       "displayName": "Gogoro 電池交換站",
-      "id": "62c656-28ff7e",
+      "id": "62c656-67e574",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "no"
-        ]
+        "include": ["001"],
+        "exclude": ["no"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -606,12 +461,8 @@
     },
     {
       "displayName": "Gridserve",
-      "id": "gridserve-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "id": "gridserve-cc3397",
+      "locationSet": {"include": ["gb"]},
       "matchNames": [
         "ecotricity",
         "electric highway"
@@ -628,11 +479,7 @@
     {
       "displayName": "Indigo",
       "id": "indigo-fd0ca8",
-      "locationSet": {
-        "include": [
-          "fr"
-        ]
-      },
+      "locationSet": {"include": ["fr"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Indigo",
@@ -641,12 +488,8 @@
     },
     {
       "displayName": "Innogy",
-      "id": "innogy-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "id": "innogy-190c99",
+      "locationSet": {"include": ["de"]},
       "matchNames": [
         "innogy emobility solutions gmbh",
         "innogy se",
@@ -664,14 +507,8 @@
     {
       "displayName": "Ionity",
       "id": "ionity-b625d6",
-      "locationSet": {
-        "include": [
-          "150"
-        ]
-      },
-      "matchNames": [
-        "ionity gmbh"
-      ],
+      "locationSet": {"include": ["150"]},
+      "matchNames": ["ionity gmbh"],
       "tags": {
         "amenity": "charging_station",
         "brand": "Ionity",
@@ -683,11 +520,7 @@
     {
       "displayName": "Ishavsveien",
       "id": "ishavsveien-054d0f",
-      "locationSet": {
-        "include": [
-          "no"
-        ]
-      },
+      "locationSet": {"include": ["no"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Ishavsveien"
@@ -696,11 +529,7 @@
     {
       "displayName": "Kople",
       "id": "kople-054d0f",
-      "locationSet": {
-        "include": [
-          "no"
-        ]
-      },
+      "locationSet": {"include": ["no"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Kople",
@@ -711,13 +540,7 @@
       "displayName": "Mer",
       "id": "mer-36d5f6",
       "locationSet": {
-        "include": [
-          "at",
-          "de",
-          "gb",
-          "no",
-          "se"
-        ]
+        "include": ["at", "de", "gb", "no", "se"]
       },
       "matchNames": [
         "bee",
@@ -737,15 +560,9 @@
     },
     {
       "displayName": "Mercedes-Benz",
-      "id": "mercedesbenz-c22d3a",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
-      "matchNames": [
-        "mercedes"
-      ],
+      "id": "mercedesbenz-4bd82e",
+      "locationSet": {"include": ["001"]},
+      "matchNames": ["mercedes"],
       "tags": {
         "amenity": "charging_station",
         "brand": "Mercedes-Benz",
@@ -756,12 +573,8 @@
     },
     {
       "displayName": "Mobiliti",
-      "id": "mobiliti-27e906",
-      "locationSet": {
-        "include": [
-          "hu"
-        ]
-      },
+      "id": "mobiliti-39fea5",
+      "locationSet": {"include": ["hu"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Mobiliti",
@@ -783,9 +596,7 @@
           "sk"
         ]
       },
-      "matchNames": [
-        "mol nyrt."
-      ],
+      "matchNames": ["mol nyrt."],
       "tags": {
         "amenity": "charging_station",
         "brand": "MOL Plugee",
@@ -798,12 +609,8 @@
       "displayName": "NIO Power Charger",
       "id": "niopowercharger-9dbcd7",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "cn"
-        ]
+        "include": ["001"],
+        "exclude": ["cn"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -820,12 +627,8 @@
       "displayName": "NIO Power Destination",
       "id": "niopowerdestination-9dbcd7",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "cn"
-        ]
+        "include": ["001"],
+        "exclude": ["cn"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -842,12 +645,8 @@
       "displayName": "NIO Power Swap",
       "id": "niopowerswap-9dbcd7",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "cn"
-        ]
+        "include": ["001"],
+        "exclude": ["cn"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -863,11 +662,7 @@
     {
       "displayName": "OpenLoop",
       "id": "openloop-dd8b2e",
-      "locationSet": {
-        "include": [
-          "nz"
-        ]
-      },
+      "locationSet": {"include": ["nz"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "OpenLoop",
@@ -878,12 +673,8 @@
     },
     {
       "displayName": "Osprey",
-      "id": "osprey-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "id": "osprey-cc3397",
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Osprey",
@@ -895,11 +686,7 @@
     {
       "displayName": "Plugit",
       "id": "plugit-4d533b",
-      "locationSet": {
-        "include": [
-          "fi"
-        ]
-      },
+      "locationSet": {"include": ["fi"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Plugit",
@@ -908,12 +695,8 @@
     },
     {
       "displayName": "Pod Point",
-      "id": "podpoint-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "id": "podpoint-cc3397",
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Pod Point",
@@ -924,14 +707,10 @@
     },
     {
       "displayName": "Porsche",
-      "id": "porsche-28ff7e",
+      "id": "porsche-67e574",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "no"
-        ]
+        "include": ["001"],
+        "exclude": ["no"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -944,12 +723,7 @@
     {
       "displayName": "Powerbox.one",
       "id": "powerboxone-391bca",
-      "locationSet": {
-        "include": [
-          "cz",
-          "sk"
-        ]
-      },
+      "locationSet": {"include": ["cz", "sk"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Powerbox.one",
@@ -960,11 +734,7 @@
       "displayName": "Powerdot",
       "id": "powerdot-f718d2",
       "locationSet": {
-        "include": [
-          "es",
-          "fr",
-          "pl"
-        ]
+        "include": ["es", "fr", "pl"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -979,12 +749,7 @@
       "displayName": "Recharge",
       "id": "recharge-12f14e",
       "locationSet": {
-        "include": [
-          "dk",
-          "fi",
-          "no",
-          "se"
-        ]
+        "include": ["dk", "fi", "no", "se"]
       },
       "matchNames": [
         "fortum",
@@ -1001,12 +766,8 @@
     },
     {
       "displayName": "Red E",
-      "id": "rede-994ed4",
-      "locationSet": {
-        "include": [
-          "us"
-        ]
-      },
+      "id": "rede-5598dd",
+      "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Red E",
@@ -1019,15 +780,8 @@
     {
       "displayName": "Rivian Adventure Network",
       "id": "rivianadventurenetwork-d2b245",
-      "locationSet": {
-        "include": [
-          "ca",
-          "us"
-        ]
-      },
-      "matchNames": [
-        "rivian adventure charger"
-      ],
+      "locationSet": {"include": ["ca", "us"]},
+      "matchNames": ["rivian adventure charger"],
       "tags": {
         "amenity": "charging_station",
         "brand": "Rivian Adventure Network",
@@ -1039,15 +793,8 @@
     {
       "displayName": "Rivian Waypoints",
       "id": "rivianwaypoints-d2b245",
-      "locationSet": {
-        "include": [
-          "ca",
-          "us"
-        ]
-      },
-      "matchNames": [
-        "rivian waypoint charger"
-      ],
+      "locationSet": {"include": ["ca", "us"]},
+      "matchNames": ["rivian waypoint charger"],
       "tags": {
         "amenity": "charging_station",
         "brand": "Rivian Waypoints",
@@ -1059,11 +806,7 @@
     {
       "displayName": "Smart Charge",
       "id": "smartcharge-cc3397",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Smart Charge",
@@ -1074,11 +817,9 @@
     },
     {
       "displayName": "Source London",
-      "id": "sourcelondon-489d95",
+      "id": "sourcelondon-477177",
       "locationSet": {
-        "include": [
-          "gb-lon.geojson"
-        ]
+        "include": ["gb-lon.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1091,12 +832,8 @@
     },
     {
       "displayName": "SureCharge",
-      "id": "fmconway-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "id": "surecharge-cc3397",
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "SureCharge",
@@ -1108,14 +845,8 @@
     {
       "displayName": "Tesla Destination Charger",
       "id": "tesladestinationcharger-4bd82e",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
-      "matchNames": [
-        "tesla wall connector"
-      ],
+      "locationSet": {"include": ["001"]},
+      "matchNames": ["tesla wall connector"],
       "tags": {
         "amenity": "charging_station",
         "brand": "Tesla",
@@ -1126,11 +857,7 @@
     {
       "displayName": "Tesla Supercharger",
       "id": "teslasupercharger-4bd82e",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
+      "locationSet": {"include": ["001"]},
       "matchNames": [
         "tesla motors",
         "tesla motors inc",
@@ -1148,12 +875,8 @@
     },
     {
       "displayName": "Toka",
-      "id": "toka-a6c3f2",
-      "locationSet": {
-        "include": [
-          "ua"
-        ]
-      },
+      "id": "toka-a6fb9c",
+      "locationSet": {"include": ["ua"]},
       "matchNames": [
         "перша національна мережа електрозаправних комплексів тока",
         "тока"
@@ -1169,15 +892,10 @@
     },
     {
       "displayName": "TotalEnergies",
-      "id": "totalenergies-0344be",
+      "id": "totalenergies-770cce",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "no",
-          "us"
-        ]
+        "include": ["001"],
+        "exclude": ["no", "us"]
       },
       "matchNames": [
         "total",
@@ -1195,17 +913,9 @@
       "displayName": "ubitricity",
       "id": "ubitricity-ef5e60",
       "locationSet": {
-        "include": [
-          "ch",
-          "de",
-          "fr",
-          "gb",
-          "ie"
-        ]
+        "include": ["ch", "de", "fr", "gb", "ie"]
       },
-      "matchNames": [
-        "ubitricity gmbh"
-      ],
+      "matchNames": ["ubitricity gmbh"],
       "tags": {
         "amenity": "charging_station",
         "brand": "ubitricity",
@@ -1217,18 +927,11 @@
     },
     {
       "displayName": "Vattenfall InCharge",
-      "id": "vattenfallincharge-648812",
+      "id": "vattenfallincharge-667d30",
       "locationSet": {
-        "include": [
-          "gb",
-          "nl",
-          "se"
-        ]
+        "include": ["gb", "nl", "se"]
       },
-      "matchNames": [
-        "incharge",
-        "vattenfall"
-      ],
+      "matchNames": ["incharge", "vattenfall"],
       "tags": {
         "amenity": "charging_station",
         "brand": "Vattenfall InCharge",
@@ -1240,15 +943,9 @@
     },
     {
       "displayName": "VIRTA",
-      "id": "virta-e80d25",
-      "locationSet": {
-        "include": [
-          "fi"
-        ]
-      },
-      "matchNames": [
-        "liikennevirta oy"
-      ],
+      "id": "virta-4d533b",
+      "locationSet": {"include": ["fi"]},
+      "matchNames": ["liikennevirta oy"],
       "tags": {
         "amenity": "charging_station",
         "brand": "VIRTA",
@@ -1260,12 +957,8 @@
     },
     {
       "displayName": "We Drive Solar",
-      "id": "wedrivesolar-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "id": "wedrivesolar-2a8f9b",
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "We Drive Solar",
@@ -1277,11 +970,7 @@
     {
       "displayName": "WINK Charging",
       "id": "wink-59a92d",
-      "locationSet": {
-        "include": [
-          "bg"
-        ]
-      },
+      "locationSet": {"include": ["bg"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "WINK",
@@ -1292,14 +981,8 @@
     {
       "displayName": "Zero",
       "id": "zero-dd8b2e",
-      "locationSet": {
-        "include": [
-          "nz"
-        ]
-      },
-      "matchNames": [
-        "meridian"
-      ],
+      "locationSet": {"include": ["nz"]},
+      "matchNames": ["meridian"],
       "tags": {
         "amenity": "charging_station",
         "brand": "Zero",
@@ -1310,12 +993,8 @@
     },
     {
       "displayName": "Zest",
-      "id": "zest-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "id": "zest-cc3397",
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Zest",
@@ -1327,14 +1006,8 @@
     {
       "displayName": "ZSE Drive",
       "id": "zsedrive-8610f2",
-      "locationSet": {
-        "include": [
-          "sk"
-        ]
-      },
-      "matchNames": [
-        "zse"
-      ],
+      "locationSet": {"include": ["sk"]},
+      "matchNames": ["zse"],
       "tags": {
         "amenity": "charging_station",
         "brand": "ZSE Drive",
@@ -1346,11 +1019,7 @@
     {
       "displayName": "Белоруснефть Malanka",
       "id": "malanka-f2a4c9",
-      "locationSet": {
-        "include": [
-          "by"
-        ]
-      },
+      "locationSet": {"include": ["by"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Malanka",
@@ -1369,11 +1038,7 @@
     {
       "displayName": "Энергия Москвы",
       "id": "energyofmoscow-012f44",
-      "locationSet": {
-        "include": [
-          "ru"
-        ]
-      },
+      "locationSet": {"include": ["ru"]},
       "note": "ISO 3166-2 RU-MOW",
       "tags": {
         "amenity": "charging_station",
@@ -1389,12 +1054,8 @@
     },
     {
       "displayName": "国家电网",
-      "id": "stategridcorporationofchina-c785ca",
-      "locationSet": {
-        "include": [
-          "cn"
-        ]
-      },
+      "id": "stategrid-07dd34",
+      "locationSet": {"include": ["cn"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "国家电网",
@@ -1413,11 +1074,7 @@
     {
       "displayName": "小鹏超充站",
       "id": "xpengsupercharger-07dd34",
-      "locationSet": {
-        "include": [
-          "cn"
-        ]
-      },
+      "locationSet": {"include": ["cn"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "小鹏",
@@ -1431,7 +1088,7 @@
     },
     {
       "displayName": "東光高岳",
-      "id": "takaokatoko-631cd5",
+      "id": "takaokatoko-610a46",
       "locationSet": {
         "include": [
           "jp-12.geojson",
@@ -1456,11 +1113,7 @@
     {
       "displayName": "特来电",
       "id": "teld-07dd34",
-      "locationSet": {
-        "include": [
-          "cn"
-        ]
-      },
+      "locationSet": {"include": ["cn"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "特来电",
@@ -1475,11 +1128,7 @@
     {
       "displayName": "蔚来换电站",
       "id": "niopowerswap-07dd34",
-      "locationSet": {
-        "include": [
-          "cn"
-        ]
-      },
+      "locationSet": {"include": ["cn"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "NIO Power",
@@ -1493,11 +1142,7 @@
     {
       "displayName": "蔚来目充站",
       "id": "niopowerdestination-07dd34",
-      "locationSet": {
-        "include": [
-          "cn"
-        ]
-      },
+      "locationSet": {"include": ["cn"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "NIO Power",
@@ -1511,11 +1156,7 @@
     {
       "displayName": "蔚来超充站",
       "id": "niopowercharger-07dd34",
-      "locationSet": {
-        "include": [
-          "cn"
-        ]
-      },
+      "locationSet": {"include": ["cn"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "NIO Power",

--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -2,18 +2,31 @@
   "properties": {
     "path": "brands/amenity/charging_station",
     "skipCollection": true,
-    "preserveTags": ["^name"],
+    "preserveTags": [
+      "^name"
+    ],
     "exclude": {
-      "generic": ["^charging station$"],
-      "named": ["^tesla, inc.$"]
+      "generic": [
+        "^charging station$"
+      ],
+      "named": [
+        "^tesla, inc.$"
+      ]
     }
   },
   "items": [
     {
       "displayName": "7-Eleven",
-      "id": "7eleven-5598dd",
-      "locationSet": {"include": ["us"]},
-      "matchNames": ["7-11", "seven eleven"],
+      "id": "7eleven-994ed4",
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "matchNames": [
+        "7-11",
+        "seven eleven"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "7-Eleven",
@@ -25,9 +38,13 @@
     },
     {
       "displayName": "Applegreen Electric",
-      "id": "applegreenelectric-731cc1",
+      "id": "applegreenelectric-f6fe0b",
       "locationSet": {
-        "include": ["gb", "ie", "us"]
+        "include": [
+          "gb",
+          "ie",
+          "us"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -39,22 +56,33 @@
     },
     {
       "displayName": "Aral pulse",
-      "id": "aralpulse-e59580",
-      "locationSet": {"include": ["de", "lu"]},
+      "id": "aral-2d0940",
+      "locationSet": {
+        "include": [
+          "de",
+          "lu"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Aral pulse",
+        "brand:wikidata": "Q130210067",
         "operator": "Aral",
         "operator:wikidata": "Q565734"
       }
     },
     {
       "displayName": "Be.EV",
-      "id": "beev-cc3397",
-      "locationSet": {"include": ["gb"]},
+      "id": "iduna-3c1cb1",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Be.EV",
+        "brand:wikidata": "Q128603119",
         "operator": "Iduna",
         "operator:wikidata": "Q118263083"
       }
@@ -62,18 +90,26 @@
     {
       "displayName": "Believ",
       "id": "believ-cc3397",
-      "locationSet": {"include": ["gb"]},
-      "matchNames": ["believe", "liberty charge"],
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
+      "matchNames": [
+        "believe",
+        "liberty charge"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Believ",
         "brand:wikidata": "Q129085075",
-        "name": "Believ"
+        "operator": "Believ",
+        "operator:wikidata": "Q129085075"
       }
     },
     {
       "displayName": "bike-energy",
-      "id": "bikeenergy-b97cbe",
+      "id": "bikeenergy-ff2890",
       "locationSet": {
         "include": [
           "at",
@@ -84,7 +120,9 @@
           "lu"
         ]
       },
-      "matchNames": ["bike-energy ladestation"],
+      "matchNames": [
+        "bike-energy ladestation"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "bike-energy",
@@ -96,8 +134,13 @@
     },
     {
       "displayName": "Blink",
-      "id": "blink-f1151b",
-      "locationSet": {"include": ["gb", "us"]},
+      "id": "blink-74901a",
+      "locationSet": {
+        "include": [
+          "gb",
+          "us"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Blink",
@@ -109,15 +152,19 @@
     },
     {
       "displayName": "Bosch eBike Systems",
-      "id": "boschebikesystems-67e574",
+      "id": "boschebikesystems-28ff7e",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no"
+        ]
       },
-      "matchNames": ["robert bosch gmbh"],
       "tags": {
         "amenity": "charging_station",
         "brand": "Bosch eBike Systems",
+        "brand:wikidata": "Q234021",
         "name": "Bosch eBike Systems",
         "operator": "Bosch eBike Systems",
         "operator:wikidata": "Q234021"
@@ -125,9 +172,14 @@
     },
     {
       "displayName": "BP Pulse",
-      "id": "bppulse-36ec13",
+      "id": "bppulse-ed9b3b",
       "locationSet": {
-        "include": ["au", "gb", "nz", "us"]
+        "include": [
+          "au",
+          "gb",
+          "nz",
+          "us"
+        ]
       },
       "matchNames": [
         "bp chargemaster",
@@ -144,7 +196,11 @@
     {
       "displayName": "char.gy",
       "id": "chargy-cc3397",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "char.gy",
@@ -154,7 +210,11 @@
     {
       "displayName": "Charge365",
       "id": "charge365-054d0f",
-      "locationSet": {"include": ["no"]},
+      "locationSet": {
+        "include": [
+          "no"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Charge365"
@@ -162,10 +222,14 @@
     },
     {
       "displayName": "ChargePoint",
-      "id": "chargepoint-67e574",
+      "id": "chargepoint-28ff7e",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -178,9 +242,11 @@
     },
     {
       "displayName": "Charging the Regions",
-      "id": "chargingtheregions-604e55",
+      "id": "centralvictoriangreenhousealliance-6c573b",
       "locationSet": {
-        "include": ["au-vic.geojson"]
+        "include": [
+          "au-vic.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -193,7 +259,11 @@
     {
       "displayName": "Chargy",
       "id": "chargy-e87a7c",
-      "locationSet": {"include": ["lu"]},
+      "locationSet": {
+        "include": [
+          "lu"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Chargy",
@@ -205,22 +275,31 @@
     },
     {
       "displayName": "Circle K",
-      "id": "circlek-4bd82e",
-      "locationSet": {"include": ["001"]},
+      "id": "circlek-c22d3a",
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Circle K",
         "brand:wikidata": "Q3268010",
-        "name": "Circle K",
         "operator": "Circle K",
         "operator:wikidata": "Q3268010"
       }
     },
     {
       "displayName": "Circuit électrique",
-      "id": "circuitelectrique-1f220b",
-      "locationSet": {"include": ["ca"]},
-      "matchNames": ["le circuit électrique"],
+      "id": "circuitelectrique-67089a",
+      "locationSet": {
+        "include": [
+          "ca"
+        ]
+      },
+      "matchNames": [
+        "le circuit électrique"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Circuit électrique",
@@ -238,8 +317,12 @@
     },
     {
       "displayName": "E-WALD",
-      "id": "ewald-190c99",
-      "locationSet": {"include": ["de"]},
+      "id": "ewald-1299a8",
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "matchNames": [
         "e-wald gmbh",
         "e-wald ladestation"
@@ -255,21 +338,32 @@
     },
     {
       "displayName": "E.ON Drive",
-      "id": "eondrive-b625d6",
-      "locationSet": {"include": ["150"]},
-      "matchNames": ["e.on danmark"],
+      "id": "eon-7f623e",
+      "locationSet": {
+        "include": [
+          "150"
+        ]
+      },
+      "matchNames": [
+        "e-on drive"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "E.ON Drive",
+        "brand:wikidata": "Q126650419",
         "operator": "E.ON",
         "operator:wikidata": "Q270223"
       }
     },
     {
       "displayName": "Electra",
-      "id": "electra-86df4c",
+      "id": "electra-1b5132",
       "locationSet": {
-        "include": ["be", "fx", "nl"]
+        "include": [
+          "be",
+          "fx",
+          "nl"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -281,8 +375,12 @@
     },
     {
       "displayName": "Electrify America",
-      "id": "electrifyamerica-5598dd",
-      "locationSet": {"include": ["us"]},
+      "id": "electrifyamerica-994ed4",
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Electrify America",
@@ -294,7 +392,11 @@
     {
       "displayName": "Electrocharge",
       "id": "electrocharge-59a92d",
-      "locationSet": {"include": ["bg"]},
+      "locationSet": {
+        "include": [
+          "bg"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Electrocharge",
@@ -303,8 +405,12 @@
     },
     {
       "displayName": "Enel",
-      "id": "enel-0532c0",
-      "locationSet": {"include": ["it"]},
+      "id": "enel-2c5517",
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "matchNames": [
         "enel - stazione di ricarica"
       ],
@@ -319,11 +425,17 @@
     },
     {
       "displayName": "Enel X",
-      "id": "enelx-01e016",
+      "id": "enelx-bdf07e",
       "locationSet": {
-        "include": ["cl", "it", "ro"]
+        "include": [
+          "cl",
+          "it",
+          "ro"
+        ]
       },
-      "matchNames": ["enel x metbus"],
+      "matchNames": [
+        "enel x metbus"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Enel X",
@@ -335,9 +447,12 @@
     },
     {
       "displayName": "ESB ecars",
-      "id": "ecars-e9c107",
+      "id": "esbgroup-881c56",
       "locationSet": {
-        "include": ["gb-nir", "ie"]
+        "include": [
+          "gb-nir",
+          "ie"
+        ]
       },
       "matchNames": [
         "ecarni",
@@ -346,15 +461,20 @@
       ],
       "tags": {
         "amenity": "charging_station",
-        "brand": "ecars",
+        "brand": "EBS ecars",
+        "brand:wikidata": "Q134882112",
         "operator": "ESB Group",
         "operator:wikidata": "Q3050566"
       }
     },
     {
       "displayName": "EV Connect",
-      "id": "evconnect-5598dd",
-      "locationSet": {"include": ["us"]},
+      "id": "evconnect-994ed4",
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "EV Connect",
@@ -365,8 +485,12 @@
     },
     {
       "displayName": "EVgo",
-      "id": "evgo-5598dd",
-      "locationSet": {"include": ["us"]},
+      "id": "evgo-994ed4",
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "EVgo",
@@ -379,7 +503,11 @@
     {
       "displayName": "Eviny",
       "id": "eviny-054d0f",
-      "locationSet": {"include": ["no"]},
+      "locationSet": {
+        "include": [
+          "no"
+        ]
+      },
       "matchNames": [
         "bkk",
         "bkk nett as for hordaland fylkeskommune",
@@ -394,8 +522,12 @@
     },
     {
       "displayName": "evyve",
-      "id": "evyve-cc3397",
-      "locationSet": {"include": ["gb"]},
+      "id": "evyve-0793ce",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "evyve",
@@ -406,9 +538,14 @@
     },
     {
       "displayName": "Fastned",
-      "id": "fastned-b69337",
+      "id": "fastned-17c03e",
       "locationSet": {
-        "include": ["be", "de", "gb", "nl"]
+        "include": [
+          "be",
+          "de",
+          "gb",
+          "nl"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -420,8 +557,13 @@
     },
     {
       "displayName": "FLO",
-      "id": "flo-d2b245",
-      "locationSet": {"include": ["ca", "us"]},
+      "id": "flo-78626b",
+      "locationSet": {
+        "include": [
+          "ca",
+          "us"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "FLO",
@@ -433,8 +575,12 @@
     },
     {
       "displayName": "GeniePoint",
-      "id": "geniepoint-cc3397",
-      "locationSet": {"include": ["gb"]},
+      "id": "geniepoint-0793ce",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "GeniePoint",
@@ -445,10 +591,14 @@
     },
     {
       "displayName": "Gogoro 電池交換站",
-      "id": "62c656-67e574",
+      "id": "62c656-28ff7e",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -461,8 +611,12 @@
     },
     {
       "displayName": "Gridserve",
-      "id": "gridserve-cc3397",
-      "locationSet": {"include": ["gb"]},
+      "id": "gridserve-0793ce",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "matchNames": [
         "ecotricity",
         "electric highway"
@@ -479,7 +633,11 @@
     {
       "displayName": "Indigo",
       "id": "indigo-fd0ca8",
-      "locationSet": {"include": ["fr"]},
+      "locationSet": {
+        "include": [
+          "fr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Indigo",
@@ -488,8 +646,12 @@
     },
     {
       "displayName": "Innogy",
-      "id": "innogy-190c99",
-      "locationSet": {"include": ["de"]},
+      "id": "innogy-1299a8",
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "matchNames": [
         "innogy emobility solutions gmbh",
         "innogy se",
@@ -507,8 +669,14 @@
     {
       "displayName": "Ionity",
       "id": "ionity-b625d6",
-      "locationSet": {"include": ["150"]},
-      "matchNames": ["ionity gmbh"],
+      "locationSet": {
+        "include": [
+          "150"
+        ]
+      },
+      "matchNames": [
+        "ionity gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Ionity",
@@ -520,7 +688,11 @@
     {
       "displayName": "Ishavsveien",
       "id": "ishavsveien-054d0f",
-      "locationSet": {"include": ["no"]},
+      "locationSet": {
+        "include": [
+          "no"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Ishavsveien"
@@ -529,7 +701,11 @@
     {
       "displayName": "Kople",
       "id": "kople-054d0f",
-      "locationSet": {"include": ["no"]},
+      "locationSet": {
+        "include": [
+          "no"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Kople",
@@ -540,7 +716,13 @@
       "displayName": "Mer",
       "id": "mer-36d5f6",
       "locationSet": {
-        "include": ["at", "de", "gb", "no", "se"]
+        "include": [
+          "at",
+          "de",
+          "gb",
+          "no",
+          "se"
+        ]
       },
       "matchNames": [
         "bee",
@@ -560,9 +742,15 @@
     },
     {
       "displayName": "Mercedes-Benz",
-      "id": "mercedesbenz-4bd82e",
-      "locationSet": {"include": ["001"]},
-      "matchNames": ["mercedes"],
+      "id": "mercedesbenz-c22d3a",
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
+      "matchNames": [
+        "mercedes"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Mercedes-Benz",
@@ -573,11 +761,16 @@
     },
     {
       "displayName": "Mobiliti",
-      "id": "mobiliti-39fea5",
-      "locationSet": {"include": ["hu"]},
+      "id": "mobiliti-27e906",
+      "locationSet": {
+        "include": [
+          "hu"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Mobiliti",
+        "brand:wikidata": "Q126734853",
         "name": "Mobiliti",
         "operator": "Mobiliti",
         "operator:wikidata": "Q126734853"
@@ -596,7 +789,9 @@
           "sk"
         ]
       },
-      "matchNames": ["mol nyrt."],
+      "matchNames": [
+        "mol nyrt."
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "MOL Plugee",
@@ -609,8 +804,12 @@
       "displayName": "NIO Power Charger",
       "id": "niopowercharger-9dbcd7",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["cn"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "cn"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -627,8 +826,12 @@
       "displayName": "NIO Power Destination",
       "id": "niopowerdestination-9dbcd7",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["cn"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "cn"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -645,8 +848,12 @@
       "displayName": "NIO Power Swap",
       "id": "niopowerswap-9dbcd7",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["cn"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "cn"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -662,7 +869,11 @@
     {
       "displayName": "OpenLoop",
       "id": "openloop-dd8b2e",
-      "locationSet": {"include": ["nz"]},
+      "locationSet": {
+        "include": [
+          "nz"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "OpenLoop",
@@ -673,8 +884,12 @@
     },
     {
       "displayName": "Osprey",
-      "id": "osprey-cc3397",
-      "locationSet": {"include": ["gb"]},
+      "id": "osprey-0793ce",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Osprey",
@@ -686,7 +901,11 @@
     {
       "displayName": "Plugit",
       "id": "plugit-4d533b",
-      "locationSet": {"include": ["fi"]},
+      "locationSet": {
+        "include": [
+          "fi"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Plugit",
@@ -695,8 +914,12 @@
     },
     {
       "displayName": "Pod Point",
-      "id": "podpoint-cc3397",
-      "locationSet": {"include": ["gb"]},
+      "id": "podpoint-0793ce",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Pod Point",
@@ -707,10 +930,14 @@
     },
     {
       "displayName": "Porsche",
-      "id": "porsche-67e574",
+      "id": "porsche-28ff7e",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -723,7 +950,12 @@
     {
       "displayName": "Powerbox.one",
       "id": "powerboxone-391bca",
-      "locationSet": {"include": ["cz", "sk"]},
+      "locationSet": {
+        "include": [
+          "cz",
+          "sk"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Powerbox.one",
@@ -734,7 +966,11 @@
       "displayName": "Powerdot",
       "id": "powerdot-f718d2",
       "locationSet": {
-        "include": ["es", "fr", "pl"]
+        "include": [
+          "es",
+          "fr",
+          "pl"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -749,7 +985,12 @@
       "displayName": "Recharge",
       "id": "recharge-12f14e",
       "locationSet": {
-        "include": ["dk", "fi", "no", "se"]
+        "include": [
+          "dk",
+          "fi",
+          "no",
+          "se"
+        ]
       },
       "matchNames": [
         "fortum",
@@ -766,8 +1007,12 @@
     },
     {
       "displayName": "Red E",
-      "id": "rede-5598dd",
-      "locationSet": {"include": ["us"]},
+      "id": "rede-994ed4",
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Red E",
@@ -780,8 +1025,15 @@
     {
       "displayName": "Rivian Adventure Network",
       "id": "rivianadventurenetwork-d2b245",
-      "locationSet": {"include": ["ca", "us"]},
-      "matchNames": ["rivian adventure charger"],
+      "locationSet": {
+        "include": [
+          "ca",
+          "us"
+        ]
+      },
+      "matchNames": [
+        "rivian adventure charger"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Rivian Adventure Network",
@@ -793,8 +1045,15 @@
     {
       "displayName": "Rivian Waypoints",
       "id": "rivianwaypoints-d2b245",
-      "locationSet": {"include": ["ca", "us"]},
-      "matchNames": ["rivian waypoint charger"],
+      "locationSet": {
+        "include": [
+          "ca",
+          "us"
+        ]
+      },
+      "matchNames": [
+        "rivian waypoint charger"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Rivian Waypoints",
@@ -806,7 +1065,11 @@
     {
       "displayName": "Smart Charge",
       "id": "smartcharge-cc3397",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Smart Charge",
@@ -817,9 +1080,11 @@
     },
     {
       "displayName": "Source London",
-      "id": "sourcelondon-477177",
+      "id": "sourcelondon-489d95",
       "locationSet": {
-        "include": ["gb-lon.geojson"]
+        "include": [
+          "gb-lon.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -832,8 +1097,12 @@
     },
     {
       "displayName": "SureCharge",
-      "id": "surecharge-cc3397",
-      "locationSet": {"include": ["gb"]},
+      "id": "fmconway-0793ce",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "SureCharge",
@@ -845,8 +1114,14 @@
     {
       "displayName": "Tesla Destination Charger",
       "id": "tesladestinationcharger-4bd82e",
-      "locationSet": {"include": ["001"]},
-      "matchNames": ["tesla wall connector"],
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
+      "matchNames": [
+        "tesla wall connector"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Tesla",
@@ -857,7 +1132,11 @@
     {
       "displayName": "Tesla Supercharger",
       "id": "teslasupercharger-4bd82e",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
       "matchNames": [
         "tesla motors",
         "tesla motors inc",
@@ -875,8 +1154,12 @@
     },
     {
       "displayName": "Toka",
-      "id": "toka-a6fb9c",
-      "locationSet": {"include": ["ua"]},
+      "id": "toka-a6c3f2",
+      "locationSet": {
+        "include": [
+          "ua"
+        ]
+      },
       "matchNames": [
         "перша національна мережа електрозаправних комплексів тока",
         "тока"
@@ -892,10 +1175,15 @@
     },
     {
       "displayName": "TotalEnergies",
-      "id": "totalenergies-770cce",
+      "id": "totalenergies-0344be",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["no", "us"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no",
+          "us"
+        ]
       },
       "matchNames": [
         "total",
@@ -913,9 +1201,17 @@
       "displayName": "ubitricity",
       "id": "ubitricity-ef5e60",
       "locationSet": {
-        "include": ["ch", "de", "fr", "gb", "ie"]
+        "include": [
+          "ch",
+          "de",
+          "fr",
+          "gb",
+          "ie"
+        ]
       },
-      "matchNames": ["ubitricity gmbh"],
+      "matchNames": [
+        "ubitricity gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "ubitricity",
@@ -927,11 +1223,18 @@
     },
     {
       "displayName": "Vattenfall InCharge",
-      "id": "vattenfallincharge-667d30",
+      "id": "vattenfallincharge-648812",
       "locationSet": {
-        "include": ["gb", "nl", "se"]
+        "include": [
+          "gb",
+          "nl",
+          "se"
+        ]
       },
-      "matchNames": ["incharge", "vattenfall"],
+      "matchNames": [
+        "incharge",
+        "vattenfall"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Vattenfall InCharge",
@@ -943,9 +1246,15 @@
     },
     {
       "displayName": "VIRTA",
-      "id": "virta-4d533b",
-      "locationSet": {"include": ["fi"]},
-      "matchNames": ["liikennevirta oy"],
+      "id": "virta-e80d25",
+      "locationSet": {
+        "include": [
+          "fi"
+        ]
+      },
+      "matchNames": [
+        "liikennevirta oy"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "VIRTA",
@@ -957,8 +1266,12 @@
     },
     {
       "displayName": "We Drive Solar",
-      "id": "wedrivesolar-2a8f9b",
-      "locationSet": {"include": ["nl"]},
+      "id": "wedrivesolar-fa6152",
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "We Drive Solar",
@@ -970,7 +1283,11 @@
     {
       "displayName": "WINK Charging",
       "id": "wink-59a92d",
-      "locationSet": {"include": ["bg"]},
+      "locationSet": {
+        "include": [
+          "bg"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "WINK",
@@ -981,8 +1298,14 @@
     {
       "displayName": "Zero",
       "id": "zero-dd8b2e",
-      "locationSet": {"include": ["nz"]},
-      "matchNames": ["meridian"],
+      "locationSet": {
+        "include": [
+          "nz"
+        ]
+      },
+      "matchNames": [
+        "meridian"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Zero",
@@ -993,8 +1316,12 @@
     },
     {
       "displayName": "Zest",
-      "id": "zest-cc3397",
-      "locationSet": {"include": ["gb"]},
+      "id": "zest-0793ce",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Zest",
@@ -1006,8 +1333,14 @@
     {
       "displayName": "ZSE Drive",
       "id": "zsedrive-8610f2",
-      "locationSet": {"include": ["sk"]},
-      "matchNames": ["zse"],
+      "locationSet": {
+        "include": [
+          "sk"
+        ]
+      },
+      "matchNames": [
+        "zse"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "ZSE Drive",
@@ -1019,7 +1352,11 @@
     {
       "displayName": "Белоруснефть Malanka",
       "id": "malanka-f2a4c9",
-      "locationSet": {"include": ["by"]},
+      "locationSet": {
+        "include": [
+          "by"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Malanka",
@@ -1038,7 +1375,11 @@
     {
       "displayName": "Энергия Москвы",
       "id": "energyofmoscow-012f44",
-      "locationSet": {"include": ["ru"]},
+      "locationSet": {
+        "include": [
+          "ru"
+        ]
+      },
       "note": "ISO 3166-2 RU-MOW",
       "tags": {
         "amenity": "charging_station",
@@ -1054,8 +1395,12 @@
     },
     {
       "displayName": "国家电网",
-      "id": "stategrid-07dd34",
-      "locationSet": {"include": ["cn"]},
+      "id": "stategridcorporationofchina-c785ca",
+      "locationSet": {
+        "include": [
+          "cn"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "国家电网",
@@ -1074,7 +1419,11 @@
     {
       "displayName": "小鹏超充站",
       "id": "xpengsupercharger-07dd34",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {
+        "include": [
+          "cn"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "小鹏",
@@ -1088,7 +1437,7 @@
     },
     {
       "displayName": "東光高岳",
-      "id": "takaokatoko-610a46",
+      "id": "takaokatoko-631cd5",
       "locationSet": {
         "include": [
           "jp-12.geojson",
@@ -1113,7 +1462,11 @@
     {
       "displayName": "特来电",
       "id": "teld-07dd34",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {
+        "include": [
+          "cn"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "特来电",
@@ -1128,7 +1481,11 @@
     {
       "displayName": "蔚来换电站",
       "id": "niopowerswap-07dd34",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {
+        "include": [
+          "cn"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "NIO Power",
@@ -1142,7 +1499,11 @@
     {
       "displayName": "蔚来目充站",
       "id": "niopowerdestination-07dd34",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {
+        "include": [
+          "cn"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "NIO Power",
@@ -1156,7 +1517,11 @@
     {
       "displayName": "蔚来超充站",
       "id": "niopowercharger-07dd34",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {
+        "include": [
+          "cn"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "NIO Power",

--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -2,18 +2,101 @@
   "properties": {
     "path": "brands/amenity/charging_station",
     "skipCollection": true,
-    "preserveTags": ["^name"],
+    "preserveTags": [
+      "^name"
+    ],
     "exclude": {
-      "generic": ["^charging station$"],
-      "named": ["^tesla, inc.$"]
+      "generic": [
+        "^charging station$"
+      ],
+      "named": [
+        "^tesla, inc.$"
+      ]
     }
   },
   "items": [
     {
+      "displayName": "7-Eleven",
+      "id": "7eleven-994ed4",
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "matchNames": [
+        "7-11",
+        "seven eleven"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "7-Eleven",
+        "brand:wikidata": "Q259340",
+        "name": "7-Eleven",
+        "operator": "7-Eleven",
+        "operator:wikidata": "Q259340"
+      }
+    },
+    {
+      "displayName": "Applegreen Electric",
+      "id": "applegreenelectric-f6fe0b",
+      "locationSet": {
+        "include": [
+          "gb",
+          "ie",
+          "us"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Applegreen Electric",
+        "brand:wikidata": "Q7178908",
+        "operator": "Applegreen Electric",
+        "operator:wikidata": "Q7178908"
+      }
+    },
+    {
+      "displayName": "Aral pulse",
+      "id": "aral-2d0940",
+      "locationSet": {
+        "include": [
+          "de",
+          "lu"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Aral pulse",
+        "operator": "Aral",
+        "operator:wikidata": "Q565734"
+      }
+    },
+    {
+      "displayName": "Be.EV",
+      "id": "iduna-3c1cb1",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Be.EV",
+        "operator": "Iduna",
+        "operator:wikidata": "Q118263083"
+      }
+    },
+    {
       "displayName": "Believ",
       "id": "believ-cc3397",
-      "locationSet": {"include": ["gb"]},
-      "matchNames": ["believe", "liberty charge"],
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
+      "matchNames": [
+        "believe",
+        "liberty charge"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Believ",
@@ -22,10 +105,77 @@
       }
     },
     {
+      "displayName": "bike-energy",
+      "id": "bikeenergy-ff2890",
+      "locationSet": {
+        "include": [
+          "at",
+          "ch",
+          "de",
+          "fx",
+          "it",
+          "lu"
+        ]
+      },
+      "matchNames": [
+        "bike-energy ladestation"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "bike-energy",
+        "brand:wikidata": "Q67770877",
+        "name": "bike-energy",
+        "operator": "bike-energy",
+        "operator:wikidata": "Q67770877"
+      }
+    },
+    {
+      "displayName": "Blink",
+      "id": "blink-74901a",
+      "locationSet": {
+        "include": [
+          "gb",
+          "us"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Blink",
+        "brand:wikidata": "Q62065645",
+        "name": "Blink",
+        "operator": "Blink",
+        "operator:wikidata": "Q62065645"
+      }
+    },
+    {
+      "displayName": "Bosch eBike Systems",
+      "id": "boschebikesystems-28ff7e",
+      "locationSet": {
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Bosch eBike Systems",
+        "name": "Bosch eBike Systems",
+        "operator": "Bosch eBike Systems",
+        "operator:wikidata": "Q234021"
+      }
+    },
+    {
       "displayName": "BP Pulse",
       "id": "bppulse-ed9b3b",
       "locationSet": {
-        "include": ["au", "gb", "nz"]
+        "include": [
+          "au",
+          "gb",
+          "nz",
+          "us"
+        ]
       },
       "matchNames": [
         "bp chargemaster",
@@ -42,7 +192,11 @@
     {
       "displayName": "char.gy",
       "id": "chargy-cc3397",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "char.gy",
@@ -52,16 +206,60 @@
     {
       "displayName": "Charge365",
       "id": "charge365-054d0f",
-      "locationSet": {"include": ["no"]},
+      "locationSet": {
+        "include": [
+          "no"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Charge365"
       }
     },
     {
+      "displayName": "ChargePoint",
+      "id": "chargepoint-28ff7e",
+      "locationSet": {
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "ChargePoint",
+        "brand:wikidata": "Q5176149",
+        "name": "ChargePoint",
+        "operator": "ChargePoint",
+        "operator:wikidata": "Q5176149"
+      }
+    },
+    {
+      "displayName": "Charging the Regions",
+      "id": "centralvictoriangreenhousealliance-6c573b",
+      "locationSet": {
+        "include": [
+          "au-vic.geojson"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Charging the Regions",
+        "brand:wikidata": "Q106320264",
+        "operator": "Central Victorian Greenhouse Alliance",
+        "operator:wikidata": "Q106320329"
+      }
+    },
+    {
       "displayName": "Chargy",
       "id": "chargy-e87a7c",
-      "locationSet": {"include": ["lu"]},
+      "locationSet": {
+        "include": [
+          "lu"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Chargy",
@@ -72,9 +270,129 @@
       }
     },
     {
+      "displayName": "Circle K",
+      "id": "circlek-c22d3a",
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Circle K",
+        "brand:wikidata": "Q3268010",
+        "name": "Circle K",
+        "operator": "Circle K",
+        "operator:wikidata": "Q3268010"
+      }
+    },
+    {
+      "displayName": "Circuit électrique",
+      "id": "circuitelectrique-67089a",
+      "locationSet": {
+        "include": [
+          "ca"
+        ]
+      },
+      "matchNames": [
+        "le circuit électrique"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Circuit électrique",
+        "brand:en": "Electric Circuit",
+        "brand:fr": "Circuit électrique",
+        "brand:wikidata": "Q24934590",
+        "name": "Circuit électrique",
+        "name:en": "Electric Circuit",
+        "name:fr": "Circuit électrique",
+        "operator": "Circuit électrique",
+        "operator:en": "Electric Circuit",
+        "operator:fr": "Circuit électrique",
+        "operator:wikidata": "Q24934590"
+      }
+    },
+    {
+      "displayName": "E-WALD",
+      "id": "ewald-1299a8",
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
+      "matchNames": [
+        "e-wald gmbh",
+        "e-wald ladestation"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "E-WALD",
+        "brand:wikidata": "Q61804335",
+        "name": "E-WALD",
+        "operator": "E-WALD",
+        "operator:wikidata": "Q61804335"
+      }
+    },
+    {
+      "displayName": "E.ON Drive",
+      "id": "eon-7f623e",
+      "locationSet": {
+        "include": [
+          "150"
+        ]
+      },
+      "matchNames": [
+        "e-on drive"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "E.ON Drive",
+        "operator": "E.ON",
+        "operator:wikidata": "Q270223"
+      }
+    },
+    {
+      "displayName": "Electra",
+      "id": "electra-1b5132",
+      "locationSet": {
+        "include": [
+          "be",
+          "fx",
+          "nl"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Electra",
+        "brand:wikidata": "Q128592938",
+        "operator": "Electra",
+        "operator:wikidata": "Q128592938"
+      }
+    },
+    {
+      "displayName": "Electrify America",
+      "id": "electrifyamerica-994ed4",
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Electrify America",
+        "brand:wikidata": "Q59773555",
+        "operator": "Electrify America",
+        "operator:wikidata": "Q59773555"
+      }
+    },
+    {
       "displayName": "Electrocharge",
       "id": "electrocharge-59a92d",
-      "locationSet": {"include": ["bg"]},
+      "locationSet": {
+        "include": [
+          "bg"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Electrocharge",
@@ -82,9 +400,109 @@
       }
     },
     {
+      "displayName": "Enel",
+      "id": "enel-2c5517",
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
+      "matchNames": [
+        "enel - stazione di ricarica"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Enel",
+        "brand:wikidata": "Q651222",
+        "name": "Enel",
+        "operator": "Enel",
+        "operator:wikidata": "Q651222"
+      }
+    },
+    {
+      "displayName": "Enel X",
+      "id": "enelx-bdf07e",
+      "locationSet": {
+        "include": [
+          "cl",
+          "it",
+          "ro"
+        ]
+      },
+      "matchNames": [
+        "enel x metbus"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Enel X",
+        "brand:wikidata": "Q5376815",
+        "name": "Enel X",
+        "operator": "Enel X",
+        "operator:wikidata": "Q5376815"
+      }
+    },
+    {
+      "displayName": "ESB ecars",
+      "id": "esbgroup-881c56",
+      "locationSet": {
+        "include": [
+          "gb-nir",
+          "ie"
+        ]
+      },
+      "matchNames": [
+        "ecarni",
+        "esb",
+        "esb ecars"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "ecars",
+        "operator": "ESB Group",
+        "operator:wikidata": "Q3050566"
+      }
+    },
+    {
+      "displayName": "EV Connect",
+      "id": "evconnect-994ed4",
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "EV Connect",
+        "brand:wikidata": "Q126652985",
+        "operator": "EV Connect",
+        "operator:wikidata": "Q126652985"
+      }
+    },
+    {
+      "displayName": "EVgo",
+      "id": "evgo-994ed4",
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "EVgo",
+        "brand:wikidata": "Q61803820",
+        "name": "EVgo",
+        "operator": "EVgo",
+        "operator:wikidata": "Q61803820"
+      }
+    },
+    {
       "displayName": "Eviny",
       "id": "eviny-054d0f",
-      "locationSet": {"include": ["no"]},
+      "locationSet": {
+        "include": [
+          "no"
+        ]
+      },
       "matchNames": [
         "bkk",
         "bkk nett as for hordaland fylkeskommune",
@@ -98,9 +516,123 @@
       }
     },
     {
+      "displayName": "evyve",
+      "id": "evyve-0793ce",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "evyve",
+        "brand:wikidata": "Q116698197",
+        "operator": "evyve",
+        "operator:wikidata": "Q116698197"
+      }
+    },
+    {
+      "displayName": "Fastned",
+      "id": "fastned-17c03e",
+      "locationSet": {
+        "include": [
+          "be",
+          "de",
+          "gb",
+          "nl"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Fastned",
+        "brand:wikidata": "Q19935749",
+        "operator": "Fastned",
+        "operator:wikidata": "Q19935749"
+      }
+    },
+    {
+      "displayName": "FLO",
+      "id": "flo-78626b",
+      "locationSet": {
+        "include": [
+          "ca",
+          "us"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "FLO",
+        "brand:wikidata": "Q64971203",
+        "name": "FLO",
+        "operator": "FLO",
+        "operator:wikidata": "Q64971203"
+      }
+    },
+    {
+      "displayName": "GeniePoint",
+      "id": "geniepoint-0793ce",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "GeniePoint",
+        "brand:wikidata": "Q111363966",
+        "operator": "GeniePoint",
+        "operator:wikidata": "Q111363966"
+      }
+    },
+    {
+      "displayName": "Gogoro 電池交換站",
+      "id": "62c656-28ff7e",
+      "locationSet": {
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Gogoro 電池交換站",
+        "brand:wikidata": "Q19880591",
+        "name": "Gogoro 電池交換站",
+        "operator": "Gogoro 電池交換站",
+        "operator:wikidata": "Q19880591"
+      }
+    },
+    {
+      "displayName": "Gridserve",
+      "id": "gridserve-0793ce",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
+      "matchNames": [
+        "ecotricity",
+        "electric highway"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Gridserve",
+        "brand:wikidata": "Q89575318",
+        "name": "Gridserve",
+        "operator": "Gridserve",
+        "operator:wikidata": "Q89575318"
+      }
+    },
+    {
       "displayName": "Indigo",
       "id": "indigo-fd0ca8",
-      "locationSet": {"include": ["fr"]},
+      "locationSet": {
+        "include": [
+          "fr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Indigo",
@@ -108,20 +640,54 @@
       }
     },
     {
+      "displayName": "Innogy",
+      "id": "innogy-1299a8",
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
+      "matchNames": [
+        "innogy emobility solutions gmbh",
+        "innogy se",
+        "rwe"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Innogy",
+        "brand:wikidata": "Q2124721",
+        "name": "Innogy",
+        "operator": "Innogy",
+        "operator:wikidata": "Q2124721"
+      }
+    },
+    {
       "displayName": "Ionity",
       "id": "ionity-b625d6",
-      "locationSet": {"include": ["150"]},
-      "matchNames": ["ionity gmbh"],
+      "locationSet": {
+        "include": [
+          "150"
+        ]
+      },
+      "matchNames": [
+        "ionity gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Ionity",
-        "brand:wikidata": "Q42717773"
+        "brand:wikidata": "Q42717773",
+        "operator": "Ionity",
+        "operator:wikidata": "Q42717773"
       }
     },
     {
       "displayName": "Ishavsveien",
       "id": "ishavsveien-054d0f",
-      "locationSet": {"include": ["no"]},
+      "locationSet": {
+        "include": [
+          "no"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Ishavsveien"
@@ -130,7 +696,11 @@
     {
       "displayName": "Kople",
       "id": "kople-054d0f",
-      "locationSet": {"include": ["no"]},
+      "locationSet": {
+        "include": [
+          "no"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Kople",
@@ -141,7 +711,13 @@
       "displayName": "Mer",
       "id": "mer-36d5f6",
       "locationSet": {
-        "include": ["at", "de", "gb", "no", "se"]
+        "include": [
+          "at",
+          "de",
+          "gb",
+          "no",
+          "se"
+        ]
       },
       "matchNames": [
         "bee",
@@ -155,7 +731,43 @@
         "amenity": "charging_station",
         "brand": "Mer",
         "brand:wikidata": "Q100821564",
-        "name": "Mer"
+        "operator": "Mer",
+        "operator:wikidata": "Q100821564"
+      }
+    },
+    {
+      "displayName": "Mercedes-Benz",
+      "id": "mercedesbenz-c22d3a",
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
+      "matchNames": [
+        "mercedes"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Mercedes-Benz",
+        "brand:wikidata": "Q36008",
+        "operator": "Mercedes-Benz",
+        "operator:wikidata": "Q36008"
+      }
+    },
+    {
+      "displayName": "Mobiliti",
+      "id": "mobiliti-27e906",
+      "locationSet": {
+        "include": [
+          "hu"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Mobiliti",
+        "name": "Mobiliti",
+        "operator": "Mobiliti",
+        "operator:wikidata": "Q126734853"
       }
     },
     {
@@ -171,7 +783,9 @@
           "sk"
         ]
       },
-      "matchNames": ["mol nyrt."],
+      "matchNames": [
+        "mol nyrt."
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "MOL Plugee",
@@ -184,8 +798,12 @@
       "displayName": "NIO Power Charger",
       "id": "niopowercharger-9dbcd7",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["cn"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "cn"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -193,15 +811,21 @@
         "brand:en": "NIO Power",
         "brand:wikidata": "Q29921278",
         "name": "NIO Power Charger",
-        "name:en": "NIO Power Charger"
+        "name:en": "NIO Power Charger",
+        "operator": "NIO Power",
+        "operator:wikidata": "Q29921278"
       }
     },
     {
       "displayName": "NIO Power Destination",
       "id": "niopowerdestination-9dbcd7",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["cn"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "cn"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -209,15 +833,21 @@
         "brand:en": "NIO Power",
         "brand:wikidata": "Q29921278",
         "name": "NIO Power Destination",
-        "name:en": "NIO Power Destination"
+        "name:en": "NIO Power Destination",
+        "operator": "NIO Power",
+        "operator:wikidata": "Q29921278"
       }
     },
     {
       "displayName": "NIO Power Swap",
       "id": "niopowerswap-9dbcd7",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["cn"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "cn"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -225,13 +855,19 @@
         "brand:en": "NIO Power",
         "brand:wikidata": "Q29921278",
         "name": "NIO Power Swap",
-        "name:en": "NIO Power Swap"
+        "name:en": "NIO Power Swap",
+        "operator": "NIO Power",
+        "operator:wikidata": "Q29921278"
       }
     },
     {
       "displayName": "OpenLoop",
       "id": "openloop-dd8b2e",
-      "locationSet": {"include": ["nz"]},
+      "locationSet": {
+        "include": [
+          "nz"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "OpenLoop",
@@ -241,9 +877,29 @@
       }
     },
     {
+      "displayName": "Osprey",
+      "id": "osprey-0793ce",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Osprey",
+        "brand:wikidata": "Q117706577",
+        "operator": "Osprey",
+        "operator:wikidata": "Q117706577"
+      }
+    },
+    {
       "displayName": "Plugit",
       "id": "plugit-4d533b",
-      "locationSet": {"include": ["fi"]},
+      "locationSet": {
+        "include": [
+          "fi"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Plugit",
@@ -251,9 +907,49 @@
       }
     },
     {
+      "displayName": "Pod Point",
+      "id": "podpoint-0793ce",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Pod Point",
+        "brand:wikidata": "Q42888154",
+        "operator": "Pod Point",
+        "operator:wikidata": "Q42888154"
+      }
+    },
+    {
+      "displayName": "Porsche",
+      "id": "porsche-28ff7e",
+      "locationSet": {
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Porsche",
+        "brand:wikidata": "Q40993",
+        "operator": "Porsche",
+        "operator:wikidata": "Q40993"
+      }
+    },
+    {
       "displayName": "Powerbox.one",
       "id": "powerboxone-391bca",
-      "locationSet": {"include": ["cz", "sk"]},
+      "locationSet": {
+        "include": [
+          "cz",
+          "sk"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Powerbox.one",
@@ -264,7 +960,11 @@
       "displayName": "Powerdot",
       "id": "powerdot-f718d2",
       "locationSet": {
-        "include": ["es", "fr", "pl"]
+        "include": [
+          "es",
+          "fr",
+          "pl"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -279,7 +979,12 @@
       "displayName": "Recharge",
       "id": "recharge-12f14e",
       "locationSet": {
-        "include": ["dk", "fi", "no", "se"]
+        "include": [
+          "dk",
+          "fi",
+          "no",
+          "se"
+        ]
       },
       "matchNames": [
         "fortum",
@@ -295,10 +1000,34 @@
       }
     },
     {
+      "displayName": "Red E",
+      "id": "rede-994ed4",
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Red E",
+        "brand:wikidata": "Q131416886",
+        "name": "Red E",
+        "operator": "Red E",
+        "operator:wikidata": "Q131416886"
+      }
+    },
+    {
       "displayName": "Rivian Adventure Network",
       "id": "rivianadventurenetwork-d2b245",
-      "locationSet": {"include": ["ca", "us"]},
-      "matchNames": ["rivian adventure charger"],
+      "locationSet": {
+        "include": [
+          "ca",
+          "us"
+        ]
+      },
+      "matchNames": [
+        "rivian adventure charger"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Rivian Adventure Network",
@@ -310,8 +1039,15 @@
     {
       "displayName": "Rivian Waypoints",
       "id": "rivianwaypoints-d2b245",
-      "locationSet": {"include": ["ca", "us"]},
-      "matchNames": ["rivian waypoint charger"],
+      "locationSet": {
+        "include": [
+          "ca",
+          "us"
+        ]
+      },
+      "matchNames": [
+        "rivian waypoint charger"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Rivian Waypoints",
@@ -323,7 +1059,11 @@
     {
       "displayName": "Smart Charge",
       "id": "smartcharge-cc3397",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Smart Charge",
@@ -333,10 +1073,49 @@
       }
     },
     {
+      "displayName": "Source London",
+      "id": "sourcelondon-489d95",
+      "locationSet": {
+        "include": [
+          "gb-lon.geojson"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Source London",
+        "brand:wikidata": "Q7565133",
+        "name": "Source London",
+        "operator": "Source London",
+        "operator:wikidata": "Q7565133"
+      }
+    },
+    {
+      "displayName": "SureCharge",
+      "id": "fmconway-0793ce",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "SureCharge",
+        "brand:wikidata": "Q118382836",
+        "operator": "FM Conway",
+        "operator:wikidata": "Q20711690"
+      }
+    },
+    {
       "displayName": "Tesla Destination Charger",
       "id": "tesladestinationcharger-4bd82e",
-      "locationSet": {"include": ["001"]},
-      "matchNames": ["tesla wall connector"],
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
+      "matchNames": [
+        "tesla wall connector"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Tesla",
@@ -347,7 +1126,11 @@
     {
       "displayName": "Tesla Supercharger",
       "id": "teslasupercharger-4bd82e",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
       "matchNames": [
         "tesla motors",
         "tesla motors inc",
@@ -364,12 +1147,65 @@
       }
     },
     {
+      "displayName": "Toka",
+      "id": "toka-a6c3f2",
+      "locationSet": {
+        "include": [
+          "ua"
+        ]
+      },
+      "matchNames": [
+        "перша національна мережа електрозаправних комплексів тока",
+        "тока"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Toka",
+        "brand:wikidata": "Q117745034",
+        "name": "Toka",
+        "operator": "Toka",
+        "operator:wikidata": "Q117745034"
+      }
+    },
+    {
+      "displayName": "TotalEnergies",
+      "id": "totalenergies-0344be",
+      "locationSet": {
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no",
+          "us"
+        ]
+      },
+      "matchNames": [
+        "total",
+        "totalenergies charging services"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "TotalEnergies",
+        "brand:wikidata": "Q154037",
+        "operator": "TotalEnergies",
+        "operator:wikidata": "Q154037"
+      }
+    },
+    {
       "displayName": "ubitricity",
       "id": "ubitricity-ef5e60",
       "locationSet": {
-        "include": ["ch", "de", "fr", "gb", "ie"]
+        "include": [
+          "ch",
+          "de",
+          "fr",
+          "gb",
+          "ie"
+        ]
       },
-      "matchNames": ["ubitricity gmbh"],
+      "matchNames": [
+        "ubitricity gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "ubitricity",
@@ -380,9 +1216,72 @@
       }
     },
     {
+      "displayName": "Vattenfall InCharge",
+      "id": "vattenfallincharge-648812",
+      "locationSet": {
+        "include": [
+          "gb",
+          "nl",
+          "se"
+        ]
+      },
+      "matchNames": [
+        "incharge",
+        "vattenfall"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Vattenfall InCharge",
+        "brand:wikidata": "Q71041027",
+        "name": "Vattenfall InCharge",
+        "operator": "Vattenfall InCharge",
+        "operator:wikidata": "Q71041027"
+      }
+    },
+    {
+      "displayName": "VIRTA",
+      "id": "virta-e80d25",
+      "locationSet": {
+        "include": [
+          "fi"
+        ]
+      },
+      "matchNames": [
+        "liikennevirta oy"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "VIRTA",
+        "brand:wikidata": "Q97205884",
+        "name": "VIRTA",
+        "operator": "VIRTA",
+        "operator:wikidata": "Q97205884"
+      }
+    },
+    {
+      "displayName": "We Drive Solar",
+      "id": "wedrivesolar-fa6152",
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "We Drive Solar",
+        "brand:wikidata": "Q127260037",
+        "operator": "We Drive Solar",
+        "operator:wikidata": "Q127260037"
+      }
+    },
+    {
       "displayName": "WINK Charging",
       "id": "wink-59a92d",
-      "locationSet": {"include": ["bg"]},
+      "locationSet": {
+        "include": [
+          "bg"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "WINK",
@@ -393,8 +1292,14 @@
     {
       "displayName": "Zero",
       "id": "zero-dd8b2e",
-      "locationSet": {"include": ["nz"]},
-      "matchNames": ["meridian"],
+      "locationSet": {
+        "include": [
+          "nz"
+        ]
+      },
+      "matchNames": [
+        "meridian"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "Zero",
@@ -404,10 +1309,32 @@
       }
     },
     {
+      "displayName": "Zest",
+      "id": "zest-0793ce",
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Zest",
+        "brand:wikidata": "Q122871256",
+        "operator": "Zest",
+        "operator:wikidata": "Q122871256"
+      }
+    },
+    {
       "displayName": "ZSE Drive",
       "id": "zsedrive-8610f2",
-      "locationSet": {"include": ["sk"]},
-      "matchNames": ["zse"],
+      "locationSet": {
+        "include": [
+          "sk"
+        ]
+      },
+      "matchNames": [
+        "zse"
+      ],
       "tags": {
         "amenity": "charging_station",
         "brand": "ZSE Drive",
@@ -419,7 +1346,11 @@
     {
       "displayName": "Белоруснефть Malanka",
       "id": "malanka-f2a4c9",
-      "locationSet": {"include": ["by"]},
+      "locationSet": {
+        "include": [
+          "by"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "Malanka",
@@ -438,7 +1369,11 @@
     {
       "displayName": "Энергия Москвы",
       "id": "energyofmoscow-012f44",
-      "locationSet": {"include": ["ru"]},
+      "locationSet": {
+        "include": [
+          "ru"
+        ]
+      },
       "note": "ISO 3166-2 RU-MOW",
       "tags": {
         "amenity": "charging_station",
@@ -453,9 +1388,36 @@
       }
     },
     {
+      "displayName": "国家电网",
+      "id": "stategridcorporationofchina-c785ca",
+      "locationSet": {
+        "include": [
+          "cn"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "国家电网",
+        "brand:en": "State Grid",
+        "brand:wikidata": "Q209078",
+        "brand:zh": "国家电网",
+        "name": "国家电网",
+        "name:en": "State Grid",
+        "name:zh": "国家电网",
+        "operator": "国家电网有限公司",
+        "operator:en": "State Grid Corporation of China",
+        "operator:wikidata": "Q209078",
+        "operator:zh": "国家电网有限公司"
+      }
+    },
+    {
       "displayName": "小鹏超充站",
       "id": "xpengsupercharger-07dd34",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {
+        "include": [
+          "cn"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "小鹏",
@@ -468,9 +1430,37 @@
       }
     },
     {
+      "displayName": "東光高岳",
+      "id": "takaokatoko-631cd5",
+      "locationSet": {
+        "include": [
+          "jp-12.geojson",
+          "jp-13.geojson"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "東光高岳",
+        "brand:en": "Takaoka Toko",
+        "brand:ja": "東光高岳",
+        "brand:wikidata": "Q17220263",
+        "name": "東光高岳",
+        "name:en": "Takaoka Toko",
+        "name:ja": "東光高岳",
+        "operator": "東光高岳",
+        "operator:en": "Takaoka Toko",
+        "operator:ja": "東光高岳",
+        "operator:wikidata": "Q17220263"
+      }
+    },
+    {
       "displayName": "特来电",
       "id": "teld-07dd34",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {
+        "include": [
+          "cn"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "特来电",
@@ -485,7 +1475,11 @@
     {
       "displayName": "蔚来换电站",
       "id": "niopowerswap-07dd34",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {
+        "include": [
+          "cn"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "NIO Power",
@@ -499,7 +1493,11 @@
     {
       "displayName": "蔚来目充站",
       "id": "niopowerdestination-07dd34",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {
+        "include": [
+          "cn"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "NIO Power",
@@ -513,7 +1511,11 @@
     {
       "displayName": "蔚来超充站",
       "id": "niopowercharger-07dd34",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {
+        "include": [
+          "cn"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "brand": "NIO Power",

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -1,9 +1,7 @@
 {
   "properties": {
     "path": "operators/amenity/charging_station",
-    "preserveTags": [
-      "^name"
-    ],
+    "preserveTags": ["^name"],
     "exclude": {
       "generic": [
         "^(charging station|oplaadpunt|stromtankstelle)$",
@@ -27,11 +25,7 @@
     {
       "displayName": "123energie",
       "id": "123energie-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "123energie",
@@ -41,11 +35,7 @@
     {
       "displayName": "a2a",
       "id": "a2a-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "a2a",
@@ -56,12 +46,8 @@
       "displayName": "ABB",
       "id": "abb-28ff7e",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "no"
-        ]
+        "include": ["001"],
+        "exclude": ["no"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -72,11 +58,7 @@
     {
       "displayName": "ABC",
       "id": "abc-e80d25",
-      "locationSet": {
-        "include": [
-          "fi"
-        ]
-      },
+      "locationSet": {"include": ["fi"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ABC",
@@ -86,11 +68,7 @@
     {
       "displayName": "ABC-lataus",
       "id": "abclataus-e80d25",
-      "locationSet": {
-        "include": [
-          "fi"
-        ]
-      },
+      "locationSet": {"include": ["fi"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ABC-lataus",
@@ -100,11 +78,7 @@
     {
       "displayName": "ABL",
       "id": "abl-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ABL",
@@ -114,14 +88,8 @@
     {
       "displayName": "Acciona Energía",
       "id": "accionaenergia-97d7cf",
-      "locationSet": {
-        "include": [
-          "es"
-        ]
-      },
-      "matchNames": [
-        "acciona"
-      ],
+      "locationSet": {"include": ["es"]},
+      "matchNames": ["acciona"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Acciona Energía",
@@ -131,11 +99,7 @@
     {
       "displayName": "Acea Energia",
       "id": "aceaenergia-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Acea Energia",
@@ -145,14 +109,8 @@
     {
       "displayName": "AcegasApsAmga",
       "id": "acegasapsamga-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
-      "matchNames": [
-        "hera / acegasapsamga"
-      ],
+      "locationSet": {"include": ["it"]},
+      "matchNames": ["hera / acegasapsamga"],
       "tags": {
         "amenity": "charging_station",
         "operator": "AcegasApsAmga",
@@ -162,11 +120,7 @@
     {
       "displayName": "ADAC",
       "id": "adac-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ADAC",
@@ -176,11 +130,7 @@
     {
       "displayName": "Aers Energy",
       "id": "aersenergy-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Aers Energy"
@@ -189,11 +139,7 @@
     {
       "displayName": "Agrisnellaad",
       "id": "agrisnellaad-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Agrisnellaad",
@@ -203,11 +149,7 @@
     {
       "displayName": "Agrola",
       "id": "agrola-086737",
-      "locationSet": {
-        "include": [
-          "ch"
-        ]
-      },
+      "locationSet": {"include": ["ch"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Agrola",
@@ -217,11 +159,7 @@
     {
       "displayName": "Agsm Verona Spa",
       "id": "agsmveronaspa-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Agsm Verona Spa",
@@ -232,11 +170,7 @@
       "displayName": "Aimo Park",
       "id": "aimopark-c6312f",
       "locationSet": {
-        "include": [
-          "fi",
-          "no",
-          "se"
-        ]
+        "include": ["fi", "no", "se"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -248,11 +182,7 @@
       "displayName": "Airbus",
       "id": "airbus-ed052c",
       "locationSet": {
-        "include": [
-          "de",
-          "fx",
-          "nl"
-        ]
+        "include": ["de", "fx", "nl"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -263,11 +193,7 @@
     {
       "displayName": "Akademiska Hus",
       "id": "akademiskahus-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Akademiska Hus",
@@ -277,9 +203,7 @@
     {
       "displayName": "Aldi (Aldi Nord group)",
       "id": "aldi-a30f4b",
-      "issues": [
-        10738
-      ],
+      "issues": [10738],
       "locationSet": {
         "include": [
           "be",
@@ -292,10 +216,7 @@
           "pt"
         ]
       },
-      "matchNames": [
-        "aldi france",
-        "aldi nord"
-      ],
+      "matchNames": ["aldi france", "aldi nord"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Aldi",
@@ -305,9 +226,7 @@
     {
       "displayName": "Aldi (Aldi Süd group)",
       "id": "aldi-141059",
-      "issues": [
-        10738
-      ],
+      "issues": [10738],
       "locationSet": {
         "include": [
           "au",
@@ -336,16 +255,10 @@
     {
       "displayName": "Aldi Nord (Deutschland)",
       "id": "aldi-de3fd8",
-      "issues": [
-        10738
-      ],
+      "issues": [10738],
       "locationSet": {
-        "include": [
-          "de"
-        ],
-        "exclude": [
-          "aldi-sued.geojson"
-        ]
+        "include": ["de"],
+        "exclude": ["aldi-sued.geojson"]
       },
       "matchNames": [
         "aldi gmbh & co. kg",
@@ -360,13 +273,9 @@
     {
       "displayName": "Aldi Süd (Deutschland)",
       "id": "aldi-fee10d",
-      "issues": [
-        10738
-      ],
+      "issues": [10738],
       "locationSet": {
-        "include": [
-          "aldi-sued.geojson"
-        ]
+        "include": ["aldi-sued.geojson"]
       },
       "matchNames": [
         "aldi gmbh & co. kg",
@@ -382,12 +291,7 @@
       "displayName": "Alfen",
       "id": "alfen-17c03e",
       "locationSet": {
-        "include": [
-          "be",
-          "de",
-          "gb",
-          "nl"
-        ]
+        "include": ["be", "de", "gb", "nl"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -398,11 +302,7 @@
     {
       "displayName": "Alizé",
       "id": "alize-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Alizé"
@@ -412,17 +312,9 @@
       "displayName": "Allego",
       "id": "allego-17c03e",
       "locationSet": {
-        "include": [
-          "be",
-          "de",
-          "gb",
-          "nl"
-        ]
+        "include": ["be", "de", "gb", "nl"]
       },
-      "matchNames": [
-        "allego gmbh",
-        "allegro"
-      ],
+      "matchNames": ["allego gmbh", "allegro"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Allego",
@@ -451,14 +343,8 @@
     {
       "displayName": "Alperia",
       "id": "alperia-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
-      "matchNames": [
-        "alperia smart mobility"
-      ],
+      "locationSet": {"include": ["it"]},
+      "matchNames": ["alperia smart mobility"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Alperia",
@@ -469,9 +355,7 @@
       "displayName": "ALTIS",
       "id": "altis-d0faa5",
       "locationSet": {
-        "include": [
-          "ch-vs.geojson"
-        ]
+        "include": ["ch-vs.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -482,11 +366,7 @@
     {
       "displayName": "AmpCharge",
       "id": "ampcharge-943805",
-      "locationSet": {
-        "include": [
-          "au"
-        ]
-      },
+      "locationSet": {"include": ["au"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "AmpCharge",
@@ -494,12 +374,23 @@
       }
     },
     {
+      "displayName": "Àrea Metropolitana de Barcelona",
+      "id": "areametropolitanadebarcelona-f58b3e",
+      "locationSet": {
+        "include": ["es-b.geojson"]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Àrea Metropolitana de Barcelona",
+        "operator:short": "AMB",
+        "operator:wikidata": "Q4859869"
+      }
+    },
+    {
       "displayName": "Areal Böhler",
       "id": "arealbohler-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -510,11 +401,7 @@
     {
       "displayName": "Arinea",
       "id": "arinea-392011",
-      "locationSet": {
-        "include": [
-          "pl"
-        ]
-      },
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Arinea",
@@ -525,9 +412,7 @@
       "displayName": "ASP",
       "id": "asp-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -538,11 +423,7 @@
     {
       "displayName": "Astor Enerji",
       "id": "astorenerji-f274f9",
-      "locationSet": {
-        "include": [
-          "tr"
-        ]
-      },
+      "locationSet": {"include": ["tr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Astor Enerji"
@@ -551,11 +432,7 @@
     {
       "displayName": "Atlante",
       "id": "atlante-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Atlante"
@@ -564,11 +441,7 @@
     {
       "displayName": "Auchan",
       "id": "auchan-f6553b",
-      "locationSet": {
-        "include": [
-          "fr"
-        ]
-      },
+      "locationSet": {"include": ["fr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Auchan",
@@ -578,11 +451,7 @@
     {
       "displayName": "Audi AG",
       "id": "audiag-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Audi AG",
@@ -593,9 +462,7 @@
       "displayName": "Austin Energy",
       "id": "austinenergy-06a9bf",
       "locationSet": {
-        "include": [
-          "us-tx-austin.geojson"
-        ]
+        "include": ["us-tx-austin.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -607,9 +474,7 @@
       "displayName": "Autolib'",
       "id": "autolib-37370f",
       "locationSet": {
-        "include": [
-          "fr-idf.geojson"
-        ]
+        "include": ["fr-idf.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -620,14 +485,8 @@
     {
       "displayName": "Avacon",
       "id": "avacon-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
-      "matchNames": [
-        "avacon ag"
-      ],
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["avacon ag"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Avacon",
@@ -637,11 +496,7 @@
     {
       "displayName": "Avia",
       "id": "avia-7f623e",
-      "locationSet": {
-        "include": [
-          "150"
-        ]
-      },
+      "locationSet": {"include": ["150"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Avia",
@@ -651,11 +506,7 @@
     {
       "displayName": "Avin",
       "id": "avin-e68869",
-      "locationSet": {
-        "include": [
-          "gr"
-        ]
-      },
+      "locationSet": {"include": ["gr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Avin",
@@ -666,9 +517,7 @@
       "displayName": "AVU",
       "id": "avu-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -680,9 +529,7 @@
       "displayName": "Aziende Industriali di Lugano",
       "id": "aziendeindustrialidilugano-d3f33a",
       "locationSet": {
-        "include": [
-          "ch-ti.geojson"
-        ]
+        "include": ["ch-ti.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -695,14 +542,9 @@
       "displayName": "Baltimore Gas and Electric",
       "id": "baltimoregasandelectric-4c7d3b",
       "locationSet": {
-        "include": [
-          "us-md.geojson"
-        ]
+        "include": ["us-md.geojson"]
       },
-      "matchNames": [
-        "bg&e",
-        "bge"
-      ],
+      "matchNames": ["bg&e", "bge"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Baltimore Gas and Electric",
@@ -712,11 +554,7 @@
     {
       "displayName": "Base2Charge",
       "id": "base2charge-7d9e8e",
-      "locationSet": {
-        "include": [
-          "dk"
-        ]
-      },
+      "locationSet": {"include": ["dk"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Base2Charge"
@@ -725,12 +563,7 @@
     {
       "displayName": "Bauhaus",
       "id": "bauhaus-a5756d",
-      "locationSet": {
-        "include": [
-          "at",
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["at", "de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Bauhaus",
@@ -740,14 +573,8 @@
     {
       "displayName": "Bayernwerk",
       "id": "bayernwerk-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
-      "matchNames": [
-        "bayernwerk ag"
-      ],
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["bayernwerk ag"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Bayernwerk",
@@ -758,9 +585,7 @@
       "displayName": "BC Hydro",
       "id": "bchydro-e7f57e",
       "locationSet": {
-        "include": [
-          "ca-bc.geojson"
-        ]
+        "include": ["ca-bc.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -771,11 +596,7 @@
     {
       "displayName": "Be Charge",
       "id": "becharge-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Be Charge",
@@ -785,11 +606,7 @@
     {
       "displayName": "be emobil",
       "id": "beemobil-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "be emobil"
@@ -799,9 +616,7 @@
       "displayName": "Belib'",
       "id": "belib-37370f",
       "locationSet": {
-        "include": [
-          "fr-idf.geojson"
-        ]
+        "include": ["fr-idf.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -812,11 +627,7 @@
     {
       "displayName": "Bender",
       "id": "bender-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Bender"
@@ -826,9 +637,7 @@
       "displayName": "Berliner Stadtwerke",
       "id": "berlinerstadtwerke-db4fd8",
       "locationSet": {
-        "include": [
-          "de-be.geojson"
-        ]
+        "include": ["de-be.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -840,9 +649,7 @@
       "displayName": "BEW",
       "id": "bew-db4fd8",
       "locationSet": {
-        "include": [
-          "de-be.geojson"
-        ]
+        "include": ["de-be.geojson"]
       },
       "matchNames": [
         "bew berliner energie und wärme ag"
@@ -857,9 +664,7 @@
       "displayName": "Bigge Energie",
       "id": "biggeenergie-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "matchNames": [
         "bigge energie gmbh & co. kg"
@@ -874,9 +679,7 @@
       "displayName": "Birmingham City Council",
       "id": "birminghamcitycouncil-56e584",
       "locationSet": {
-        "include": [
-          "gb-bir.geojson"
-        ]
+        "include": ["gb-bir.geojson"]
       },
       "note": "ISO_3166-2:GB - gb-eng (England), gb-bir (Birmingham)",
       "tags": {
@@ -888,11 +691,7 @@
     {
       "displayName": "Blue Corner",
       "id": "bluecorner-87ebf4",
-      "locationSet": {
-        "include": [
-          "be"
-        ]
-      },
+      "locationSet": {"include": ["be"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Blue Corner",
@@ -902,11 +701,7 @@
     {
       "displayName": "Bluecharge",
       "id": "bluecharge-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Bluecharge",
@@ -917,16 +712,10 @@
       "displayName": "BMW",
       "id": "bmw-28ff7e",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "no"
-        ]
+        "include": ["001"],
+        "exclude": ["no"]
       },
-      "matchNames": [
-        "bmw group"
-      ],
+      "matchNames": ["bmw group"],
       "tags": {
         "amenity": "charging_station",
         "operator": "BMW",
@@ -937,9 +726,7 @@
       "displayName": "Bocholter Energie- und Wasserversorgung",
       "id": "bocholterenergieundwasserversorgung-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "matchNames": [
         "bocholter energie- und wasserversorgung gmbh"
@@ -954,11 +741,7 @@
     {
       "displayName": "Booths",
       "id": "booths-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Booths",
@@ -968,11 +751,7 @@
     {
       "displayName": "Bouygues (1-OUEST)",
       "id": "bouygues1ouest-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Bouygues (1-OUEST)"
@@ -981,11 +760,7 @@
     {
       "displayName": "Bouygues Energies & Services",
       "id": "bouyguesenergiesandservices-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "matchNames": [
         "bouygues",
         "bouygues e&s",
@@ -1000,11 +775,7 @@
     {
       "displayName": "BP",
       "id": "bp-c22d3a",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
+      "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "BP",
@@ -1015,11 +786,7 @@
       "displayName": "BP Europa SE",
       "id": "bpeuropase-abd07b",
       "locationSet": {
-        "include": [
-          "ch",
-          "de",
-          "pl"
-        ]
+        "include": ["ch", "de", "pl"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1029,11 +796,7 @@
     {
       "displayName": "Branäsgruppen AB",
       "id": "branasgruppenab-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Branäsgruppen AB"
@@ -1043,12 +806,7 @@
       "displayName": "Brighton and Hove City Council",
       "id": "brightonandhovecitycouncil-a4110c",
       "locationSet": {
-        "include": [
-          [
-            -0.15,
-            50.85
-          ]
-        ]
+        "include": [[-0.15, 50.85]]
       },
       "note": "ISO_3166-2:GB - gb-eng (England), gb-esx (East Sussex)",
       "tags": {
@@ -1061,9 +819,7 @@
       "displayName": "BS Energy",
       "id": "bsenergy-d9ec6c",
       "locationSet": {
-        "include": [
-          "de-ni.geojson"
-        ]
+        "include": ["de-ni.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1074,14 +830,8 @@
     {
       "displayName": "Budimex Mobility",
       "id": "budimexmobility-392011",
-      "locationSet": {
-        "include": [
-          "pl"
-        ]
-      },
-      "matchNames": [
-        "budimex mobility s.a."
-      ],
+      "locationSet": {"include": ["pl"]},
+      "matchNames": ["budimex mobility s.a."],
       "tags": {
         "amenity": "charging_station",
         "operator": "Budimex Mobility",
@@ -1091,11 +841,7 @@
     {
       "displayName": "Bump",
       "id": "bump-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Bump"
@@ -1104,11 +850,7 @@
     {
       "displayName": "Burgenland Energie",
       "id": "burgenlandenergieag-3f60da",
-      "locationSet": {
-        "include": [
-          "at"
-        ]
-      },
+      "locationSet": {"include": ["at"]},
       "matchNames": [
         "energie burgenland",
         "energie burgenland ag"
@@ -1123,9 +865,7 @@
       "displayName": "Caritas",
       "id": "caritas-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1136,11 +876,7 @@
     {
       "displayName": "Carrefour",
       "id": "carrefour-c22d3a",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
+      "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Carrefour",
@@ -1151,9 +887,7 @@
       "displayName": "Caruso Carsharing",
       "id": "carusocarsharing-53499e",
       "locationSet": {
-        "include": [
-          "at-8.geojson"
-        ]
+        "include": ["at-8.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1165,9 +899,7 @@
       "displayName": "Centralschweizerische Kraftwerke",
       "id": "centralschweizerischekraftwerke-8e9cb9",
       "locationSet": {
-        "include": [
-          "ch-lu.geojson"
-        ]
+        "include": ["ch-lu.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1178,12 +910,7 @@
     {
       "displayName": "Cepsa",
       "id": "cepsa-3948da",
-      "locationSet": {
-        "include": [
-          "es",
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["es", "pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Cepsa",
@@ -1191,16 +918,23 @@
       }
     },
     {
+      "displayName": "ČEZ",
+      "id": "cez-f67a50",
+      "locationSet": {"include": ["cz"]},
+      "matchNames": [
+        "čez (ccs/chademo/mennekes type2)"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "ČEZ",
+        "operator:wikidata": "Q336735"
+      }
+    },
+    {
       "displayName": "Charge Your Car",
       "id": "chargeyourcar-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
-      "matchNames": [
-        "cyc"
-      ],
+      "locationSet": {"include": ["gb"]},
+      "matchNames": ["cyc"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Charge Your Car",
@@ -1210,11 +944,7 @@
     {
       "displayName": "Charge-ON GmbH",
       "id": "chargeongmbh-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Charge-ON GmbH"
@@ -1224,17 +954,9 @@
       "displayName": "charge.brussels",
       "id": "pitpoint-e7c13f",
       "locationSet": {
-        "include": [
-          [
-            4.376,
-            50.844,
-            10
-          ]
-        ]
+        "include": [[4.376, 50.844, 10]]
       },
-      "matchNames": [
-        "pitpoint (cng)"
-      ],
+      "matchNames": ["pitpoint (cng)"],
       "tags": {
         "amenity": "charging_station",
         "name": "charge.brussels",
@@ -1247,12 +969,7 @@
     {
       "displayName": "Chargefox",
       "id": "chargefox-61042c",
-      "locationSet": {
-        "include": [
-          "au",
-          "nz"
-        ]
-      },
+      "locationSet": {"include": ["au", "nz"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Chargefox",
@@ -1262,14 +979,8 @@
     {
       "displayName": "ChargeNet NZ",
       "id": "chargenetnz-9850e1",
-      "locationSet": {
-        "include": [
-          "nz"
-        ]
-      },
-      "matchNames": [
-        "chargenet"
-      ],
+      "locationSet": {"include": ["nz"]},
+      "matchNames": ["chargenet"],
       "tags": {
         "amenity": "charging_station",
         "operator": "ChargeNet NZ",
@@ -1279,11 +990,7 @@
     {
       "displayName": "ChargeNode",
       "id": "chargenode-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ChargeNode"
@@ -1292,12 +999,7 @@
     {
       "displayName": "ChargeOne",
       "id": "chargeone-61c5f2",
-      "locationSet": {
-        "include": [
-          "ch",
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["ch", "de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ChargeOne"
@@ -1306,11 +1008,7 @@
     {
       "displayName": "ChargePlace Scotland",
       "id": "chargeplacescotland-416a92",
-      "locationSet": {
-        "include": [
-          "gb-sct"
-        ]
-      },
+      "locationSet": {"include": ["gb-sct"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ChargePlace Scotland",
@@ -1320,11 +1018,7 @@
     {
       "displayName": "ChargePoint Austria GmbH",
       "id": "chargepointaustriagmbh-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ChargePoint Austria GmbH"
@@ -1333,11 +1027,7 @@
     {
       "displayName": "chargEV",
       "id": "chargev-1845ed",
-      "locationSet": {
-        "include": [
-          "my"
-        ]
-      },
+      "locationSet": {"include": ["my"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "chargEV"
@@ -1346,11 +1036,7 @@
     {
       "displayName": "Charging Together",
       "id": "chargingtogether-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Charging Together"
@@ -1359,11 +1045,7 @@
     {
       "displayName": "City Charging",
       "id": "citycharging-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "City Charging",
@@ -1373,14 +1055,7 @@
     {
       "displayName": "City of Gold Coast",
       "id": "cityofgoldcoast-bd4e91",
-      "locationSet": {
-        "include": [
-          [
-            153.4,
-            -28
-          ]
-        ]
-      },
+      "locationSet": {"include": [[153.4, -28]]},
       "tags": {
         "amenity": "charging_station",
         "operator": "City of Gold Coast",
@@ -1391,12 +1066,7 @@
       "displayName": "City of Hobart",
       "id": "cityofhobart-becf90",
       "locationSet": {
-        "include": [
-          [
-            147.3,
-            -42.9
-          ]
-        ]
+        "include": [[147.3, -42.9]]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1408,12 +1078,7 @@
       "displayName": "City of Launceston",
       "id": "cityoflaunceston-2fce2c",
       "locationSet": {
-        "include": [
-          [
-            147.1,
-            -41.4
-          ]
-        ]
+        "include": [[147.1, -41.4]]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1424,14 +1089,8 @@
     {
       "displayName": "Citywatt",
       "id": "citywatt-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
-      "matchNames": [
-        "citywatt gmbh"
-      ],
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["citywatt gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Citywatt",
@@ -1441,11 +1100,7 @@
     {
       "displayName": "Clem",
       "id": "clem-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Clem"
@@ -1455,15 +1110,9 @@
       "displayName": "Clever",
       "id": "clever-28cec3",
       "locationSet": {
-        "include": [
-          "de",
-          "dk",
-          "se"
-        ]
+        "include": ["de", "dk", "se"]
       },
-      "matchNames": [
-        "clever a/s"
-      ],
+      "matchNames": ["clever a/s"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Clever",
@@ -1473,14 +1122,8 @@
     {
       "displayName": "Comfortcharge",
       "id": "comfortcharge-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
-      "matchNames": [
-        "comfortcharge gmbh"
-      ],
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["comfortcharge gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Comfortcharge",
@@ -1491,13 +1134,9 @@
       "displayName": "Compleo Charging Technologies GmbH",
       "id": "compleochargingtechnologiesgmbh-43ff7e",
       "locationSet": {
-        "include": [
-          "de-he.geojson"
-        ]
+        "include": ["de-he.geojson"]
       },
-      "matchNames": [
-        "compleo"
-      ],
+      "matchNames": ["compleo"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Compleo Charging Technologies GmbH",
@@ -1507,11 +1146,7 @@
     {
       "displayName": "Connected Kerb",
       "id": "connectedkerb-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Connected Kerb",
@@ -1521,11 +1156,7 @@
     {
       "displayName": "Coop (Italia)",
       "id": "coop-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Coop",
@@ -1535,11 +1166,7 @@
     {
       "displayName": "Coop (Schweiz)",
       "id": "coop-086737",
-      "locationSet": {
-        "include": [
-          "ch"
-        ]
-      },
+      "locationSet": {"include": ["ch"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Coop",
@@ -1549,11 +1176,7 @@
     {
       "displayName": "Coop (Sverige)",
       "id": "coop-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Coop",
@@ -1563,11 +1186,7 @@
     {
       "displayName": "Coop Norge",
       "id": "coop-476d58",
-      "locationSet": {
-        "include": [
-          "no"
-        ]
-      },
+      "locationSet": {"include": ["no"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Coop",
@@ -1577,11 +1196,7 @@
     {
       "displayName": "Copec",
       "id": "copec-df2b32",
-      "locationSet": {
-        "include": [
-          "cl"
-        ]
-      },
+      "locationSet": {"include": ["cl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Copec",
@@ -1591,11 +1206,7 @@
     {
       "displayName": "Counties Energy",
       "id": "countiesenergy-9850e1",
-      "locationSet": {
-        "include": [
-          "nz"
-        ]
-      },
+      "locationSet": {"include": ["nz"]},
       "tags": {
         "amenity": "charging_station",
         "network": "OpenLoop",
@@ -1607,11 +1218,7 @@
     {
       "displayName": "CSDD",
       "id": "csdd-94e3c4",
-      "locationSet": {
-        "include": [
-          "lv"
-        ]
-      },
+      "locationSet": {"include": ["lv"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "CSDD",
@@ -1622,9 +1229,7 @@
       "displayName": "Cut! Energy GmbH",
       "id": "cutenergygmbh-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1647,9 +1252,7 @@
           "it"
         ]
       },
-      "matchNames": [
-        "da emobil gmbh & co kg"
-      ],
+      "matchNames": ["da emobil gmbh & co kg"],
       "tags": {
         "amenity": "charging_station",
         "operator": "da emobil",
@@ -1659,11 +1262,7 @@
     {
       "displayName": "Daimler AG",
       "id": "daimlerag-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Daimler AG"
@@ -1672,12 +1271,7 @@
     {
       "displayName": "DATS 24",
       "id": "dats24-292b4b",
-      "locationSet": {
-        "include": [
-          "be",
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["be", "fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "DATS 24",
@@ -1687,11 +1281,7 @@
     {
       "displayName": "DBT",
       "id": "dbt-7f623e",
-      "locationSet": {
-        "include": [
-          "150"
-        ]
-      },
+      "locationSet": {"include": ["150"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "DBT"
@@ -1700,14 +1290,8 @@
     {
       "displayName": "deer GmbH",
       "id": "deergmbh-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
-      "matchNames": [
-        "deer"
-      ],
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["deer"],
       "tags": {
         "amenity": "charging_station",
         "operator": "deer GmbH",
@@ -1718,11 +1302,7 @@
       "displayName": "Delta",
       "id": "delta-ed052c",
       "locationSet": {
-        "include": [
-          "de",
-          "fx",
-          "nl"
-        ]
+        "include": ["de", "fx", "nl"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1733,9 +1313,7 @@
       "displayName": "Denkfabrik im Grünen Service GmbH",
       "id": "denkfabrikimgrunenservicegmbh-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1745,11 +1323,7 @@
     {
       "displayName": "Deutsche Post DHL Group",
       "id": "deutschepostdhlgroup-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Deutsche Post DHL Group"
@@ -1758,11 +1332,7 @@
     {
       "displayName": "Deutsche Telekom",
       "id": "deutschetelekom-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "matchNames": [
         "deutsche telekom ag",
         "telekom"
@@ -1777,9 +1347,7 @@
       "displayName": "Deviwa",
       "id": "deviwa-d0faa5",
       "locationSet": {
-        "include": [
-          "ch-vs.geojson"
-        ]
+        "include": ["ch-vs.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1791,9 +1359,7 @@
       "displayName": "DEW21",
       "id": "dew21-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "matchNames": [
         "dew",
@@ -1809,9 +1375,7 @@
       "displayName": "DREWAG",
       "id": "drewag-b8794d",
       "locationSet": {
-        "include": [
-          "de-sn.geojson"
-        ]
+        "include": ["de-sn.geojson"]
       },
       "matchNames": [
         "drewag - stadtwerke dresden",
@@ -1827,9 +1391,7 @@
       "displayName": "Drivalia",
       "id": "drivalia-5d7058",
       "locationSet": {
-        "include": [
-          "it-21.geojson"
-        ]
+        "include": ["it-21.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1839,11 +1401,7 @@
     {
       "displayName": "DRIVECO",
       "id": "driveco-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "DRIVECO"
@@ -1853,9 +1411,7 @@
       "displayName": "DTE",
       "id": "dte-aadb9e",
       "locationSet": {
-        "include": [
-          "pt-05.geojson"
-        ]
+        "include": ["pt-05.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1865,11 +1421,7 @@
     {
       "displayName": "Dubai Electricity and Water Authority",
       "id": "dubaielectricityandwaterauthority-76711b",
-      "locationSet": {
-        "include": [
-          "ae"
-        ]
-      },
+      "locationSet": {"include": ["ae"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Dubai Electricity and Water Authority",
@@ -1880,11 +1432,7 @@
     {
       "displayName": "Duferco",
       "id": "duferco-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Duferco",
@@ -1894,11 +1442,7 @@
     {
       "displayName": "Duferco Energia",
       "id": "dufercoenergia-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Duferco Energia",
@@ -1908,11 +1452,7 @@
     {
       "displayName": "Duke Energy",
       "id": "dukeenergy-994ed4",
-      "locationSet": {
-        "include": [
-          "us"
-        ]
-      },
+      "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Duke Energy",
@@ -1923,11 +1463,7 @@
       "displayName": "E-Flux",
       "id": "eflux-35c01b",
       "locationSet": {
-        "include": [
-          "be",
-          "de",
-          "nl"
-        ]
+        "include": ["be", "de", "nl"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1938,11 +1474,7 @@
     {
       "displayName": "e-Mobi",
       "id": "emobi-27e906",
-      "locationSet": {
-        "include": [
-          "hu"
-        ]
-      },
+      "locationSet": {"include": ["hu"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "e-Mobi"
@@ -1951,11 +1483,7 @@
     {
       "displayName": "e-Mobi Elektromobilitás Nonprofit Kft.",
       "id": "emobielektromobilitasnonprofitkft-27e906",
-      "locationSet": {
-        "include": [
-          "hu"
-        ]
-      },
+      "locationSet": {"include": ["hu"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "e-Mobi Elektromobilitás Nonprofit Kft."
@@ -1964,11 +1492,7 @@
     {
       "displayName": "E-Plug",
       "id": "eplug-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "E-Plug"
@@ -1978,13 +1502,9 @@
       "displayName": "e-regio",
       "id": "eregio-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
-      "matchNames": [
-        "e-regio gmbh & co. kg"
-      ],
+      "matchNames": ["e-regio gmbh & co. kg"],
       "tags": {
         "amenity": "charging_station",
         "operator": "e-regio",
@@ -1994,11 +1514,7 @@
     {
       "displayName": "e-Totem",
       "id": "etotem-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "e-Totem",
@@ -2008,11 +1524,7 @@
     {
       "displayName": "E-Werk Mittelbaden",
       "id": "ewerkmittelbaden-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "E-Werk Mittelbaden",
@@ -2022,11 +1534,7 @@
     {
       "displayName": "e.dis",
       "id": "edis-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "e.dis",
@@ -2036,14 +1544,8 @@
     {
       "displayName": "E.Leclerc",
       "id": "eleclerc-f6553b",
-      "locationSet": {
-        "include": [
-          "fr"
-        ]
-      },
-      "matchNames": [
-        "leclerc"
-      ],
+      "locationSet": {"include": ["fr"]},
+      "matchNames": ["leclerc"],
       "tags": {
         "amenity": "charging_station",
         "operator": "E.Leclerc",
@@ -2053,11 +1555,7 @@
     {
       "displayName": "EAM",
       "id": "eam-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EAM",
@@ -2067,11 +1565,7 @@
     {
       "displayName": "EasyGo",
       "id": "easygo-179e3e",
-      "locationSet": {
-        "include": [
-          "ie"
-        ]
-      },
+      "locationSet": {"include": ["ie"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EasyGo",
@@ -2081,12 +1575,7 @@
     {
       "displayName": "EasyPark",
       "id": "easypark-c454f0",
-      "locationSet": {
-        "include": [
-          "no",
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["no", "se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EasyPark"
@@ -2095,11 +1584,7 @@
     {
       "displayName": "eborn",
       "id": "eborn-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "eborn",
@@ -2109,11 +1594,7 @@
     {
       "displayName": "EC Charging",
       "id": "eccharging-179e3e",
-      "locationSet": {
-        "include": [
-          "ie"
-        ]
-      },
+      "locationSet": {"include": ["ie"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EC Charging"
@@ -2122,11 +1603,7 @@
     {
       "displayName": "eCarUp",
       "id": "ecarup-086737",
-      "locationSet": {
-        "include": [
-          "ch"
-        ]
-      },
+      "locationSet": {"include": ["ch"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "eCarUp",
@@ -2136,11 +1613,7 @@
     {
       "displayName": "EcoInside",
       "id": "ecoinside-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EcoInside"
@@ -2149,11 +1622,7 @@
     {
       "displayName": "econec.eu",
       "id": "econeceu-b23832",
-      "locationSet": {
-        "include": [
-          "sk"
-        ]
-      },
+      "locationSet": {"include": ["sk"]},
       "note": "ISO 3166-2 SK-KI, SK-PV",
       "tags": {
         "amenity": "charging_station",
@@ -2163,12 +1632,7 @@
     {
       "displayName": "Ecotap",
       "id": "ecotap-c98650",
-      "locationSet": {
-        "include": [
-          "nl",
-          "pl"
-        ]
-      },
+      "locationSet": {"include": ["nl", "pl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Ecotap",
@@ -2178,11 +1642,7 @@
     {
       "displayName": "EDEKA",
       "id": "edeka-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EDEKA",
@@ -2193,11 +1653,7 @@
       "displayName": "EDP",
       "id": "edp-387085",
       "locationSet": {
-        "include": [
-          "br",
-          "es",
-          "pt"
-        ]
+        "include": ["br", "es", "pt"]
       },
       "matchNames": [
         "edp comercial",
@@ -2212,12 +1668,7 @@
     {
       "displayName": "eE4mobile eG",
       "id": "ee4mobileeg-0c60c5",
-      "locationSet": {
-        "include": [
-          "de",
-          "dk"
-        ]
-      },
+      "locationSet": {"include": ["de", "dk"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "eE4mobile eG",
@@ -2227,14 +1678,8 @@
     {
       "displayName": "Eesti Energia",
       "id": "eestienergia-733008",
-      "locationSet": {
-        "include": [
-          "ee"
-        ]
-      },
-      "matchNames": [
-        "eesti energia as"
-      ],
+      "locationSet": {"include": ["ee"]},
+      "matchNames": ["eesti energia as"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Eesti Energia",
@@ -2245,12 +1690,7 @@
       "displayName": "efacec",
       "id": "efacec-f9df65",
       "locationSet": {
-        "include": [
-          "de",
-          "gb",
-          "mt",
-          "pt"
-        ]
+        "include": ["de", "gb", "mt", "pt"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2261,11 +1701,7 @@
     {
       "displayName": "Effia",
       "id": "effia-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Effia",
@@ -2276,9 +1712,7 @@
       "displayName": "EGG Energieversorgung Gera",
       "id": "eggenergieversorgunggera-8c6e73",
       "locationSet": {
-        "include": [
-          "de-th.geojson"
-        ]
+        "include": ["de-th.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2289,11 +1723,7 @@
     {
       "displayName": "eins energie in sachsen",
       "id": "einsenergieinsachsen-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "eins energie in sachsen",
@@ -2303,11 +1733,7 @@
     {
       "displayName": "ejoin",
       "id": "ejoin-b23832",
-      "locationSet": {
-        "include": [
-          "sk"
-        ]
-      },
+      "locationSet": {"include": ["sk"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ejoin",
@@ -2317,11 +1743,7 @@
     {
       "displayName": "EKZ",
       "id": "ekz-086737",
-      "locationSet": {
-        "include": [
-          "ch"
-        ]
-      },
+      "locationSet": {"include": ["ch"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EKZ",
@@ -2332,11 +1754,7 @@
       "displayName": "Eldrive",
       "id": "eldrive-8c357e",
       "locationSet": {
-        "include": [
-          "bg",
-          "lt",
-          "ro"
-        ]
+        "include": ["bg", "lt", "ro"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2347,11 +1765,7 @@
     {
       "displayName": "Electric 55 Charging",
       "id": "electric55charging-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Electric 55 Charging"
@@ -2360,11 +1774,7 @@
     {
       "displayName": "Electric Highway Tasmania",
       "id": "electrichighwaytasmania-341d66",
-      "locationSet": {
-        "include": [
-          "au-tas"
-        ]
-      },
+      "locationSet": {"include": ["au-tas"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Electric Highway Tasmania",
@@ -2372,13 +1782,20 @@
       }
     },
     {
+      "displayName": "Électricité de France",
+      "id": "electricitedefrance-c22d3a",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Électricité de France",
+        "operator:short": "EDF",
+        "operator:wikidata": "Q274591"
+      }
+    },
+    {
       "displayName": "Electricity Authority of Cyprus",
       "id": "electricityauthorityofcyprus-fb82c8",
-      "locationSet": {
-        "include": [
-          "cy"
-        ]
-      },
+      "locationSet": {"include": ["cy"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Electricity Authority of Cyprus",
@@ -2389,11 +1806,7 @@
     {
       "displayName": "Electrip",
       "id": "electrip-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Electrip"
@@ -2403,9 +1816,7 @@
       "displayName": "ElectRoad",
       "id": "electroad-a0ff9c",
       "locationSet": {
-        "include": [
-          "gb-east-england.geojson"
-        ]
+        "include": ["gb-east-england.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2415,11 +1826,7 @@
     {
       "displayName": "Electromin",
       "id": "electromin-a3af2f",
-      "locationSet": {
-        "include": [
-          "sa"
-        ]
-      },
+      "locationSet": {"include": ["sa"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Electromin"
@@ -2428,11 +1835,7 @@
     {
       "displayName": "Electromin Limited Company",
       "id": "electrominlimitedcompany-a3af2f",
-      "locationSet": {
-        "include": [
-          "sa"
-        ]
-      },
+      "locationSet": {"include": ["sa"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Electromin Limited Company"
@@ -2441,14 +1844,7 @@
     {
       "displayName": "Elektrizitätswerk Davos",
       "id": "elektrizitatswerkdavos-ba2d61",
-      "locationSet": {
-        "include": [
-          [
-            9.8,
-            46.8
-          ]
-        ]
-      },
+      "locationSet": {"include": [[9.8, 46.8]]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Elektrizitätswerk Davos",
@@ -2459,9 +1855,7 @@
       "displayName": "Elektrizitätswerk Obwalden",
       "id": "elektrizitatswerkobwalden-714754",
       "locationSet": {
-        "include": [
-          "ch-ow.geojson"
-        ]
+        "include": ["ch-ow.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2472,11 +1866,7 @@
     {
       "displayName": "Elektrum Latvija",
       "id": "elektrum-94e3c4",
-      "locationSet": {
-        "include": [
-          "lv"
-        ]
-      },
+      "locationSet": {"include": ["lv"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Elektrum",
@@ -2486,11 +1876,7 @@
     {
       "displayName": "Elektrum Lietuva",
       "id": "elektrum-467e3c",
-      "locationSet": {
-        "include": [
-          "lt"
-        ]
-      },
+      "locationSet": {"include": ["lt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Elektrum",
@@ -2500,11 +1886,7 @@
     {
       "displayName": "ELEN",
       "id": "elen-5bea2c",
-      "locationSet": {
-        "include": [
-          "hr"
-        ]
-      },
+      "locationSet": {"include": ["hr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ELEN",
@@ -2514,12 +1896,7 @@
     {
       "displayName": "Eleport",
       "id": "eleport-512be8",
-      "locationSet": {
-        "include": [
-          "ee",
-          "lv"
-        ]
-      },
+      "locationSet": {"include": ["ee", "lv"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Eleport",
@@ -2529,11 +1906,7 @@
     {
       "displayName": "Elinta",
       "id": "elinta-467e3c",
-      "locationSet": {
-        "include": [
-          "lt"
-        ]
-      },
+      "locationSet": {"include": ["lt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Elinta"
@@ -2542,11 +1915,7 @@
     {
       "displayName": "Ella",
       "id": "ella-3f60da",
-      "locationSet": {
-        "include": [
-          "at"
-        ]
-      },
+      "locationSet": {"include": ["at"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Ella",
@@ -2556,11 +1925,7 @@
     {
       "displayName": "Elli",
       "id": "elli-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "matchNames": [
         "volkswagen group charging gmbh"
       ],
@@ -2573,11 +1938,7 @@
     {
       "displayName": "ELMŰ",
       "id": "elmu-27e906",
-      "locationSet": {
-        "include": [
-          "hu"
-        ]
-      },
+      "locationSet": {"include": ["hu"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ELMŰ",
@@ -2587,11 +1948,7 @@
     {
       "displayName": "Elocity",
       "id": "elocity-392011",
-      "locationSet": {
-        "include": [
-          "pl"
-        ]
-      },
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Elocity",
@@ -2601,11 +1958,7 @@
     {
       "displayName": "Emacom",
       "id": "emacom-bd0810",
-      "locationSet": {
-        "include": [
-          "pt-30"
-        ]
-      },
+      "locationSet": {"include": ["pt-30"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Emacom"
@@ -2615,9 +1968,7 @@
       "displayName": "EMEL",
       "id": "emel-8fbbd7",
       "locationSet": {
-        "include": [
-          "pt-11.geojson"
-        ]
+        "include": ["pt-11.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2629,9 +1980,7 @@
       "displayName": "EMERGY Führungs- und Servicegesellschaft mbH",
       "id": "emergyfuhrungsundservicegesellschaftmbh-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2641,11 +1990,7 @@
     {
       "displayName": "eMobility",
       "id": "emobility-392011",
-      "locationSet": {
-        "include": [
-          "pl"
-        ]
-      },
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "eMobility"
@@ -2655,9 +2000,7 @@
       "displayName": "emotì",
       "id": "emoti-d3f33a",
       "locationSet": {
-        "include": [
-          "ch-ti.geojson"
-        ]
+        "include": ["ch-ti.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2669,9 +2012,7 @@
       "displayName": "Emscher Lippe Energie",
       "id": "emscherlippeenergie-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "matchNames": [
         "ele emscher lippe energie gmbh",
@@ -2687,11 +2028,7 @@
     {
       "displayName": "EnBW Energie Baden-Württemberg AG",
       "id": "enbwenergiebadenwurttembergag-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "matchNames": [
         "enbw",
         "enbw energie baden-württemberg",
@@ -2706,11 +2043,7 @@
     {
       "displayName": "EnBW mobility+ AG und Co.KG",
       "id": "enbwmobilityagundcokg-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EnBW mobility+ AG und Co.KG",
@@ -2720,11 +2053,7 @@
     {
       "displayName": "EnBW Ostwürttemberg DonauRies AG",
       "id": "enbwostwurttembergdonauriesag-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EnBW Ostwürttemberg DonauRies AG"
@@ -2733,11 +2062,7 @@
     {
       "displayName": "Endesa",
       "id": "endesa-97d7cf",
-      "locationSet": {
-        "include": [
-          "es"
-        ]
-      },
+      "locationSet": {"include": ["es"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Endesa",
@@ -2747,11 +2072,7 @@
     {
       "displayName": "Endesa X",
       "id": "endesax-97d7cf",
-      "locationSet": {
-        "include": [
-          "es"
-        ]
-      },
+      "locationSet": {"include": ["es"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Endesa X",
@@ -2762,9 +2083,7 @@
       "displayName": "Endolla Barcelona",
       "id": "endollabarcelona-f58b3e",
       "locationSet": {
-        "include": [
-          "es-b.geojson"
-        ]
+        "include": ["es-b.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2776,11 +2095,7 @@
       "displayName": "Eneco",
       "id": "eneco-35c01b",
       "locationSet": {
-        "include": [
-          "be",
-          "de",
-          "nl"
-        ]
+        "include": ["be", "de", "nl"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2792,11 +2107,7 @@
       "displayName": "Enefit",
       "id": "enefit-f7f98b",
       "locationSet": {
-        "include": [
-          "ee",
-          "lt",
-          "lv"
-        ]
+        "include": ["ee", "lt", "lv"]
       },
       "note": "possibly Q55285976 and/or Q104429275",
       "tags": {
@@ -2807,11 +2118,7 @@
     {
       "displayName": "Enefit Volt",
       "id": "enefitvolt-733008",
-      "locationSet": {
-        "include": [
-          "ee"
-        ]
-      },
+      "locationSet": {"include": ["ee"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Enefit Volt"
@@ -2820,11 +2127,7 @@
     {
       "displayName": "Enel X Way",
       "id": "enelxway-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Enel X Way",
@@ -2835,9 +2138,7 @@
       "displayName": "enercity",
       "id": "enercity-d9ec6c",
       "locationSet": {
-        "include": [
-          "de-ni.geojson"
-        ]
+        "include": ["de-ni.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2848,11 +2149,7 @@
     {
       "displayName": "Energa",
       "id": "energa-392011",
-      "locationSet": {
-        "include": [
-          "pl"
-        ]
-      },
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Energa",
@@ -2862,11 +2159,7 @@
     {
       "displayName": "Energie 360°",
       "id": "7977b1-086737",
-      "locationSet": {
-        "include": [
-          "ch"
-        ]
-      },
+      "locationSet": {"include": ["ch"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Energie 360°",
@@ -2876,11 +2169,7 @@
     {
       "displayName": "Energie AG",
       "id": "energieag-3f60da",
-      "locationSet": {
-        "include": [
-          "at"
-        ]
-      },
+      "locationSet": {"include": ["at"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Energie AG",
@@ -2891,13 +2180,9 @@
       "displayName": "Energie Calw",
       "id": "energiecalw-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
-      "matchNames": [
-        "energie calw gmbh"
-      ],
+      "matchNames": ["energie calw gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Energie Calw",
@@ -2908,9 +2193,7 @@
       "displayName": "ENERGIE Eure-et-Loir",
       "id": "energieeureetloir-0f5d07",
       "locationSet": {
-        "include": [
-          "fr-cvl.geojson"
-        ]
+        "include": ["fr-cvl.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2921,11 +2204,7 @@
     {
       "displayName": "Energie SaarLorLux",
       "id": "energiesaarlorlux-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Energie SaarLorLux",
@@ -2951,9 +2230,7 @@
       "displayName": "Energie Südbayern",
       "id": "energiesudbayern-259ab2",
       "locationSet": {
-        "include": [
-          "de-by.geojson"
-        ]
+        "include": ["de-by.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2965,9 +2242,7 @@
       "displayName": "Energie und Wasser Potsdam GmbH",
       "id": "energieundwasserpotsdamgmbh-4f5737",
       "locationSet": {
-        "include": [
-          "de-bb.geojson"
-        ]
+        "include": ["de-bb.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2977,11 +2252,7 @@
     {
       "displayName": "Energie- und Wasserversorgung Bonn/Rhein-Sieg GmbH",
       "id": "energieundwasserversorgungbonnrheinsieggmbh-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Energie- und Wasserversorgung Bonn/Rhein-Sieg GmbH"
@@ -2990,11 +2261,7 @@
     {
       "displayName": "Energie- und Wasserversorgung Bruchsal GmbH",
       "id": "energieundwasserversorgungbruchsalgmbh-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Energie- und Wasserversorgung Bruchsal GmbH"
@@ -3004,10 +2271,7 @@
       "displayName": "Energiedienst",
       "id": "energiedienst-6cf9a8",
       "locationSet": {
-        "include": [
-          "ch-ag.geojson",
-          "de"
-        ]
+        "include": ["ch-ag.geojson", "de"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3019,9 +2283,7 @@
       "displayName": "Energieversorgung Beckum GmbH & Co. KG",
       "id": "energieversorgungbeckumgmbhandcokg-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3046,9 +2308,7 @@
       "displayName": "Energieversorgung Rodau",
       "id": "energieversorgungrodau-43ff7e",
       "locationSet": {
-        "include": [
-          "de-he.geojson"
-        ]
+        "include": ["de-he.geojson"]
       },
       "matchNames": [
         "energieversorgung rodau gmbh"
@@ -3063,9 +2323,7 @@
       "displayName": "energis",
       "id": "energis-124d23",
       "locationSet": {
-        "include": [
-          "de-sl.geojson"
-        ]
+        "include": ["de-sl.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3077,9 +2335,7 @@
       "displayName": "EnergyDrive",
       "id": "energydrive-1b9db6",
       "locationSet": {
-        "include": [
-          "be-bru.geojson"
-        ]
+        "include": ["be-bru.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3090,9 +2346,7 @@
       "displayName": "EneRSIEIL",
       "id": "enersieil-0f5d07",
       "locationSet": {
-        "include": [
-          "fr-cvl.geojson"
-        ]
+        "include": ["fr-cvl.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3102,12 +2356,7 @@
     {
       "displayName": "Engie",
       "id": "engie-b2225d",
-      "locationSet": {
-        "include": [
-          "be",
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["be", "nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Engie",
@@ -3117,11 +2366,7 @@
     {
       "displayName": "Eni",
       "id": "eni-c22d3a",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
+      "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Eni",
@@ -3131,14 +2376,7 @@
     {
       "displayName": "Eniwa",
       "id": "eniwa-d48833",
-      "locationSet": {
-        "include": [
-          [
-            8.1,
-            47.4
-          ]
-        ]
-      },
+      "locationSet": {"include": [[8.1, 47.4]]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Eniwa",
@@ -3148,11 +2386,7 @@
     {
       "displayName": "ENSO Energie Sachsen Ost AG",
       "id": "ensoenergiesachsenostag-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ENSO Energie Sachsen Ost AG",
@@ -3162,14 +2396,8 @@
     {
       "displayName": "Entega",
       "id": "entega-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
-      "matchNames": [
-        "entega energie gmbh"
-      ],
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["entega energie gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Entega",
@@ -3179,11 +2407,7 @@
     {
       "displayName": "enviaM",
       "id": "enviam-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "matchNames": [
         "envia mitteldeutsche energie ag"
       ],
@@ -3196,15 +2420,8 @@
     {
       "displayName": "EO",
       "id": "eo-f6fe0b",
-      "locationSet": {
-        "include": [
-          "gb",
-          "ie"
-        ]
-      },
-      "matchNames": [
-        "eo charging"
-      ],
+      "locationSet": {"include": ["gb", "ie"]},
+      "matchNames": ["eo charging"],
       "tags": {
         "amenity": "charging_station",
         "operator": "EO",
@@ -3214,11 +2431,7 @@
     {
       "displayName": "eONE",
       "id": "eone-8fcd5a",
-      "locationSet": {
-        "include": [
-          "is"
-        ]
-      },
+      "locationSet": {"include": ["is"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "eONE"
@@ -3227,11 +2440,7 @@
     {
       "displayName": "eParking",
       "id": "eparking-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "eParking"
@@ -3240,11 +2449,7 @@
     {
       "displayName": "ePower",
       "id": "epower-179e3e",
-      "locationSet": {
-        "include": [
-          "ie"
-        ]
-      },
+      "locationSet": {"include": ["ie"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ePower"
@@ -3253,11 +2458,7 @@
     {
       "displayName": "Equans",
       "id": "equans-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Equans",
@@ -3268,11 +2469,7 @@
       "displayName": "Eranovum",
       "id": "eranovum-171c5d",
       "locationSet": {
-        "include": [
-          "be",
-          "es",
-          "fx"
-        ]
+        "include": ["be", "es", "fx"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3284,9 +2481,7 @@
       "displayName": "Erlanger Stadtwerke",
       "id": "erlangerstadtwerke-259ab2",
       "locationSet": {
-        "include": [
-          "de-by.geojson"
-        ]
+        "include": ["de-by.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3298,29 +2493,19 @@
       "displayName": "ESB (Schweiz)",
       "id": "energieservicebielbienne-0c1e54",
       "locationSet": {
-        "include": [
-          "ch-be.geojson"
-        ]
+        "include": ["ch-be.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
         "operator": "Energie Service Biel / Bienne",
-        "operator:short": "ESB",
         "operator:wikidata": "Q96755178"
       }
     },
     {
       "displayName": "ESB Energy",
       "id": "esbenergy-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
-      "matchNames": [
-        "esb",
-        "esb ev solutions"
-      ],
+      "locationSet": {"include": ["gb"]},
+      "matchNames": ["esb ev solutions"],
       "tags": {
         "amenity": "charging_station",
         "operator": "ESB Energy",
@@ -3330,11 +2515,7 @@
     {
       "displayName": "Esso",
       "id": "esso-c22d3a",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
+      "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Esso",
@@ -3345,9 +2526,7 @@
       "displayName": "ESWE",
       "id": "eswe-43ff7e",
       "locationSet": {
-        "include": [
-          "de-he.geojson"
-        ]
+        "include": ["de-he.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3376,9 +2555,7 @@
       "displayName": "Eulektro",
       "id": "eulektro-152e8e",
       "locationSet": {
-        "include": [
-          "de-hb.geojson"
-        ]
+        "include": ["de-hb.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3388,11 +2565,7 @@
     {
       "displayName": "EuroSpin",
       "id": "eurospin-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EuroSpin",
@@ -3402,11 +2575,7 @@
     {
       "displayName": "EV Power",
       "id": "evpower-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EV Power"
@@ -3415,11 +2584,7 @@
     {
       "displayName": "EV+",
       "id": "ev-392011",
-      "locationSet": {
-        "include": [
-          "pl"
-        ]
-      },
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EV+"
@@ -3428,11 +2593,7 @@
     {
       "displayName": "EVA Chargers",
       "id": "evachargers-a6c3f2",
-      "locationSet": {
-        "include": [
-          "ua"
-        ]
-      },
+      "locationSet": {"include": ["ua"]},
       "matchNames": [
         "ae charge point",
         "ae charger",
@@ -3452,11 +2613,7 @@
     {
       "displayName": "EVBox",
       "id": "evbox-7f623e",
-      "locationSet": {
-        "include": [
-          "150"
-        ]
-      },
+      "locationSet": {"include": ["150"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EVBox",
@@ -3466,11 +2623,7 @@
     {
       "displayName": "EVC EV Chargers",
       "id": "evc-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "locationSet": {"include": ["gb"]},
       "matchNames": [
         "ev chargers ltd",
         "ev chargers uk"
@@ -3484,11 +2637,7 @@
     {
       "displayName": "EVCS",
       "id": "evcs-994ed4",
-      "locationSet": {
-        "include": [
-          "us"
-        ]
-      },
+      "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EVCS",
@@ -3499,9 +2648,7 @@
       "displayName": "evd energieversorgung dormagen",
       "id": "evdenergieversorgungdormagen-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3512,14 +2659,8 @@
     {
       "displayName": "Evie Networks",
       "id": "evienetworks-943805",
-      "locationSet": {
-        "include": [
-          "au"
-        ]
-      },
-      "matchNames": [
-        "evie"
-      ],
+      "locationSet": {"include": ["au"]},
+      "matchNames": ["evie"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Evie Networks",
@@ -3529,11 +2670,7 @@
     {
       "displayName": "Evio",
       "id": "evio-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Evio"
@@ -3542,11 +2679,7 @@
     {
       "displayName": "EVlink",
       "id": "evlink-c22d3a",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
+      "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EVlink",
@@ -3571,14 +2704,8 @@
     {
       "displayName": "EVN (Österreich)",
       "id": "evn-3f60da",
-      "locationSet": {
-        "include": [
-          "at"
-        ]
-      },
-      "matchNames": [
-        "evn ag"
-      ],
+      "locationSet": {"include": ["at"]},
+      "matchNames": ["evn ag"],
       "tags": {
         "amenity": "charging_station",
         "operator": "EVN",
@@ -3588,11 +2715,7 @@
     {
       "displayName": "EVN (Северна Македонија)",
       "id": "evn-12d20d",
-      "locationSet": {
-        "include": [
-          "mk"
-        ]
-      },
+      "locationSet": {"include": ["mk"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EVN",
@@ -3602,11 +2725,7 @@
     {
       "displayName": "EVnetNL",
       "id": "evnetnl-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EVnetNL"
@@ -3615,11 +2734,7 @@
     {
       "displayName": "EVO",
       "id": "evo-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EVO",
@@ -3629,11 +2744,7 @@
     {
       "displayName": "evolt",
       "id": "evolt-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "evolt"
@@ -3642,11 +2753,7 @@
     {
       "displayName": "evpass",
       "id": "evpass-086737",
-      "locationSet": {
-        "include": [
-          "ch"
-        ]
-      },
+      "locationSet": {"include": ["ch"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "evpass",
@@ -3656,11 +2763,7 @@
     {
       "displayName": "Evway",
       "id": "evway-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Evway",
@@ -3671,9 +2774,7 @@
       "displayName": "evzen (SMEG Développement)",
       "id": "evzensmegdeveloppement-5e108d",
       "locationSet": {
-        "include": [
-          "fr-pac.geojson"
-        ]
+        "include": ["fr-pac.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3683,14 +2784,7 @@
     {
       "displayName": "EW Höfe",
       "id": "ewhofe-485cc9",
-      "locationSet": {
-        "include": [
-          [
-            8.8,
-            47.2
-          ]
-        ]
-      },
+      "locationSet": {"include": [[8.8, 47.2]]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EW Höfe",
@@ -3700,11 +2794,7 @@
     {
       "displayName": "Eways",
       "id": "eways-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Eways",
@@ -3714,11 +2804,7 @@
     {
       "displayName": "EWE Go",
       "id": "ewego-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "matchNames": [
         "ewe",
         "ewe go gmbh",
@@ -3733,11 +2819,7 @@
     {
       "displayName": "EWII",
       "id": "ewii-7d9e8e",
-      "locationSet": {
-        "include": [
-          "dk"
-        ]
-      },
+      "locationSet": {"include": ["dk"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EWII",
@@ -3747,11 +2829,7 @@
     {
       "displayName": "Ewiva",
       "id": "ewiva-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Ewiva",
@@ -3761,11 +2839,7 @@
     {
       "displayName": "EWR",
       "id": "ewr-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EWR",
@@ -3775,11 +2849,7 @@
     {
       "displayName": "EWV",
       "id": "ewv-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "EWV",
@@ -3789,11 +2859,7 @@
     {
       "displayName": "Exploren",
       "id": "exploren-943805",
-      "locationSet": {
-        "include": [
-          "au"
-        ]
-      },
+      "locationSet": {"include": ["au"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Exploren",
@@ -3803,11 +2869,7 @@
     {
       "displayName": "EZE",
       "id": "eze-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "matchNames": [
         "eze.network",
         "eze.network gmbh"
@@ -3821,11 +2883,7 @@
     {
       "displayName": "Factor Energia",
       "id": "factorenergia-bd0810",
-      "locationSet": {
-        "include": [
-          "pt-30"
-        ]
-      },
+      "locationSet": {"include": ["pt-30"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Factor Energia",
@@ -3835,11 +2893,7 @@
     {
       "displayName": "FairEnergie GmbH",
       "id": "fairenergiegmbh-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "FairEnergie GmbH",
@@ -3847,13 +2901,25 @@
       }
     },
     {
+      "displayName": "Fédération Départementale d'Énergie de la Somme",
+      "id": "federationdepartementaledenergiedelasomme-13949b",
+      "locationSet": {
+        "include": ["fr-hdf.geojson"]
+      },
+      "matchNames": [
+        "fédération départementale d'énergie de la somme (fde80)"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Fédération Départementale d'Énergie de la Somme",
+        "operator:short": "FDE80",
+        "operator:wikidata": "Q64731375"
+      }
+    },
+    {
       "displayName": "Feníe Energía",
       "id": "fenieenergia-97d7cf",
-      "locationSet": {
-        "include": [
-          "es"
-        ]
-      },
+      "locationSet": {"include": ["es"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Feníe Energía",
@@ -3864,9 +2930,7 @@
       "displayName": "Filderstadtwerke",
       "id": "filderstadtwerke-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3877,11 +2941,7 @@
     {
       "displayName": "FINES Charging",
       "id": "c9c8bd-befeeb",
-      "locationSet": {
-        "include": [
-          "bg"
-        ]
-      },
+      "locationSet": {"include": ["bg"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Финес Енерджи ООД",
@@ -3891,11 +2951,7 @@
     {
       "displayName": "Free to X",
       "id": "freetox-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Free to X"
@@ -3904,14 +2960,8 @@
     {
       "displayName": "Freshmile",
       "id": "freshmile-f6553b",
-      "locationSet": {
-        "include": [
-          "fr"
-        ]
-      },
-      "matchNames": [
-        "freshmile sas"
-      ],
+      "locationSet": {"include": ["fr"]},
+      "matchNames": ["freshmile sas"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Freshmile",
@@ -3936,11 +2986,7 @@
     {
       "displayName": "Fyrfasen Energi AB",
       "id": "fyrfasenenergiab-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Fyrfasen Energi AB",
@@ -3948,31 +2994,9 @@
       }
     },
     {
-      "displayName": "Fédération Départementale d'Énergie de la Somme",
-      "id": "federationdepartementaledenergiedelasomme-13949b",
-      "locationSet": {
-        "include": [
-          "fr-hdf.geojson"
-        ]
-      },
-      "matchNames": [
-        "fédération départementale d'énergie de la somme (fde80)"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Fédération Départementale d'Énergie de la Somme",
-        "operator:short": "FDE80",
-        "operator:wikidata": "Q64731375"
-      }
-    },
-    {
       "displayName": "Galp Geste",
       "id": "galpgeste-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Galp Geste"
@@ -3981,11 +3005,7 @@
     {
       "displayName": "Galp Power",
       "id": "galppower-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Galp Power"
@@ -3994,11 +3014,7 @@
     {
       "displayName": "GaraGeeks",
       "id": "garageeks-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "GaraGeeks"
@@ -4007,11 +3023,7 @@
     {
       "displayName": "Gemeente Den Haag",
       "id": "gemeentedenhaag-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Gemeente Den Haag",
@@ -4021,11 +3033,7 @@
     {
       "displayName": "Gemeente Rotterdam",
       "id": "gemeenterotterdam-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Gemeente Rotterdam",
@@ -4035,11 +3043,7 @@
     {
       "displayName": "Gemeente Utrecht",
       "id": "gemeenteutrecht-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Gemeente Utrecht",
@@ -4050,9 +3054,7 @@
       "displayName": "Gemeinde Unterhaching",
       "id": "gemeindeunterhaching-259ab2",
       "locationSet": {
-        "include": [
-          "de-by.geojson"
-        ]
+        "include": ["de-by.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4064,9 +3066,7 @@
       "displayName": "Gemeindewerke Garmisch-Partenkirchen",
       "id": "gemeindewerkegarmischpartenkirchen-259ab2",
       "locationSet": {
-        "include": [
-          "de-by.geojson"
-        ]
+        "include": ["de-by.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4078,9 +3078,7 @@
       "displayName": "Gemeindewerke Oberhaching",
       "id": "gemeindewerkeoberhaching-259ab2",
       "locationSet": {
-        "include": [
-          "de-by.geojson"
-        ]
+        "include": ["de-by.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4091,11 +3089,7 @@
     {
       "displayName": "Generation Journey",
       "id": "generationjourney-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Generation Journey"
@@ -4104,11 +3098,7 @@
     {
       "displayName": "Gentari",
       "id": "gentari-1845ed",
-      "locationSet": {
-        "include": [
-          "my"
-        ]
-      },
+      "locationSet": {"include": ["my"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Gentari",
@@ -4119,9 +3109,7 @@
       "displayName": "Georgia Power",
       "id": "georgiapower-c1e164",
       "locationSet": {
-        "include": [
-          "us-ga.geojson"
-        ]
+        "include": ["us-ga.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4133,9 +3121,7 @@
       "displayName": "Gesvican",
       "id": "gesvican-7d2e65",
       "locationSet": {
-        "include": [
-          "es-s.geojson"
-        ]
+        "include": ["es-s.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4146,9 +3132,7 @@
       "displayName": "GGEW",
       "id": "ggew-43ff7e",
       "locationSet": {
-        "include": [
-          "de-he.geojson"
-        ]
+        "include": ["de-he.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4160,9 +3144,7 @@
       "displayName": "GIC",
       "id": "gic-8c07b0",
       "locationSet": {
-        "include": [
-          "es-m.geojson"
-        ]
+        "include": ["es-m.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4172,11 +3154,7 @@
     {
       "displayName": "GigaCharger",
       "id": "gigacharger-befeeb",
-      "locationSet": {
-        "include": [
-          "bg"
-        ]
-      },
+      "locationSet": {"include": ["bg"]},
       "tags": {
         "amenity": "charging_station",
         "name": "GigaCharger",
@@ -4187,11 +3165,7 @@
     {
       "displayName": "GO+EAuto",
       "id": "goeauto-392011",
-      "locationSet": {
-        "include": [
-          "pl"
-        ]
-      },
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "GO+EAuto"
@@ -4200,11 +3174,7 @@
     {
       "displayName": "GOcharge",
       "id": "gocharge-179e3e",
-      "locationSet": {
-        "include": [
-          "ie"
-        ]
-      },
+      "locationSet": {"include": ["ie"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "GOcharge",
@@ -4214,11 +3184,7 @@
     {
       "displayName": "GOFAST",
       "id": "gofast-086737",
-      "locationSet": {
-        "include": [
-          "ch"
-        ]
-      },
+      "locationSet": {"include": ["ch"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "GOFAST",
@@ -4226,149 +3192,9 @@
       }
     },
     {
-      "displayName": "GP JOULE Connect",
-      "id": "gpjouleconnect-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
-      "matchNames": [
-        "gp joule connect gmbh"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "GP JOULE Connect",
-        "operator:wikidata": "Q128032138"
-      }
-    },
-    {
-      "displayName": "Green Motion",
-      "id": "greenmotion-086737",
-      "locationSet": {
-        "include": [
-          "ch"
-        ]
-      },
-      "matchNames": [
-        "green motion sa"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Green Motion",
-        "operator:wikidata": "Q86664476"
-      }
-    },
-    {
-      "displayName": "Green Technologie",
-      "id": "greentechnologie-508af8",
-      "locationSet": {
-        "include": [
-          "gf",
-          "gp",
-          "mq"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Green Technologie"
-      }
-    },
-    {
-      "displayName": "GreenCharge",
-      "id": "greencharge-8fbbd7",
-      "locationSet": {
-        "include": [
-          "pt-11.geojson"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "GreenCharge"
-      }
-    },
-    {
-      "displayName": "GreenFlux",
-      "id": "greenflux-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "GreenFlux",
-        "operator:wikidata": "Q126728390"
-      }
-    },
-    {
-      "displayName": "GreenTE",
-      "id": "greente-5b32c5",
-      "locationSet": {
-        "include": [
-          "uz"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "GreenTE"
-      }
-    },
-    {
-      "displayName": "GreenWay",
-      "id": "greenway-40951a",
-      "locationSet": {
-        "include": [
-          "hr",
-          "pl",
-          "sk"
-        ]
-      },
-      "matchNames": [
-        "greenway infrastructure"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "GreenWay",
-        "operator:wikidata": "Q116450281"
-      }
-    },
-    {
-      "displayName": "Gremo na elektriko",
-      "id": "gremonaelektriko-64fbf7",
-      "locationSet": {
-        "include": [
-          "si"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Gremo na elektriko",
-        "operator:wikidata": "Q30294660"
-      }
-    },
-    {
-      "displayName": "Groupe E",
-      "id": "groupee-086737",
-      "locationSet": {
-        "include": [
-          "ch"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Groupe E",
-        "operator:wikidata": "Q1547733"
-      }
-    },
-    {
       "displayName": "Göteborgs Stads Parkerings AB",
       "id": "goteborgsstadsparkeringsab-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "matchNames": [
         "göteborg energi",
         "göteborg stads parkerings ab",
@@ -4381,13 +3207,105 @@
       }
     },
     {
+      "displayName": "GP JOULE Connect",
+      "id": "gpjouleconnect-1299a8",
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["gp joule connect gmbh"],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "GP JOULE Connect",
+        "operator:wikidata": "Q128032138"
+      }
+    },
+    {
+      "displayName": "Green Motion",
+      "id": "greenmotion-086737",
+      "locationSet": {"include": ["ch"]},
+      "matchNames": ["green motion sa"],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Green Motion",
+        "operator:wikidata": "Q86664476"
+      }
+    },
+    {
+      "displayName": "Green Technologie",
+      "id": "greentechnologie-508af8",
+      "locationSet": {
+        "include": ["gf", "gp", "mq"]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Green Technologie"
+      }
+    },
+    {
+      "displayName": "GreenCharge",
+      "id": "greencharge-8fbbd7",
+      "locationSet": {
+        "include": ["pt-11.geojson"]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "GreenCharge"
+      }
+    },
+    {
+      "displayName": "GreenFlux",
+      "id": "greenflux-fa6152",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "GreenFlux",
+        "operator:wikidata": "Q126728390"
+      }
+    },
+    {
+      "displayName": "GreenTE",
+      "id": "greente-5b32c5",
+      "locationSet": {"include": ["uz"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "GreenTE"
+      }
+    },
+    {
+      "displayName": "GreenWay",
+      "id": "greenway-40951a",
+      "locationSet": {
+        "include": ["hr", "pl", "sk"]
+      },
+      "matchNames": ["greenway infrastructure"],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "GreenWay",
+        "operator:wikidata": "Q116450281"
+      }
+    },
+    {
+      "displayName": "Gremo na elektriko",
+      "id": "gremonaelektriko-64fbf7",
+      "locationSet": {"include": ["si"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Gremo na elektriko",
+        "operator:wikidata": "Q30294660"
+      }
+    },
+    {
+      "displayName": "Groupe E",
+      "id": "groupee-086737",
+      "locationSet": {"include": ["ch"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Groupe E",
+        "operator:wikidata": "Q1547733"
+      }
+    },
+    {
       "displayName": "Helen",
       "id": "helen-e80d25",
-      "locationSet": {
-        "include": [
-          "fi"
-        ]
-      },
+      "locationSet": {"include": ["fi"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Helen",
@@ -4397,11 +3315,7 @@
     {
       "displayName": "Helexia II",
       "id": "helexiaii-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Helexia II"
@@ -4410,11 +3324,7 @@
     {
       "displayName": "Hera",
       "id": "hera-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Hera"
@@ -4424,9 +3334,7 @@
       "displayName": "Herzo Werke",
       "id": "herzowerke-259ab2",
       "locationSet": {
-        "include": [
-          "de-by.geojson"
-        ]
+        "include": ["de-by.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4437,11 +3345,7 @@
     {
       "displayName": "Hesse GmbH",
       "id": "hessegmbh-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Hesse GmbH"
@@ -4450,11 +3354,7 @@
     {
       "displayName": "Hexagonal Ocean",
       "id": "hexagonalocean-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Hexagonal Ocean"
@@ -4463,11 +3363,7 @@
     {
       "displayName": "High Green Power",
       "id": "highgreenpower-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "High Green Power"
@@ -4476,11 +3372,7 @@
     {
       "displayName": "Hikotron",
       "id": "hikotron-9850e1",
-      "locationSet": {
-        "include": [
-          "nz"
-        ]
-      },
+      "locationSet": {"include": ["nz"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Hikotron",
@@ -4491,9 +3383,7 @@
       "displayName": "Hochtief",
       "id": "hochtief-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4501,13 +3391,18 @@
       }
     },
     {
+      "displayName": "Höganäs Energi AB",
+      "id": "hoganasenergiab-c9e89f",
+      "locationSet": {"include": ["se"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Höganäs Energi AB"
+      }
+    },
+    {
       "displayName": "Holmgrens bil AB",
       "id": "holmgrensbilab-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Holmgrens bil AB",
@@ -4518,12 +3413,8 @@
       "displayName": "Hyundai",
       "id": "hyundai-28ff7e",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "no"
-        ]
+        "include": ["001"],
+        "exclude": ["no"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4532,26 +3423,9 @@
       }
     },
     {
-      "displayName": "Höganäs Energi AB",
-      "id": "hoganasenergiab-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Höganäs Energi AB"
-      }
-    },
-    {
       "displayName": "Iberdrola",
       "id": "iberdrola-97d7cf",
-      "locationSet": {
-        "include": [
-          "es"
-        ]
-      },
+      "locationSet": {"include": ["es"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Iberdrola",
@@ -4561,11 +3435,7 @@
     {
       "displayName": "Ibil",
       "id": "ibil-97d7cf",
-      "locationSet": {
-        "include": [
-          "es"
-        ]
-      },
+      "locationSet": {"include": ["es"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Ibil",
@@ -4575,11 +3445,7 @@
     {
       "displayName": "ICE",
       "id": "ice-296db6",
-      "locationSet": {
-        "include": [
-          "cr"
-        ]
-      },
+      "locationSet": {"include": ["cr"]},
       "matchNames": [
         "instituto costarricense de electricidad"
       ],
@@ -4592,11 +3458,7 @@
     {
       "displayName": "IECharge",
       "id": "iecharge-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "IECharge"
@@ -4605,11 +3467,7 @@
     {
       "displayName": "Ignitis",
       "id": "ignitis-467e3c",
-      "locationSet": {
-        "include": [
-          "lt"
-        ]
-      },
+      "locationSet": {"include": ["lt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Ignitis",
@@ -4619,11 +3477,7 @@
     {
       "displayName": "IgnitisON",
       "id": "ignitison-467e3c",
-      "locationSet": {
-        "include": [
-          "lt"
-        ]
-      },
+      "locationSet": {"include": ["lt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "IgnitisON"
@@ -4633,9 +3487,7 @@
       "displayName": "IKB",
       "id": "ikb-f691eb",
       "locationSet": {
-        "include": [
-          "at-7.geojson"
-        ]
+        "include": ["at-7.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4646,14 +3498,8 @@
     {
       "displayName": "IKEA",
       "id": "ikea-c22d3a",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
-      "matchNames": [
-        "ikea delft"
-      ],
+      "locationSet": {"include": ["001"]},
+      "matchNames": ["ikea delft"],
       "tags": {
         "amenity": "charging_station",
         "operator": "IKEA",
@@ -4663,11 +3509,7 @@
     {
       "displayName": "illwerke vkw",
       "id": "illwerkevkw-3f60da",
-      "locationSet": {
-        "include": [
-          "at"
-        ]
-      },
+      "locationSet": {"include": ["at"]},
       "matchNames": [
         "illwerke vkw ag",
         "vkw",
@@ -4685,9 +3527,7 @@
       "displayName": "InEnergies",
       "id": "inenergies-0f5d07",
       "locationSet": {
-        "include": [
-          "fr-cvl.geojson"
-        ]
+        "include": ["fr-cvl.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4697,11 +3537,7 @@
     {
       "displayName": "Infinite Charge",
       "id": "infinitecharge-a6c3f2",
-      "locationSet": {
-        "include": [
-          "ua"
-        ]
-      },
+      "locationSet": {"include": ["ua"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Infinite Charge"
@@ -4710,14 +3546,8 @@
     {
       "displayName": "Inselwerke",
       "id": "inselwerke-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
-      "matchNames": [
-        "inselwerke eg"
-      ],
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["inselwerke eg"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Inselwerke",
@@ -4727,11 +3557,7 @@
     {
       "displayName": "InstaVolt",
       "id": "instavolt-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "InstaVolt",
@@ -4741,11 +3567,7 @@
     {
       "displayName": "Intel Corporation",
       "id": "intelcorporation-994ed4",
-      "locationSet": {
-        "include": [
-          "us"
-        ]
-      },
+      "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Intel Corporation",
@@ -4755,12 +3577,7 @@
     {
       "displayName": "Intermarché",
       "id": "intermarche-abe4b6",
-      "locationSet": {
-        "include": [
-          "fx",
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["fx", "pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Intermarché",
@@ -4768,13 +3585,19 @@
       }
     },
     {
+      "displayName": "Ísorka",
+      "id": "isorka-8fcd5a",
+      "locationSet": {"include": ["is"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Ísorka",
+        "operator:wikidata": "Q127783906"
+      }
+    },
+    {
       "displayName": "Italia Vento Power Corporation",
       "id": "italiaventopowercorporation-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Italia Vento Power Corporation"
@@ -4783,11 +3606,7 @@
     {
       "displayName": "IWB",
       "id": "iwb-086737",
-      "locationSet": {
-        "include": [
-          "ch"
-        ]
-      },
+      "locationSet": {"include": ["ch"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "IWB",
@@ -4797,11 +3616,7 @@
     {
       "displayName": "Izivia",
       "id": "izivia-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Izivia",
@@ -4809,16 +3624,20 @@
       }
     },
     {
+      "displayName": "Jämtkraft",
+      "id": "jamtkraft-c9e89f",
+      "locationSet": {"include": ["se"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Jämtkraft",
+        "operator:wikidata": "Q10541693"
+      }
+    },
+    {
       "displayName": "Jolt",
       "id": "jolt-743b2f",
       "locationSet": {
-        "include": [
-          "au",
-          "ca",
-          "gb",
-          "nz",
-          "us"
-        ]
+        "include": ["au", "ca", "gb", "nz", "us"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4829,38 +3648,16 @@
     {
       "displayName": "JomCharge",
       "id": "jomcharge-1845ed",
-      "locationSet": {
-        "include": [
-          "my"
-        ]
-      },
+      "locationSet": {"include": ["my"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "JomCharge"
       }
     },
     {
-      "displayName": "Jämtkraft",
-      "id": "jamtkraft-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Jämtkraft",
-        "operator:wikidata": "Q10541693"
-      }
-    },
-    {
       "displayName": "Jönköping Energi",
       "id": "jonkopingenergi-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "matchNames": [
         "jönköping energi ab",
         "jönköpings energi ab"
@@ -4874,11 +3671,7 @@
     {
       "displayName": "K-Lataus",
       "id": "klataus-e80d25",
-      "locationSet": {
-        "include": [
-          "fi"
-        ]
-      },
+      "locationSet": {"include": ["fi"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "K-Lataus",
@@ -4888,11 +3681,7 @@
     {
       "displayName": "Kaufland",
       "id": "kaufland-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Kaufland",
@@ -4902,12 +3691,7 @@
     {
       "displayName": "KEBA",
       "id": "keba-a5756d",
-      "locationSet": {
-        "include": [
-          "at",
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["at", "de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "KEBA",
@@ -4932,11 +3716,7 @@
     {
       "displayName": "kiwEV",
       "id": "kiwev-9850e1",
-      "locationSet": {
-        "include": [
-          "nz"
-        ]
-      },
+      "locationSet": {"include": ["nz"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "kiwEV",
@@ -4946,14 +3726,8 @@
     {
       "displayName": "KLC Serviços",
       "id": "klcservicos-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
-      "matchNames": [
-        "klc"
-      ],
+      "locationSet": {"include": ["pt"]},
+      "matchNames": ["klc"],
       "tags": {
         "amenity": "charging_station",
         "operator": "KLC Serviços"
@@ -4963,9 +3737,7 @@
       "displayName": "Kreis Paderborn",
       "id": "kreispaderborn-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4976,9 +3748,7 @@
       "displayName": "Kreiswerke Main-Kinzig",
       "id": "kreiswerkemainkinzig-43ff7e",
       "locationSet": {
-        "include": [
-          "de-he.geojson"
-        ]
+        "include": ["de-he.geojson"]
       },
       "matchNames": [
         "kreiswerke main-kinzig gmbh"
@@ -4992,11 +3762,7 @@
     {
       "displayName": "Kungsbacka Kommun",
       "id": "kungsbackakommun-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Kungsbacka Kommun",
@@ -5006,11 +3772,7 @@
     {
       "displayName": "Lade i Norge",
       "id": "ladeinorge-476d58",
-      "locationSet": {
-        "include": [
-          "no"
-        ]
-      },
+      "locationSet": {"include": ["no"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Lade i Norge"
@@ -5019,11 +3781,7 @@
     {
       "displayName": "ladenetz.de",
       "id": "ladenetzde-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ladenetz.de"
@@ -5032,11 +3790,7 @@
     {
       "displayName": "Ladeverbund+",
       "id": "ladeverbund-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Ladeverbund+"
@@ -5046,9 +3800,7 @@
       "displayName": "Lancaster City Council",
       "id": "lancastercitycouncil-9ba54b",
       "locationSet": {
-        "include": [
-          "gb-lan.geojson"
-        ]
+        "include": ["gb-lan.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5060,9 +3812,7 @@
       "displayName": "Lancaster University",
       "id": "lancasteruniversity-9ba54b",
       "locationSet": {
-        "include": [
-          "gb-lan.geojson"
-        ]
+        "include": ["gb-lan.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5073,11 +3823,7 @@
     {
       "displayName": "Last Mile Solutions",
       "id": "lastmilesolutions-7f623e",
-      "locationSet": {
-        "include": [
-          "150"
-        ]
-      },
+      "locationSet": {"include": ["150"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Last Mile Solutions",
@@ -5088,9 +3834,7 @@
       "displayName": "Laudert GmbH & Co. KG",
       "id": "laudertgmbhandcokg-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5100,12 +3844,7 @@
     {
       "displayName": "LEAP24",
       "id": "leap24-461188",
-      "locationSet": {
-        "include": [
-          "de",
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["de", "nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "LEAP24",
@@ -5115,12 +3854,7 @@
     {
       "displayName": "Leasys",
       "id": "leasys-257863",
-      "locationSet": {
-        "include": [
-          "fx",
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["fx", "it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Leasys",
@@ -5144,11 +3878,7 @@
     {
       "displayName": "Lechwerke AG",
       "id": "lechwerkeag-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "matchNames": [
         "lech elektrizitätswerke augsburg",
         "lew"
@@ -5163,13 +3893,8 @@
       "displayName": "Lidl",
       "id": "lidl-e2f086",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "no",
-          "se"
-        ]
+        "include": ["001"],
+        "exclude": ["no", "se"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5180,11 +3905,7 @@
     {
       "displayName": "Lidl France",
       "id": "lidlfrance-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Lidl France",
@@ -5194,11 +3915,7 @@
     {
       "displayName": "Lidl Sverige KB",
       "id": "lidlsverigekb-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Lidl Sverige KB",
@@ -5224,9 +3941,7 @@
       "displayName": "LokalWerke",
       "id": "lokalwerke-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "matchNames": [
         "stadtwerke ahaus",
@@ -5243,11 +3958,7 @@
     {
       "displayName": "Lotos",
       "id": "lotos-392011",
-      "locationSet": {
-        "include": [
-          "pl"
-        ]
-      },
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Lotos",
@@ -5258,9 +3969,7 @@
       "displayName": "Loulé Concelho Global",
       "id": "louleconcelhoglobal-faf071",
       "locationSet": {
-        "include": [
-          "pt-08.geojson"
-        ]
+        "include": ["pt-08.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5271,13 +3980,9 @@
       "displayName": "LSW Energie",
       "id": "lswenergie-d9ec6c",
       "locationSet": {
-        "include": [
-          "de-ni.geojson"
-        ]
+        "include": ["de-ni.geojson"]
       },
-      "matchNames": [
-        "lsw"
-      ],
+      "matchNames": ["lsw"],
       "tags": {
         "amenity": "charging_station",
         "operator": "LSW Energie",
@@ -5287,11 +3992,7 @@
     {
       "displayName": "LUMI'IN",
       "id": "lumiin-f6553b",
-      "locationSet": {
-        "include": [
-          "fr"
-        ]
-      },
+      "locationSet": {"include": ["fr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "LUMI'IN"
@@ -5300,11 +4001,7 @@
     {
       "displayName": "Luminus",
       "id": "luminus-87ebf4",
-      "locationSet": {
-        "include": [
-          "be"
-        ]
-      },
+      "locationSet": {"include": ["be"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Luminus",
@@ -5314,11 +4011,7 @@
     {
       "displayName": "Lüneparken",
       "id": "luneparken-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Lüneparken"
@@ -5327,11 +4020,7 @@
     {
       "displayName": "Maingau Energie",
       "id": "maingauenergie-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Maingau Energie",
@@ -5341,11 +4030,7 @@
     {
       "displayName": "Mainova",
       "id": "mainova-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Mainova",
@@ -5356,9 +4041,7 @@
       "displayName": "Mainzer Stadtwerke",
       "id": "mainzerstadtwerke-bb1d73",
       "locationSet": {
-        "include": [
-          "de-rp.geojson"
-        ]
+        "include": ["de-rp.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5370,9 +4053,7 @@
       "displayName": "Mairie de Paris",
       "id": "mairiedeparis-37370f",
       "locationSet": {
-        "include": [
-          "fr-idf.geojson"
-        ]
+        "include": ["fr-idf.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5383,24 +4064,27 @@
     {
       "displayName": "Maksu Services",
       "id": "maksuservices-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Maksu Services"
       }
     },
     {
+      "displayName": "Mälarenergi",
+      "id": "malarenergi-c9e89f",
+      "locationSet": {"include": ["se"]},
+      "matchNames": ["mälarenergi ab"],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Mälarenergi",
+        "operator:wikidata": "Q6949955"
+      }
+    },
+    {
       "displayName": "Mark-E",
       "id": "marke-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Mark-E",
@@ -5410,11 +4094,7 @@
     {
       "displayName": "MaxSolar",
       "id": "maxsolar-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "MaxSolar",
@@ -5424,11 +4104,7 @@
     {
       "displayName": "McDonald's",
       "id": "mcdonalds-c22d3a",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
+      "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "McDonald's",
@@ -5438,11 +4114,7 @@
     {
       "displayName": "Mennekes",
       "id": "mennekes-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Mennekes",
@@ -5452,12 +4124,7 @@
     {
       "displayName": "Mercadona",
       "id": "mercadona-3948da",
-      "locationSet": {
-        "include": [
-          "es",
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["es", "pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Mercadona",
@@ -5468,9 +4135,7 @@
       "displayName": "Merkur",
       "id": "merkur-3fe9f3",
       "locationSet": {
-        "include": [
-          "dk-84.geojson"
-        ]
+        "include": ["dk-84.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5480,11 +4145,7 @@
     {
       "displayName": "METRO Cash & Carry",
       "id": "metrocashandcarry-e68869",
-      "locationSet": {
-        "include": [
-          "gr"
-        ]
-      },
+      "locationSet": {"include": ["gr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "METRO Cash & Carry",
@@ -5495,9 +4156,7 @@
       "displayName": "Michigan State University",
       "id": "michiganstateuniversity-258d0b",
       "locationSet": {
-        "include": [
-          "us-mi.geojson"
-        ]
+        "include": ["us-mi.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5508,11 +4167,7 @@
     {
       "displayName": "Migrol",
       "id": "migrol-086737",
-      "locationSet": {
-        "include": [
-          "ch"
-        ]
-      },
+      "locationSet": {"include": ["ch"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Migrol",
@@ -5522,11 +4177,7 @@
     {
       "displayName": "Mobi.E",
       "id": "mobie-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Mobi.E",
@@ -5536,14 +4187,8 @@
     {
       "displayName": "Mobiletric",
       "id": "mobiletric-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
-      "matchNames": [
-        "mobilectric"
-      ],
+      "locationSet": {"include": ["pt"]},
+      "matchNames": ["mobilectric"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Mobiletric"
@@ -5552,11 +4197,7 @@
     {
       "displayName": "MobilityPlus",
       "id": "mobilityplus-87ebf4",
-      "locationSet": {
-        "include": [
-          "be"
-        ]
-      },
+      "locationSet": {"include": ["be"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "MobilityPlus",
@@ -5566,11 +4207,7 @@
     {
       "displayName": "MobiSmart",
       "id": "mobismart-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "MobiSmart"
@@ -5580,9 +4217,7 @@
       "displayName": "Mobive",
       "id": "mobive-c4b7fc",
       "locationSet": {
-        "include": [
-          "fr-naq.geojson"
-        ]
+        "include": ["fr-naq.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5593,11 +4228,7 @@
     {
       "displayName": "Modulo",
       "id": "modulo-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Modulo",
@@ -5608,12 +4239,7 @@
       "displayName": "Monta",
       "id": "monta-47be25",
       "locationSet": {
-        "include": [
-          "de",
-          "gb",
-          "ie",
-          "se"
-        ]
+        "include": ["de", "gb", "ie", "se"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5623,11 +4249,7 @@
     {
       "displayName": "Moon",
       "id": "moon-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Moon"
@@ -5636,11 +4258,7 @@
     {
       "displayName": "Morbihan énergies",
       "id": "morbihanenergies-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Morbihan énergies",
@@ -5651,9 +4269,7 @@
       "displayName": "Mota",
       "id": "mota-5e108d",
       "locationSet": {
-        "include": [
-          "fr-pac.geojson"
-        ]
+        "include": ["fr-pac.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5663,11 +4279,7 @@
     {
       "displayName": "Mota Engil II",
       "id": "motaengilii-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Mota Engil II"
@@ -5676,11 +4288,7 @@
     {
       "displayName": "Motor Fuel Group",
       "id": "motorfuelgroup-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Motor Fuel Group",
@@ -5692,9 +4300,7 @@
       "displayName": "Mouv Élec Var",
       "id": "mouvelecvar-5e108d",
       "locationSet": {
-        "include": [
-          "fr-pac.geojson"
-        ]
+        "include": ["fr-pac.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5704,11 +4310,7 @@
     {
       "displayName": "MOVE",
       "id": "move-086737",
-      "locationSet": {
-        "include": [
-          "ch"
-        ]
-      },
+      "locationSet": {"include": ["ch"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "MOVE",
@@ -5719,14 +4321,9 @@
       "displayName": "MVV Energie",
       "id": "mvvenergie-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
-      "matchNames": [
-        "mvv",
-        "mvv energie ag"
-      ],
+      "matchNames": ["mvv", "mvv energie ag"],
       "tags": {
         "amenity": "charging_station",
         "operator": "MVV Energie",
@@ -5736,11 +4333,7 @@
     {
       "displayName": "My Market",
       "id": "mymarket-e68869",
-      "locationSet": {
-        "include": [
-          "gr"
-        ]
-      },
+      "locationSet": {"include": ["gr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "My Market",
@@ -5748,30 +4341,9 @@
       }
     },
     {
-      "displayName": "Mälarenergi",
-      "id": "malarenergi-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
-      "matchNames": [
-        "mälarenergi ab"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Mälarenergi",
-        "operator:wikidata": "Q6949955"
-      }
-    },
-    {
       "displayName": "N-ERGIE",
       "id": "nergie-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "matchNames": [
         "n-ergie ag",
         "n-ergie aktiengesellschaft"
@@ -5785,11 +4357,7 @@
     {
       "displayName": "N1",
       "id": "n1-8fcd5a",
-      "locationSet": {
-        "include": [
-          "is"
-        ]
-      },
+      "locationSet": {"include": ["is"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "N1",
@@ -5799,14 +4367,8 @@
     {
       "displayName": "NabiBajk",
       "id": "nabibajk-b23832",
-      "locationSet": {
-        "include": [
-          "sk"
-        ]
-      },
-      "matchNames": [
-        "nabibajk.sk"
-      ],
+      "locationSet": {"include": ["sk"]},
+      "matchNames": ["nabibajk.sk"],
       "tags": {
         "amenity": "charging_station",
         "operator": "NabiBajk",
@@ -5817,10 +4379,7 @@
       "displayName": "NaturEnergie",
       "id": "naturenergie-6cf9a8",
       "locationSet": {
-        "include": [
-          "ch-ag.geojson",
-          "de"
-        ]
+        "include": ["ch-ag.geojson", "de"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5831,11 +4390,7 @@
     {
       "displayName": "Neogy",
       "id": "neogy-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Neogy",
@@ -5845,11 +4400,7 @@
     {
       "displayName": "Neuwoges",
       "id": "neuwoges-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Neuwoges"
@@ -5858,11 +4409,7 @@
     {
       "displayName": "NEW",
       "id": "new-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "NEW",
@@ -5873,9 +4420,7 @@
       "displayName": "next step mobility GmbH",
       "id": "nextstepmobilitygmbh-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5885,11 +4430,7 @@
     {
       "displayName": "nextgreen",
       "id": "nextgreen-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "nextgreen"
@@ -5899,12 +4440,8 @@
       "displayName": "Nissan",
       "id": "nissan-28ff7e",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "no"
-        ]
+        "include": ["001"],
+        "exclude": ["no"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5915,11 +4452,7 @@
     {
       "displayName": "NKM Mobilitás Kft.",
       "id": "nkmmobilitaskft-27e906",
-      "locationSet": {
-        "include": [
-          "hu"
-        ]
-      },
+      "locationSet": {"include": ["hu"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "NKM Mobilitás Kft."
@@ -5928,11 +4461,7 @@
     {
       "displayName": "Norlys",
       "id": "norlys-7d9e8e",
-      "locationSet": {
-        "include": [
-          "dk"
-        ]
-      },
+      "locationSet": {"include": ["dk"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Norlys",
@@ -5942,11 +4471,7 @@
     {
       "displayName": "NOXO.",
       "id": "noxo-392011",
-      "locationSet": {
-        "include": [
-          "pl"
-        ]
-      },
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "NOXO.",
@@ -5956,11 +4481,7 @@
     {
       "displayName": "NRG Energy",
       "id": "nrgenergy-994ed4",
-      "locationSet": {
-        "include": [
-          "us"
-        ]
-      },
+      "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "NRG Energy",
@@ -5970,11 +4491,7 @@
     {
       "displayName": "NRMA",
       "id": "nrma-943805",
-      "locationSet": {
-        "include": [
-          "au"
-        ]
-      },
+      "locationSet": {"include": ["au"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "NRMA",
@@ -5984,11 +4501,7 @@
     {
       "displayName": "NUON",
       "id": "nuon-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "NUON",
@@ -5996,12 +4509,20 @@
       }
     },
     {
+      "displayName": "ÖAMTC",
+      "id": "oamtc-3f60da",
+      "locationSet": {"include": ["at"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "ÖAMTC",
+        "operator:wikidata": "Q306057"
+      }
+    },
+    {
       "displayName": "OIKEN",
       "id": "oiken-d0faa5",
       "locationSet": {
-        "include": [
-          "ch-vs.geojson"
-        ]
+        "include": ["ch-vs.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6011,11 +4532,7 @@
     {
       "displayName": "OK",
       "id": "ok-7d9e8e",
-      "locationSet": {
-        "include": [
-          "dk"
-        ]
-      },
+      "locationSet": {"include": ["dk"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "OK",
@@ -6025,11 +4542,7 @@
     {
       "displayName": "OMV eMotion",
       "id": "omv-c22d3a",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
+      "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "OMV",
@@ -6039,11 +4552,7 @@
     {
       "displayName": "OOO \"TOK BOR\"",
       "id": "oootokbor-5b32c5",
-      "locationSet": {
-        "include": [
-          "uz"
-        ]
-      },
+      "locationSet": {"include": ["uz"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "OOO \"TOK BOR\""
@@ -6052,11 +4561,7 @@
     {
       "displayName": "Opcharge",
       "id": "opcharge-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Opcharge",
@@ -6066,11 +4571,7 @@
     {
       "displayName": "Oppegård kommune",
       "id": "oppegardkommune-476d58",
-      "locationSet": {
-        "include": [
-          "no"
-        ]
-      },
+      "locationSet": {"include": ["no"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Oppegård kommune",
@@ -6080,11 +4581,7 @@
     {
       "displayName": "Orion",
       "id": "orion-9850e1",
-      "locationSet": {
-        "include": [
-          "nz"
-        ]
-      },
+      "locationSet": {"include": ["nz"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Orion",
@@ -6094,11 +4591,7 @@
     {
       "displayName": "Orka náttúrunnar",
       "id": "orkanatturunnar-8fcd5a",
-      "locationSet": {
-        "include": [
-          "is"
-        ]
-      },
+      "locationSet": {"include": ["is"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Orka náttúrunnar",
@@ -6108,11 +4601,7 @@
     {
       "displayName": "Orkubú Vestfjarða",
       "id": "orkubuvestfjardha-8fcd5a",
-      "locationSet": {
-        "include": [
-          "is"
-        ]
-      },
+      "locationSet": {"include": ["is"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Orkubú Vestfjarða",
@@ -6122,11 +4611,7 @@
     {
       "displayName": "Orlen",
       "id": "orlen-392011",
-      "locationSet": {
-        "include": [
-          "pl"
-        ]
-      },
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Orlen",
@@ -6136,11 +4621,7 @@
     {
       "displayName": "Oskarshamn Energi AB",
       "id": "oskarshamnenergiab-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Oskarshamn Energi AB"
@@ -6149,11 +4630,7 @@
     {
       "displayName": "Oslo kommune",
       "id": "oslokommune-476d58",
-      "locationSet": {
-        "include": [
-          "no"
-        ]
-      },
+      "locationSet": {"include": ["no"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Oslo kommune",
@@ -6164,9 +4641,7 @@
       "displayName": "Osnabrücker Parkstätten-Betriebsgesellschaft mbH",
       "id": "osnabruckerparkstattenbetriebsgesellschaftmbh-d9ec6c",
       "locationSet": {
-        "include": [
-          "de-ni.geojson"
-        ]
+        "include": ["de-ni.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6176,11 +4651,7 @@
     {
       "displayName": "Ouest Charge",
       "id": "ouestcharge-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Ouest Charge"
@@ -6189,11 +4660,7 @@
     {
       "displayName": "OVAG",
       "id": "ovag-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "OVAG",
@@ -6203,11 +4670,7 @@
     {
       "displayName": "Paris-Saclay Innovation Playground",
       "id": "parissaclayinnovationplayground-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Paris-Saclay Innovation Playground"
@@ -6216,14 +4679,8 @@
     {
       "displayName": "Park&Charge",
       "id": "parkandcharge-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
-      "matchNames": [
-        "park n charge"
-      ],
+      "locationSet": {"include": ["nl"]},
+      "matchNames": ["park n charge"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Park&Charge",
@@ -6233,11 +4690,7 @@
     {
       "displayName": "Penny Market",
       "id": "pennymarket-27e906",
-      "locationSet": {
-        "include": [
-          "hu"
-        ]
-      },
+      "locationSet": {"include": ["hu"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Penny Market",
@@ -6247,11 +4700,7 @@
     {
       "displayName": "Perusahaan Listrik Negara",
       "id": "perusahaanlistriknegara-34ae8c",
-      "locationSet": {
-        "include": [
-          "id"
-        ]
-      },
+      "locationSet": {"include": ["id"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Perusahaan Listrik Negara",
@@ -6262,12 +4711,7 @@
     {
       "displayName": "Petrol",
       "id": "petrol-6b6292",
-      "locationSet": {
-        "include": [
-          "hr",
-          "si"
-        ]
-      },
+      "locationSet": {"include": ["hr", "si"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Petrol",
@@ -6277,14 +4721,8 @@
     {
       "displayName": "Pfalzwerke",
       "id": "pfalzwerke-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
-      "matchNames": [
-        "pfalzwerke ag"
-      ],
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["pfalzwerke ag"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Pfalzwerke",
@@ -6294,11 +4732,7 @@
     {
       "displayName": "PGE Nowa Energia",
       "id": "pgenowaenergia-392011",
-      "locationSet": {
-        "include": [
-          "pl"
-        ]
-      },
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "PGE Nowa Energia"
@@ -6307,12 +4741,7 @@
     {
       "displayName": "PitPoint",
       "id": "pitpoint-b2225d",
-      "locationSet": {
-        "include": [
-          "be",
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["be", "nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "PitPoint",
@@ -6322,11 +4751,7 @@
     {
       "displayName": "Plenitude",
       "id": "plenitude-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Plenitude",
@@ -6336,11 +4761,7 @@
     {
       "displayName": "Plug'n Roll",
       "id": "plugnroll-086737",
-      "locationSet": {
-        "include": [
-          "ch"
-        ]
-      },
+      "locationSet": {"include": ["ch"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Plug'n Roll",
@@ -6350,11 +4771,7 @@
     {
       "displayName": "Plus de Bornes",
       "id": "plusdebornes-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Plus de Bornes"
@@ -6363,11 +4780,7 @@
     {
       "displayName": "PNB",
       "id": "pnb-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "PNB"
@@ -6376,11 +4789,7 @@
     {
       "displayName": "Power Dot France",
       "id": "powerdotfrance-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Power Dot France"
@@ -6389,11 +4798,7 @@
     {
       "displayName": "Power EV",
       "id": "powerev-392011",
-      "locationSet": {
-        "include": [
-          "pl"
-        ]
-      },
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Power EV"
@@ -6402,14 +4807,8 @@
     {
       "displayName": "Pradella Sistemi",
       "id": "pradellasistemi-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
-      "matchNames": [
-        "pradella sistemi srl"
-      ],
+      "locationSet": {"include": ["it"]},
+      "matchNames": ["pradella sistemi srl"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Pradella Sistemi"
@@ -6418,14 +4817,8 @@
     {
       "displayName": "PRE",
       "id": "pre-f67a50",
-      "locationSet": {
-        "include": [
-          "cz"
-        ]
-      },
-      "matchNames": [
-        "pražská energetika"
-      ],
+      "locationSet": {"include": ["cz"]},
+      "matchNames": ["pražská energetika"],
       "tags": {
         "amenity": "charging_station",
         "operator": "PRE",
@@ -6435,11 +4828,7 @@
     {
       "displayName": "Prio.E",
       "id": "prioe-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Prio.E"
@@ -6448,11 +4837,7 @@
     {
       "displayName": "Protergia",
       "id": "protergia-e68869",
-      "locationSet": {
-        "include": [
-          "gr"
-        ]
-      },
+      "locationSet": {"include": ["gr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Protergia",
@@ -6462,11 +4847,7 @@
     {
       "displayName": "Q-Park",
       "id": "qpark-7f623e",
-      "locationSet": {
-        "include": [
-          "150"
-        ]
-      },
+      "locationSet": {"include": ["150"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Q-Park",
@@ -6494,11 +4875,7 @@
     {
       "displayName": "Qbuzz",
       "id": "qbuzz-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Qbuzz",
@@ -6508,11 +4885,7 @@
     {
       "displayName": "Qelo",
       "id": "qelo-5bea2c",
-      "locationSet": {
-        "include": [
-          "hr"
-        ]
-      },
+      "locationSet": {"include": ["hr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Qelo"
@@ -6522,9 +4895,7 @@
       "displayName": "Queensland Electric Super Highway",
       "id": "yurika-830192",
       "locationSet": {
-        "include": [
-          "au-qld.geojson"
-        ]
+        "include": ["au-qld.geojson"]
       },
       "matchNames": [
         "queensland electric super highway"
@@ -6538,15 +4909,8 @@
     {
       "displayName": "Qwello",
       "id": "qwello-381a82",
-      "locationSet": {
-        "include": [
-          "de",
-          "se"
-        ]
-      },
-      "matchNames": [
-        "qwello gmbh"
-      ],
+      "locationSet": {"include": ["de", "se"]},
+      "matchNames": ["qwello gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Qwello",
@@ -6556,11 +4920,7 @@
     {
       "displayName": "R3",
       "id": "r3-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "R3"
@@ -6584,15 +4944,8 @@
     {
       "displayName": "reev",
       "id": "reev-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
-      "matchNames": [
-        "reev gmbh",
-        "reev.org"
-      ],
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["reev gmbh", "reev.org"],
       "tags": {
         "amenity": "charging_station",
         "operator": "reev"
@@ -6601,11 +4954,7 @@
     {
       "displayName": "Reload Solution",
       "id": "reloadsolution-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Reload Solution"
@@ -6615,12 +4964,8 @@
       "displayName": "Renault",
       "id": "renault-28ff7e",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "no"
-        ]
+        "include": ["001"],
+        "exclude": ["no"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6631,11 +4976,7 @@
     {
       "displayName": "Renovatio e-charge",
       "id": "renovatioecharge-806f62",
-      "locationSet": {
-        "include": [
-          "ro"
-        ]
-      },
+      "locationSet": {"include": ["ro"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Renovatio e-charge",
@@ -6645,15 +4986,8 @@
     {
       "displayName": "Repower",
       "id": "repower-c58b31",
-      "locationSet": {
-        "include": [
-          "ch",
-          "it"
-        ]
-      },
-      "matchNames": [
-        "repower ag"
-      ],
+      "locationSet": {"include": ["ch", "it"]},
+      "matchNames": ["repower ag"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Repower",
@@ -6663,12 +4997,7 @@
     {
       "displayName": "Repsol",
       "id": "repsol-3948da",
-      "locationSet": {
-        "include": [
-          "es",
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["es", "pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Repsol",
@@ -6676,13 +5005,19 @@
       }
     },
     {
+      "displayName": "Révéo",
+      "id": "reveo-170e94",
+      "locationSet": {"include": ["fx"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Révéo",
+        "operator:wikidata": "Q125960237"
+      }
+    },
+    {
       "displayName": "Revnet",
       "id": "revnet-392011",
-      "locationSet": {
-        "include": [
-          "pl"
-        ]
-      },
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Revnet"
@@ -6691,11 +5026,7 @@
     {
       "displayName": "Rewag",
       "id": "rewag-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "matchNames": [
         "regensburger energie- und wasserversorgung ag & co kg"
       ],
@@ -6708,11 +5039,7 @@
     {
       "displayName": "Rewe",
       "id": "rewe-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Rewe",
@@ -6722,11 +5049,7 @@
     {
       "displayName": "RheinEnergie",
       "id": "rheinenergie-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "RheinEnergie",
@@ -6737,9 +5060,7 @@
       "displayName": "RhönEnergie Fulda",
       "id": "rhonenergiefulda-43ff7e",
       "locationSet": {
-        "include": [
-          "de-he.geojson"
-        ]
+        "include": ["de-he.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6750,11 +5071,7 @@
     {
       "displayName": "Ringeriks-kraft AS",
       "id": "ringerikskraftas-476d58",
-      "locationSet": {
-        "include": [
-          "no"
-        ]
-      },
+      "locationSet": {"include": ["no"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Ringeriks-kraft AS",
@@ -6762,27 +5079,9 @@
       }
     },
     {
-      "displayName": "Robert Bosch GmbH",
-      "id": "robertboschgmbh-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Robert Bosch GmbH",
-        "operator:wikidata": "Q234021"
-      }
-    },
-    {
       "displayName": "Roche",
       "id": "roche-c22d3a",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
+      "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Roche",
@@ -6792,11 +5091,7 @@
     {
       "displayName": "Rotterdam Elektrisch",
       "id": "rotterdamelektrisch-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Rotterdam Elektrisch"
@@ -6806,9 +5101,7 @@
       "displayName": "RSE",
       "id": "rse-634961",
       "locationSet": {
-        "include": [
-          "fr-ara.geojson"
-        ]
+        "include": ["fr-ara.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6818,38 +5111,16 @@
     {
       "displayName": "RWE-Effizienz",
       "id": "rweeffizienz-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "RWE-Effizienz"
       }
     },
     {
-      "displayName": "Révéo",
-      "id": "reveo-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Révéo",
-        "operator:wikidata": "Q125960237"
-      }
-    },
-    {
       "displayName": "S.T.P.T.",
       "id": "stpt-806f62",
-      "locationSet": {
-        "include": [
-          "ro"
-        ]
-      },
+      "locationSet": {"include": ["ro"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "S.T.P.T.",
@@ -6860,13 +5131,9 @@
       "displayName": "SachsenEnergie",
       "id": "sachsenenergie-b8794d",
       "locationSet": {
-        "include": [
-          "de-sn.geojson"
-        ]
+        "include": ["de-sn.geojson"]
       },
-      "matchNames": [
-        "sachsenenergie ag"
-      ],
+      "matchNames": ["sachsenenergie ag"],
       "tags": {
         "amenity": "charging_station",
         "operator": "SachsenEnergie",
@@ -6876,11 +5143,7 @@
     {
       "displayName": "SAK",
       "id": "sak-086737",
-      "locationSet": {
-        "include": [
-          "ch"
-        ]
-      },
+      "locationSet": {"include": ["ch"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SAK",
@@ -6905,11 +5168,7 @@
     {
       "displayName": "Samenwerkende Gemeenten Zuid-Holland",
       "id": "samenwerkendegemeentenzuidholland-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Samenwerkende Gemeenten Zuid-Holland"
@@ -6918,11 +5177,7 @@
     {
       "displayName": "Sandviken Energi AB",
       "id": "sandvikenenergiab-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Sandviken Energi AB"
@@ -6932,9 +5187,7 @@
       "displayName": "sas e-motum",
       "id": "sasemotum-34216a",
       "locationSet": {
-        "include": [
-          "fr-20r.geojson"
-        ]
+        "include": ["fr-20r.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6945,12 +5198,8 @@
       "displayName": "Schneider Electric",
       "id": "schneiderelectric-28ff7e",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "no"
-        ]
+        "include": ["001"],
+        "exclude": ["no"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6961,11 +5210,7 @@
     {
       "displayName": "SDE04",
       "id": "sde04-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SDE04"
@@ -6974,11 +5219,7 @@
     {
       "displayName": "SDE07",
       "id": "sde07-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SDE07"
@@ -6987,11 +5228,7 @@
     {
       "displayName": "SDE35",
       "id": "sde35-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SDE35"
@@ -7001,9 +5238,7 @@
       "displayName": "SDEC Énergie",
       "id": "sdecenergie-172d11",
       "locationSet": {
-        "include": [
-          "fr-nor.geojson"
-        ]
+        "include": ["fr-nor.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7014,11 +5249,7 @@
     {
       "displayName": "SDED",
       "id": "sded-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SDED"
@@ -7027,11 +5258,7 @@
     {
       "displayName": "SDEI36",
       "id": "sdei36-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SDEI36"
@@ -7040,11 +5267,7 @@
     {
       "displayName": "SDEM50",
       "id": "sdem50-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SDEM50"
@@ -7053,11 +5276,7 @@
     {
       "displayName": "SDEV",
       "id": "sdev-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SDEV"
@@ -7066,11 +5285,7 @@
     {
       "displayName": "SDEY",
       "id": "sdey-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SDEY"
@@ -7079,11 +5294,7 @@
     {
       "displayName": "SEDI",
       "id": "sedi-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SEDI"
@@ -7092,11 +5303,7 @@
     {
       "displayName": "SEGMA",
       "id": "segma-7cc336",
-      "locationSet": {
-        "include": [
-          "pt-20"
-        ]
-      },
+      "locationSet": {"include": ["pt-20"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SEGMA"
@@ -7105,11 +5312,7 @@
     {
       "displayName": "SemaConnect",
       "id": "semaconnect-994ed4",
-      "locationSet": {
-        "include": [
-          "us"
-        ]
-      },
+      "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SemaConnect",
@@ -7117,13 +5320,20 @@
       }
     },
     {
+      "displayName": "Séolis",
+      "id": "seolis-c4b7fc",
+      "locationSet": {
+        "include": ["fr-naq.geojson"]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Séolis"
+      }
+    },
+    {
       "displayName": "SERVICE plus GmbH",
       "id": "serviceplusgmbh-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SERVICE plus GmbH"
@@ -7132,11 +5342,7 @@
     {
       "displayName": "SEY 78",
       "id": "sey78-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SEY 78"
@@ -7145,11 +5351,7 @@
     {
       "displayName": "SEYMABORNE",
       "id": "seymaborne-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SEYMABORNE"
@@ -7158,11 +5360,7 @@
     {
       "displayName": "SGA Mobility",
       "id": "sgamobility-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SGA Mobility"
@@ -7171,11 +5369,7 @@
     {
       "displayName": "SHARZ",
       "id": "sharz-f274f9",
-      "locationSet": {
-        "include": [
-          "tr"
-        ]
-      },
+      "locationSet": {"include": ["tr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SHARZ"
@@ -7185,12 +5379,8 @@
       "displayName": "Shell",
       "id": "shell-28ff7e",
       "locationSet": {
-        "include": [
-          "001"
-        ],
-        "exclude": [
-          "no"
-        ]
+        "include": ["001"],
+        "exclude": ["no"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7201,11 +5391,7 @@
     {
       "displayName": "Shell Recharge Solutions",
       "id": "shellrechargesolutions-c22d3a",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
+      "locationSet": {"include": ["001"]},
       "matchNames": [
         "greenlots",
         "newmotion",
@@ -7221,11 +5407,7 @@
     {
       "displayName": "SIEEEN",
       "id": "sieeen-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SIEEEN",
@@ -7236,9 +5418,7 @@
       "displayName": "SIEGE 27",
       "id": "siege27-172d11",
       "locationSet": {
-        "include": [
-          "fr-nor.geojson"
-        ]
+        "include": ["fr-nor.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7249,9 +5429,7 @@
       "displayName": "SIEL42",
       "id": "siel42-634961",
       "locationSet": {
-        "include": [
-          "fr-ara.geojson"
-        ]
+        "include": ["fr-ara.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7262,11 +5440,7 @@
     {
       "displayName": "Siemens SRE",
       "id": "siemenssre-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Siemens SRE"
@@ -7275,11 +5449,7 @@
     {
       "displayName": "SIEML",
       "id": "sieml-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SIEML",
@@ -7289,11 +5459,7 @@
     {
       "displayName": "Sigeif",
       "id": "sigeif-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Sigeif",
@@ -7303,11 +5469,7 @@
     {
       "displayName": "SIPLEC",
       "id": "siplec-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SIPLEC",
@@ -7317,11 +5479,7 @@
     {
       "displayName": "SMATRICS",
       "id": "smatrics-3f60da",
-      "locationSet": {
-        "include": [
-          "at"
-        ]
-      },
+      "locationSet": {"include": ["at"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SMATRICS",
@@ -7331,12 +5489,7 @@
     {
       "displayName": "Smoov",
       "id": "smoov-b2225d",
-      "locationSet": {
-        "include": [
-          "be",
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["be", "nl"]},
       "matchNames": [
         "smoov allego",
         "smoov by allego"
@@ -7349,14 +5502,8 @@
     {
       "displayName": "Sodetrel",
       "id": "sodetrel-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
-      "matchNames": [
-        "sodetrel mobilité"
-      ],
+      "locationSet": {"include": ["fx"]},
+      "matchNames": ["sodetrel mobilité"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Sodetrel"
@@ -7365,11 +5512,7 @@
     {
       "displayName": "SODO",
       "id": "sodo-64fbf7",
-      "locationSet": {
-        "include": [
-          "si"
-        ]
-      },
+      "locationSet": {"include": ["si"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SODO"
@@ -7392,11 +5535,7 @@
     {
       "displayName": "Sonae",
       "id": "sonae-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Sonae"
@@ -7406,9 +5545,7 @@
       "displayName": "Sorégies",
       "id": "soregies-c4b7fc",
       "locationSet": {
-        "include": [
-          "fr-naq.geojson"
-        ]
+        "include": ["fr-naq.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7420,9 +5557,7 @@
       "displayName": "South Lakeland District Council",
       "id": "southlakelanddistrictcouncil-16207f",
       "locationSet": {
-        "include": [
-          "gb-north-west.geojson"
-        ]
+        "include": ["gb-north-west.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7433,11 +5568,7 @@
     {
       "displayName": "Spar",
       "id": "spar-c22d3a",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
+      "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Spar",
@@ -7447,11 +5578,7 @@
     {
       "displayName": "SPBR1",
       "id": "spbr1-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SPBR1"
@@ -7460,11 +5587,7 @@
     {
       "displayName": "Sperto",
       "id": "sperto-7d9e8e",
-      "locationSet": {
-        "include": [
-          "dk"
-        ]
-      },
+      "locationSet": {"include": ["dk"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Sperto"
@@ -7473,11 +5596,7 @@
     {
       "displayName": "Spie",
       "id": "spie-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Spie"
@@ -7486,11 +5605,7 @@
     {
       "displayName": "SPIE CityNetworks",
       "id": "spiecitynetworks-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SPIE CityNetworks"
@@ -7499,11 +5614,7 @@
     {
       "displayName": "Spirii",
       "id": "spirii-7d9e8e",
-      "locationSet": {
-        "include": [
-          "dk"
-        ]
-      },
+      "locationSet": {"include": ["dk"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Spirii",
@@ -7514,9 +5625,7 @@
       "displayName": "Stadt Lorch",
       "id": "stadtlorch-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7525,12 +5634,23 @@
       }
     },
     {
+      "displayName": "Städtische Werke Magdeburg",
+      "id": "stadtischewerkemagdeburg-eaf1ad",
+      "locationSet": {
+        "include": [[11.63, 52.13, 50]]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Städtische Werke Magdeburg",
+        "operator:short": "SWM",
+        "operator:wikidata": "Q2359984"
+      }
+    },
+    {
       "displayName": "Stadtwerk am See",
       "id": "stadtwerkamsee-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7543,13 +5663,9 @@
       "displayName": "Stadtwerke Ahlen",
       "id": "stadtwerkeahlen-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
-      "matchNames": [
-        "stadtwerke ahlen gmbh"
-      ],
+      "matchNames": ["stadtwerke ahlen gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Ahlen",
@@ -7560,9 +5676,7 @@
       "displayName": "Stadtwerke Augsburg",
       "id": "stadtwerkeaugsburg-259ab2",
       "locationSet": {
-        "include": [
-          "de-by.geojson"
-        ]
+        "include": ["de-by.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7574,9 +5688,7 @@
       "displayName": "Stadtwerke Bad Aibling",
       "id": "stadtwerkebadaibling-259ab2",
       "locationSet": {
-        "include": [
-          "de-by.geojson"
-        ]
+        "include": ["de-by.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7588,9 +5700,7 @@
       "displayName": "Stadtwerke Bad Homburg",
       "id": "stadtwerkebadhomburg-43ff7e",
       "locationSet": {
-        "include": [
-          "de-he.geojson"
-        ]
+        "include": ["de-he.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7602,9 +5712,7 @@
       "displayName": "Stadtwerke Baden-Baden",
       "id": "stadtwerkebadenbaden-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7616,9 +5724,7 @@
       "displayName": "Stadtwerke Bayreuth Energie und Wasser GmbH",
       "id": "stadtwerkebayreuthenergieundwassergmbh-259ab2",
       "locationSet": {
-        "include": [
-          "de-by.geojson"
-        ]
+        "include": ["de-by.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7629,9 +5735,7 @@
       "displayName": "Stadtwerke Bielefeld",
       "id": "stadtwerkebielefeld-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7643,9 +5747,7 @@
       "displayName": "Stadtwerke Bochum",
       "id": "stadtwerkebochum-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7657,9 +5759,7 @@
       "displayName": "Stadtwerke Bruchsal",
       "id": "stadtwerkebruchsal-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7671,9 +5771,7 @@
       "displayName": "Stadtwerke Brunsbüttel",
       "id": "stadtwerkebrunsbuttel-cf3cf5",
       "locationSet": {
-        "include": [
-          "de-sh.geojson"
-        ]
+        "include": ["de-sh.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7685,9 +5783,7 @@
       "displayName": "Stadtwerke Dachau",
       "id": "stadtwerkedachau-259ab2",
       "locationSet": {
-        "include": [
-          "de-by.geojson"
-        ]
+        "include": ["de-by.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7699,9 +5795,7 @@
       "displayName": "Stadtwerke Dessau",
       "id": "stadtwerkedessau-b7b244",
       "locationSet": {
-        "include": [
-          "de-st.geojson"
-        ]
+        "include": ["de-st.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7713,9 +5807,7 @@
       "displayName": "Stadtwerke Duisburg",
       "id": "stadtwerkeduisburg-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7727,9 +5819,7 @@
       "displayName": "Stadtwerke Düsseldorf",
       "id": "stadtwerkedusseldorf-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7741,9 +5831,7 @@
       "displayName": "Stadtwerke Elmshorn",
       "id": "stadtwerkeelmshorn-cf3cf5",
       "locationSet": {
-        "include": [
-          "de-sh.geojson"
-        ]
+        "include": ["de-sh.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7755,9 +5843,7 @@
       "displayName": "Stadtwerke Energie Jena-Pößneck GmbH",
       "id": "stadtwerkeenergiejenapossneckgmbh-8c6e73",
       "locationSet": {
-        "include": [
-          "de-th.geojson"
-        ]
+        "include": ["de-th.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7769,9 +5855,7 @@
       "displayName": "Stadtwerke Erfurt",
       "id": "stadtwerkeerfurt-8c6e73",
       "locationSet": {
-        "include": [
-          "de-th.geojson"
-        ]
+        "include": ["de-th.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7784,9 +5868,7 @@
       "displayName": "Stadtwerke EVB Huntetal GmbH",
       "id": "stadtwerkeevbhuntetalgmbh-d9ec6c",
       "locationSet": {
-        "include": [
-          "de-ni.geojson"
-        ]
+        "include": ["de-ni.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7798,9 +5880,7 @@
       "displayName": "Stadtwerke Fürstenfeldbruck",
       "id": "stadtwerkefurstenfeldbruck-259ab2",
       "locationSet": {
-        "include": [
-          "de-by.geojson"
-        ]
+        "include": ["de-by.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7812,9 +5892,7 @@
       "displayName": "Stadtwerke Gießen",
       "id": "stadtwerkegiessen-43ff7e",
       "locationSet": {
-        "include": [
-          "de-he.geojson"
-        ]
+        "include": ["de-he.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7827,9 +5905,7 @@
       "displayName": "Stadtwerke Goch GmbH",
       "id": "stadtwerkegochgmbh-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7838,29 +5914,10 @@
       }
     },
     {
-      "displayName": "Stadtwerke Gronau",
-      "id": "stadtwerkegronau-fcc3c2",
-      "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
-      },
-      "matchNames": [
-        "stadtwerke gronau gmbh"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Stadtwerke Gronau",
-        "operator:wikidata": "Q113464830"
-      }
-    },
-    {
       "displayName": "Stadtwerke Göttingen",
       "id": "stadtwerkegottingen-d9ec6c",
       "locationSet": {
-        "include": [
-          "de-ni.geojson"
-        ]
+        "include": ["de-ni.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7869,12 +5926,23 @@
       }
     },
     {
+      "displayName": "Stadtwerke Gronau",
+      "id": "stadtwerkegronau-fcc3c2",
+      "locationSet": {
+        "include": ["de-nw.geojson"]
+      },
+      "matchNames": ["stadtwerke gronau gmbh"],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Stadtwerke Gronau",
+        "operator:wikidata": "Q113464830"
+      }
+    },
+    {
       "displayName": "Stadtwerke Hamm",
       "id": "stadtwerkehamm-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7886,9 +5954,7 @@
       "displayName": "Stadtwerke Heide",
       "id": "stadtwerkeheide-cf3cf5",
       "locationSet": {
-        "include": [
-          "de-sh.geojson"
-        ]
+        "include": ["de-sh.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7900,9 +5966,7 @@
       "displayName": "Stadtwerke Heidelberg",
       "id": "stadtwerkeheidelberg-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7914,9 +5978,7 @@
       "displayName": "Stadtwerke Herne",
       "id": "stadtwerkeherne-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7929,9 +5991,7 @@
       "displayName": "Stadtwerke Iserlohn",
       "id": "stadtwerkeiserlohn-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "matchNames": [
         "stadtwerke iserlohn - heimatversorger"
@@ -7946,9 +6006,7 @@
       "displayName": "Stadtwerke Kiel",
       "id": "stadtwerkekiel-cf3cf5",
       "locationSet": {
-        "include": [
-          "de-sh.geojson"
-        ]
+        "include": ["de-sh.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7961,13 +6019,9 @@
       "displayName": "Stadtwerke Klagenfurt",
       "id": "stadtwerkeklagenfurt-f703d0",
       "locationSet": {
-        "include": [
-          "at-2.geojson"
-        ]
+        "include": ["at-2.geojson"]
       },
-      "matchNames": [
-        "stw"
-      ],
+      "matchNames": ["stw"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Klagenfurt",
@@ -7978,9 +6032,7 @@
       "displayName": "Stadtwerke Konstanz",
       "id": "stadtwerkekonstanz-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7992,9 +6044,7 @@
       "displayName": "Stadtwerke Landshut",
       "id": "stadtwerkelandshut-259ab2",
       "locationSet": {
-        "include": [
-          "de-by.geojson"
-        ]
+        "include": ["de-by.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8006,9 +6056,7 @@
       "displayName": "Stadtwerke Langen",
       "id": "stadtwerkelangen-43ff7e",
       "locationSet": {
-        "include": [
-          "de-he.geojson"
-        ]
+        "include": ["de-he.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8020,9 +6068,7 @@
       "displayName": "Stadtwerke Leinfelden-Echterdingen",
       "id": "stadtwerkeleinfeldenechterdingen-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8034,9 +6080,7 @@
       "displayName": "Stadtwerke Leipzig",
       "id": "stadtwerkeleipzig-b8794d",
       "locationSet": {
-        "include": [
-          "de-sn.geojson"
-        ]
+        "include": ["de-sn.geojson"]
       },
       "matchNames": [
         "leipziger",
@@ -8046,23 +6090,6 @@
         "amenity": "charging_station",
         "operator": "Stadtwerke Leipzig",
         "operator:wikidata": "Q2328555"
-      }
-    },
-    {
-      "displayName": "Stadtwerke Ludwigsburg-Kornwestheim",
-      "id": "stadtwerkeludwigsburgkornwestheim-6bc1fb",
-      "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
-      },
-      "matchNames": [
-        "stadtwerke ludwigsburg-kornwestheim gmbh"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Stadtwerke Ludwigsburg-Kornwestheim",
-        "operator:wikidata": "Q1667735"
       }
     },
     {
@@ -8081,12 +6108,25 @@
       }
     },
     {
+      "displayName": "Stadtwerke Ludwigsburg-Kornwestheim",
+      "id": "stadtwerkeludwigsburgkornwestheim-6bc1fb",
+      "locationSet": {
+        "include": ["de-bw.geojson"]
+      },
+      "matchNames": [
+        "stadtwerke ludwigsburg-kornwestheim gmbh"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Stadtwerke Ludwigsburg-Kornwestheim",
+        "operator:wikidata": "Q1667735"
+      }
+    },
+    {
       "displayName": "Stadtwerke Marburg",
       "id": "stadtwerkemarburg-43ff7e",
       "locationSet": {
-        "include": [
-          "de-he.geojson"
-        ]
+        "include": ["de-he.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8098,9 +6138,7 @@
       "displayName": "Stadtwerke Meerbusch GmbH",
       "id": "stadtwerkemeerbuschgmbh-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8112,17 +6150,9 @@
       "displayName": "Stadtwerke München",
       "id": "stadtwerkemunchen-4b68f8",
       "locationSet": {
-        "include": [
-          [
-            11.58,
-            48.14,
-            60
-          ]
-        ]
+        "include": [[11.58, 48.14, 60]]
       },
-      "matchNames": [
-        "stadtwerke münchen gmbh"
-      ],
+      "matchNames": ["stadtwerke münchen gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke München",
@@ -8134,13 +6164,9 @@
       "displayName": "Stadtwerke Münster",
       "id": "stadtwerkemunster-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
-      "matchNames": [
-        "stadtwerke münster gmbh"
-      ],
+      "matchNames": ["stadtwerke münster gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Münster",
@@ -8151,9 +6177,7 @@
       "displayName": "Stadtwerke Neumünster",
       "id": "stadtwerkeneumunster-cf3cf5",
       "locationSet": {
-        "include": [
-          "de-sh.geojson"
-        ]
+        "include": ["de-sh.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8166,9 +6190,7 @@
       "displayName": "Stadtwerke Neuruppin",
       "id": "stadtwerkeneuruppin-4f5737",
       "locationSet": {
-        "include": [
-          "de-bb.geojson"
-        ]
+        "include": ["de-bb.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8181,9 +6203,7 @@
       "displayName": "Stadtwerke Neuss",
       "id": "stadtwerkeneuss-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8196,9 +6216,7 @@
       "displayName": "Stadtwerke Neustadt an der Weinstraße",
       "id": "stadtwerkeneustadtanderweinstrasse-bb1d73",
       "locationSet": {
-        "include": [
-          "de-rp.geojson"
-        ]
+        "include": ["de-rp.geojson"]
       },
       "matchNames": [
         "stadtwerke neustadt an der weinstraße gmbh"
@@ -8213,9 +6231,7 @@
       "displayName": "Stadtwerke Norderstedt",
       "id": "stadtwerkenorderstedt-cf3cf5",
       "locationSet": {
-        "include": [
-          "de-sh.geojson"
-        ]
+        "include": ["de-sh.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8227,9 +6243,7 @@
       "displayName": "Stadtwerke Oberkirch",
       "id": "stadtwerkeoberkirch-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8241,9 +6255,7 @@
       "displayName": "Stadtwerke Osnabrück",
       "id": "stadtwerkeosnabruck-d9ec6c",
       "locationSet": {
-        "include": [
-          "de-ni.geojson"
-        ]
+        "include": ["de-ni.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8255,9 +6267,7 @@
       "displayName": "Stadtwerke Ostmünsterland GmbH & Co. KG",
       "id": "stadtwerkeostmunsterlandgmbhandcokg-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8269,9 +6279,7 @@
       "displayName": "Stadtwerke Pforzheim",
       "id": "stadtwerkepforzheim-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8284,9 +6292,7 @@
       "displayName": "Stadtwerke Ratingen",
       "id": "stadtwerkeratingen-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8298,13 +6304,9 @@
       "displayName": "Stadtwerke Rhede",
       "id": "stadtwerkerhede-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
-      "matchNames": [
-        "stadtwerke rhede gmbh"
-      ],
+      "matchNames": ["stadtwerke rhede gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Rhede",
@@ -8315,9 +6317,7 @@
       "displayName": "Stadtwerke Rostock",
       "id": "stadtwerkerostock-f1e045",
       "locationSet": {
-        "include": [
-          "de-mv.geojson"
-        ]
+        "include": ["de-mv.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8329,9 +6329,7 @@
       "displayName": "Stadtwerke Rüsselsheim",
       "id": "stadtwerkerusselsheim-43ff7e",
       "locationSet": {
-        "include": [
-          "de-he.geojson"
-        ]
+        "include": ["de-he.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8340,26 +6338,10 @@
       }
     },
     {
-      "displayName": "Stadtwerke Schweinfurt",
-      "id": "stadtwerkeschweinfurt-259ab2",
-      "locationSet": {
-        "include": [
-          "de-by.geojson"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Stadtwerke Schweinfurt",
-        "operator:wikidata": "Q130303093"
-      }
-    },
-    {
       "displayName": "Stadtwerke Schwäbisch Hall",
       "id": "stadtwerkeschwabischhall-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8368,12 +6350,22 @@
       }
     },
     {
+      "displayName": "Stadtwerke Schweinfurt",
+      "id": "stadtwerkeschweinfurt-259ab2",
+      "locationSet": {
+        "include": ["de-by.geojson"]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Stadtwerke Schweinfurt",
+        "operator:wikidata": "Q130303093"
+      }
+    },
+    {
       "displayName": "Stadtwerke SH",
       "id": "stadtwerkesh-cf3cf5",
       "locationSet": {
-        "include": [
-          "de-sh.geojson"
-        ]
+        "include": ["de-sh.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8385,9 +6377,7 @@
       "displayName": "Stadtwerke Sindelfingen",
       "id": "stadtwerkesindelfingen-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "matchNames": [
         "stadtwerke sindelfingen gmbh"
@@ -8402,9 +6392,7 @@
       "displayName": "Stadtwerke Soest Energiedienstleistungs GmbH",
       "id": "stadtwerkesoestenergiedienstleistungsgmbh-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8415,13 +6403,9 @@
       "displayName": "Stadtwerke Solingen",
       "id": "stadtwerkesolingen-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
-      "matchNames": [
-        "stadtwerke solingen gmbh"
-      ],
+      "matchNames": ["stadtwerke solingen gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Solingen",
@@ -8432,9 +6416,7 @@
       "displayName": "Stadtwerke Soltau",
       "id": "stadtwerkesoltau-d9ec6c",
       "locationSet": {
-        "include": [
-          "de-ni.geojson"
-        ]
+        "include": ["de-ni.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8446,13 +6428,9 @@
       "displayName": "Stadtwerke Speyer",
       "id": "stadtwerkespeyer-bb1d73",
       "locationSet": {
-        "include": [
-          "de-rp.geojson"
-        ]
+        "include": ["de-rp.geojson"]
       },
-      "matchNames": [
-        "stadtwerke speyer gmbh"
-      ],
+      "matchNames": ["stadtwerke speyer gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Speyer",
@@ -8464,9 +6442,7 @@
       "displayName": "Stadtwerke Stendal",
       "id": "stadtwerkestendal-b7b244",
       "locationSet": {
-        "include": [
-          "de-st.geojson"
-        ]
+        "include": ["de-st.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8477,9 +6453,7 @@
       "displayName": "Stadtwerke Stralsund",
       "id": "stadtwerkestralsund-f1e045",
       "locationSet": {
-        "include": [
-          "de-mv.geojson"
-        ]
+        "include": ["de-mv.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8490,13 +6464,9 @@
       "displayName": "Stadtwerke Stuttgart",
       "id": "stadtwerkestuttgart-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
-      "matchNames": [
-        "stadtwerke stuttgart gmbh"
-      ],
+      "matchNames": ["stadtwerke stuttgart gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Stuttgart",
@@ -8507,9 +6477,7 @@
       "displayName": "Stadtwerke Troisdorf",
       "id": "stadtwerketroisdorf-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8521,13 +6489,9 @@
       "displayName": "Stadtwerke Tübingen",
       "id": "stadtwerketubingen-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
-      "matchNames": [
-        "stadtwerke tübingen gmbh"
-      ],
+      "matchNames": ["stadtwerke tübingen gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Tübingen",
@@ -8539,9 +6503,7 @@
       "displayName": "Stadtwerke Union Nordhessen",
       "id": "stadtwerkeunionnordhessen-43ff7e",
       "locationSet": {
-        "include": [
-          "de-he.geojson"
-        ]
+        "include": ["de-he.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8553,9 +6515,7 @@
       "displayName": "Stadtwerke Velbert",
       "id": "stadtwerkevelbert-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8567,9 +6527,7 @@
       "displayName": "Stadtwerke Villingen-Schwenningen",
       "id": "stadtwerkevillingenschwenningen-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8581,9 +6539,7 @@
       "displayName": "Stadtwerke Warendorf GmbH",
       "id": "stadtwerkewarendorfgmbh-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8594,9 +6550,7 @@
       "displayName": "Stadtwerke Wedel",
       "id": "stadtwerkewedel-cf3cf5",
       "locationSet": {
-        "include": [
-          "de-sh.geojson"
-        ]
+        "include": ["de-sh.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8607,9 +6561,7 @@
       "displayName": "Stadtwerke Weimar",
       "id": "stadtwerkeweimar-8c6e73",
       "locationSet": {
-        "include": [
-          "de-th.geojson"
-        ]
+        "include": ["de-th.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8621,9 +6573,7 @@
       "displayName": "Stadtwerke Weinheim",
       "id": "stadtwerkeweinheim-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8636,9 +6586,7 @@
       "displayName": "Stadtwerke Weinstadt",
       "id": "stadtwerkeweinstadt-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8649,9 +6597,7 @@
       "displayName": "Stadtwerke Wernigerode",
       "id": "stadtwerkewernigerode-b7b244",
       "locationSet": {
-        "include": [
-          "de-st.geojson"
-        ]
+        "include": ["de-st.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8663,9 +6609,7 @@
       "displayName": "Stadtwerke Willich",
       "id": "stadtwerkewillich-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8677,9 +6621,7 @@
       "displayName": "Stadtwerke Witten",
       "id": "stadtwerkewitten-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8690,11 +6632,7 @@
     {
       "displayName": "STATIONS-E",
       "id": "stationse-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "STATIONS-E"
@@ -8703,11 +6641,7 @@
     {
       "displayName": "Stavanger Parkering",
       "id": "stavangerparkering-476d58",
-      "locationSet": {
-        "include": [
-          "no"
-        ]
-      },
+      "locationSet": {"include": ["no"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Stavanger Parkering"
@@ -8717,9 +6651,7 @@
       "displayName": "STAWAG",
       "id": "stawag-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8731,9 +6663,7 @@
       "displayName": "Stromnetz Hamburg",
       "id": "stromnetzhamburg-43ccfe",
       "locationSet": {
-        "include": [
-          "de-hh.geojson"
-        ]
+        "include": ["de-hh.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8742,32 +6672,20 @@
       }
     },
     {
-      "displayName": "Städtische Werke Magdeburg",
-      "id": "stadtischewerkemagdeburg-eaf1ad",
-      "locationSet": {
-        "include": [
-          [
-            11.63,
-            52.13,
-            50
-          ]
-        ]
-      },
+      "displayName": "Süwag",
+      "id": "suwag-1299a8",
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["süwag energie ag"],
       "tags": {
         "amenity": "charging_station",
-        "operator": "Städtische Werke Magdeburg",
-        "operator:short": "SWM",
-        "operator:wikidata": "Q2359984"
+        "operator": "Süwag",
+        "operator:wikidata": "Q2382300"
       }
     },
     {
       "displayName": "Swarco",
       "id": "swarco-0793ce",
-      "locationSet": {
-        "include": [
-          "gb"
-        ]
-      },
+      "locationSet": {"include": ["gb"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Swarco",
@@ -8778,9 +6696,7 @@
       "displayName": "swb (Bremen)",
       "id": "swb-152e8e",
       "locationSet": {
-        "include": [
-          "de-hb.geojson"
-        ]
+        "include": ["de-hb.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8792,9 +6708,7 @@
       "displayName": "SWB Energie und Wasser",
       "id": "swbenergieundwasser-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8806,11 +6720,7 @@
     {
       "displayName": "Swisscharge",
       "id": "swisscharge-086737",
-      "locationSet": {
-        "include": [
-          "ch"
-        ]
-      },
+      "locationSet": {"include": ["ch"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Swisscharge",
@@ -8837,9 +6747,7 @@
       "displayName": "SYANE",
       "id": "syane-634961",
       "locationSet": {
-        "include": [
-          "fr-ara.geojson"
-        ]
+        "include": ["fr-ara.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8850,9 +6758,7 @@
       "displayName": "SYDELA",
       "id": "sydela-d56302",
       "locationSet": {
-        "include": [
-          "fr-pdl.geojson"
-        ]
+        "include": ["fr-pdl.geojson"]
       },
       "matchNames": [
         "syndicat départemental d'énergie de loire-atlantique (sydela)"
@@ -8866,9 +6772,7 @@
       "displayName": "SYDER",
       "id": "syder-634961",
       "locationSet": {
-        "include": [
-          "fr-ara.geojson"
-        ]
+        "include": ["fr-ara.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -8879,11 +6783,7 @@
     {
       "displayName": "SYME05",
       "id": "syme05-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "SYME05"
@@ -8893,9 +6793,7 @@
       "displayName": "Syndicat de l'Énergie de l'Orne",
       "id": "syndicatdelenergiedelorne-172d11",
       "locationSet": {
-        "include": [
-          "fr-nor.geojson"
-        ]
+        "include": ["fr-nor.geojson"]
       },
       "matchNames": [
         "syndicat de l'énergie de l'orne (te61)"
@@ -8906,43 +6804,9 @@
       }
     },
     {
-      "displayName": "Séolis",
-      "id": "seolis-c4b7fc",
-      "locationSet": {
-        "include": [
-          "fr-naq.geojson"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Séolis"
-      }
-    },
-    {
-      "displayName": "Süwag",
-      "id": "suwag-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
-      "matchNames": [
-        "süwag energie ag"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Süwag",
-        "operator:wikidata": "Q2382300"
-      }
-    },
-    {
       "displayName": "Tank & Rast",
       "id": "tankandrast-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Tank & Rast",
@@ -8952,14 +6816,8 @@
     {
       "displayName": "TankE",
       "id": "tanke-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
-      "matchNames": [
-        "tanke gmbh"
-      ],
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["tanke gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "TankE",
@@ -8969,11 +6827,7 @@
     {
       "displayName": "Tauron",
       "id": "tauron-392011",
-      "locationSet": {
-        "include": [
-          "pl"
-        ]
-      },
+      "locationSet": {"include": ["pl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Tauron",
@@ -8983,11 +6837,7 @@
     {
       "displayName": "TEAG Mobil",
       "id": "teagmobil-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "matchNames": [
         "teag",
         "teag mobil gmbh",
@@ -9004,9 +6854,7 @@
       "displayName": "Technische Werke Osning",
       "id": "technischewerkeosning-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "matchNames": [
         "technische werke osning gmbh"
@@ -9022,9 +6870,7 @@
       "displayName": "Technische Werke Schussental",
       "id": "technischewerkeschussental-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
       "matchNames": [
         "technische werke schussental gmbh"
@@ -9038,11 +6884,7 @@
     {
       "displayName": "teilAuto",
       "id": "teilauto-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "teilAuto",
@@ -9053,9 +6895,7 @@
       "displayName": "Teplárny Brno",
       "id": "teplarnybrno-dd96af",
       "locationSet": {
-        "include": [
-          "cz-64.geojson"
-        ]
+        "include": ["cz-64.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -9066,11 +6906,7 @@
     {
       "displayName": "TESLA France SARL",
       "id": "teslafrancesarl-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "TESLA France SARL"
@@ -9079,11 +6915,7 @@
     {
       "displayName": "Tesla Germany GmbH",
       "id": "teslagermanygmbh-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Tesla Germany GmbH"
@@ -9092,14 +6924,8 @@
     {
       "displayName": "TIWAG",
       "id": "tiwag-3f60da",
-      "locationSet": {
-        "include": [
-          "at"
-        ]
-      },
-      "matchNames": [
-        "tiroler wasserkraft ag"
-      ],
+      "locationSet": {"include": ["at"]},
+      "matchNames": ["tiroler wasserkraft ag"],
       "tags": {
         "amenity": "charging_station",
         "operator": "TIWAG",
@@ -9109,11 +6935,7 @@
     {
       "displayName": "Total Marketing France",
       "id": "totalmarketingfrance-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Total Marketing France",
@@ -9123,11 +6945,7 @@
     {
       "displayName": "TotalEnergies Marketing France",
       "id": "totalenergiesmarketingfrance-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "TotalEnergies Marketing France"
@@ -9136,11 +6954,7 @@
     {
       "displayName": "Trondheim kommune, Miljøenheten",
       "id": "trondheimkommunemiljoenheten-476d58",
-      "locationSet": {
-        "include": [
-          "no"
-        ]
-      },
+      "locationSet": {"include": ["no"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Trondheim kommune, Miljøenheten"
@@ -9149,11 +6963,7 @@
     {
       "displayName": "True Kare",
       "id": "truekare-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "True Kare"
@@ -9162,11 +6972,7 @@
     {
       "displayName": "Turmstrom",
       "id": "turmstrom-3f60da",
-      "locationSet": {
-        "include": [
-          "at"
-        ]
-      },
+      "locationSet": {"include": ["at"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Turmstrom"
@@ -9175,11 +6981,7 @@
     {
       "displayName": "UAB Ignitis",
       "id": "uabignitis-467e3c",
-      "locationSet": {
-        "include": [
-          "lt"
-        ]
-      },
+      "locationSet": {"include": ["lt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "UAB Ignitis",
@@ -9189,11 +6991,7 @@
     {
       "displayName": "Ubeeqo",
       "id": "ubeeqo-c22d3a",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
+      "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Ubeeqo",
@@ -9201,13 +6999,18 @@
       }
     },
     {
+      "displayName": "Überlandwerk Groß-Gerau GmbH",
+      "id": "uberlandwerkgrossgeraugmbh-1299a8",
+      "locationSet": {"include": ["de"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Überlandwerk Groß-Gerau GmbH"
+      }
+    },
+    {
       "displayName": "Ucharge",
       "id": "ucharge-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Ucharge"
@@ -9217,9 +7020,7 @@
       "displayName": "UEM",
       "id": "uem-4dd58e",
       "locationSet": {
-        "include": [
-          "fr-ges.geojson"
-        ]
+        "include": ["fr-ges.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -9230,11 +7031,7 @@
     {
       "displayName": "Umbria Energy",
       "id": "umbriaenergy-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Umbria Energy"
@@ -9243,11 +7040,7 @@
     {
       "displayName": "Umeå Energi",
       "id": "umeaenergi-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Umeå Energi",
@@ -9257,12 +7050,7 @@
     {
       "displayName": "Uno-X",
       "id": "unox-285e25",
-      "locationSet": {
-        "include": [
-          "dk",
-          "no"
-        ]
-      },
+      "locationSet": {"include": ["dk", "no"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Uno-X",
@@ -9272,11 +7060,7 @@
     {
       "displayName": "Uppsala parkerings AB",
       "id": "uppsalaparkeringsab-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Uppsala parkerings AB"
@@ -9285,11 +7069,7 @@
     {
       "displayName": "UTE",
       "id": "ute-dde172",
-      "locationSet": {
-        "include": [
-          "uy"
-        ]
-      },
+      "locationSet": {"include": ["uy"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "UTE",
@@ -9299,11 +7079,7 @@
     {
       "displayName": "V-MARKT",
       "id": "vmarkt-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "V-MARKT",
@@ -9313,11 +7089,7 @@
     {
       "displayName": "Vattenvall",
       "id": "vattenvall-fa6152",
-      "locationSet": {
-        "include": [
-          "nl"
-        ]
-      },
+      "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Vattenvall"
@@ -9326,11 +7098,7 @@
     {
       "displayName": "Vector",
       "id": "vector-9850e1",
-      "locationSet": {
-        "include": [
-          "nz"
-        ]
-      },
+      "locationSet": {"include": ["nz"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Vector",
@@ -9340,12 +7108,7 @@
     {
       "displayName": "VendElectric",
       "id": "vendelectric-f6fe0b",
-      "locationSet": {
-        "include": [
-          "gb",
-          "ie"
-        ]
-      },
+      "locationSet": {"include": ["gb", "ie"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "VendElectric"
@@ -9355,9 +7118,7 @@
       "displayName": "Vereinigte Stadtwerke",
       "id": "vereinigtestadtwerke-cf3cf5",
       "locationSet": {
-        "include": [
-          "de-sh.geojson"
-        ]
+        "include": ["de-sh.geojson"]
       },
       "matchNames": [
         "vereinigte stadtwerke gmbh"
@@ -9371,11 +7132,7 @@
     {
       "displayName": "VGS mbH",
       "id": "vgsmbh-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "VGS mbH"
@@ -9384,11 +7141,7 @@
     {
       "displayName": "Viesgo",
       "id": "viesgo-97d7cf",
-      "locationSet": {
-        "include": [
-          "es"
-        ]
-      },
+      "locationSet": {"include": ["es"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Viesgo",
@@ -9399,13 +7152,9 @@
       "displayName": "Ville de Saint-Louis",
       "id": "villedesaintlouis-4dd58e",
       "locationSet": {
-        "include": [
-          "fr-ges.geojson"
-        ]
+        "include": ["fr-ges.geojson"]
       },
-      "matchNames": [
-        "saint-louis"
-      ],
+      "matchNames": ["saint-louis"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Ville de Saint-Louis",
@@ -9415,11 +7164,7 @@
     {
       "displayName": "VinFast",
       "id": "vinfast-2da5cb",
-      "locationSet": {
-        "include": [
-          "vn"
-        ]
-      },
+      "locationSet": {"include": ["vn"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "VinFast"
@@ -9428,14 +7173,8 @@
     {
       "displayName": "vkw vlotte",
       "id": "vkwvlotte-3f60da",
-      "locationSet": {
-        "include": [
-          "at"
-        ]
-      },
-      "matchNames": [
-        "vlotte"
-      ],
+      "locationSet": {"include": ["at"]},
+      "matchNames": ["vlotte"],
       "tags": {
         "amenity": "charging_station",
         "operator": "vkw vlotte",
@@ -9445,11 +7184,7 @@
     {
       "displayName": "Volkswagen",
       "id": "volkswagen-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Volkswagen",
@@ -9459,11 +7194,7 @@
     {
       "displayName": "Volta",
       "id": "volta-994ed4",
-      "locationSet": {
-        "include": [
-          "us"
-        ]
-      },
+      "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Volta",
@@ -9473,11 +7204,7 @@
     {
       "displayName": "VOLTRUN",
       "id": "voltrun-f274f9",
-      "locationSet": {
-        "include": [
-          "tr"
-        ]
-      },
+      "locationSet": {"include": ["tr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "VOLTRUN"
@@ -9486,11 +7213,7 @@
     {
       "displayName": "Vолна",
       "id": "16e62d-18ef61",
-      "locationSet": {
-        "include": [
-          "ru"
-        ]
-      },
+      "locationSet": {"include": ["ru"]},
       "note": "ISO 3166-2 RU-VGG",
       "tags": {
         "amenity": "charging_station",
@@ -9500,14 +7223,8 @@
     {
       "displayName": "WAAT",
       "id": "waat-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
-      "matchNames": [
-        "waat sas"
-      ],
+      "locationSet": {"include": ["fx"]},
+      "matchNames": ["waat sas"],
       "tags": {
         "amenity": "charging_station",
         "operator": "WAAT"
@@ -9516,11 +7233,7 @@
     {
       "displayName": "wallbe",
       "id": "wallbe-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "wallbe"
@@ -9529,14 +7242,8 @@
     {
       "displayName": "Waybler",
       "id": "waybler-c9e89f",
-      "locationSet": {
-        "include": [
-          "se"
-        ]
-      },
-      "matchNames": [
-        "cacharge"
-      ],
+      "locationSet": {"include": ["se"]},
+      "matchNames": ["cacharge"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Waybler",
@@ -9546,11 +7253,7 @@
     {
       "displayName": "WEL Networks",
       "id": "welnetworks-9850e1",
-      "locationSet": {
-        "include": [
-          "nz"
-        ]
-      },
+      "locationSet": {"include": ["nz"]},
       "tags": {
         "amenity": "charging_station",
         "network": "OpenLoop",
@@ -9563,9 +7266,7 @@
       "displayName": "Wels Strom E-Mobil",
       "id": "welsstromemobil-f73649",
       "locationSet": {
-        "include": [
-          "at-4.geojson"
-        ]
+        "include": ["at-4.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -9575,11 +7276,7 @@
     {
       "displayName": "WEMAG",
       "id": "wemag-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "WEMAG",
@@ -9589,12 +7286,7 @@
     {
       "displayName": "Wenea",
       "id": "wenea-417ce7",
-      "locationSet": {
-        "include": [
-          "es",
-          "gb"
-        ]
-      },
+      "locationSet": {"include": ["es", "gb"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Wenea",
@@ -9604,11 +7296,7 @@
     {
       "displayName": "westenergie",
       "id": "westenergie-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "westenergie",
@@ -9618,11 +7306,7 @@
     {
       "displayName": "Westenergie Metering GmbH",
       "id": "westenergiemeteringgmbh-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Westenergie Metering GmbH"
@@ -9632,9 +7316,7 @@
       "displayName": "Westfalen AG",
       "id": "westfalenag-fcc3c2",
       "locationSet": {
-        "include": [
-          "de-nw.geojson"
-        ]
+        "include": ["de-nw.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -9645,11 +7327,7 @@
     {
       "displayName": "Westfalen Weser Ladeservice",
       "id": "westfalenweserladeservice-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "matchNames": [
         "westfalen weser",
         "westfalen weser energie",
@@ -9664,11 +7342,7 @@
     {
       "displayName": "Whole Foods",
       "id": "wholefoods-994ed4",
-      "locationSet": {
-        "include": [
-          "us"
-        ]
-      },
+      "locationSet": {"include": ["us"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Whole Foods",
@@ -9678,14 +7352,8 @@
     {
       "displayName": "Wien Energie",
       "id": "wienenergie-3f60da",
-      "locationSet": {
-        "include": [
-          "at"
-        ]
-      },
-      "matchNames": [
-        "wien energie gmbh"
-      ],
+      "locationSet": {"include": ["at"]},
+      "matchNames": ["wien energie gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Wien Energie",
@@ -9696,9 +7364,7 @@
       "displayName": "WiiiZ",
       "id": "izivia-5e108d",
       "locationSet": {
-        "include": [
-          "fr-pac.geojson"
-        ]
+        "include": ["fr-pac.geojson"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -9711,14 +7377,8 @@
     {
       "displayName": "Wirelane",
       "id": "wirelane-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
-      "matchNames": [
-        "wirelane gmbh"
-      ],
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["wirelane gmbh"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Wirelane",
@@ -9728,11 +7388,7 @@
     {
       "displayName": "Wowplug",
       "id": "wowplug-a1285d",
-      "locationSet": {
-        "include": [
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Wowplug"
@@ -9741,11 +7397,7 @@
     {
       "displayName": "WVV",
       "id": "wvv-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "matchNames": [
         "würzburger versorgungs- und verkehrs-gmbh"
       ],
@@ -9758,14 +7410,8 @@
     {
       "displayName": "Z Energy",
       "id": "zenergy-9850e1",
-      "locationSet": {
-        "include": [
-          "nz"
-        ]
-      },
-      "matchNames": [
-        "z"
-      ],
+      "locationSet": {"include": ["nz"]},
+      "matchNames": ["z"],
       "tags": {
         "amenity": "charging_station",
         "network": "Z Energy",
@@ -9778,13 +7424,9 @@
       "displayName": "ZDiTM Lublin",
       "id": "zditmlublin-a7df86",
       "locationSet": {
-        "include": [
-          "pl-06.geojson"
-        ]
+        "include": ["pl-06.geojson"]
       },
-      "matchNames": [
-        "ztm lublin"
-      ],
+      "matchNames": ["ztm lublin"],
       "tags": {
         "amenity": "charging_station",
         "operator": "ZDiTM Lublin",
@@ -9795,13 +7437,9 @@
       "displayName": "ZEAG Energie",
       "id": "zeagenergie-6bc1fb",
       "locationSet": {
-        "include": [
-          "de-bw.geojson"
-        ]
+        "include": ["de-bw.geojson"]
       },
-      "matchNames": [
-        "zeag"
-      ],
+      "matchNames": ["zeag"],
       "tags": {
         "amenity": "charging_station",
         "operator": "ZEAG Energie",
@@ -9811,11 +7449,7 @@
     {
       "displayName": "ZEBORNE",
       "id": "zeborne-170e94",
-      "locationSet": {
-        "include": [
-          "fx"
-        ]
-      },
+      "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ZEBORNE"
@@ -9824,11 +7458,7 @@
     {
       "displayName": "ZES",
       "id": "zes-f274f9",
-      "locationSet": {
-        "include": [
-          "tr"
-        ]
-      },
+      "locationSet": {"include": ["tr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ZES",
@@ -9838,11 +7468,7 @@
     {
       "displayName": "Zeus",
       "id": "zeus-2c5517",
-      "locationSet": {
-        "include": [
-          "it"
-        ]
-      },
+      "locationSet": {"include": ["it"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Zeus"
@@ -9852,13 +7478,9 @@
       "displayName": "ZTM Warszawa",
       "id": "ztmwarszawa-003b26",
       "locationSet": {
-        "include": [
-          "pl-14.geojson"
-        ]
+        "include": ["pl-14.geojson"]
       },
-      "matchNames": [
-        "ztm"
-      ],
+      "matchNames": ["ztm"],
       "tags": {
         "amenity": "charging_station",
         "operator": "ZTM Warszawa",
@@ -9868,12 +7490,7 @@
     {
       "displayName": "Zunder",
       "id": "zunder-3948da",
-      "locationSet": {
-        "include": [
-          "es",
-          "pt"
-        ]
-      },
+      "locationSet": {"include": ["es", "pt"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Zunder",
@@ -9883,11 +7500,7 @@
     {
       "displayName": "Zwickau",
       "id": "zwickau-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
+      "locationSet": {"include": ["de"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Zwickau",
@@ -9895,101 +7508,9 @@
       }
     },
     {
-      "displayName": "Àrea Metropolitana de Barcelona",
-      "id": "areametropolitanadebarcelona-f58b3e",
-      "locationSet": {
-        "include": [
-          "es-b.geojson"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Àrea Metropolitana de Barcelona",
-        "operator:short": "AMB",
-        "operator:wikidata": "Q4859869"
-      }
-    },
-    {
-      "displayName": "Électricité de France",
-      "id": "electricitedefrance-c22d3a",
-      "locationSet": {
-        "include": [
-          "001"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Électricité de France",
-        "operator:short": "EDF",
-        "operator:wikidata": "Q274591"
-      }
-    },
-    {
-      "displayName": "Ísorka",
-      "id": "isorka-8fcd5a",
-      "locationSet": {
-        "include": [
-          "is"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Ísorka",
-        "operator:wikidata": "Q127783906"
-      }
-    },
-    {
-      "displayName": "ÖAMTC",
-      "id": "oamtc-3f60da",
-      "locationSet": {
-        "include": [
-          "at"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "ÖAMTC",
-        "operator:wikidata": "Q306057"
-      }
-    },
-    {
-      "displayName": "Überlandwerk Groß-Gerau GmbH",
-      "id": "uberlandwerkgrossgeraugmbh-1299a8",
-      "locationSet": {
-        "include": [
-          "de"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Überlandwerk Groß-Gerau GmbH"
-      }
-    },
-    {
-      "displayName": "ČEZ",
-      "id": "cez-f67a50",
-      "locationSet": {
-        "include": [
-          "cz"
-        ]
-      },
-      "matchNames": [
-        "čez (ccs/chademo/mennekes type2)"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "ČEZ",
-        "operator:wikidata": "Q336735"
-      }
-    },
-    {
       "displayName": "ΑΒ Βασιλόπουλος",
       "id": "1f0d32-e68869",
-      "locationSet": {
-        "include": [
-          "gr"
-        ]
-      },
+      "locationSet": {"include": ["gr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ΑΒ Βασιλόπουλος"
@@ -9998,14 +7519,8 @@
     {
       "displayName": "Γαλαξίας",
       "id": "443698-e68869",
-      "locationSet": {
-        "include": [
-          "gr"
-        ]
-      },
-      "matchNames": [
-        "γαλαξίας supermarket"
-      ],
+      "locationSet": {"include": ["gr"]},
+      "matchNames": ["γαλαξίας supermarket"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Γαλαξίας",
@@ -10015,11 +7530,7 @@
     {
       "displayName": "ΔΕΗ",
       "id": "788cf3-e68869",
-      "locationSet": {
-        "include": [
-          "gr"
-        ]
-      },
+      "locationSet": {"include": ["gr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ΔΕΗ",
@@ -10029,11 +7540,7 @@
     {
       "displayName": "ΔΕΗ blue",
       "id": "3ef695-e68869",
-      "locationSet": {
-        "include": [
-          "gr"
-        ]
-      },
+      "locationSet": {"include": ["gr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ΔΕΗ blue"
@@ -10042,11 +7549,7 @@
     {
       "displayName": "Μασούτης",
       "id": "8c5a72-e68869",
-      "locationSet": {
-        "include": [
-          "gr"
-        ]
-      },
+      "locationSet": {"include": ["gr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Μασούτης",
@@ -10056,11 +7559,7 @@
     {
       "displayName": "Σκλαβενίτης",
       "id": "46ef11-e68869",
-      "locationSet": {
-        "include": [
-          "gr"
-        ]
-      },
+      "locationSet": {"include": ["gr"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Σκλαβενίτης",
@@ -10070,11 +7569,7 @@
     {
       "displayName": "АО \"Сетевая компания\"",
       "id": "e19896-18ef61",
-      "locationSet": {
-        "include": [
-          "ru"
-        ]
-      },
+      "locationSet": {"include": ["ru"]},
       "note": "ISO 3166-2 RU-TA",
       "tags": {
         "amenity": "charging_station",
@@ -10085,11 +7580,7 @@
     {
       "displayName": "Белтелеком",
       "id": "672155-20a807",
-      "locationSet": {
-        "include": [
-          "by"
-        ]
-      },
+      "locationSet": {"include": ["by"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Белтелеком"
@@ -10104,9 +7595,7 @@
           "ru-spe.geojson"
         ]
       },
-      "matchNames": [
-        "пао \"ленэнерго\""
-      ],
+      "matchNames": ["пао \"ленэнерго\""],
       "tags": {
         "amenity": "charging_station",
         "operator": "Ленэнерго",
@@ -10116,11 +7605,7 @@
     {
       "displayName": "Мосэнерго",
       "id": "1e6fb1-18ef61",
-      "locationSet": {
-        "include": [
-          "ru"
-        ]
-      },
+      "locationSet": {"include": ["ru"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Мосэнерго",
@@ -10130,11 +7615,7 @@
     {
       "displayName": "Одеська міська рада",
       "id": "09a705-a6c3f2",
-      "locationSet": {
-        "include": [
-          "ua"
-        ]
-      },
+      "locationSet": {"include": ["ua"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Одеська міська рада",
@@ -10144,11 +7625,7 @@
     {
       "displayName": "ПО «Белоруснефть»",
       "id": "ab4fd9-20a807",
-      "locationSet": {
-        "include": [
-          "by"
-        ]
-      },
+      "locationSet": {"include": ["by"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "ПО «Белоруснефть»"
@@ -10157,11 +7634,7 @@
     {
       "displayName": "Пункт Е",
       "id": "59d85b-18ef61",
-      "locationSet": {
-        "include": [
-          "ru"
-        ]
-      },
+      "locationSet": {"include": ["ru"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Пункт Е"
@@ -10170,11 +7643,7 @@
     {
       "displayName": "Россети",
       "id": "rosseti-18ef61",
-      "locationSet": {
-        "include": [
-          "ru"
-        ]
-      },
+      "locationSet": {"include": ["ru"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Россети",
@@ -10186,11 +7655,7 @@
     {
       "displayName": "РУП \"Белоруснефть-Гомельоблнефтепродукт\"",
       "id": "026cd5-20a807",
-      "locationSet": {
-        "include": [
-          "by"
-        ]
-      },
+      "locationSet": {"include": ["by"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "РУП \"Белоруснефть-Гомельоблнефтепродукт\""
@@ -10199,11 +7664,7 @@
     {
       "displayName": "РУП \"Белоруснефть-Минскавтозаправка\"",
       "id": "44a84d-20a807",
-      "locationSet": {
-        "include": [
-          "by"
-        ]
-      },
+      "locationSet": {"include": ["by"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "РУП \"Белоруснефть-Минскавтозаправка\""
@@ -10212,11 +7673,7 @@
     {
       "displayName": "РусГидро",
       "id": "70aabc-18ef61",
-      "locationSet": {
-        "include": [
-          "ru"
-        ]
-      },
+      "locationSet": {"include": ["ru"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "РусГидро",
@@ -10226,11 +7683,7 @@
     {
       "displayName": "Столичен електротранспорт",
       "id": "28c7ea-befeeb",
-      "locationSet": {
-        "include": [
-          "bg"
-        ]
-      },
+      "locationSet": {"include": ["bg"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "Столичен електротранспорт"
@@ -10239,11 +7692,7 @@
     {
       "displayName": "小兔充充",
       "id": "bunnypower-c785ca",
-      "locationSet": {
-        "include": [
-          "cn"
-        ]
-      },
+      "locationSet": {"include": ["cn"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "小兔充充",
@@ -10255,11 +7704,7 @@
     {
       "displayName": "睿能創意股份有限公司",
       "id": "d4b35c-265fde",
-      "locationSet": {
-        "include": [
-          "tw"
-        ]
-      },
+      "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "睿能創意股份有限公司"
@@ -10268,11 +7713,7 @@
     {
       "displayName": "英屬開曼群島商睿能新動力股份有限公司台灣分公司",
       "id": "66d0d4-265fde",
-      "locationSet": {
-        "include": [
-          "tw"
-        ]
-      },
+      "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "charging_station",
         "operator": "英屬開曼群島商睿能新動力股份有限公司台灣分公司"

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -1,7 +1,9 @@
 {
   "properties": {
     "path": "operators/amenity/charging_station",
-    "preserveTags": ["^name"],
+    "preserveTags": [
+      "^name"
+    ],
     "exclude": {
       "generic": [
         "^(charging station|oplaadpunt|stromtankstelle)$",
@@ -25,7 +27,11 @@
     {
       "displayName": "123energie",
       "id": "123energie-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "123energie",
@@ -33,23 +39,13 @@
       }
     },
     {
-      "displayName": "7-Eleven",
-      "id": "7eleven-994ed4",
-      "locationSet": {"include": ["us"]},
-      "matchNames": ["7-11", "seven eleven"],
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "7-Eleven",
-        "brand:wikidata": "Q259340",
-        "name": "7-Eleven",
-        "operator": "7-Eleven",
-        "operator:wikidata": "Q259340"
-      }
-    },
-    {
       "displayName": "a2a",
       "id": "a2a-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "a2a",
@@ -60,8 +56,12 @@
       "displayName": "ABB",
       "id": "abb-28ff7e",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -72,7 +72,11 @@
     {
       "displayName": "ABC",
       "id": "abc-e80d25",
-      "locationSet": {"include": ["fi"]},
+      "locationSet": {
+        "include": [
+          "fi"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ABC",
@@ -82,7 +86,11 @@
     {
       "displayName": "ABC-lataus",
       "id": "abclataus-e80d25",
-      "locationSet": {"include": ["fi"]},
+      "locationSet": {
+        "include": [
+          "fi"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ABC-lataus",
@@ -92,7 +100,11 @@
     {
       "displayName": "ABL",
       "id": "abl-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ABL",
@@ -102,8 +114,14 @@
     {
       "displayName": "Acciona Energía",
       "id": "accionaenergia-97d7cf",
-      "locationSet": {"include": ["es"]},
-      "matchNames": ["acciona"],
+      "locationSet": {
+        "include": [
+          "es"
+        ]
+      },
+      "matchNames": [
+        "acciona"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Acciona Energía",
@@ -113,7 +131,11 @@
     {
       "displayName": "Acea Energia",
       "id": "aceaenergia-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Acea Energia",
@@ -123,8 +145,14 @@
     {
       "displayName": "AcegasApsAmga",
       "id": "acegasapsamga-2c5517",
-      "locationSet": {"include": ["it"]},
-      "matchNames": ["hera / acegasapsamga"],
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
+      "matchNames": [
+        "hera / acegasapsamga"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "AcegasApsAmga",
@@ -134,7 +162,11 @@
     {
       "displayName": "ADAC",
       "id": "adac-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ADAC",
@@ -144,7 +176,11 @@
     {
       "displayName": "Aers Energy",
       "id": "aersenergy-fa6152",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Aers Energy"
@@ -153,7 +189,11 @@
     {
       "displayName": "Agrisnellaad",
       "id": "agrisnellaad-fa6152",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Agrisnellaad",
@@ -163,7 +203,11 @@
     {
       "displayName": "Agrola",
       "id": "agrola-086737",
-      "locationSet": {"include": ["ch"]},
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Agrola",
@@ -173,7 +217,11 @@
     {
       "displayName": "Agsm Verona Spa",
       "id": "agsmveronaspa-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Agsm Verona Spa",
@@ -184,7 +232,11 @@
       "displayName": "Aimo Park",
       "id": "aimopark-c6312f",
       "locationSet": {
-        "include": ["fi", "no", "se"]
+        "include": [
+          "fi",
+          "no",
+          "se"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -196,7 +248,11 @@
       "displayName": "Airbus",
       "id": "airbus-ed052c",
       "locationSet": {
-        "include": ["de", "fx", "nl"]
+        "include": [
+          "de",
+          "fx",
+          "nl"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -207,7 +263,11 @@
     {
       "displayName": "Akademiska Hus",
       "id": "akademiskahus-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Akademiska Hus",
@@ -217,7 +277,9 @@
     {
       "displayName": "Aldi (Aldi Nord group)",
       "id": "aldi-a30f4b",
-      "issues": [10738],
+      "issues": [
+        10738
+      ],
       "locationSet": {
         "include": [
           "be",
@@ -230,7 +292,10 @@
           "pt"
         ]
       },
-      "matchNames": ["aldi france", "aldi nord"],
+      "matchNames": [
+        "aldi france",
+        "aldi nord"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Aldi",
@@ -240,7 +305,9 @@
     {
       "displayName": "Aldi (Aldi Süd group)",
       "id": "aldi-141059",
-      "issues": [10738],
+      "issues": [
+        10738
+      ],
       "locationSet": {
         "include": [
           "au",
@@ -269,10 +336,16 @@
     {
       "displayName": "Aldi Nord (Deutschland)",
       "id": "aldi-de3fd8",
-      "issues": [10738],
+      "issues": [
+        10738
+      ],
       "locationSet": {
-        "include": ["de"],
-        "exclude": ["aldi-sued.geojson"]
+        "include": [
+          "de"
+        ],
+        "exclude": [
+          "aldi-sued.geojson"
+        ]
       },
       "matchNames": [
         "aldi gmbh & co. kg",
@@ -287,9 +360,13 @@
     {
       "displayName": "Aldi Süd (Deutschland)",
       "id": "aldi-fee10d",
-      "issues": [10738],
+      "issues": [
+        10738
+      ],
       "locationSet": {
-        "include": ["aldi-sued.geojson"]
+        "include": [
+          "aldi-sued.geojson"
+        ]
       },
       "matchNames": [
         "aldi gmbh & co. kg",
@@ -305,7 +382,12 @@
       "displayName": "Alfen",
       "id": "alfen-17c03e",
       "locationSet": {
-        "include": ["be", "de", "gb", "nl"]
+        "include": [
+          "be",
+          "de",
+          "gb",
+          "nl"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -316,7 +398,11 @@
     {
       "displayName": "Alizé",
       "id": "alize-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Alizé"
@@ -326,9 +412,17 @@
       "displayName": "Allego",
       "id": "allego-17c03e",
       "locationSet": {
-        "include": ["be", "de", "gb", "nl"]
+        "include": [
+          "be",
+          "de",
+          "gb",
+          "nl"
+        ]
       },
-      "matchNames": ["allego gmbh", "allegro"],
+      "matchNames": [
+        "allego gmbh",
+        "allegro"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Allego",
@@ -357,8 +451,14 @@
     {
       "displayName": "Alperia",
       "id": "alperia-2c5517",
-      "locationSet": {"include": ["it"]},
-      "matchNames": ["alperia smart mobility"],
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
+      "matchNames": [
+        "alperia smart mobility"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Alperia",
@@ -369,7 +469,9 @@
       "displayName": "ALTIS",
       "id": "altis-d0faa5",
       "locationSet": {
-        "include": ["ch-vs.geojson"]
+        "include": [
+          "ch-vs.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -380,7 +482,11 @@
     {
       "displayName": "AmpCharge",
       "id": "ampcharge-943805",
-      "locationSet": {"include": ["au"]},
+      "locationSet": {
+        "include": [
+          "au"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "AmpCharge",
@@ -388,44 +494,12 @@
       }
     },
     {
-      "displayName": "Applegreen Electric",
-      "id": "applegreenelectric-f6fe0b",
-      "locationSet": {"include": ["gb", "ie"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Applegreen Electric",
-        "operator:wikidata": "Q7178908"
-      }
-    },
-    {
-      "displayName": "Aral pulse",
-      "id": "aral-2d0940",
-      "locationSet": {"include": ["de", "lu"]},
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "Aral pulse",
-        "operator": "Aral",
-        "operator:wikidata": "Q565734"
-      }
-    },
-    {
-      "displayName": "Àrea Metropolitana de Barcelona",
-      "id": "areametropolitanadebarcelona-f58b3e",
-      "locationSet": {
-        "include": ["es-b.geojson"]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Àrea Metropolitana de Barcelona",
-        "operator:short": "AMB",
-        "operator:wikidata": "Q4859869"
-      }
-    },
-    {
       "displayName": "Areal Böhler",
       "id": "arealbohler-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -436,7 +510,11 @@
     {
       "displayName": "Arinea",
       "id": "arinea-392011",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": {
+        "include": [
+          "pl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Arinea",
@@ -447,7 +525,9 @@
       "displayName": "ASP",
       "id": "asp-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -458,7 +538,11 @@
     {
       "displayName": "Astor Enerji",
       "id": "astorenerji-f274f9",
-      "locationSet": {"include": ["tr"]},
+      "locationSet": {
+        "include": [
+          "tr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Astor Enerji"
@@ -467,7 +551,11 @@
     {
       "displayName": "Atlante",
       "id": "atlante-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Atlante"
@@ -476,7 +564,11 @@
     {
       "displayName": "Auchan",
       "id": "auchan-f6553b",
-      "locationSet": {"include": ["fr"]},
+      "locationSet": {
+        "include": [
+          "fr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Auchan",
@@ -486,7 +578,11 @@
     {
       "displayName": "Audi AG",
       "id": "audiag-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Audi AG",
@@ -497,7 +593,9 @@
       "displayName": "Austin Energy",
       "id": "austinenergy-06a9bf",
       "locationSet": {
-        "include": ["us-tx-austin.geojson"]
+        "include": [
+          "us-tx-austin.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -509,7 +607,9 @@
       "displayName": "Autolib'",
       "id": "autolib-37370f",
       "locationSet": {
-        "include": ["fr-idf.geojson"]
+        "include": [
+          "fr-idf.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -520,8 +620,14 @@
     {
       "displayName": "Avacon",
       "id": "avacon-1299a8",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["avacon ag"],
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
+      "matchNames": [
+        "avacon ag"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Avacon",
@@ -531,7 +637,11 @@
     {
       "displayName": "Avia",
       "id": "avia-7f623e",
-      "locationSet": {"include": ["150"]},
+      "locationSet": {
+        "include": [
+          "150"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Avia",
@@ -541,7 +651,11 @@
     {
       "displayName": "Avin",
       "id": "avin-e68869",
-      "locationSet": {"include": ["gr"]},
+      "locationSet": {
+        "include": [
+          "gr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Avin",
@@ -552,7 +666,9 @@
       "displayName": "AVU",
       "id": "avu-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -564,7 +680,9 @@
       "displayName": "Aziende Industriali di Lugano",
       "id": "aziendeindustrialidilugano-d3f33a",
       "locationSet": {
-        "include": ["ch-ti.geojson"]
+        "include": [
+          "ch-ti.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -577,9 +695,14 @@
       "displayName": "Baltimore Gas and Electric",
       "id": "baltimoregasandelectric-4c7d3b",
       "locationSet": {
-        "include": ["us-md.geojson"]
+        "include": [
+          "us-md.geojson"
+        ]
       },
-      "matchNames": ["bg&e", "bge"],
+      "matchNames": [
+        "bg&e",
+        "bge"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Baltimore Gas and Electric",
@@ -589,7 +712,11 @@
     {
       "displayName": "Base2Charge",
       "id": "base2charge-7d9e8e",
-      "locationSet": {"include": ["dk"]},
+      "locationSet": {
+        "include": [
+          "dk"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Base2Charge"
@@ -598,7 +725,12 @@
     {
       "displayName": "Bauhaus",
       "id": "bauhaus-a5756d",
-      "locationSet": {"include": ["at", "de"]},
+      "locationSet": {
+        "include": [
+          "at",
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Bauhaus",
@@ -608,8 +740,14 @@
     {
       "displayName": "Bayernwerk",
       "id": "bayernwerk-1299a8",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["bayernwerk ag"],
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
+      "matchNames": [
+        "bayernwerk ag"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Bayernwerk",
@@ -620,7 +758,9 @@
       "displayName": "BC Hydro",
       "id": "bchydro-e7f57e",
       "locationSet": {
-        "include": ["ca-bc.geojson"]
+        "include": [
+          "ca-bc.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -631,7 +771,11 @@
     {
       "displayName": "Be Charge",
       "id": "becharge-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Be Charge",
@@ -641,28 +785,23 @@
     {
       "displayName": "be emobil",
       "id": "beemobil-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "be emobil"
       }
     },
     {
-      "displayName": "Be.EV",
-      "id": "iduna-3c1cb1",
-      "locationSet": {"include": ["gb-eng"]},
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "Be.EV",
-        "operator": "Iduna",
-        "operator:wikidata": "Q118263083"
-      }
-    },
-    {
       "displayName": "Belib'",
       "id": "belib-37370f",
       "locationSet": {
-        "include": ["fr-idf.geojson"]
+        "include": [
+          "fr-idf.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -673,7 +812,11 @@
     {
       "displayName": "Bender",
       "id": "bender-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Bender"
@@ -683,7 +826,9 @@
       "displayName": "Berliner Stadtwerke",
       "id": "berlinerstadtwerke-db4fd8",
       "locationSet": {
-        "include": ["de-be.geojson"]
+        "include": [
+          "de-be.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -695,7 +840,9 @@
       "displayName": "BEW",
       "id": "bew-db4fd8",
       "locationSet": {
-        "include": ["de-be.geojson"]
+        "include": [
+          "de-be.geojson"
+        ]
       },
       "matchNames": [
         "bew berliner energie und wärme ag"
@@ -710,7 +857,9 @@
       "displayName": "Bigge Energie",
       "id": "biggeenergie-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "matchNames": [
         "bigge energie gmbh & co. kg"
@@ -722,33 +871,12 @@
       }
     },
     {
-      "displayName": "bike-energy",
-      "id": "bikeenergy-ff2890",
-      "locationSet": {
-        "include": [
-          "at",
-          "ch",
-          "de",
-          "fx",
-          "it",
-          "lu"
-        ]
-      },
-      "matchNames": ["bike-energy ladestation"],
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "bike-energy",
-        "brand:wikidata": "Q67770877",
-        "name": "bike-energy",
-        "operator": "bike-energy",
-        "operator:wikidata": "Q67770877"
-      }
-    },
-    {
       "displayName": "Birmingham City Council",
       "id": "birminghamcitycouncil-56e584",
       "locationSet": {
-        "include": ["gb-bir.geojson"]
+        "include": [
+          "gb-bir.geojson"
+        ]
       },
       "note": "ISO_3166-2:GB - gb-eng (England), gb-bir (Birmingham)",
       "tags": {
@@ -758,22 +886,13 @@
       }
     },
     {
-      "displayName": "Blink",
-      "id": "blink-74901a",
-      "locationSet": {"include": ["gb", "us"]},
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "Blink",
-        "brand:wikidata": "Q62065645",
-        "name": "Blink",
-        "operator": "Blink",
-        "operator:wikidata": "Q62065645"
-      }
-    },
-    {
       "displayName": "Blue Corner",
       "id": "bluecorner-87ebf4",
-      "locationSet": {"include": ["be"]},
+      "locationSet": {
+        "include": [
+          "be"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Blue Corner",
@@ -783,7 +902,11 @@
     {
       "displayName": "Bluecharge",
       "id": "bluecharge-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Bluecharge",
@@ -794,10 +917,16 @@
       "displayName": "BMW",
       "id": "bmw-28ff7e",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no"
+        ]
       },
-      "matchNames": ["bmw group"],
+      "matchNames": [
+        "bmw group"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "BMW",
@@ -808,7 +937,9 @@
       "displayName": "Bocholter Energie- und Wasserversorgung",
       "id": "bocholterenergieundwasserversorgung-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "matchNames": [
         "bocholter energie- und wasserversorgung gmbh"
@@ -823,7 +954,11 @@
     {
       "displayName": "Booths",
       "id": "booths-0793ce",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Booths",
@@ -831,24 +966,13 @@
       }
     },
     {
-      "displayName": "Bosch eBike Systems",
-      "id": "boschebikesystems-28ff7e",
-      "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "Bosch eBike Systems",
-        "name": "Bosch eBike Systems",
-        "operator": "Bosch eBike Systems",
-        "operator:wikidata": "Q234021"
-      }
-    },
-    {
       "displayName": "Bouygues (1-OUEST)",
       "id": "bouygues1ouest-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Bouygues (1-OUEST)"
@@ -857,7 +981,11 @@
     {
       "displayName": "Bouygues Energies & Services",
       "id": "bouyguesenergiesandservices-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "matchNames": [
         "bouygues",
         "bouygues e&s",
@@ -872,7 +1000,11 @@
     {
       "displayName": "BP",
       "id": "bp-c22d3a",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "BP",
@@ -883,7 +1015,11 @@
       "displayName": "BP Europa SE",
       "id": "bpeuropase-abd07b",
       "locationSet": {
-        "include": ["ch", "de", "pl"]
+        "include": [
+          "ch",
+          "de",
+          "pl"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -893,7 +1029,11 @@
     {
       "displayName": "Branäsgruppen AB",
       "id": "branasgruppenab-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Branäsgruppen AB"
@@ -903,7 +1043,12 @@
       "displayName": "Brighton and Hove City Council",
       "id": "brightonandhovecitycouncil-a4110c",
       "locationSet": {
-        "include": [[-0.15, 50.85]]
+        "include": [
+          [
+            -0.15,
+            50.85
+          ]
+        ]
       },
       "note": "ISO_3166-2:GB - gb-eng (England), gb-esx (East Sussex)",
       "tags": {
@@ -916,7 +1061,9 @@
       "displayName": "BS Energy",
       "id": "bsenergy-d9ec6c",
       "locationSet": {
-        "include": ["de-ni.geojson"]
+        "include": [
+          "de-ni.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -927,8 +1074,14 @@
     {
       "displayName": "Budimex Mobility",
       "id": "budimexmobility-392011",
-      "locationSet": {"include": ["pl"]},
-      "matchNames": ["budimex mobility s.a."],
+      "locationSet": {
+        "include": [
+          "pl"
+        ]
+      },
+      "matchNames": [
+        "budimex mobility s.a."
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Budimex Mobility",
@@ -938,7 +1091,11 @@
     {
       "displayName": "Bump",
       "id": "bump-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Bump"
@@ -947,7 +1104,11 @@
     {
       "displayName": "Burgenland Energie",
       "id": "burgenlandenergieag-3f60da",
-      "locationSet": {"include": ["at"]},
+      "locationSet": {
+        "include": [
+          "at"
+        ]
+      },
       "matchNames": [
         "energie burgenland",
         "energie burgenland ag"
@@ -962,7 +1123,9 @@
       "displayName": "Caritas",
       "id": "caritas-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -973,7 +1136,11 @@
     {
       "displayName": "Carrefour",
       "id": "carrefour-c22d3a",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Carrefour",
@@ -984,7 +1151,9 @@
       "displayName": "Caruso Carsharing",
       "id": "carusocarsharing-53499e",
       "locationSet": {
-        "include": ["at-8.geojson"]
+        "include": [
+          "at-8.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -996,7 +1165,9 @@
       "displayName": "Centralschweizerische Kraftwerke",
       "id": "centralschweizerischekraftwerke-8e9cb9",
       "locationSet": {
-        "include": ["ch-lu.geojson"]
+        "include": [
+          "ch-lu.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1007,7 +1178,12 @@
     {
       "displayName": "Cepsa",
       "id": "cepsa-3948da",
-      "locationSet": {"include": ["es", "pt"]},
+      "locationSet": {
+        "include": [
+          "es",
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Cepsa",
@@ -1015,23 +1191,16 @@
       }
     },
     {
-      "displayName": "ČEZ",
-      "id": "cez-f67a50",
-      "locationSet": {"include": ["cz"]},
-      "matchNames": [
-        "čez (ccs/chademo/mennekes type2)"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "ČEZ",
-        "operator:wikidata": "Q336735"
-      }
-    },
-    {
       "displayName": "Charge Your Car",
       "id": "chargeyourcar-0793ce",
-      "locationSet": {"include": ["gb"]},
-      "matchNames": ["cyc"],
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
+      "matchNames": [
+        "cyc"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Charge Your Car",
@@ -1041,7 +1210,11 @@
     {
       "displayName": "Charge-ON GmbH",
       "id": "chargeongmbh-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Charge-ON GmbH"
@@ -1051,9 +1224,17 @@
       "displayName": "charge.brussels",
       "id": "pitpoint-e7c13f",
       "locationSet": {
-        "include": [[4.376, 50.844, 10]]
+        "include": [
+          [
+            4.376,
+            50.844,
+            10
+          ]
+        ]
       },
-      "matchNames": ["pitpoint (cng)"],
+      "matchNames": [
+        "pitpoint (cng)"
+      ],
       "tags": {
         "amenity": "charging_station",
         "name": "charge.brussels",
@@ -1066,7 +1247,12 @@
     {
       "displayName": "Chargefox",
       "id": "chargefox-61042c",
-      "locationSet": {"include": ["au", "nz"]},
+      "locationSet": {
+        "include": [
+          "au",
+          "nz"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Chargefox",
@@ -1076,8 +1262,14 @@
     {
       "displayName": "ChargeNet NZ",
       "id": "chargenetnz-9850e1",
-      "locationSet": {"include": ["nz"]},
-      "matchNames": ["chargenet"],
+      "locationSet": {
+        "include": [
+          "nz"
+        ]
+      },
+      "matchNames": [
+        "chargenet"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "ChargeNet NZ",
@@ -1087,7 +1279,11 @@
     {
       "displayName": "ChargeNode",
       "id": "chargenode-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ChargeNode"
@@ -1096,7 +1292,12 @@
     {
       "displayName": "ChargeOne",
       "id": "chargeone-61c5f2",
-      "locationSet": {"include": ["ch", "de"]},
+      "locationSet": {
+        "include": [
+          "ch",
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ChargeOne"
@@ -1105,7 +1306,11 @@
     {
       "displayName": "ChargePlace Scotland",
       "id": "chargeplacescotland-416a92",
-      "locationSet": {"include": ["gb-sct"]},
+      "locationSet": {
+        "include": [
+          "gb-sct"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ChargePlace Scotland",
@@ -1113,25 +1318,13 @@
       }
     },
     {
-      "displayName": "ChargePoint",
-      "id": "chargepoint-28ff7e",
-      "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "ChargePoint",
-        "brand:wikidata": "Q5176149",
-        "name": "ChargePoint",
-        "operator": "ChargePoint",
-        "operator:wikidata": "Q5176149"
-      }
-    },
-    {
       "displayName": "ChargePoint Austria GmbH",
       "id": "chargepointaustriagmbh-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ChargePoint Austria GmbH"
@@ -1140,72 +1333,37 @@
     {
       "displayName": "chargEV",
       "id": "chargev-1845ed",
-      "locationSet": {"include": ["my"]},
+      "locationSet": {
+        "include": [
+          "my"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "chargEV"
       }
     },
     {
-      "displayName": "Charging the Regions",
-      "id": "centralvictoriangreenhousealliance-6c573b",
-      "locationSet": {
-        "include": ["au-vic.geojson"]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "Charging the Regions",
-        "brand:wikidata": "Q106320264",
-        "operator": "Central Victorian Greenhouse Alliance",
-        "operator:wikidata": "Q106320329"
-      }
-    },
-    {
       "displayName": "Charging Together",
       "id": "chargingtogether-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Charging Together"
       }
     },
     {
-      "displayName": "Circle K",
-      "id": "circlek-c22d3a",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "Circle K",
-        "brand:wikidata": "Q3268010",
-        "name": "Circle K",
-        "operator": "Circle K",
-        "operator:wikidata": "Q3268010"
-      }
-    },
-    {
-      "displayName": "Circuit électrique",
-      "id": "circuitelectrique-67089a",
-      "locationSet": {"include": ["ca"]},
-      "matchNames": ["le circuit électrique"],
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "Circuit électrique",
-        "brand:en": "Electric Circuit",
-        "brand:fr": "Circuit électrique",
-        "brand:wikidata": "Q24934590",
-        "name": "Circuit électrique",
-        "name:en": "Electric Circuit",
-        "name:fr": "Circuit électrique",
-        "operator": "Circuit électrique",
-        "operator:en": "Electric Circuit",
-        "operator:fr": "Circuit électrique",
-        "operator:wikidata": "Q24934590"
-      }
-    },
-    {
       "displayName": "City Charging",
       "id": "citycharging-fa6152",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "City Charging",
@@ -1215,7 +1373,14 @@
     {
       "displayName": "City of Gold Coast",
       "id": "cityofgoldcoast-bd4e91",
-      "locationSet": {"include": [[153.4, -28]]},
+      "locationSet": {
+        "include": [
+          [
+            153.4,
+            -28
+          ]
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "City of Gold Coast",
@@ -1226,7 +1391,12 @@
       "displayName": "City of Hobart",
       "id": "cityofhobart-becf90",
       "locationSet": {
-        "include": [[147.3, -42.9]]
+        "include": [
+          [
+            147.3,
+            -42.9
+          ]
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1238,7 +1408,12 @@
       "displayName": "City of Launceston",
       "id": "cityoflaunceston-2fce2c",
       "locationSet": {
-        "include": [[147.1, -41.4]]
+        "include": [
+          [
+            147.1,
+            -41.4
+          ]
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1249,8 +1424,14 @@
     {
       "displayName": "Citywatt",
       "id": "citywatt-1299a8",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["citywatt gmbh"],
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
+      "matchNames": [
+        "citywatt gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Citywatt",
@@ -1260,7 +1441,11 @@
     {
       "displayName": "Clem",
       "id": "clem-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Clem"
@@ -1270,9 +1455,15 @@
       "displayName": "Clever",
       "id": "clever-28cec3",
       "locationSet": {
-        "include": ["de", "dk", "se"]
+        "include": [
+          "de",
+          "dk",
+          "se"
+        ]
       },
-      "matchNames": ["clever a/s"],
+      "matchNames": [
+        "clever a/s"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Clever",
@@ -1282,8 +1473,14 @@
     {
       "displayName": "Comfortcharge",
       "id": "comfortcharge-1299a8",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["comfortcharge gmbh"],
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
+      "matchNames": [
+        "comfortcharge gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Comfortcharge",
@@ -1294,9 +1491,13 @@
       "displayName": "Compleo Charging Technologies GmbH",
       "id": "compleochargingtechnologiesgmbh-43ff7e",
       "locationSet": {
-        "include": ["de-he.geojson"]
+        "include": [
+          "de-he.geojson"
+        ]
       },
-      "matchNames": ["compleo"],
+      "matchNames": [
+        "compleo"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Compleo Charging Technologies GmbH",
@@ -1306,7 +1507,11 @@
     {
       "displayName": "Connected Kerb",
       "id": "connectedkerb-0793ce",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Connected Kerb",
@@ -1316,7 +1521,11 @@
     {
       "displayName": "Coop (Italia)",
       "id": "coop-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Coop",
@@ -1326,7 +1535,11 @@
     {
       "displayName": "Coop (Schweiz)",
       "id": "coop-086737",
-      "locationSet": {"include": ["ch"]},
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Coop",
@@ -1336,7 +1549,11 @@
     {
       "displayName": "Coop (Sverige)",
       "id": "coop-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Coop",
@@ -1346,7 +1563,11 @@
     {
       "displayName": "Coop Norge",
       "id": "coop-476d58",
-      "locationSet": {"include": ["no"]},
+      "locationSet": {
+        "include": [
+          "no"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Coop",
@@ -1356,7 +1577,11 @@
     {
       "displayName": "Copec",
       "id": "copec-df2b32",
-      "locationSet": {"include": ["cl"]},
+      "locationSet": {
+        "include": [
+          "cl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Copec",
@@ -1366,7 +1591,11 @@
     {
       "displayName": "Counties Energy",
       "id": "countiesenergy-9850e1",
-      "locationSet": {"include": ["nz"]},
+      "locationSet": {
+        "include": [
+          "nz"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "network": "OpenLoop",
@@ -1378,7 +1607,11 @@
     {
       "displayName": "CSDD",
       "id": "csdd-94e3c4",
-      "locationSet": {"include": ["lv"]},
+      "locationSet": {
+        "include": [
+          "lv"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "CSDD",
@@ -1389,7 +1622,9 @@
       "displayName": "Cut! Energy GmbH",
       "id": "cutenergygmbh-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1412,7 +1647,9 @@
           "it"
         ]
       },
-      "matchNames": ["da emobil gmbh & co kg"],
+      "matchNames": [
+        "da emobil gmbh & co kg"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "da emobil",
@@ -1422,7 +1659,11 @@
     {
       "displayName": "Daimler AG",
       "id": "daimlerag-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Daimler AG"
@@ -1431,7 +1672,12 @@
     {
       "displayName": "DATS 24",
       "id": "dats24-292b4b",
-      "locationSet": {"include": ["be", "fx"]},
+      "locationSet": {
+        "include": [
+          "be",
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "DATS 24",
@@ -1441,7 +1687,11 @@
     {
       "displayName": "DBT",
       "id": "dbt-7f623e",
-      "locationSet": {"include": ["150"]},
+      "locationSet": {
+        "include": [
+          "150"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "DBT"
@@ -1450,8 +1700,14 @@
     {
       "displayName": "deer GmbH",
       "id": "deergmbh-1299a8",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["deer"],
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
+      "matchNames": [
+        "deer"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "deer GmbH",
@@ -1462,7 +1718,11 @@
       "displayName": "Delta",
       "id": "delta-ed052c",
       "locationSet": {
-        "include": ["de", "fx", "nl"]
+        "include": [
+          "de",
+          "fx",
+          "nl"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1473,7 +1733,9 @@
       "displayName": "Denkfabrik im Grünen Service GmbH",
       "id": "denkfabrikimgrunenservicegmbh-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1483,7 +1745,11 @@
     {
       "displayName": "Deutsche Post DHL Group",
       "id": "deutschepostdhlgroup-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Deutsche Post DHL Group"
@@ -1492,7 +1758,11 @@
     {
       "displayName": "Deutsche Telekom",
       "id": "deutschetelekom-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "matchNames": [
         "deutsche telekom ag",
         "telekom"
@@ -1507,7 +1777,9 @@
       "displayName": "Deviwa",
       "id": "deviwa-d0faa5",
       "locationSet": {
-        "include": ["ch-vs.geojson"]
+        "include": [
+          "ch-vs.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1519,7 +1791,9 @@
       "displayName": "DEW21",
       "id": "dew21-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "matchNames": [
         "dew",
@@ -1535,7 +1809,9 @@
       "displayName": "DREWAG",
       "id": "drewag-b8794d",
       "locationSet": {
-        "include": ["de-sn.geojson"]
+        "include": [
+          "de-sn.geojson"
+        ]
       },
       "matchNames": [
         "drewag - stadtwerke dresden",
@@ -1551,7 +1827,9 @@
       "displayName": "Drivalia",
       "id": "drivalia-5d7058",
       "locationSet": {
-        "include": ["it-21.geojson"]
+        "include": [
+          "it-21.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1561,7 +1839,11 @@
     {
       "displayName": "DRIVECO",
       "id": "driveco-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "DRIVECO"
@@ -1571,7 +1853,9 @@
       "displayName": "DTE",
       "id": "dte-aadb9e",
       "locationSet": {
-        "include": ["pt-05.geojson"]
+        "include": [
+          "pt-05.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1581,7 +1865,11 @@
     {
       "displayName": "Dubai Electricity and Water Authority",
       "id": "dubaielectricityandwaterauthority-76711b",
-      "locationSet": {"include": ["ae"]},
+      "locationSet": {
+        "include": [
+          "ae"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Dubai Electricity and Water Authority",
@@ -1592,7 +1880,11 @@
     {
       "displayName": "Duferco",
       "id": "duferco-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Duferco",
@@ -1602,7 +1894,11 @@
     {
       "displayName": "Duferco Energia",
       "id": "dufercoenergia-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Duferco Energia",
@@ -1612,7 +1908,11 @@
     {
       "displayName": "Duke Energy",
       "id": "dukeenergy-994ed4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Duke Energy",
@@ -1623,7 +1923,11 @@
       "displayName": "E-Flux",
       "id": "eflux-35c01b",
       "locationSet": {
-        "include": ["be", "de", "nl"]
+        "include": [
+          "be",
+          "de",
+          "nl"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1634,7 +1938,11 @@
     {
       "displayName": "e-Mobi",
       "id": "emobi-27e906",
-      "locationSet": {"include": ["hu"]},
+      "locationSet": {
+        "include": [
+          "hu"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "e-Mobi"
@@ -1643,7 +1951,11 @@
     {
       "displayName": "e-Mobi Elektromobilitás Nonprofit Kft.",
       "id": "emobielektromobilitasnonprofitkft-27e906",
-      "locationSet": {"include": ["hu"]},
+      "locationSet": {
+        "include": [
+          "hu"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "e-Mobi Elektromobilitás Nonprofit Kft."
@@ -1652,7 +1964,11 @@
     {
       "displayName": "E-Plug",
       "id": "eplug-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "E-Plug"
@@ -1662,9 +1978,13 @@
       "displayName": "e-regio",
       "id": "eregio-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
-      "matchNames": ["e-regio gmbh & co. kg"],
+      "matchNames": [
+        "e-regio gmbh & co. kg"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "e-regio",
@@ -1674,7 +1994,11 @@
     {
       "displayName": "e-Totem",
       "id": "etotem-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "e-Totem",
@@ -1682,26 +2006,13 @@
       }
     },
     {
-      "displayName": "E-WALD",
-      "id": "ewald-1299a8",
-      "locationSet": {"include": ["de"]},
-      "matchNames": [
-        "e-wald gmbh",
-        "e-wald ladestation"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "E-WALD",
-        "brand:wikidata": "Q61804335",
-        "name": "E-WALD",
-        "operator": "E-WALD",
-        "operator:wikidata": "Q61804335"
-      }
-    },
-    {
       "displayName": "E-Werk Mittelbaden",
       "id": "ewerkmittelbaden-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "E-Werk Mittelbaden",
@@ -1711,7 +2022,11 @@
     {
       "displayName": "e.dis",
       "id": "edis-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "e.dis",
@@ -1721,8 +2036,14 @@
     {
       "displayName": "E.Leclerc",
       "id": "eleclerc-f6553b",
-      "locationSet": {"include": ["fr"]},
-      "matchNames": ["leclerc"],
+      "locationSet": {
+        "include": [
+          "fr"
+        ]
+      },
+      "matchNames": [
+        "leclerc"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "E.Leclerc",
@@ -1730,29 +2051,13 @@
       }
     },
     {
-      "displayName": "E.ON",
-      "id": "eon-7f623e",
-      "locationSet": {"include": ["150"]},
-      "matchNames": ["e-on drive"],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "E.ON",
-        "operator:wikidata": "Q270223"
-      }
-    },
-    {
-      "displayName": "E.On Danmark",
-      "id": "eondanmark-7d9e8e",
-      "locationSet": {"include": ["dk"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "E.On Danmark"
-      }
-    },
-    {
       "displayName": "EAM",
       "id": "eam-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EAM",
@@ -1762,7 +2067,11 @@
     {
       "displayName": "EasyGo",
       "id": "easygo-179e3e",
-      "locationSet": {"include": ["ie"]},
+      "locationSet": {
+        "include": [
+          "ie"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EasyGo",
@@ -1772,7 +2081,12 @@
     {
       "displayName": "EasyPark",
       "id": "easypark-c454f0",
-      "locationSet": {"include": ["no", "se"]},
+      "locationSet": {
+        "include": [
+          "no",
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EasyPark"
@@ -1781,7 +2095,11 @@
     {
       "displayName": "eborn",
       "id": "eborn-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "eborn",
@@ -1791,7 +2109,11 @@
     {
       "displayName": "EC Charging",
       "id": "eccharging-179e3e",
-      "locationSet": {"include": ["ie"]},
+      "locationSet": {
+        "include": [
+          "ie"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EC Charging"
@@ -1800,7 +2122,11 @@
     {
       "displayName": "eCarUp",
       "id": "ecarup-086737",
-      "locationSet": {"include": ["ch"]},
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "eCarUp",
@@ -1810,7 +2136,11 @@
     {
       "displayName": "EcoInside",
       "id": "ecoinside-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EcoInside"
@@ -1819,7 +2149,11 @@
     {
       "displayName": "econec.eu",
       "id": "econeceu-b23832",
-      "locationSet": {"include": ["sk"]},
+      "locationSet": {
+        "include": [
+          "sk"
+        ]
+      },
       "note": "ISO 3166-2 SK-KI, SK-PV",
       "tags": {
         "amenity": "charging_station",
@@ -1829,7 +2163,12 @@
     {
       "displayName": "Ecotap",
       "id": "ecotap-c98650",
-      "locationSet": {"include": ["nl", "pl"]},
+      "locationSet": {
+        "include": [
+          "nl",
+          "pl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Ecotap",
@@ -1839,7 +2178,11 @@
     {
       "displayName": "EDEKA",
       "id": "edeka-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EDEKA",
@@ -1850,7 +2193,11 @@
       "displayName": "EDP",
       "id": "edp-387085",
       "locationSet": {
-        "include": ["br", "es", "pt"]
+        "include": [
+          "br",
+          "es",
+          "pt"
+        ]
       },
       "matchNames": [
         "edp comercial",
@@ -1865,7 +2212,12 @@
     {
       "displayName": "eE4mobile eG",
       "id": "ee4mobileeg-0c60c5",
-      "locationSet": {"include": ["de", "dk"]},
+      "locationSet": {
+        "include": [
+          "de",
+          "dk"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "eE4mobile eG",
@@ -1875,8 +2227,14 @@
     {
       "displayName": "Eesti Energia",
       "id": "eestienergia-733008",
-      "locationSet": {"include": ["ee"]},
-      "matchNames": ["eesti energia as"],
+      "locationSet": {
+        "include": [
+          "ee"
+        ]
+      },
+      "matchNames": [
+        "eesti energia as"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Eesti Energia",
@@ -1887,7 +2245,12 @@
       "displayName": "efacec",
       "id": "efacec-f9df65",
       "locationSet": {
-        "include": ["de", "gb", "mt", "pt"]
+        "include": [
+          "de",
+          "gb",
+          "mt",
+          "pt"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1898,7 +2261,11 @@
     {
       "displayName": "Effia",
       "id": "effia-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Effia",
@@ -1909,7 +2276,9 @@
       "displayName": "EGG Energieversorgung Gera",
       "id": "eggenergieversorgunggera-8c6e73",
       "locationSet": {
-        "include": ["de-th.geojson"]
+        "include": [
+          "de-th.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1920,7 +2289,11 @@
     {
       "displayName": "eins energie in sachsen",
       "id": "einsenergieinsachsen-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "eins energie in sachsen",
@@ -1930,7 +2303,11 @@
     {
       "displayName": "ejoin",
       "id": "ejoin-b23832",
-      "locationSet": {"include": ["sk"]},
+      "locationSet": {
+        "include": [
+          "sk"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ejoin",
@@ -1940,7 +2317,11 @@
     {
       "displayName": "EKZ",
       "id": "ekz-086737",
-      "locationSet": {"include": ["ch"]},
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EKZ",
@@ -1951,7 +2332,11 @@
       "displayName": "Eldrive",
       "id": "eldrive-8c357e",
       "locationSet": {
-        "include": ["bg", "lt", "ro"]
+        "include": [
+          "bg",
+          "lt",
+          "ro"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -1960,21 +2345,13 @@
       }
     },
     {
-      "displayName": "Electra",
-      "id": "electra-1b5132",
-      "locationSet": {
-        "include": ["be", "fx", "nl"]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Electra",
-        "operator:wikidata": "Q128592938"
-      }
-    },
-    {
       "displayName": "Electric 55 Charging",
       "id": "electric55charging-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Electric 55 Charging"
@@ -1983,7 +2360,11 @@
     {
       "displayName": "Electric Highway Tasmania",
       "id": "electrichighwaytasmania-341d66",
-      "locationSet": {"include": ["au-tas"]},
+      "locationSet": {
+        "include": [
+          "au-tas"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Electric Highway Tasmania",
@@ -1991,20 +2372,13 @@
       }
     },
     {
-      "displayName": "Électricité de France",
-      "id": "electricitedefrance-c22d3a",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Électricité de France",
-        "operator:short": "EDF",
-        "operator:wikidata": "Q274591"
-      }
-    },
-    {
       "displayName": "Electricity Authority of Cyprus",
       "id": "electricityauthorityofcyprus-fb82c8",
-      "locationSet": {"include": ["cy"]},
+      "locationSet": {
+        "include": [
+          "cy"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Electricity Authority of Cyprus",
@@ -2013,19 +2387,13 @@
       }
     },
     {
-      "displayName": "Electrify America",
-      "id": "electrifyamerica-994ed4",
-      "locationSet": {"include": ["us"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Electrify America",
-        "operator:wikidata": "Q59773555"
-      }
-    },
-    {
       "displayName": "Electrip",
       "id": "electrip-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Electrip"
@@ -2035,7 +2403,9 @@
       "displayName": "ElectRoad",
       "id": "electroad-a0ff9c",
       "locationSet": {
-        "include": ["gb-east-england.geojson"]
+        "include": [
+          "gb-east-england.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2045,7 +2415,11 @@
     {
       "displayName": "Electromin",
       "id": "electromin-a3af2f",
-      "locationSet": {"include": ["sa"]},
+      "locationSet": {
+        "include": [
+          "sa"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Electromin"
@@ -2054,7 +2428,11 @@
     {
       "displayName": "Electromin Limited Company",
       "id": "electrominlimitedcompany-a3af2f",
-      "locationSet": {"include": ["sa"]},
+      "locationSet": {
+        "include": [
+          "sa"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Electromin Limited Company"
@@ -2063,7 +2441,14 @@
     {
       "displayName": "Elektrizitätswerk Davos",
       "id": "elektrizitatswerkdavos-ba2d61",
-      "locationSet": {"include": [[9.8, 46.8]]},
+      "locationSet": {
+        "include": [
+          [
+            9.8,
+            46.8
+          ]
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Elektrizitätswerk Davos",
@@ -2074,7 +2459,9 @@
       "displayName": "Elektrizitätswerk Obwalden",
       "id": "elektrizitatswerkobwalden-714754",
       "locationSet": {
-        "include": ["ch-ow.geojson"]
+        "include": [
+          "ch-ow.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2085,7 +2472,11 @@
     {
       "displayName": "Elektrum Latvija",
       "id": "elektrum-94e3c4",
-      "locationSet": {"include": ["lv"]},
+      "locationSet": {
+        "include": [
+          "lv"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Elektrum",
@@ -2095,7 +2486,11 @@
     {
       "displayName": "Elektrum Lietuva",
       "id": "elektrum-467e3c",
-      "locationSet": {"include": ["lt"]},
+      "locationSet": {
+        "include": [
+          "lt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Elektrum",
@@ -2105,7 +2500,11 @@
     {
       "displayName": "ELEN",
       "id": "elen-5bea2c",
-      "locationSet": {"include": ["hr"]},
+      "locationSet": {
+        "include": [
+          "hr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ELEN",
@@ -2115,7 +2514,12 @@
     {
       "displayName": "Eleport",
       "id": "eleport-512be8",
-      "locationSet": {"include": ["ee", "lv"]},
+      "locationSet": {
+        "include": [
+          "ee",
+          "lv"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Eleport",
@@ -2125,7 +2529,11 @@
     {
       "displayName": "Elinta",
       "id": "elinta-467e3c",
-      "locationSet": {"include": ["lt"]},
+      "locationSet": {
+        "include": [
+          "lt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Elinta"
@@ -2134,7 +2542,11 @@
     {
       "displayName": "Ella",
       "id": "ella-3f60da",
-      "locationSet": {"include": ["at"]},
+      "locationSet": {
+        "include": [
+          "at"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Ella",
@@ -2144,7 +2556,11 @@
     {
       "displayName": "Elli",
       "id": "elli-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "matchNames": [
         "volkswagen group charging gmbh"
       ],
@@ -2157,7 +2573,11 @@
     {
       "displayName": "ELMŰ",
       "id": "elmu-27e906",
-      "locationSet": {"include": ["hu"]},
+      "locationSet": {
+        "include": [
+          "hu"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ELMŰ",
@@ -2167,7 +2587,11 @@
     {
       "displayName": "Elocity",
       "id": "elocity-392011",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": {
+        "include": [
+          "pl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Elocity",
@@ -2177,7 +2601,11 @@
     {
       "displayName": "Emacom",
       "id": "emacom-bd0810",
-      "locationSet": {"include": ["pt-30"]},
+      "locationSet": {
+        "include": [
+          "pt-30"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Emacom"
@@ -2187,7 +2615,9 @@
       "displayName": "EMEL",
       "id": "emel-8fbbd7",
       "locationSet": {
-        "include": ["pt-11.geojson"]
+        "include": [
+          "pt-11.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2199,7 +2629,9 @@
       "displayName": "EMERGY Führungs- und Servicegesellschaft mbH",
       "id": "emergyfuhrungsundservicegesellschaftmbh-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2209,7 +2641,11 @@
     {
       "displayName": "eMobility",
       "id": "emobility-392011",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": {
+        "include": [
+          "pl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "eMobility"
@@ -2219,7 +2655,9 @@
       "displayName": "emotì",
       "id": "emoti-d3f33a",
       "locationSet": {
-        "include": ["ch-ti.geojson"]
+        "include": [
+          "ch-ti.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2231,7 +2669,9 @@
       "displayName": "Emscher Lippe Energie",
       "id": "emscherlippeenergie-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "matchNames": [
         "ele emscher lippe energie gmbh",
@@ -2247,7 +2687,11 @@
     {
       "displayName": "EnBW Energie Baden-Württemberg AG",
       "id": "enbwenergiebadenwurttembergag-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "matchNames": [
         "enbw",
         "enbw energie baden-württemberg",
@@ -2262,7 +2706,11 @@
     {
       "displayName": "EnBW mobility+ AG und Co.KG",
       "id": "enbwmobilityagundcokg-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EnBW mobility+ AG und Co.KG",
@@ -2272,7 +2720,11 @@
     {
       "displayName": "EnBW Ostwürttemberg DonauRies AG",
       "id": "enbwostwurttembergdonauriesag-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EnBW Ostwürttemberg DonauRies AG"
@@ -2281,7 +2733,11 @@
     {
       "displayName": "Endesa",
       "id": "endesa-97d7cf",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {
+        "include": [
+          "es"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Endesa",
@@ -2291,7 +2747,11 @@
     {
       "displayName": "Endesa X",
       "id": "endesax-97d7cf",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {
+        "include": [
+          "es"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Endesa X",
@@ -2302,7 +2762,9 @@
       "displayName": "Endolla Barcelona",
       "id": "endollabarcelona-f58b3e",
       "locationSet": {
-        "include": ["es-b.geojson"]
+        "include": [
+          "es-b.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2314,7 +2776,11 @@
       "displayName": "Eneco",
       "id": "eneco-35c01b",
       "locationSet": {
-        "include": ["be", "de", "nl"]
+        "include": [
+          "be",
+          "de",
+          "nl"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2326,7 +2792,11 @@
       "displayName": "Enefit",
       "id": "enefit-f7f98b",
       "locationSet": {
-        "include": ["ee", "lt", "lv"]
+        "include": [
+          "ee",
+          "lt",
+          "lv"
+        ]
       },
       "note": "possibly Q55285976 and/or Q104429275",
       "tags": {
@@ -2337,48 +2807,24 @@
     {
       "displayName": "Enefit Volt",
       "id": "enefitvolt-733008",
-      "locationSet": {"include": ["ee"]},
+      "locationSet": {
+        "include": [
+          "ee"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Enefit Volt"
       }
     },
     {
-      "displayName": "Enel",
-      "id": "enel-2c5517",
-      "locationSet": {"include": ["it"]},
-      "matchNames": [
-        "enel - stazione di ricarica"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "Enel",
-        "brand:wikidata": "Q651222",
-        "name": "Enel",
-        "operator": "Enel",
-        "operator:wikidata": "Q651222"
-      }
-    },
-    {
-      "displayName": "Enel X",
-      "id": "enelx-bdf07e",
-      "locationSet": {
-        "include": ["cl", "it", "ro"]
-      },
-      "matchNames": ["enel x metbus"],
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "Enel X",
-        "brand:wikidata": "Q5376815",
-        "name": "Enel X",
-        "operator": "Enel X",
-        "operator:wikidata": "Q5376815"
-      }
-    },
-    {
       "displayName": "Enel X Way",
       "id": "enelxway-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Enel X Way",
@@ -2389,7 +2835,9 @@
       "displayName": "enercity",
       "id": "enercity-d9ec6c",
       "locationSet": {
-        "include": ["de-ni.geojson"]
+        "include": [
+          "de-ni.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2400,7 +2848,11 @@
     {
       "displayName": "Energa",
       "id": "energa-392011",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": {
+        "include": [
+          "pl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Energa",
@@ -2410,7 +2862,11 @@
     {
       "displayName": "Energie 360°",
       "id": "7977b1-086737",
-      "locationSet": {"include": ["ch"]},
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Energie 360°",
@@ -2420,7 +2876,11 @@
     {
       "displayName": "Energie AG",
       "id": "energieag-3f60da",
-      "locationSet": {"include": ["at"]},
+      "locationSet": {
+        "include": [
+          "at"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Energie AG",
@@ -2431,9 +2891,13 @@
       "displayName": "Energie Calw",
       "id": "energiecalw-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
-      "matchNames": ["energie calw gmbh"],
+      "matchNames": [
+        "energie calw gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Energie Calw",
@@ -2444,7 +2908,9 @@
       "displayName": "ENERGIE Eure-et-Loir",
       "id": "energieeureetloir-0f5d07",
       "locationSet": {
-        "include": ["fr-cvl.geojson"]
+        "include": [
+          "fr-cvl.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2455,7 +2921,11 @@
     {
       "displayName": "Energie SaarLorLux",
       "id": "energiesaarlorlux-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Energie SaarLorLux",
@@ -2481,7 +2951,9 @@
       "displayName": "Energie Südbayern",
       "id": "energiesudbayern-259ab2",
       "locationSet": {
-        "include": ["de-by.geojson"]
+        "include": [
+          "de-by.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2493,7 +2965,9 @@
       "displayName": "Energie und Wasser Potsdam GmbH",
       "id": "energieundwasserpotsdamgmbh-4f5737",
       "locationSet": {
-        "include": ["de-bb.geojson"]
+        "include": [
+          "de-bb.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2503,7 +2977,11 @@
     {
       "displayName": "Energie- und Wasserversorgung Bonn/Rhein-Sieg GmbH",
       "id": "energieundwasserversorgungbonnrheinsieggmbh-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Energie- und Wasserversorgung Bonn/Rhein-Sieg GmbH"
@@ -2512,7 +2990,11 @@
     {
       "displayName": "Energie- und Wasserversorgung Bruchsal GmbH",
       "id": "energieundwasserversorgungbruchsalgmbh-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Energie- und Wasserversorgung Bruchsal GmbH"
@@ -2522,7 +3004,10 @@
       "displayName": "Energiedienst",
       "id": "energiedienst-6cf9a8",
       "locationSet": {
-        "include": ["ch-ag.geojson", "de"]
+        "include": [
+          "ch-ag.geojson",
+          "de"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2534,7 +3019,9 @@
       "displayName": "Energieversorgung Beckum GmbH & Co. KG",
       "id": "energieversorgungbeckumgmbhandcokg-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2559,7 +3046,9 @@
       "displayName": "Energieversorgung Rodau",
       "id": "energieversorgungrodau-43ff7e",
       "locationSet": {
-        "include": ["de-he.geojson"]
+        "include": [
+          "de-he.geojson"
+        ]
       },
       "matchNames": [
         "energieversorgung rodau gmbh"
@@ -2574,7 +3063,9 @@
       "displayName": "energis",
       "id": "energis-124d23",
       "locationSet": {
-        "include": ["de-sl.geojson"]
+        "include": [
+          "de-sl.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2586,7 +3077,9 @@
       "displayName": "EnergyDrive",
       "id": "energydrive-1b9db6",
       "locationSet": {
-        "include": ["be-bru.geojson"]
+        "include": [
+          "be-bru.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2597,7 +3090,9 @@
       "displayName": "EneRSIEIL",
       "id": "enersieil-0f5d07",
       "locationSet": {
-        "include": ["fr-cvl.geojson"]
+        "include": [
+          "fr-cvl.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2607,7 +3102,12 @@
     {
       "displayName": "Engie",
       "id": "engie-b2225d",
-      "locationSet": {"include": ["be", "nl"]},
+      "locationSet": {
+        "include": [
+          "be",
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Engie",
@@ -2617,7 +3117,11 @@
     {
       "displayName": "Eni",
       "id": "eni-c22d3a",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Eni",
@@ -2627,7 +3131,14 @@
     {
       "displayName": "Eniwa",
       "id": "eniwa-d48833",
-      "locationSet": {"include": [[8.1, 47.4]]},
+      "locationSet": {
+        "include": [
+          [
+            8.1,
+            47.4
+          ]
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Eniwa",
@@ -2637,7 +3148,11 @@
     {
       "displayName": "ENSO Energie Sachsen Ost AG",
       "id": "ensoenergiesachsenostag-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ENSO Energie Sachsen Ost AG",
@@ -2647,8 +3162,14 @@
     {
       "displayName": "Entega",
       "id": "entega-1299a8",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["entega energie gmbh"],
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
+      "matchNames": [
+        "entega energie gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Entega",
@@ -2658,7 +3179,11 @@
     {
       "displayName": "enviaM",
       "id": "enviam-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "matchNames": [
         "envia mitteldeutsche energie ag"
       ],
@@ -2671,8 +3196,15 @@
     {
       "displayName": "EO",
       "id": "eo-f6fe0b",
-      "locationSet": {"include": ["gb", "ie"]},
-      "matchNames": ["eo charging"],
+      "locationSet": {
+        "include": [
+          "gb",
+          "ie"
+        ]
+      },
+      "matchNames": [
+        "eo charging"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "EO",
@@ -2682,7 +3214,11 @@
     {
       "displayName": "eONE",
       "id": "eone-8fcd5a",
-      "locationSet": {"include": ["is"]},
+      "locationSet": {
+        "include": [
+          "is"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "eONE"
@@ -2691,7 +3227,11 @@
     {
       "displayName": "eParking",
       "id": "eparking-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "eParking"
@@ -2700,7 +3240,11 @@
     {
       "displayName": "ePower",
       "id": "epower-179e3e",
-      "locationSet": {"include": ["ie"]},
+      "locationSet": {
+        "include": [
+          "ie"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ePower"
@@ -2709,7 +3253,11 @@
     {
       "displayName": "Equans",
       "id": "equans-fa6152",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Equans",
@@ -2720,7 +3268,11 @@
       "displayName": "Eranovum",
       "id": "eranovum-171c5d",
       "locationSet": {
-        "include": ["be", "es", "fx"]
+        "include": [
+          "be",
+          "es",
+          "fx"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2732,7 +3284,9 @@
       "displayName": "Erlanger Stadtwerke",
       "id": "erlangerstadtwerke-259ab2",
       "locationSet": {
-        "include": ["de-by.geojson"]
+        "include": [
+          "de-by.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2744,7 +3298,9 @@
       "displayName": "ESB (Schweiz)",
       "id": "energieservicebielbienne-0c1e54",
       "locationSet": {
-        "include": ["ch-be.geojson"]
+        "include": [
+          "ch-be.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2754,28 +3310,17 @@
       }
     },
     {
-      "displayName": "ESB ecars",
-      "id": "esbgroup-881c56",
-      "locationSet": {
-        "include": ["gb-nir", "ie"]
-      },
-      "matchNames": [
-        "ecarni",
-        "esb",
-        "esb ecars"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "ecars",
-        "operator": "ESB Group",
-        "operator:wikidata": "Q3050566"
-      }
-    },
-    {
       "displayName": "ESB Energy",
       "id": "esbenergy-0793ce",
-      "locationSet": {"include": ["gb"]},
-      "matchNames": ["esb", "esb ev solutions"],
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
+      "matchNames": [
+        "esb",
+        "esb ev solutions"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "ESB Energy",
@@ -2785,7 +3330,11 @@
     {
       "displayName": "Esso",
       "id": "esso-c22d3a",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Esso",
@@ -2796,7 +3345,9 @@
       "displayName": "ESWE",
       "id": "eswe-43ff7e",
       "locationSet": {
-        "include": ["de-he.geojson"]
+        "include": [
+          "de-he.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2825,7 +3376,9 @@
       "displayName": "Eulektro",
       "id": "eulektro-152e8e",
       "locationSet": {
-        "include": ["de-hb.geojson"]
+        "include": [
+          "de-hb.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2835,7 +3388,11 @@
     {
       "displayName": "EuroSpin",
       "id": "eurospin-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EuroSpin",
@@ -2843,19 +3400,13 @@
       }
     },
     {
-      "displayName": "EV Connect",
-      "id": "evconnect-994ed4",
-      "locationSet": {"include": ["us"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "EV Connect",
-        "operator:wikidata": "Q126652985"
-      }
-    },
-    {
       "displayName": "EV Power",
       "id": "evpower-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EV Power"
@@ -2864,7 +3415,11 @@
     {
       "displayName": "EV+",
       "id": "ev-392011",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": {
+        "include": [
+          "pl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EV+"
@@ -2873,7 +3428,11 @@
     {
       "displayName": "EVA Chargers",
       "id": "evachargers-a6c3f2",
-      "locationSet": {"include": ["ua"]},
+      "locationSet": {
+        "include": [
+          "ua"
+        ]
+      },
       "matchNames": [
         "ae charge point",
         "ae charger",
@@ -2893,7 +3452,11 @@
     {
       "displayName": "EVBox",
       "id": "evbox-7f623e",
-      "locationSet": {"include": ["150"]},
+      "locationSet": {
+        "include": [
+          "150"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EVBox",
@@ -2903,7 +3466,11 @@
     {
       "displayName": "EVC EV Chargers",
       "id": "evc-0793ce",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "matchNames": [
         "ev chargers ltd",
         "ev chargers uk"
@@ -2917,7 +3484,11 @@
     {
       "displayName": "EVCS",
       "id": "evcs-994ed4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EVCS",
@@ -2928,7 +3499,9 @@
       "displayName": "evd energieversorgung dormagen",
       "id": "evdenergieversorgungdormagen-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -2937,23 +3510,16 @@
       }
     },
     {
-      "displayName": "EVgo",
-      "id": "evgo-994ed4",
-      "locationSet": {"include": ["us"]},
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "EVgo",
-        "brand:wikidata": "Q61803820",
-        "name": "EVgo",
-        "operator": "EVgo",
-        "operator:wikidata": "Q61803820"
-      }
-    },
-    {
       "displayName": "Evie Networks",
       "id": "evienetworks-943805",
-      "locationSet": {"include": ["au"]},
-      "matchNames": ["evie"],
+      "locationSet": {
+        "include": [
+          "au"
+        ]
+      },
+      "matchNames": [
+        "evie"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Evie Networks",
@@ -2963,7 +3529,11 @@
     {
       "displayName": "Evio",
       "id": "evio-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Evio"
@@ -2972,7 +3542,11 @@
     {
       "displayName": "EVlink",
       "id": "evlink-c22d3a",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EVlink",
@@ -2997,8 +3571,14 @@
     {
       "displayName": "EVN (Österreich)",
       "id": "evn-3f60da",
-      "locationSet": {"include": ["at"]},
-      "matchNames": ["evn ag"],
+      "locationSet": {
+        "include": [
+          "at"
+        ]
+      },
+      "matchNames": [
+        "evn ag"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "EVN",
@@ -3008,7 +3588,11 @@
     {
       "displayName": "EVN (Северна Македонија)",
       "id": "evn-12d20d",
-      "locationSet": {"include": ["mk"]},
+      "locationSet": {
+        "include": [
+          "mk"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EVN",
@@ -3018,7 +3602,11 @@
     {
       "displayName": "EVnetNL",
       "id": "evnetnl-fa6152",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EVnetNL"
@@ -3027,7 +3615,11 @@
     {
       "displayName": "EVO",
       "id": "evo-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EVO",
@@ -3037,7 +3629,11 @@
     {
       "displayName": "evolt",
       "id": "evolt-0793ce",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "evolt"
@@ -3046,7 +3642,11 @@
     {
       "displayName": "evpass",
       "id": "evpass-086737",
-      "locationSet": {"include": ["ch"]},
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "evpass",
@@ -3056,7 +3656,11 @@
     {
       "displayName": "Evway",
       "id": "evway-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Evway",
@@ -3064,20 +3668,12 @@
       }
     },
     {
-      "displayName": "evyve",
-      "id": "evyve-0793ce",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "evyve",
-        "operator:wikidata": "Q116698197"
-      }
-    },
-    {
       "displayName": "evzen (SMEG Développement)",
       "id": "evzensmegdeveloppement-5e108d",
       "locationSet": {
-        "include": ["fr-pac.geojson"]
+        "include": [
+          "fr-pac.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3087,7 +3683,14 @@
     {
       "displayName": "EW Höfe",
       "id": "ewhofe-485cc9",
-      "locationSet": {"include": [[8.8, 47.2]]},
+      "locationSet": {
+        "include": [
+          [
+            8.8,
+            47.2
+          ]
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EW Höfe",
@@ -3097,7 +3700,11 @@
     {
       "displayName": "Eways",
       "id": "eways-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Eways",
@@ -3107,7 +3714,11 @@
     {
       "displayName": "EWE Go",
       "id": "ewego-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "matchNames": [
         "ewe",
         "ewe go gmbh",
@@ -3122,7 +3733,11 @@
     {
       "displayName": "EWII",
       "id": "ewii-7d9e8e",
-      "locationSet": {"include": ["dk"]},
+      "locationSet": {
+        "include": [
+          "dk"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EWII",
@@ -3132,7 +3747,11 @@
     {
       "displayName": "Ewiva",
       "id": "ewiva-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Ewiva",
@@ -3142,7 +3761,11 @@
     {
       "displayName": "EWR",
       "id": "ewr-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EWR",
@@ -3152,7 +3775,11 @@
     {
       "displayName": "EWV",
       "id": "ewv-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "EWV",
@@ -3162,7 +3789,11 @@
     {
       "displayName": "Exploren",
       "id": "exploren-943805",
-      "locationSet": {"include": ["au"]},
+      "locationSet": {
+        "include": [
+          "au"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Exploren",
@@ -3172,7 +3803,11 @@
     {
       "displayName": "EZE",
       "id": "eze-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "matchNames": [
         "eze.network",
         "eze.network gmbh"
@@ -3186,7 +3821,11 @@
     {
       "displayName": "Factor Energia",
       "id": "factorenergia-bd0810",
-      "locationSet": {"include": ["pt-30"]},
+      "locationSet": {
+        "include": [
+          "pt-30"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Factor Energia",
@@ -3196,7 +3835,11 @@
     {
       "displayName": "FairEnergie GmbH",
       "id": "fairenergiegmbh-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "FairEnergie GmbH",
@@ -3204,37 +3847,13 @@
       }
     },
     {
-      "displayName": "Fastned",
-      "id": "fastned-17c03e",
-      "locationSet": {
-        "include": ["be", "de", "gb", "nl"]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Fastned",
-        "operator:wikidata": "Q19935749"
-      }
-    },
-    {
-      "displayName": "Fédération Départementale d'Énergie de la Somme",
-      "id": "federationdepartementaledenergiedelasomme-13949b",
-      "locationSet": {
-        "include": ["fr-hdf.geojson"]
-      },
-      "matchNames": [
-        "fédération départementale d'énergie de la somme (fde80)"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Fédération Départementale d'Énergie de la Somme",
-        "operator:short": "FDE80",
-        "operator:wikidata": "Q64731375"
-      }
-    },
-    {
       "displayName": "Feníe Energía",
       "id": "fenieenergia-97d7cf",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {
+        "include": [
+          "es"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Feníe Energía",
@@ -3245,7 +3864,9 @@
       "displayName": "Filderstadtwerke",
       "id": "filderstadtwerke-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3256,7 +3877,11 @@
     {
       "displayName": "FINES Charging",
       "id": "c9c8bd-befeeb",
-      "locationSet": {"include": ["bg"]},
+      "locationSet": {
+        "include": [
+          "bg"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Финес Енерджи ООД",
@@ -3264,22 +3889,13 @@
       }
     },
     {
-      "displayName": "FLO",
-      "id": "flo-78626b",
-      "locationSet": {"include": ["ca", "us"]},
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "FLO",
-        "brand:wikidata": "Q64971203",
-        "name": "FLO",
-        "operator": "FLO",
-        "operator:wikidata": "Q64971203"
-      }
-    },
-    {
       "displayName": "Free to X",
       "id": "freetox-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Free to X"
@@ -3288,8 +3904,14 @@
     {
       "displayName": "Freshmile",
       "id": "freshmile-f6553b",
-      "locationSet": {"include": ["fr"]},
-      "matchNames": ["freshmile sas"],
+      "locationSet": {
+        "include": [
+          "fr"
+        ]
+      },
+      "matchNames": [
+        "freshmile sas"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Freshmile",
@@ -3314,7 +3936,11 @@
     {
       "displayName": "Fyrfasen Energi AB",
       "id": "fyrfasenenergiab-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Fyrfasen Energi AB",
@@ -3322,9 +3948,31 @@
       }
     },
     {
+      "displayName": "Fédération Départementale d'Énergie de la Somme",
+      "id": "federationdepartementaledenergiedelasomme-13949b",
+      "locationSet": {
+        "include": [
+          "fr-hdf.geojson"
+        ]
+      },
+      "matchNames": [
+        "fédération départementale d'énergie de la somme (fde80)"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Fédération Départementale d'Énergie de la Somme",
+        "operator:short": "FDE80",
+        "operator:wikidata": "Q64731375"
+      }
+    },
+    {
       "displayName": "Galp Geste",
       "id": "galpgeste-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Galp Geste"
@@ -3333,7 +3981,11 @@
     {
       "displayName": "Galp Power",
       "id": "galppower-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Galp Power"
@@ -3342,7 +3994,11 @@
     {
       "displayName": "GaraGeeks",
       "id": "garageeks-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "GaraGeeks"
@@ -3351,7 +4007,11 @@
     {
       "displayName": "Gemeente Den Haag",
       "id": "gemeentedenhaag-fa6152",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Gemeente Den Haag",
@@ -3361,7 +4021,11 @@
     {
       "displayName": "Gemeente Rotterdam",
       "id": "gemeenterotterdam-fa6152",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Gemeente Rotterdam",
@@ -3371,7 +4035,11 @@
     {
       "displayName": "Gemeente Utrecht",
       "id": "gemeenteutrecht-fa6152",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Gemeente Utrecht",
@@ -3382,7 +4050,9 @@
       "displayName": "Gemeinde Unterhaching",
       "id": "gemeindeunterhaching-259ab2",
       "locationSet": {
-        "include": ["de-by.geojson"]
+        "include": [
+          "de-by.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3394,7 +4064,9 @@
       "displayName": "Gemeindewerke Garmisch-Partenkirchen",
       "id": "gemeindewerkegarmischpartenkirchen-259ab2",
       "locationSet": {
-        "include": ["de-by.geojson"]
+        "include": [
+          "de-by.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3406,7 +4078,9 @@
       "displayName": "Gemeindewerke Oberhaching",
       "id": "gemeindewerkeoberhaching-259ab2",
       "locationSet": {
-        "include": ["de-by.geojson"]
+        "include": [
+          "de-by.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3417,26 +4091,24 @@
     {
       "displayName": "Generation Journey",
       "id": "generationjourney-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Generation Journey"
       }
     },
     {
-      "displayName": "GeniePoint",
-      "id": "geniepoint-0793ce",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "GeniePoint",
-        "operator:wikidata": "Q111363966"
-      }
-    },
-    {
       "displayName": "Gentari",
       "id": "gentari-1845ed",
-      "locationSet": {"include": ["my"]},
+      "locationSet": {
+        "include": [
+          "my"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Gentari",
@@ -3447,7 +4119,9 @@
       "displayName": "Georgia Power",
       "id": "georgiapower-c1e164",
       "locationSet": {
-        "include": ["us-ga.geojson"]
+        "include": [
+          "us-ga.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3459,7 +4133,9 @@
       "displayName": "Gesvican",
       "id": "gesvican-7d2e65",
       "locationSet": {
-        "include": ["es-s.geojson"]
+        "include": [
+          "es-s.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3470,7 +4146,9 @@
       "displayName": "GGEW",
       "id": "ggew-43ff7e",
       "locationSet": {
-        "include": ["de-he.geojson"]
+        "include": [
+          "de-he.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3482,7 +4160,9 @@
       "displayName": "GIC",
       "id": "gic-8c07b0",
       "locationSet": {
-        "include": ["es-m.geojson"]
+        "include": [
+          "es-m.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3492,7 +4172,11 @@
     {
       "displayName": "GigaCharger",
       "id": "gigacharger-befeeb",
-      "locationSet": {"include": ["bg"]},
+      "locationSet": {
+        "include": [
+          "bg"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "name": "GigaCharger",
@@ -3503,7 +4187,11 @@
     {
       "displayName": "GO+EAuto",
       "id": "goeauto-392011",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": {
+        "include": [
+          "pl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "GO+EAuto"
@@ -3512,7 +4200,11 @@
     {
       "displayName": "GOcharge",
       "id": "gocharge-179e3e",
-      "locationSet": {"include": ["ie"]},
+      "locationSet": {
+        "include": [
+          "ie"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "GOcharge",
@@ -3522,7 +4214,11 @@
     {
       "displayName": "GOFAST",
       "id": "gofast-086737",
-      "locationSet": {"include": ["ch"]},
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "GOFAST",
@@ -3530,25 +4226,149 @@
       }
     },
     {
-      "displayName": "Gogoro 電池交換站",
-      "id": "62c656-28ff7e",
+      "displayName": "GP JOULE Connect",
+      "id": "gpjouleconnect-1299a8",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
+        "include": [
+          "de"
+        ]
+      },
+      "matchNames": [
+        "gp joule connect gmbh"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "GP JOULE Connect",
+        "operator:wikidata": "Q128032138"
+      }
+    },
+    {
+      "displayName": "Green Motion",
+      "id": "greenmotion-086737",
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
+      "matchNames": [
+        "green motion sa"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Green Motion",
+        "operator:wikidata": "Q86664476"
+      }
+    },
+    {
+      "displayName": "Green Technologie",
+      "id": "greentechnologie-508af8",
+      "locationSet": {
+        "include": [
+          "gf",
+          "gp",
+          "mq"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
-        "brand": "Gogoro 電池交換站",
-        "brand:wikidata": "Q19880591",
-        "name": "Gogoro 電池交換站",
-        "operator": "Gogoro 電池交換站",
-        "operator:wikidata": "Q19880591"
+        "operator": "Green Technologie"
+      }
+    },
+    {
+      "displayName": "GreenCharge",
+      "id": "greencharge-8fbbd7",
+      "locationSet": {
+        "include": [
+          "pt-11.geojson"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "GreenCharge"
+      }
+    },
+    {
+      "displayName": "GreenFlux",
+      "id": "greenflux-fa6152",
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "GreenFlux",
+        "operator:wikidata": "Q126728390"
+      }
+    },
+    {
+      "displayName": "GreenTE",
+      "id": "greente-5b32c5",
+      "locationSet": {
+        "include": [
+          "uz"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "GreenTE"
+      }
+    },
+    {
+      "displayName": "GreenWay",
+      "id": "greenway-40951a",
+      "locationSet": {
+        "include": [
+          "hr",
+          "pl",
+          "sk"
+        ]
+      },
+      "matchNames": [
+        "greenway infrastructure"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "GreenWay",
+        "operator:wikidata": "Q116450281"
+      }
+    },
+    {
+      "displayName": "Gremo na elektriko",
+      "id": "gremonaelektriko-64fbf7",
+      "locationSet": {
+        "include": [
+          "si"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Gremo na elektriko",
+        "operator:wikidata": "Q30294660"
+      }
+    },
+    {
+      "displayName": "Groupe E",
+      "id": "groupee-086737",
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Groupe E",
+        "operator:wikidata": "Q1547733"
       }
     },
     {
       "displayName": "Göteborgs Stads Parkerings AB",
       "id": "goteborgsstadsparkeringsab-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "matchNames": [
         "göteborg energi",
         "göteborg stads parkerings ab",
@@ -3561,120 +4381,13 @@
       }
     },
     {
-      "displayName": "GP JOULE Connect",
-      "id": "gpjouleconnect-1299a8",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["gp joule connect gmbh"],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "GP JOULE Connect",
-        "operator:wikidata": "Q128032138"
-      }
-    },
-    {
-      "displayName": "Green Motion",
-      "id": "greenmotion-086737",
-      "locationSet": {"include": ["ch"]},
-      "matchNames": ["green motion sa"],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Green Motion",
-        "operator:wikidata": "Q86664476"
-      }
-    },
-    {
-      "displayName": "Green Technologie",
-      "id": "greentechnologie-508af8",
-      "locationSet": {
-        "include": ["gf", "gp", "mq"]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Green Technologie"
-      }
-    },
-    {
-      "displayName": "GreenCharge",
-      "id": "greencharge-8fbbd7",
-      "locationSet": {
-        "include": ["pt-11.geojson"]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "GreenCharge"
-      }
-    },
-    {
-      "displayName": "GreenFlux",
-      "id": "greenflux-fa6152",
-      "locationSet": {"include": ["nl"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "GreenFlux",
-        "operator:wikidata": "Q126728390"
-      }
-    },
-    {
-      "displayName": "GreenTE",
-      "id": "greente-5b32c5",
-      "locationSet": {"include": ["uz"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "GreenTE"
-      }
-    },
-    {
-      "displayName": "GreenWay",
-      "id": "greenway-40951a",
-      "locationSet": {
-        "include": ["hr", "pl", "sk"]
-      },
-      "matchNames": ["greenway infrastructure"],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "GreenWay",
-        "operator:wikidata": "Q116450281"
-      }
-    },
-    {
-      "displayName": "Gremo na elektriko",
-      "id": "gremonaelektriko-64fbf7",
-      "locationSet": {"include": ["si"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Gremo na elektriko",
-        "operator:wikidata": "Q30294660"
-      }
-    },
-    {
-      "displayName": "Gridserve",
-      "id": "gridserve-0793ce",
-      "locationSet": {"include": ["gb"]},
-      "matchNames": [
-        "ecotricity",
-        "electric highway"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "name": "Gridserve",
-        "operator": "Gridserve",
-        "operator:wikidata": "Q89575318"
-      }
-    },
-    {
-      "displayName": "Groupe E",
-      "id": "groupee-086737",
-      "locationSet": {"include": ["ch"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Groupe E",
-        "operator:wikidata": "Q1547733"
-      }
-    },
-    {
       "displayName": "Helen",
       "id": "helen-e80d25",
-      "locationSet": {"include": ["fi"]},
+      "locationSet": {
+        "include": [
+          "fi"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Helen",
@@ -3684,7 +4397,11 @@
     {
       "displayName": "Helexia II",
       "id": "helexiaii-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Helexia II"
@@ -3693,7 +4410,11 @@
     {
       "displayName": "Hera",
       "id": "hera-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Hera"
@@ -3703,7 +4424,9 @@
       "displayName": "Herzo Werke",
       "id": "herzowerke-259ab2",
       "locationSet": {
-        "include": ["de-by.geojson"]
+        "include": [
+          "de-by.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3714,7 +4437,11 @@
     {
       "displayName": "Hesse GmbH",
       "id": "hessegmbh-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Hesse GmbH"
@@ -3723,7 +4450,11 @@
     {
       "displayName": "Hexagonal Ocean",
       "id": "hexagonalocean-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Hexagonal Ocean"
@@ -3732,7 +4463,11 @@
     {
       "displayName": "High Green Power",
       "id": "highgreenpower-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "High Green Power"
@@ -3741,7 +4476,11 @@
     {
       "displayName": "Hikotron",
       "id": "hikotron-9850e1",
-      "locationSet": {"include": ["nz"]},
+      "locationSet": {
+        "include": [
+          "nz"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Hikotron",
@@ -3752,7 +4491,9 @@
       "displayName": "Hochtief",
       "id": "hochtief-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3760,18 +4501,13 @@
       }
     },
     {
-      "displayName": "Höganäs Energi AB",
-      "id": "hoganasenergiab-c9e89f",
-      "locationSet": {"include": ["se"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Höganäs Energi AB"
-      }
-    },
-    {
       "displayName": "Holmgrens bil AB",
       "id": "holmgrensbilab-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Holmgrens bil AB",
@@ -3782,8 +4518,12 @@
       "displayName": "Hyundai",
       "id": "hyundai-28ff7e",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3792,9 +4532,26 @@
       }
     },
     {
+      "displayName": "Höganäs Energi AB",
+      "id": "hoganasenergiab-c9e89f",
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Höganäs Energi AB"
+      }
+    },
+    {
       "displayName": "Iberdrola",
       "id": "iberdrola-97d7cf",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {
+        "include": [
+          "es"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Iberdrola",
@@ -3804,7 +4561,11 @@
     {
       "displayName": "Ibil",
       "id": "ibil-97d7cf",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {
+        "include": [
+          "es"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Ibil",
@@ -3814,7 +4575,11 @@
     {
       "displayName": "ICE",
       "id": "ice-296db6",
-      "locationSet": {"include": ["cr"]},
+      "locationSet": {
+        "include": [
+          "cr"
+        ]
+      },
       "matchNames": [
         "instituto costarricense de electricidad"
       ],
@@ -3827,7 +4592,11 @@
     {
       "displayName": "IECharge",
       "id": "iecharge-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "IECharge"
@@ -3836,7 +4605,11 @@
     {
       "displayName": "Ignitis",
       "id": "ignitis-467e3c",
-      "locationSet": {"include": ["lt"]},
+      "locationSet": {
+        "include": [
+          "lt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Ignitis",
@@ -3846,7 +4619,11 @@
     {
       "displayName": "IgnitisON",
       "id": "ignitison-467e3c",
-      "locationSet": {"include": ["lt"]},
+      "locationSet": {
+        "include": [
+          "lt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "IgnitisON"
@@ -3856,7 +4633,9 @@
       "displayName": "IKB",
       "id": "ikb-f691eb",
       "locationSet": {
-        "include": ["at-7.geojson"]
+        "include": [
+          "at-7.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3867,8 +4646,14 @@
     {
       "displayName": "IKEA",
       "id": "ikea-c22d3a",
-      "locationSet": {"include": ["001"]},
-      "matchNames": ["ikea delft"],
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
+      "matchNames": [
+        "ikea delft"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "IKEA",
@@ -3878,7 +4663,11 @@
     {
       "displayName": "illwerke vkw",
       "id": "illwerkevkw-3f60da",
-      "locationSet": {"include": ["at"]},
+      "locationSet": {
+        "include": [
+          "at"
+        ]
+      },
       "matchNames": [
         "illwerke vkw ag",
         "vkw",
@@ -3896,7 +4685,9 @@
       "displayName": "InEnergies",
       "id": "inenergies-0f5d07",
       "locationSet": {
-        "include": ["fr-cvl.geojson"]
+        "include": [
+          "fr-cvl.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -3906,35 +4697,27 @@
     {
       "displayName": "Infinite Charge",
       "id": "infinitecharge-a6c3f2",
-      "locationSet": {"include": ["ua"]},
+      "locationSet": {
+        "include": [
+          "ua"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Infinite Charge"
       }
     },
     {
-      "displayName": "Innogy",
-      "id": "innogy-1299a8",
-      "locationSet": {"include": ["de"]},
-      "matchNames": [
-        "innogy emobility solutions gmbh",
-        "innogy se",
-        "rwe"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "Innogy",
-        "brand:wikidata": "Q2124721",
-        "name": "Innogy",
-        "operator": "Innogy",
-        "operator:wikidata": "Q2124721"
-      }
-    },
-    {
       "displayName": "Inselwerke",
       "id": "inselwerke-1299a8",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["inselwerke eg"],
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
+      "matchNames": [
+        "inselwerke eg"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Inselwerke",
@@ -3944,7 +4727,11 @@
     {
       "displayName": "InstaVolt",
       "id": "instavolt-0793ce",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "InstaVolt",
@@ -3954,7 +4741,11 @@
     {
       "displayName": "Intel Corporation",
       "id": "intelcorporation-994ed4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Intel Corporation",
@@ -3964,7 +4755,12 @@
     {
       "displayName": "Intermarché",
       "id": "intermarche-abe4b6",
-      "locationSet": {"include": ["fx", "pt"]},
+      "locationSet": {
+        "include": [
+          "fx",
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Intermarché",
@@ -3972,19 +4768,13 @@
       }
     },
     {
-      "displayName": "Ísorka",
-      "id": "isorka-8fcd5a",
-      "locationSet": {"include": ["is"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Ísorka",
-        "operator:wikidata": "Q127783906"
-      }
-    },
-    {
       "displayName": "Italia Vento Power Corporation",
       "id": "italiaventopowercorporation-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Italia Vento Power Corporation"
@@ -3993,7 +4783,11 @@
     {
       "displayName": "IWB",
       "id": "iwb-086737",
-      "locationSet": {"include": ["ch"]},
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "IWB",
@@ -4003,7 +4797,11 @@
     {
       "displayName": "Izivia",
       "id": "izivia-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Izivia",
@@ -4011,20 +4809,16 @@
       }
     },
     {
-      "displayName": "Jämtkraft",
-      "id": "jamtkraft-c9e89f",
-      "locationSet": {"include": ["se"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Jämtkraft",
-        "operator:wikidata": "Q10541693"
-      }
-    },
-    {
       "displayName": "Jolt",
       "id": "jolt-743b2f",
       "locationSet": {
-        "include": ["au", "ca", "gb", "nz", "us"]
+        "include": [
+          "au",
+          "ca",
+          "gb",
+          "nz",
+          "us"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4035,16 +4829,38 @@
     {
       "displayName": "JomCharge",
       "id": "jomcharge-1845ed",
-      "locationSet": {"include": ["my"]},
+      "locationSet": {
+        "include": [
+          "my"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "JomCharge"
       }
     },
     {
+      "displayName": "Jämtkraft",
+      "id": "jamtkraft-c9e89f",
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Jämtkraft",
+        "operator:wikidata": "Q10541693"
+      }
+    },
+    {
       "displayName": "Jönköping Energi",
       "id": "jonkopingenergi-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "matchNames": [
         "jönköping energi ab",
         "jönköpings energi ab"
@@ -4058,7 +4874,11 @@
     {
       "displayName": "K-Lataus",
       "id": "klataus-e80d25",
-      "locationSet": {"include": ["fi"]},
+      "locationSet": {
+        "include": [
+          "fi"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "K-Lataus",
@@ -4068,7 +4888,11 @@
     {
       "displayName": "Kaufland",
       "id": "kaufland-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Kaufland",
@@ -4078,7 +4902,12 @@
     {
       "displayName": "KEBA",
       "id": "keba-a5756d",
-      "locationSet": {"include": ["at", "de"]},
+      "locationSet": {
+        "include": [
+          "at",
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "KEBA",
@@ -4103,7 +4932,11 @@
     {
       "displayName": "kiwEV",
       "id": "kiwev-9850e1",
-      "locationSet": {"include": ["nz"]},
+      "locationSet": {
+        "include": [
+          "nz"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "kiwEV",
@@ -4113,8 +4946,14 @@
     {
       "displayName": "KLC Serviços",
       "id": "klcservicos-a1285d",
-      "locationSet": {"include": ["pt"]},
-      "matchNames": ["klc"],
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
+      "matchNames": [
+        "klc"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "KLC Serviços"
@@ -4124,7 +4963,9 @@
       "displayName": "Kreis Paderborn",
       "id": "kreispaderborn-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4135,7 +4976,9 @@
       "displayName": "Kreiswerke Main-Kinzig",
       "id": "kreiswerkemainkinzig-43ff7e",
       "locationSet": {
-        "include": ["de-he.geojson"]
+        "include": [
+          "de-he.geojson"
+        ]
       },
       "matchNames": [
         "kreiswerke main-kinzig gmbh"
@@ -4149,7 +4992,11 @@
     {
       "displayName": "Kungsbacka Kommun",
       "id": "kungsbackakommun-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Kungsbacka Kommun",
@@ -4159,7 +5006,11 @@
     {
       "displayName": "Lade i Norge",
       "id": "ladeinorge-476d58",
-      "locationSet": {"include": ["no"]},
+      "locationSet": {
+        "include": [
+          "no"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Lade i Norge"
@@ -4168,7 +5019,11 @@
     {
       "displayName": "ladenetz.de",
       "id": "ladenetzde-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ladenetz.de"
@@ -4177,7 +5032,11 @@
     {
       "displayName": "Ladeverbund+",
       "id": "ladeverbund-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Ladeverbund+"
@@ -4187,7 +5046,9 @@
       "displayName": "Lancaster City Council",
       "id": "lancastercitycouncil-9ba54b",
       "locationSet": {
-        "include": ["gb-lan.geojson"]
+        "include": [
+          "gb-lan.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4199,7 +5060,9 @@
       "displayName": "Lancaster University",
       "id": "lancasteruniversity-9ba54b",
       "locationSet": {
-        "include": ["gb-lan.geojson"]
+        "include": [
+          "gb-lan.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4210,7 +5073,11 @@
     {
       "displayName": "Last Mile Solutions",
       "id": "lastmilesolutions-7f623e",
-      "locationSet": {"include": ["150"]},
+      "locationSet": {
+        "include": [
+          "150"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Last Mile Solutions",
@@ -4221,7 +5088,9 @@
       "displayName": "Laudert GmbH & Co. KG",
       "id": "laudertgmbhandcokg-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4231,7 +5100,12 @@
     {
       "displayName": "LEAP24",
       "id": "leap24-461188",
-      "locationSet": {"include": ["de", "nl"]},
+      "locationSet": {
+        "include": [
+          "de",
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "LEAP24",
@@ -4241,7 +5115,12 @@
     {
       "displayName": "Leasys",
       "id": "leasys-257863",
-      "locationSet": {"include": ["fx", "it"]},
+      "locationSet": {
+        "include": [
+          "fx",
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Leasys",
@@ -4265,7 +5144,11 @@
     {
       "displayName": "Lechwerke AG",
       "id": "lechwerkeag-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "matchNames": [
         "lech elektrizitätswerke augsburg",
         "lew"
@@ -4280,8 +5163,13 @@
       "displayName": "Lidl",
       "id": "lidl-e2f086",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["no", "se"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no",
+          "se"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4292,7 +5180,11 @@
     {
       "displayName": "Lidl France",
       "id": "lidlfrance-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Lidl France",
@@ -4302,7 +5194,11 @@
     {
       "displayName": "Lidl Sverige KB",
       "id": "lidlsverigekb-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Lidl Sverige KB",
@@ -4328,7 +5224,9 @@
       "displayName": "LokalWerke",
       "id": "lokalwerke-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "matchNames": [
         "stadtwerke ahaus",
@@ -4345,7 +5243,11 @@
     {
       "displayName": "Lotos",
       "id": "lotos-392011",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": {
+        "include": [
+          "pl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Lotos",
@@ -4356,7 +5258,9 @@
       "displayName": "Loulé Concelho Global",
       "id": "louleconcelhoglobal-faf071",
       "locationSet": {
-        "include": ["pt-08.geojson"]
+        "include": [
+          "pt-08.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4367,9 +5271,13 @@
       "displayName": "LSW Energie",
       "id": "lswenergie-d9ec6c",
       "locationSet": {
-        "include": ["de-ni.geojson"]
+        "include": [
+          "de-ni.geojson"
+        ]
       },
-      "matchNames": ["lsw"],
+      "matchNames": [
+        "lsw"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "LSW Energie",
@@ -4379,7 +5287,11 @@
     {
       "displayName": "LUMI'IN",
       "id": "lumiin-f6553b",
-      "locationSet": {"include": ["fr"]},
+      "locationSet": {
+        "include": [
+          "fr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "LUMI'IN"
@@ -4388,7 +5300,11 @@
     {
       "displayName": "Luminus",
       "id": "luminus-87ebf4",
-      "locationSet": {"include": ["be"]},
+      "locationSet": {
+        "include": [
+          "be"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Luminus",
@@ -4398,7 +5314,11 @@
     {
       "displayName": "Lüneparken",
       "id": "luneparken-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Lüneparken"
@@ -4407,7 +5327,11 @@
     {
       "displayName": "Maingau Energie",
       "id": "maingauenergie-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Maingau Energie",
@@ -4417,7 +5341,11 @@
     {
       "displayName": "Mainova",
       "id": "mainova-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Mainova",
@@ -4428,7 +5356,9 @@
       "displayName": "Mainzer Stadtwerke",
       "id": "mainzerstadtwerke-bb1d73",
       "locationSet": {
-        "include": ["de-rp.geojson"]
+        "include": [
+          "de-rp.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4440,7 +5370,9 @@
       "displayName": "Mairie de Paris",
       "id": "mairiedeparis-37370f",
       "locationSet": {
-        "include": ["fr-idf.geojson"]
+        "include": [
+          "fr-idf.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4451,27 +5383,24 @@
     {
       "displayName": "Maksu Services",
       "id": "maksuservices-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Maksu Services"
       }
     },
     {
-      "displayName": "Mälarenergi",
-      "id": "malarenergi-c9e89f",
-      "locationSet": {"include": ["se"]},
-      "matchNames": ["mälarenergi ab"],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Mälarenergi",
-        "operator:wikidata": "Q6949955"
-      }
-    },
-    {
       "displayName": "Mark-E",
       "id": "marke-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Mark-E",
@@ -4481,7 +5410,11 @@
     {
       "displayName": "MaxSolar",
       "id": "maxsolar-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "MaxSolar",
@@ -4491,7 +5424,11 @@
     {
       "displayName": "McDonald's",
       "id": "mcdonalds-c22d3a",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "McDonald's",
@@ -4501,7 +5438,11 @@
     {
       "displayName": "Mennekes",
       "id": "mennekes-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Mennekes",
@@ -4511,7 +5452,12 @@
     {
       "displayName": "Mercadona",
       "id": "mercadona-3948da",
-      "locationSet": {"include": ["es", "pt"]},
+      "locationSet": {
+        "include": [
+          "es",
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Mercadona",
@@ -4519,21 +5465,12 @@
       }
     },
     {
-      "displayName": "Mercedes-Benz",
-      "id": "mercedesbenz-c22d3a",
-      "locationSet": {"include": ["001"]},
-      "matchNames": ["mercedes"],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Mercedes-Benz",
-        "operator:wikidata": "Q36008"
-      }
-    },
-    {
       "displayName": "Merkur",
       "id": "merkur-3fe9f3",
       "locationSet": {
-        "include": ["dk-84.geojson"]
+        "include": [
+          "dk-84.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4543,7 +5480,11 @@
     {
       "displayName": "METRO Cash & Carry",
       "id": "metrocashandcarry-e68869",
-      "locationSet": {"include": ["gr"]},
+      "locationSet": {
+        "include": [
+          "gr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "METRO Cash & Carry",
@@ -4554,7 +5495,9 @@
       "displayName": "Michigan State University",
       "id": "michiganstateuniversity-258d0b",
       "locationSet": {
-        "include": ["us-mi.geojson"]
+        "include": [
+          "us-mi.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4565,7 +5508,11 @@
     {
       "displayName": "Migrol",
       "id": "migrol-086737",
-      "locationSet": {"include": ["ch"]},
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Migrol",
@@ -4575,7 +5522,11 @@
     {
       "displayName": "Mobi.E",
       "id": "mobie-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Mobi.E",
@@ -4585,29 +5536,27 @@
     {
       "displayName": "Mobiletric",
       "id": "mobiletric-a1285d",
-      "locationSet": {"include": ["pt"]},
-      "matchNames": ["mobilectric"],
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
+      "matchNames": [
+        "mobilectric"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Mobiletric"
       }
     },
     {
-      "displayName": "Mobiliti",
-      "id": "mobiliti-27e906",
-      "locationSet": {"include": ["hu"]},
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "Mobiliti",
-        "name": "Mobiliti",
-        "operator": "Mobiliti",
-        "operator:wikidata": "Q126734853"
-      }
-    },
-    {
       "displayName": "MobilityPlus",
       "id": "mobilityplus-87ebf4",
-      "locationSet": {"include": ["be"]},
+      "locationSet": {
+        "include": [
+          "be"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "MobilityPlus",
@@ -4617,7 +5566,11 @@
     {
       "displayName": "MobiSmart",
       "id": "mobismart-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "MobiSmart"
@@ -4627,7 +5580,9 @@
       "displayName": "Mobive",
       "id": "mobive-c4b7fc",
       "locationSet": {
-        "include": ["fr-naq.geojson"]
+        "include": [
+          "fr-naq.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4638,7 +5593,11 @@
     {
       "displayName": "Modulo",
       "id": "modulo-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Modulo",
@@ -4649,7 +5608,12 @@
       "displayName": "Monta",
       "id": "monta-47be25",
       "locationSet": {
-        "include": ["de", "gb", "ie", "se"]
+        "include": [
+          "de",
+          "gb",
+          "ie",
+          "se"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4659,7 +5623,11 @@
     {
       "displayName": "Moon",
       "id": "moon-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Moon"
@@ -4668,7 +5636,11 @@
     {
       "displayName": "Morbihan énergies",
       "id": "morbihanenergies-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Morbihan énergies",
@@ -4679,7 +5651,9 @@
       "displayName": "Mota",
       "id": "mota-5e108d",
       "locationSet": {
-        "include": ["fr-pac.geojson"]
+        "include": [
+          "fr-pac.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4689,7 +5663,11 @@
     {
       "displayName": "Mota Engil II",
       "id": "motaengilii-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Mota Engil II"
@@ -4698,7 +5676,11 @@
     {
       "displayName": "Motor Fuel Group",
       "id": "motorfuelgroup-0793ce",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Motor Fuel Group",
@@ -4710,7 +5692,9 @@
       "displayName": "Mouv Élec Var",
       "id": "mouvelecvar-5e108d",
       "locationSet": {
-        "include": ["fr-pac.geojson"]
+        "include": [
+          "fr-pac.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4720,7 +5704,11 @@
     {
       "displayName": "MOVE",
       "id": "move-086737",
-      "locationSet": {"include": ["ch"]},
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "MOVE",
@@ -4731,9 +5719,14 @@
       "displayName": "MVV Energie",
       "id": "mvvenergie-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
-      "matchNames": ["mvv", "mvv energie ag"],
+      "matchNames": [
+        "mvv",
+        "mvv energie ag"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "MVV Energie",
@@ -4743,7 +5736,11 @@
     {
       "displayName": "My Market",
       "id": "mymarket-e68869",
-      "locationSet": {"include": ["gr"]},
+      "locationSet": {
+        "include": [
+          "gr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "My Market",
@@ -4751,9 +5748,30 @@
       }
     },
     {
+      "displayName": "Mälarenergi",
+      "id": "malarenergi-c9e89f",
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
+      "matchNames": [
+        "mälarenergi ab"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Mälarenergi",
+        "operator:wikidata": "Q6949955"
+      }
+    },
+    {
       "displayName": "N-ERGIE",
       "id": "nergie-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "matchNames": [
         "n-ergie ag",
         "n-ergie aktiengesellschaft"
@@ -4767,7 +5785,11 @@
     {
       "displayName": "N1",
       "id": "n1-8fcd5a",
-      "locationSet": {"include": ["is"]},
+      "locationSet": {
+        "include": [
+          "is"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "N1",
@@ -4777,8 +5799,14 @@
     {
       "displayName": "NabiBajk",
       "id": "nabibajk-b23832",
-      "locationSet": {"include": ["sk"]},
-      "matchNames": ["nabibajk.sk"],
+      "locationSet": {
+        "include": [
+          "sk"
+        ]
+      },
+      "matchNames": [
+        "nabibajk.sk"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "NabiBajk",
@@ -4789,7 +5817,10 @@
       "displayName": "NaturEnergie",
       "id": "naturenergie-6cf9a8",
       "locationSet": {
-        "include": ["ch-ag.geojson", "de"]
+        "include": [
+          "ch-ag.geojson",
+          "de"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4800,7 +5831,11 @@
     {
       "displayName": "Neogy",
       "id": "neogy-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Neogy",
@@ -4810,7 +5845,11 @@
     {
       "displayName": "Neuwoges",
       "id": "neuwoges-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Neuwoges"
@@ -4819,7 +5858,11 @@
     {
       "displayName": "NEW",
       "id": "new-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "NEW",
@@ -4830,7 +5873,9 @@
       "displayName": "next step mobility GmbH",
       "id": "nextstepmobilitygmbh-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4840,7 +5885,11 @@
     {
       "displayName": "nextgreen",
       "id": "nextgreen-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "nextgreen"
@@ -4850,8 +5899,12 @@
       "displayName": "Nissan",
       "id": "nissan-28ff7e",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4862,7 +5915,11 @@
     {
       "displayName": "NKM Mobilitás Kft.",
       "id": "nkmmobilitaskft-27e906",
-      "locationSet": {"include": ["hu"]},
+      "locationSet": {
+        "include": [
+          "hu"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "NKM Mobilitás Kft."
@@ -4871,7 +5928,11 @@
     {
       "displayName": "Norlys",
       "id": "norlys-7d9e8e",
-      "locationSet": {"include": ["dk"]},
+      "locationSet": {
+        "include": [
+          "dk"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Norlys",
@@ -4881,7 +5942,11 @@
     {
       "displayName": "NOXO.",
       "id": "noxo-392011",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": {
+        "include": [
+          "pl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "NOXO.",
@@ -4891,7 +5956,11 @@
     {
       "displayName": "NRG Energy",
       "id": "nrgenergy-994ed4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "NRG Energy",
@@ -4901,7 +5970,11 @@
     {
       "displayName": "NRMA",
       "id": "nrma-943805",
-      "locationSet": {"include": ["au"]},
+      "locationSet": {
+        "include": [
+          "au"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "NRMA",
@@ -4911,7 +5984,11 @@
     {
       "displayName": "NUON",
       "id": "nuon-fa6152",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "NUON",
@@ -4919,20 +5996,12 @@
       }
     },
     {
-      "displayName": "ÖAMTC",
-      "id": "oamtc-3f60da",
-      "locationSet": {"include": ["at"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "ÖAMTC",
-        "operator:wikidata": "Q306057"
-      }
-    },
-    {
       "displayName": "OIKEN",
       "id": "oiken-d0faa5",
       "locationSet": {
-        "include": ["ch-vs.geojson"]
+        "include": [
+          "ch-vs.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -4942,7 +6011,11 @@
     {
       "displayName": "OK",
       "id": "ok-7d9e8e",
-      "locationSet": {"include": ["dk"]},
+      "locationSet": {
+        "include": [
+          "dk"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "OK",
@@ -4952,7 +6025,11 @@
     {
       "displayName": "OMV eMotion",
       "id": "omv-c22d3a",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "OMV",
@@ -4962,7 +6039,11 @@
     {
       "displayName": "OOO \"TOK BOR\"",
       "id": "oootokbor-5b32c5",
-      "locationSet": {"include": ["uz"]},
+      "locationSet": {
+        "include": [
+          "uz"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "OOO \"TOK BOR\""
@@ -4971,7 +6052,11 @@
     {
       "displayName": "Opcharge",
       "id": "opcharge-fa6152",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Opcharge",
@@ -4981,7 +6066,11 @@
     {
       "displayName": "Oppegård kommune",
       "id": "oppegardkommune-476d58",
-      "locationSet": {"include": ["no"]},
+      "locationSet": {
+        "include": [
+          "no"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Oppegård kommune",
@@ -4991,7 +6080,11 @@
     {
       "displayName": "Orion",
       "id": "orion-9850e1",
-      "locationSet": {"include": ["nz"]},
+      "locationSet": {
+        "include": [
+          "nz"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Orion",
@@ -5001,7 +6094,11 @@
     {
       "displayName": "Orka náttúrunnar",
       "id": "orkanatturunnar-8fcd5a",
-      "locationSet": {"include": ["is"]},
+      "locationSet": {
+        "include": [
+          "is"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Orka náttúrunnar",
@@ -5011,7 +6108,11 @@
     {
       "displayName": "Orkubú Vestfjarða",
       "id": "orkubuvestfjardha-8fcd5a",
-      "locationSet": {"include": ["is"]},
+      "locationSet": {
+        "include": [
+          "is"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Orkubú Vestfjarða",
@@ -5021,7 +6122,11 @@
     {
       "displayName": "Orlen",
       "id": "orlen-392011",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": {
+        "include": [
+          "pl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Orlen",
@@ -5031,7 +6136,11 @@
     {
       "displayName": "Oskarshamn Energi AB",
       "id": "oskarshamnenergiab-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Oskarshamn Energi AB"
@@ -5040,7 +6149,11 @@
     {
       "displayName": "Oslo kommune",
       "id": "oslokommune-476d58",
-      "locationSet": {"include": ["no"]},
+      "locationSet": {
+        "include": [
+          "no"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Oslo kommune",
@@ -5051,7 +6164,9 @@
       "displayName": "Osnabrücker Parkstätten-Betriebsgesellschaft mbH",
       "id": "osnabruckerparkstattenbetriebsgesellschaftmbh-d9ec6c",
       "locationSet": {
-        "include": ["de-ni.geojson"]
+        "include": [
+          "de-ni.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5059,19 +6174,13 @@
       }
     },
     {
-      "displayName": "Osprey",
-      "id": "osprey-0793ce",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Osprey",
-        "operator:wikidata": "Q117706577"
-      }
-    },
-    {
       "displayName": "Ouest Charge",
       "id": "ouestcharge-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Ouest Charge"
@@ -5080,7 +6189,11 @@
     {
       "displayName": "OVAG",
       "id": "ovag-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "OVAG",
@@ -5090,7 +6203,11 @@
     {
       "displayName": "Paris-Saclay Innovation Playground",
       "id": "parissaclayinnovationplayground-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Paris-Saclay Innovation Playground"
@@ -5099,8 +6216,14 @@
     {
       "displayName": "Park&Charge",
       "id": "parkandcharge-fa6152",
-      "locationSet": {"include": ["nl"]},
-      "matchNames": ["park n charge"],
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
+      "matchNames": [
+        "park n charge"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Park&Charge",
@@ -5110,7 +6233,11 @@
     {
       "displayName": "Penny Market",
       "id": "pennymarket-27e906",
-      "locationSet": {"include": ["hu"]},
+      "locationSet": {
+        "include": [
+          "hu"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Penny Market",
@@ -5120,7 +6247,11 @@
     {
       "displayName": "Perusahaan Listrik Negara",
       "id": "perusahaanlistriknegara-34ae8c",
-      "locationSet": {"include": ["id"]},
+      "locationSet": {
+        "include": [
+          "id"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Perusahaan Listrik Negara",
@@ -5131,7 +6262,12 @@
     {
       "displayName": "Petrol",
       "id": "petrol-6b6292",
-      "locationSet": {"include": ["hr", "si"]},
+      "locationSet": {
+        "include": [
+          "hr",
+          "si"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Petrol",
@@ -5141,8 +6277,14 @@
     {
       "displayName": "Pfalzwerke",
       "id": "pfalzwerke-1299a8",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["pfalzwerke ag"],
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
+      "matchNames": [
+        "pfalzwerke ag"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Pfalzwerke",
@@ -5152,7 +6294,11 @@
     {
       "displayName": "PGE Nowa Energia",
       "id": "pgenowaenergia-392011",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": {
+        "include": [
+          "pl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "PGE Nowa Energia"
@@ -5161,7 +6307,12 @@
     {
       "displayName": "PitPoint",
       "id": "pitpoint-b2225d",
-      "locationSet": {"include": ["be", "nl"]},
+      "locationSet": {
+        "include": [
+          "be",
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "PitPoint",
@@ -5171,7 +6322,11 @@
     {
       "displayName": "Plenitude",
       "id": "plenitude-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Plenitude",
@@ -5181,7 +6336,11 @@
     {
       "displayName": "Plug'n Roll",
       "id": "plugnroll-086737",
-      "locationSet": {"include": ["ch"]},
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Plug'n Roll",
@@ -5191,7 +6350,11 @@
     {
       "displayName": "Plus de Bornes",
       "id": "plusdebornes-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Plus de Bornes"
@@ -5200,39 +6363,24 @@
     {
       "displayName": "PNB",
       "id": "pnb-fa6152",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "PNB"
       }
     },
     {
-      "displayName": "Pod Point",
-      "id": "podpoint-0793ce",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Pod Point",
-        "operator:wikidata": "Q42888154"
-      }
-    },
-    {
-      "displayName": "Porsche",
-      "id": "porsche-28ff7e",
-      "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Porsche",
-        "operator:wikidata": "Q40993"
-      }
-    },
-    {
       "displayName": "Power Dot France",
       "id": "powerdotfrance-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Power Dot France"
@@ -5241,7 +6389,11 @@
     {
       "displayName": "Power EV",
       "id": "powerev-392011",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": {
+        "include": [
+          "pl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Power EV"
@@ -5250,8 +6402,14 @@
     {
       "displayName": "Pradella Sistemi",
       "id": "pradellasistemi-2c5517",
-      "locationSet": {"include": ["it"]},
-      "matchNames": ["pradella sistemi srl"],
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
+      "matchNames": [
+        "pradella sistemi srl"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Pradella Sistemi"
@@ -5260,8 +6418,14 @@
     {
       "displayName": "PRE",
       "id": "pre-f67a50",
-      "locationSet": {"include": ["cz"]},
-      "matchNames": ["pražská energetika"],
+      "locationSet": {
+        "include": [
+          "cz"
+        ]
+      },
+      "matchNames": [
+        "pražská energetika"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "PRE",
@@ -5271,7 +6435,11 @@
     {
       "displayName": "Prio.E",
       "id": "prioe-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Prio.E"
@@ -5280,7 +6448,11 @@
     {
       "displayName": "Protergia",
       "id": "protergia-e68869",
-      "locationSet": {"include": ["gr"]},
+      "locationSet": {
+        "include": [
+          "gr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Protergia",
@@ -5290,7 +6462,11 @@
     {
       "displayName": "Q-Park",
       "id": "qpark-7f623e",
-      "locationSet": {"include": ["150"]},
+      "locationSet": {
+        "include": [
+          "150"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Q-Park",
@@ -5318,7 +6494,11 @@
     {
       "displayName": "Qbuzz",
       "id": "qbuzz-fa6152",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Qbuzz",
@@ -5328,7 +6508,11 @@
     {
       "displayName": "Qelo",
       "id": "qelo-5bea2c",
-      "locationSet": {"include": ["hr"]},
+      "locationSet": {
+        "include": [
+          "hr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Qelo"
@@ -5338,7 +6522,9 @@
       "displayName": "Queensland Electric Super Highway",
       "id": "yurika-830192",
       "locationSet": {
-        "include": ["au-qld.geojson"]
+        "include": [
+          "au-qld.geojson"
+        ]
       },
       "matchNames": [
         "queensland electric super highway"
@@ -5352,8 +6538,15 @@
     {
       "displayName": "Qwello",
       "id": "qwello-381a82",
-      "locationSet": {"include": ["de", "se"]},
-      "matchNames": ["qwello gmbh"],
+      "locationSet": {
+        "include": [
+          "de",
+          "se"
+        ]
+      },
+      "matchNames": [
+        "qwello gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Qwello",
@@ -5363,7 +6556,11 @@
     {
       "displayName": "R3",
       "id": "r3-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "R3"
@@ -5385,23 +6582,17 @@
       }
     },
     {
-      "displayName": "Red E",
-      "id": "rede-994ed4",
-      "locationSet": {"include": ["us"]},
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "Red E",
-        "brand:wikidata": "Q131416886",
-        "name": "Red E",
-        "operator": "Red E",
-        "operator:wikidata": "Q131416886"
-      }
-    },
-    {
       "displayName": "reev",
       "id": "reev-1299a8",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["reev gmbh", "reev.org"],
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
+      "matchNames": [
+        "reev gmbh",
+        "reev.org"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "reev"
@@ -5410,7 +6601,11 @@
     {
       "displayName": "Reload Solution",
       "id": "reloadsolution-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Reload Solution"
@@ -5420,8 +6615,12 @@
       "displayName": "Renault",
       "id": "renault-28ff7e",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5432,7 +6631,11 @@
     {
       "displayName": "Renovatio e-charge",
       "id": "renovatioecharge-806f62",
-      "locationSet": {"include": ["ro"]},
+      "locationSet": {
+        "include": [
+          "ro"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Renovatio e-charge",
@@ -5442,8 +6645,15 @@
     {
       "displayName": "Repower",
       "id": "repower-c58b31",
-      "locationSet": {"include": ["ch", "it"]},
-      "matchNames": ["repower ag"],
+      "locationSet": {
+        "include": [
+          "ch",
+          "it"
+        ]
+      },
+      "matchNames": [
+        "repower ag"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Repower",
@@ -5453,7 +6663,12 @@
     {
       "displayName": "Repsol",
       "id": "repsol-3948da",
-      "locationSet": {"include": ["es", "pt"]},
+      "locationSet": {
+        "include": [
+          "es",
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Repsol",
@@ -5461,19 +6676,13 @@
       }
     },
     {
-      "displayName": "Révéo",
-      "id": "reveo-170e94",
-      "locationSet": {"include": ["fx"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Révéo",
-        "operator:wikidata": "Q125960237"
-      }
-    },
-    {
       "displayName": "Revnet",
       "id": "revnet-392011",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": {
+        "include": [
+          "pl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Revnet"
@@ -5482,7 +6691,11 @@
     {
       "displayName": "Rewag",
       "id": "rewag-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "matchNames": [
         "regensburger energie- und wasserversorgung ag & co kg"
       ],
@@ -5495,7 +6708,11 @@
     {
       "displayName": "Rewe",
       "id": "rewe-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Rewe",
@@ -5505,7 +6722,11 @@
     {
       "displayName": "RheinEnergie",
       "id": "rheinenergie-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "RheinEnergie",
@@ -5516,7 +6737,9 @@
       "displayName": "RhönEnergie Fulda",
       "id": "rhonenergiefulda-43ff7e",
       "locationSet": {
-        "include": ["de-he.geojson"]
+        "include": [
+          "de-he.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5527,7 +6750,11 @@
     {
       "displayName": "Ringeriks-kraft AS",
       "id": "ringerikskraftas-476d58",
-      "locationSet": {"include": ["no"]},
+      "locationSet": {
+        "include": [
+          "no"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Ringeriks-kraft AS",
@@ -5537,7 +6764,11 @@
     {
       "displayName": "Robert Bosch GmbH",
       "id": "robertboschgmbh-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Robert Bosch GmbH",
@@ -5547,7 +6778,11 @@
     {
       "displayName": "Roche",
       "id": "roche-c22d3a",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Roche",
@@ -5557,7 +6792,11 @@
     {
       "displayName": "Rotterdam Elektrisch",
       "id": "rotterdamelektrisch-fa6152",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Rotterdam Elektrisch"
@@ -5567,7 +6806,9 @@
       "displayName": "RSE",
       "id": "rse-634961",
       "locationSet": {
-        "include": ["fr-ara.geojson"]
+        "include": [
+          "fr-ara.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5577,16 +6818,38 @@
     {
       "displayName": "RWE-Effizienz",
       "id": "rweeffizienz-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "RWE-Effizienz"
       }
     },
     {
+      "displayName": "Révéo",
+      "id": "reveo-170e94",
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Révéo",
+        "operator:wikidata": "Q125960237"
+      }
+    },
+    {
       "displayName": "S.T.P.T.",
       "id": "stpt-806f62",
-      "locationSet": {"include": ["ro"]},
+      "locationSet": {
+        "include": [
+          "ro"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "S.T.P.T.",
@@ -5597,9 +6860,13 @@
       "displayName": "SachsenEnergie",
       "id": "sachsenenergie-b8794d",
       "locationSet": {
-        "include": ["de-sn.geojson"]
+        "include": [
+          "de-sn.geojson"
+        ]
       },
-      "matchNames": ["sachsenenergie ag"],
+      "matchNames": [
+        "sachsenenergie ag"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "SachsenEnergie",
@@ -5609,7 +6876,11 @@
     {
       "displayName": "SAK",
       "id": "sak-086737",
-      "locationSet": {"include": ["ch"]},
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SAK",
@@ -5634,7 +6905,11 @@
     {
       "displayName": "Samenwerkende Gemeenten Zuid-Holland",
       "id": "samenwerkendegemeentenzuidholland-fa6152",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Samenwerkende Gemeenten Zuid-Holland"
@@ -5643,7 +6918,11 @@
     {
       "displayName": "Sandviken Energi AB",
       "id": "sandvikenenergiab-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Sandviken Energi AB"
@@ -5653,7 +6932,9 @@
       "displayName": "sas e-motum",
       "id": "sasemotum-34216a",
       "locationSet": {
-        "include": ["fr-20r.geojson"]
+        "include": [
+          "fr-20r.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5664,8 +6945,12 @@
       "displayName": "Schneider Electric",
       "id": "schneiderelectric-28ff7e",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5676,7 +6961,11 @@
     {
       "displayName": "SDE04",
       "id": "sde04-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SDE04"
@@ -5685,7 +6974,11 @@
     {
       "displayName": "SDE07",
       "id": "sde07-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SDE07"
@@ -5694,7 +6987,11 @@
     {
       "displayName": "SDE35",
       "id": "sde35-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SDE35"
@@ -5704,7 +7001,9 @@
       "displayName": "SDEC Énergie",
       "id": "sdecenergie-172d11",
       "locationSet": {
-        "include": ["fr-nor.geojson"]
+        "include": [
+          "fr-nor.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5715,7 +7014,11 @@
     {
       "displayName": "SDED",
       "id": "sded-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SDED"
@@ -5724,7 +7027,11 @@
     {
       "displayName": "SDEI36",
       "id": "sdei36-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SDEI36"
@@ -5733,7 +7040,11 @@
     {
       "displayName": "SDEM50",
       "id": "sdem50-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SDEM50"
@@ -5742,7 +7053,11 @@
     {
       "displayName": "SDEV",
       "id": "sdev-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SDEV"
@@ -5751,7 +7066,11 @@
     {
       "displayName": "SDEY",
       "id": "sdey-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SDEY"
@@ -5760,7 +7079,11 @@
     {
       "displayName": "SEDI",
       "id": "sedi-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SEDI"
@@ -5769,7 +7092,11 @@
     {
       "displayName": "SEGMA",
       "id": "segma-7cc336",
-      "locationSet": {"include": ["pt-20"]},
+      "locationSet": {
+        "include": [
+          "pt-20"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SEGMA"
@@ -5778,7 +7105,11 @@
     {
       "displayName": "SemaConnect",
       "id": "semaconnect-994ed4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SemaConnect",
@@ -5786,20 +7117,13 @@
       }
     },
     {
-      "displayName": "Séolis",
-      "id": "seolis-c4b7fc",
-      "locationSet": {
-        "include": ["fr-naq.geojson"]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Séolis"
-      }
-    },
-    {
       "displayName": "SERVICE plus GmbH",
       "id": "serviceplusgmbh-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SERVICE plus GmbH"
@@ -5808,7 +7132,11 @@
     {
       "displayName": "SEY 78",
       "id": "sey78-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SEY 78"
@@ -5817,7 +7145,11 @@
     {
       "displayName": "SEYMABORNE",
       "id": "seymaborne-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SEYMABORNE"
@@ -5826,7 +7158,11 @@
     {
       "displayName": "SGA Mobility",
       "id": "sgamobility-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SGA Mobility"
@@ -5835,7 +7171,11 @@
     {
       "displayName": "SHARZ",
       "id": "sharz-f274f9",
-      "locationSet": {"include": ["tr"]},
+      "locationSet": {
+        "include": [
+          "tr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SHARZ"
@@ -5845,8 +7185,12 @@
       "displayName": "Shell",
       "id": "shell-28ff7e",
       "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
+        "include": [
+          "001"
+        ],
+        "exclude": [
+          "no"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5857,7 +7201,11 @@
     {
       "displayName": "Shell Recharge Solutions",
       "id": "shellrechargesolutions-c22d3a",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
       "matchNames": [
         "greenlots",
         "newmotion",
@@ -5873,7 +7221,11 @@
     {
       "displayName": "SIEEEN",
       "id": "sieeen-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SIEEEN",
@@ -5884,7 +7236,9 @@
       "displayName": "SIEGE 27",
       "id": "siege27-172d11",
       "locationSet": {
-        "include": ["fr-nor.geojson"]
+        "include": [
+          "fr-nor.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5895,7 +7249,9 @@
       "displayName": "SIEL42",
       "id": "siel42-634961",
       "locationSet": {
-        "include": ["fr-ara.geojson"]
+        "include": [
+          "fr-ara.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -5906,7 +7262,11 @@
     {
       "displayName": "Siemens SRE",
       "id": "siemenssre-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Siemens SRE"
@@ -5915,7 +7275,11 @@
     {
       "displayName": "SIEML",
       "id": "sieml-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SIEML",
@@ -5925,7 +7289,11 @@
     {
       "displayName": "Sigeif",
       "id": "sigeif-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Sigeif",
@@ -5935,7 +7303,11 @@
     {
       "displayName": "SIPLEC",
       "id": "siplec-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SIPLEC",
@@ -5945,7 +7317,11 @@
     {
       "displayName": "SMATRICS",
       "id": "smatrics-3f60da",
-      "locationSet": {"include": ["at"]},
+      "locationSet": {
+        "include": [
+          "at"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SMATRICS",
@@ -5955,7 +7331,12 @@
     {
       "displayName": "Smoov",
       "id": "smoov-b2225d",
-      "locationSet": {"include": ["be", "nl"]},
+      "locationSet": {
+        "include": [
+          "be",
+          "nl"
+        ]
+      },
       "matchNames": [
         "smoov allego",
         "smoov by allego"
@@ -5968,8 +7349,14 @@
     {
       "displayName": "Sodetrel",
       "id": "sodetrel-170e94",
-      "locationSet": {"include": ["fx"]},
-      "matchNames": ["sodetrel mobilité"],
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
+      "matchNames": [
+        "sodetrel mobilité"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Sodetrel"
@@ -5978,7 +7365,11 @@
     {
       "displayName": "SODO",
       "id": "sodo-64fbf7",
-      "locationSet": {"include": ["si"]},
+      "locationSet": {
+        "include": [
+          "si"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SODO"
@@ -6001,7 +7392,11 @@
     {
       "displayName": "Sonae",
       "id": "sonae-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Sonae"
@@ -6011,7 +7406,9 @@
       "displayName": "Sorégies",
       "id": "soregies-c4b7fc",
       "locationSet": {
-        "include": ["fr-naq.geojson"]
+        "include": [
+          "fr-naq.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6020,25 +7417,12 @@
       }
     },
     {
-      "displayName": "Source London",
-      "id": "sourcelondon-489d95",
-      "locationSet": {
-        "include": ["gb-lon.geojson"]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "Source London",
-        "brand:wikidata": "Q7565133",
-        "name": "Source London",
-        "operator": "Source London",
-        "operator:wikidata": "Q7565133"
-      }
-    },
-    {
       "displayName": "South Lakeland District Council",
       "id": "southlakelanddistrictcouncil-16207f",
       "locationSet": {
-        "include": ["gb-north-west.geojson"]
+        "include": [
+          "gb-north-west.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6049,7 +7433,11 @@
     {
       "displayName": "Spar",
       "id": "spar-c22d3a",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Spar",
@@ -6059,7 +7447,11 @@
     {
       "displayName": "SPBR1",
       "id": "spbr1-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SPBR1"
@@ -6068,7 +7460,11 @@
     {
       "displayName": "Sperto",
       "id": "sperto-7d9e8e",
-      "locationSet": {"include": ["dk"]},
+      "locationSet": {
+        "include": [
+          "dk"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Sperto"
@@ -6077,7 +7473,11 @@
     {
       "displayName": "Spie",
       "id": "spie-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Spie"
@@ -6086,7 +7486,11 @@
     {
       "displayName": "SPIE CityNetworks",
       "id": "spiecitynetworks-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SPIE CityNetworks"
@@ -6095,7 +7499,11 @@
     {
       "displayName": "Spirii",
       "id": "spirii-7d9e8e",
-      "locationSet": {"include": ["dk"]},
+      "locationSet": {
+        "include": [
+          "dk"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Spirii",
@@ -6106,7 +7514,9 @@
       "displayName": "Stadt Lorch",
       "id": "stadtlorch-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6115,23 +7525,12 @@
       }
     },
     {
-      "displayName": "Städtische Werke Magdeburg",
-      "id": "stadtischewerkemagdeburg-eaf1ad",
-      "locationSet": {
-        "include": [[11.63, 52.13, 50]]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Städtische Werke Magdeburg",
-        "operator:short": "SWM",
-        "operator:wikidata": "Q2359984"
-      }
-    },
-    {
       "displayName": "Stadtwerk am See",
       "id": "stadtwerkamsee-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6144,9 +7543,13 @@
       "displayName": "Stadtwerke Ahlen",
       "id": "stadtwerkeahlen-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
-      "matchNames": ["stadtwerke ahlen gmbh"],
+      "matchNames": [
+        "stadtwerke ahlen gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Ahlen",
@@ -6157,7 +7560,9 @@
       "displayName": "Stadtwerke Augsburg",
       "id": "stadtwerkeaugsburg-259ab2",
       "locationSet": {
-        "include": ["de-by.geojson"]
+        "include": [
+          "de-by.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6169,7 +7574,9 @@
       "displayName": "Stadtwerke Bad Aibling",
       "id": "stadtwerkebadaibling-259ab2",
       "locationSet": {
-        "include": ["de-by.geojson"]
+        "include": [
+          "de-by.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6181,7 +7588,9 @@
       "displayName": "Stadtwerke Bad Homburg",
       "id": "stadtwerkebadhomburg-43ff7e",
       "locationSet": {
-        "include": ["de-he.geojson"]
+        "include": [
+          "de-he.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6193,7 +7602,9 @@
       "displayName": "Stadtwerke Baden-Baden",
       "id": "stadtwerkebadenbaden-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6205,7 +7616,9 @@
       "displayName": "Stadtwerke Bayreuth Energie und Wasser GmbH",
       "id": "stadtwerkebayreuthenergieundwassergmbh-259ab2",
       "locationSet": {
-        "include": ["de-by.geojson"]
+        "include": [
+          "de-by.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6216,7 +7629,9 @@
       "displayName": "Stadtwerke Bielefeld",
       "id": "stadtwerkebielefeld-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6228,7 +7643,9 @@
       "displayName": "Stadtwerke Bochum",
       "id": "stadtwerkebochum-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6240,7 +7657,9 @@
       "displayName": "Stadtwerke Bruchsal",
       "id": "stadtwerkebruchsal-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6252,7 +7671,9 @@
       "displayName": "Stadtwerke Brunsbüttel",
       "id": "stadtwerkebrunsbuttel-cf3cf5",
       "locationSet": {
-        "include": ["de-sh.geojson"]
+        "include": [
+          "de-sh.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6264,7 +7685,9 @@
       "displayName": "Stadtwerke Dachau",
       "id": "stadtwerkedachau-259ab2",
       "locationSet": {
-        "include": ["de-by.geojson"]
+        "include": [
+          "de-by.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6276,7 +7699,9 @@
       "displayName": "Stadtwerke Dessau",
       "id": "stadtwerkedessau-b7b244",
       "locationSet": {
-        "include": ["de-st.geojson"]
+        "include": [
+          "de-st.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6288,7 +7713,9 @@
       "displayName": "Stadtwerke Duisburg",
       "id": "stadtwerkeduisburg-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6300,7 +7727,9 @@
       "displayName": "Stadtwerke Düsseldorf",
       "id": "stadtwerkedusseldorf-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6312,7 +7741,9 @@
       "displayName": "Stadtwerke Elmshorn",
       "id": "stadtwerkeelmshorn-cf3cf5",
       "locationSet": {
-        "include": ["de-sh.geojson"]
+        "include": [
+          "de-sh.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6324,7 +7755,9 @@
       "displayName": "Stadtwerke Energie Jena-Pößneck GmbH",
       "id": "stadtwerkeenergiejenapossneckgmbh-8c6e73",
       "locationSet": {
-        "include": ["de-th.geojson"]
+        "include": [
+          "de-th.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6336,7 +7769,9 @@
       "displayName": "Stadtwerke Erfurt",
       "id": "stadtwerkeerfurt-8c6e73",
       "locationSet": {
-        "include": ["de-th.geojson"]
+        "include": [
+          "de-th.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6349,7 +7784,9 @@
       "displayName": "Stadtwerke EVB Huntetal GmbH",
       "id": "stadtwerkeevbhuntetalgmbh-d9ec6c",
       "locationSet": {
-        "include": ["de-ni.geojson"]
+        "include": [
+          "de-ni.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6361,7 +7798,9 @@
       "displayName": "Stadtwerke Fürstenfeldbruck",
       "id": "stadtwerkefurstenfeldbruck-259ab2",
       "locationSet": {
-        "include": ["de-by.geojson"]
+        "include": [
+          "de-by.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6373,7 +7812,9 @@
       "displayName": "Stadtwerke Gießen",
       "id": "stadtwerkegiessen-43ff7e",
       "locationSet": {
-        "include": ["de-he.geojson"]
+        "include": [
+          "de-he.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6386,7 +7827,9 @@
       "displayName": "Stadtwerke Goch GmbH",
       "id": "stadtwerkegochgmbh-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6395,10 +7838,29 @@
       }
     },
     {
+      "displayName": "Stadtwerke Gronau",
+      "id": "stadtwerkegronau-fcc3c2",
+      "locationSet": {
+        "include": [
+          "de-nw.geojson"
+        ]
+      },
+      "matchNames": [
+        "stadtwerke gronau gmbh"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Stadtwerke Gronau",
+        "operator:wikidata": "Q113464830"
+      }
+    },
+    {
       "displayName": "Stadtwerke Göttingen",
       "id": "stadtwerkegottingen-d9ec6c",
       "locationSet": {
-        "include": ["de-ni.geojson"]
+        "include": [
+          "de-ni.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6407,23 +7869,12 @@
       }
     },
     {
-      "displayName": "Stadtwerke Gronau",
-      "id": "stadtwerkegronau-fcc3c2",
-      "locationSet": {
-        "include": ["de-nw.geojson"]
-      },
-      "matchNames": ["stadtwerke gronau gmbh"],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Stadtwerke Gronau",
-        "operator:wikidata": "Q113464830"
-      }
-    },
-    {
       "displayName": "Stadtwerke Hamm",
       "id": "stadtwerkehamm-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6435,7 +7886,9 @@
       "displayName": "Stadtwerke Heide",
       "id": "stadtwerkeheide-cf3cf5",
       "locationSet": {
-        "include": ["de-sh.geojson"]
+        "include": [
+          "de-sh.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6447,7 +7900,9 @@
       "displayName": "Stadtwerke Heidelberg",
       "id": "stadtwerkeheidelberg-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6459,7 +7914,9 @@
       "displayName": "Stadtwerke Herne",
       "id": "stadtwerkeherne-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6472,7 +7929,9 @@
       "displayName": "Stadtwerke Iserlohn",
       "id": "stadtwerkeiserlohn-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "matchNames": [
         "stadtwerke iserlohn - heimatversorger"
@@ -6487,7 +7946,9 @@
       "displayName": "Stadtwerke Kiel",
       "id": "stadtwerkekiel-cf3cf5",
       "locationSet": {
-        "include": ["de-sh.geojson"]
+        "include": [
+          "de-sh.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6500,9 +7961,13 @@
       "displayName": "Stadtwerke Klagenfurt",
       "id": "stadtwerkeklagenfurt-f703d0",
       "locationSet": {
-        "include": ["at-2.geojson"]
+        "include": [
+          "at-2.geojson"
+        ]
       },
-      "matchNames": ["stw"],
+      "matchNames": [
+        "stw"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Klagenfurt",
@@ -6513,7 +7978,9 @@
       "displayName": "Stadtwerke Konstanz",
       "id": "stadtwerkekonstanz-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6525,7 +7992,9 @@
       "displayName": "Stadtwerke Landshut",
       "id": "stadtwerkelandshut-259ab2",
       "locationSet": {
-        "include": ["de-by.geojson"]
+        "include": [
+          "de-by.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6537,7 +8006,9 @@
       "displayName": "Stadtwerke Langen",
       "id": "stadtwerkelangen-43ff7e",
       "locationSet": {
-        "include": ["de-he.geojson"]
+        "include": [
+          "de-he.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6549,7 +8020,9 @@
       "displayName": "Stadtwerke Leinfelden-Echterdingen",
       "id": "stadtwerkeleinfeldenechterdingen-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6561,7 +8034,9 @@
       "displayName": "Stadtwerke Leipzig",
       "id": "stadtwerkeleipzig-b8794d",
       "locationSet": {
-        "include": ["de-sn.geojson"]
+        "include": [
+          "de-sn.geojson"
+        ]
       },
       "matchNames": [
         "leipziger",
@@ -6571,6 +8046,23 @@
         "amenity": "charging_station",
         "operator": "Stadtwerke Leipzig",
         "operator:wikidata": "Q2328555"
+      }
+    },
+    {
+      "displayName": "Stadtwerke Ludwigsburg-Kornwestheim",
+      "id": "stadtwerkeludwigsburgkornwestheim-6bc1fb",
+      "locationSet": {
+        "include": [
+          "de-bw.geojson"
+        ]
+      },
+      "matchNames": [
+        "stadtwerke ludwigsburg-kornwestheim gmbh"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Stadtwerke Ludwigsburg-Kornwestheim",
+        "operator:wikidata": "Q1667735"
       }
     },
     {
@@ -6589,25 +8081,12 @@
       }
     },
     {
-      "displayName": "Stadtwerke Ludwigsburg-Kornwestheim",
-      "id": "stadtwerkeludwigsburgkornwestheim-6bc1fb",
-      "locationSet": {
-        "include": ["de-bw.geojson"]
-      },
-      "matchNames": [
-        "stadtwerke ludwigsburg-kornwestheim gmbh"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Stadtwerke Ludwigsburg-Kornwestheim",
-        "operator:wikidata": "Q1667735"
-      }
-    },
-    {
       "displayName": "Stadtwerke Marburg",
       "id": "stadtwerkemarburg-43ff7e",
       "locationSet": {
-        "include": ["de-he.geojson"]
+        "include": [
+          "de-he.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6619,7 +8098,9 @@
       "displayName": "Stadtwerke Meerbusch GmbH",
       "id": "stadtwerkemeerbuschgmbh-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6631,9 +8112,17 @@
       "displayName": "Stadtwerke München",
       "id": "stadtwerkemunchen-4b68f8",
       "locationSet": {
-        "include": [[11.58, 48.14, 60]]
+        "include": [
+          [
+            11.58,
+            48.14,
+            60
+          ]
+        ]
       },
-      "matchNames": ["stadtwerke münchen gmbh"],
+      "matchNames": [
+        "stadtwerke münchen gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke München",
@@ -6645,9 +8134,13 @@
       "displayName": "Stadtwerke Münster",
       "id": "stadtwerkemunster-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
-      "matchNames": ["stadtwerke münster gmbh"],
+      "matchNames": [
+        "stadtwerke münster gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Münster",
@@ -6658,7 +8151,9 @@
       "displayName": "Stadtwerke Neumünster",
       "id": "stadtwerkeneumunster-cf3cf5",
       "locationSet": {
-        "include": ["de-sh.geojson"]
+        "include": [
+          "de-sh.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6671,7 +8166,9 @@
       "displayName": "Stadtwerke Neuruppin",
       "id": "stadtwerkeneuruppin-4f5737",
       "locationSet": {
-        "include": ["de-bb.geojson"]
+        "include": [
+          "de-bb.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6684,7 +8181,9 @@
       "displayName": "Stadtwerke Neuss",
       "id": "stadtwerkeneuss-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6697,7 +8196,9 @@
       "displayName": "Stadtwerke Neustadt an der Weinstraße",
       "id": "stadtwerkeneustadtanderweinstrasse-bb1d73",
       "locationSet": {
-        "include": ["de-rp.geojson"]
+        "include": [
+          "de-rp.geojson"
+        ]
       },
       "matchNames": [
         "stadtwerke neustadt an der weinstraße gmbh"
@@ -6712,7 +8213,9 @@
       "displayName": "Stadtwerke Norderstedt",
       "id": "stadtwerkenorderstedt-cf3cf5",
       "locationSet": {
-        "include": ["de-sh.geojson"]
+        "include": [
+          "de-sh.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6724,7 +8227,9 @@
       "displayName": "Stadtwerke Oberkirch",
       "id": "stadtwerkeoberkirch-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6736,7 +8241,9 @@
       "displayName": "Stadtwerke Osnabrück",
       "id": "stadtwerkeosnabruck-d9ec6c",
       "locationSet": {
-        "include": ["de-ni.geojson"]
+        "include": [
+          "de-ni.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6748,7 +8255,9 @@
       "displayName": "Stadtwerke Ostmünsterland GmbH & Co. KG",
       "id": "stadtwerkeostmunsterlandgmbhandcokg-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6760,7 +8269,9 @@
       "displayName": "Stadtwerke Pforzheim",
       "id": "stadtwerkepforzheim-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6773,7 +8284,9 @@
       "displayName": "Stadtwerke Ratingen",
       "id": "stadtwerkeratingen-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6785,9 +8298,13 @@
       "displayName": "Stadtwerke Rhede",
       "id": "stadtwerkerhede-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
-      "matchNames": ["stadtwerke rhede gmbh"],
+      "matchNames": [
+        "stadtwerke rhede gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Rhede",
@@ -6798,7 +8315,9 @@
       "displayName": "Stadtwerke Rostock",
       "id": "stadtwerkerostock-f1e045",
       "locationSet": {
-        "include": ["de-mv.geojson"]
+        "include": [
+          "de-mv.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6810,7 +8329,9 @@
       "displayName": "Stadtwerke Rüsselsheim",
       "id": "stadtwerkerusselsheim-43ff7e",
       "locationSet": {
-        "include": ["de-he.geojson"]
+        "include": [
+          "de-he.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6819,22 +8340,12 @@
       }
     },
     {
-      "displayName": "Stadtwerke Schwäbisch Hall",
-      "id": "stadtwerkeschwabischhall-6bc1fb",
-      "locationSet": {
-        "include": ["de-bw.geojson"]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Stadtwerke Schwäbisch Hall",
-        "operator:wikidata": "Q1462457"
-      }
-    },
-    {
       "displayName": "Stadtwerke Schweinfurt",
       "id": "stadtwerkeschweinfurt-259ab2",
       "locationSet": {
-        "include": ["de-by.geojson"]
+        "include": [
+          "de-by.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6843,10 +8354,26 @@
       }
     },
     {
+      "displayName": "Stadtwerke Schwäbisch Hall",
+      "id": "stadtwerkeschwabischhall-6bc1fb",
+      "locationSet": {
+        "include": [
+          "de-bw.geojson"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Stadtwerke Schwäbisch Hall",
+        "operator:wikidata": "Q1462457"
+      }
+    },
+    {
       "displayName": "Stadtwerke SH",
       "id": "stadtwerkesh-cf3cf5",
       "locationSet": {
-        "include": ["de-sh.geojson"]
+        "include": [
+          "de-sh.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6858,7 +8385,9 @@
       "displayName": "Stadtwerke Sindelfingen",
       "id": "stadtwerkesindelfingen-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "matchNames": [
         "stadtwerke sindelfingen gmbh"
@@ -6873,7 +8402,9 @@
       "displayName": "Stadtwerke Soest Energiedienstleistungs GmbH",
       "id": "stadtwerkesoestenergiedienstleistungsgmbh-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6884,9 +8415,13 @@
       "displayName": "Stadtwerke Solingen",
       "id": "stadtwerkesolingen-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
-      "matchNames": ["stadtwerke solingen gmbh"],
+      "matchNames": [
+        "stadtwerke solingen gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Solingen",
@@ -6897,7 +8432,9 @@
       "displayName": "Stadtwerke Soltau",
       "id": "stadtwerkesoltau-d9ec6c",
       "locationSet": {
-        "include": ["de-ni.geojson"]
+        "include": [
+          "de-ni.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6909,9 +8446,13 @@
       "displayName": "Stadtwerke Speyer",
       "id": "stadtwerkespeyer-bb1d73",
       "locationSet": {
-        "include": ["de-rp.geojson"]
+        "include": [
+          "de-rp.geojson"
+        ]
       },
-      "matchNames": ["stadtwerke speyer gmbh"],
+      "matchNames": [
+        "stadtwerke speyer gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Speyer",
@@ -6923,7 +8464,9 @@
       "displayName": "Stadtwerke Stendal",
       "id": "stadtwerkestendal-b7b244",
       "locationSet": {
-        "include": ["de-st.geojson"]
+        "include": [
+          "de-st.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6934,7 +8477,9 @@
       "displayName": "Stadtwerke Stralsund",
       "id": "stadtwerkestralsund-f1e045",
       "locationSet": {
-        "include": ["de-mv.geojson"]
+        "include": [
+          "de-mv.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6945,9 +8490,13 @@
       "displayName": "Stadtwerke Stuttgart",
       "id": "stadtwerkestuttgart-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
-      "matchNames": ["stadtwerke stuttgart gmbh"],
+      "matchNames": [
+        "stadtwerke stuttgart gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Stuttgart",
@@ -6958,7 +8507,9 @@
       "displayName": "Stadtwerke Troisdorf",
       "id": "stadtwerketroisdorf-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6970,9 +8521,13 @@
       "displayName": "Stadtwerke Tübingen",
       "id": "stadtwerketubingen-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
-      "matchNames": ["stadtwerke tübingen gmbh"],
+      "matchNames": [
+        "stadtwerke tübingen gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Stadtwerke Tübingen",
@@ -6984,7 +8539,9 @@
       "displayName": "Stadtwerke Union Nordhessen",
       "id": "stadtwerkeunionnordhessen-43ff7e",
       "locationSet": {
-        "include": ["de-he.geojson"]
+        "include": [
+          "de-he.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -6996,7 +8553,9 @@
       "displayName": "Stadtwerke Velbert",
       "id": "stadtwerkevelbert-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7008,7 +8567,9 @@
       "displayName": "Stadtwerke Villingen-Schwenningen",
       "id": "stadtwerkevillingenschwenningen-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7020,7 +8581,9 @@
       "displayName": "Stadtwerke Warendorf GmbH",
       "id": "stadtwerkewarendorfgmbh-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7031,7 +8594,9 @@
       "displayName": "Stadtwerke Wedel",
       "id": "stadtwerkewedel-cf3cf5",
       "locationSet": {
-        "include": ["de-sh.geojson"]
+        "include": [
+          "de-sh.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7042,7 +8607,9 @@
       "displayName": "Stadtwerke Weimar",
       "id": "stadtwerkeweimar-8c6e73",
       "locationSet": {
-        "include": ["de-th.geojson"]
+        "include": [
+          "de-th.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7054,7 +8621,9 @@
       "displayName": "Stadtwerke Weinheim",
       "id": "stadtwerkeweinheim-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7067,7 +8636,9 @@
       "displayName": "Stadtwerke Weinstadt",
       "id": "stadtwerkeweinstadt-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7078,7 +8649,9 @@
       "displayName": "Stadtwerke Wernigerode",
       "id": "stadtwerkewernigerode-b7b244",
       "locationSet": {
-        "include": ["de-st.geojson"]
+        "include": [
+          "de-st.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7090,7 +8663,9 @@
       "displayName": "Stadtwerke Willich",
       "id": "stadtwerkewillich-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7102,7 +8677,9 @@
       "displayName": "Stadtwerke Witten",
       "id": "stadtwerkewitten-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7113,7 +8690,11 @@
     {
       "displayName": "STATIONS-E",
       "id": "stationse-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "STATIONS-E"
@@ -7122,7 +8703,11 @@
     {
       "displayName": "Stavanger Parkering",
       "id": "stavangerparkering-476d58",
-      "locationSet": {"include": ["no"]},
+      "locationSet": {
+        "include": [
+          "no"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Stavanger Parkering"
@@ -7132,7 +8717,9 @@
       "displayName": "STAWAG",
       "id": "stawag-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7144,7 +8731,9 @@
       "displayName": "Stromnetz Hamburg",
       "id": "stromnetzhamburg-43ccfe",
       "locationSet": {
-        "include": ["de-hh.geojson"]
+        "include": [
+          "de-hh.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7153,32 +8742,32 @@
       }
     },
     {
-      "displayName": "SureCharge",
-      "id": "fmconway-0793ce",
-      "locationSet": {"include": ["gb"]},
+      "displayName": "Städtische Werke Magdeburg",
+      "id": "stadtischewerkemagdeburg-eaf1ad",
+      "locationSet": {
+        "include": [
+          [
+            11.63,
+            52.13,
+            50
+          ]
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
-        "brand": "SureCharge",
-        "brand:wikidata": "Q118382836",
-        "operator": "FM Conway",
-        "operator:wikidata": "Q20711690"
-      }
-    },
-    {
-      "displayName": "Süwag",
-      "id": "suwag-1299a8",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["süwag energie ag"],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Süwag",
-        "operator:wikidata": "Q2382300"
+        "operator": "Städtische Werke Magdeburg",
+        "operator:short": "SWM",
+        "operator:wikidata": "Q2359984"
       }
     },
     {
       "displayName": "Swarco",
       "id": "swarco-0793ce",
-      "locationSet": {"include": ["gb"]},
+      "locationSet": {
+        "include": [
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Swarco",
@@ -7189,7 +8778,9 @@
       "displayName": "swb (Bremen)",
       "id": "swb-152e8e",
       "locationSet": {
-        "include": ["de-hb.geojson"]
+        "include": [
+          "de-hb.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7201,7 +8792,9 @@
       "displayName": "SWB Energie und Wasser",
       "id": "swbenergieundwasser-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7213,7 +8806,11 @@
     {
       "displayName": "Swisscharge",
       "id": "swisscharge-086737",
-      "locationSet": {"include": ["ch"]},
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Swisscharge",
@@ -7240,7 +8837,9 @@
       "displayName": "SYANE",
       "id": "syane-634961",
       "locationSet": {
-        "include": ["fr-ara.geojson"]
+        "include": [
+          "fr-ara.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7251,7 +8850,9 @@
       "displayName": "SYDELA",
       "id": "sydela-d56302",
       "locationSet": {
-        "include": ["fr-pdl.geojson"]
+        "include": [
+          "fr-pdl.geojson"
+        ]
       },
       "matchNames": [
         "syndicat départemental d'énergie de loire-atlantique (sydela)"
@@ -7265,7 +8866,9 @@
       "displayName": "SYDER",
       "id": "syder-634961",
       "locationSet": {
-        "include": ["fr-ara.geojson"]
+        "include": [
+          "fr-ara.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7276,7 +8879,11 @@
     {
       "displayName": "SYME05",
       "id": "syme05-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "SYME05"
@@ -7286,7 +8893,9 @@
       "displayName": "Syndicat de l'Énergie de l'Orne",
       "id": "syndicatdelenergiedelorne-172d11",
       "locationSet": {
-        "include": ["fr-nor.geojson"]
+        "include": [
+          "fr-nor.geojson"
+        ]
       },
       "matchNames": [
         "syndicat de l'énergie de l'orne (te61)"
@@ -7297,9 +8906,43 @@
       }
     },
     {
+      "displayName": "Séolis",
+      "id": "seolis-c4b7fc",
+      "locationSet": {
+        "include": [
+          "fr-naq.geojson"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Séolis"
+      }
+    },
+    {
+      "displayName": "Süwag",
+      "id": "suwag-1299a8",
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
+      "matchNames": [
+        "süwag energie ag"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Süwag",
+        "operator:wikidata": "Q2382300"
+      }
+    },
+    {
       "displayName": "Tank & Rast",
       "id": "tankandrast-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Tank & Rast",
@@ -7309,8 +8952,14 @@
     {
       "displayName": "TankE",
       "id": "tanke-1299a8",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["tanke gmbh"],
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
+      "matchNames": [
+        "tanke gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "TankE",
@@ -7320,7 +8969,11 @@
     {
       "displayName": "Tauron",
       "id": "tauron-392011",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": {
+        "include": [
+          "pl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Tauron",
@@ -7330,7 +8983,11 @@
     {
       "displayName": "TEAG Mobil",
       "id": "teagmobil-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "matchNames": [
         "teag",
         "teag mobil gmbh",
@@ -7347,7 +9004,9 @@
       "displayName": "Technische Werke Osning",
       "id": "technischewerkeosning-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "matchNames": [
         "technische werke osning gmbh"
@@ -7363,7 +9022,9 @@
       "displayName": "Technische Werke Schussental",
       "id": "technischewerkeschussental-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
       "matchNames": [
         "technische werke schussental gmbh"
@@ -7377,7 +9038,11 @@
     {
       "displayName": "teilAuto",
       "id": "teilauto-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "teilAuto",
@@ -7388,7 +9053,9 @@
       "displayName": "Teplárny Brno",
       "id": "teplarnybrno-dd96af",
       "locationSet": {
-        "include": ["cz-64.geojson"]
+        "include": [
+          "cz-64.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7399,7 +9066,11 @@
     {
       "displayName": "TESLA France SARL",
       "id": "teslafrancesarl-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "TESLA France SARL"
@@ -7408,7 +9079,11 @@
     {
       "displayName": "Tesla Germany GmbH",
       "id": "teslagermanygmbh-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Tesla Germany GmbH"
@@ -7417,8 +9092,14 @@
     {
       "displayName": "TIWAG",
       "id": "tiwag-3f60da",
-      "locationSet": {"include": ["at"]},
-      "matchNames": ["tiroler wasserkraft ag"],
+      "locationSet": {
+        "include": [
+          "at"
+        ]
+      },
+      "matchNames": [
+        "tiroler wasserkraft ag"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "TIWAG",
@@ -7426,26 +9107,13 @@
       }
     },
     {
-      "displayName": "Toka",
-      "id": "toka-a6c3f2",
-      "locationSet": {"include": ["ua"]},
-      "matchNames": [
-        "перша національна мережа електрозаправних комплексів тока",
-        "тока"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "Toka",
-        "brand:wikidata": "Q117745034",
-        "name": "Toka",
-        "operator": "Toka",
-        "operator:wikidata": "Q117745034"
-      }
-    },
-    {
       "displayName": "Total Marketing France",
       "id": "totalmarketingfrance-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Total Marketing France",
@@ -7453,26 +9121,13 @@
       }
     },
     {
-      "displayName": "TotalEnergies",
-      "id": "totalenergies-0344be",
-      "locationSet": {
-        "include": ["001"],
-        "exclude": ["no", "us"]
-      },
-      "matchNames": [
-        "total",
-        "totalenergies charging services"
-      ],
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "TotalEnergies",
-        "operator:wikidata": "Q154037"
-      }
-    },
-    {
       "displayName": "TotalEnergies Marketing France",
       "id": "totalenergiesmarketingfrance-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "TotalEnergies Marketing France"
@@ -7481,7 +9136,11 @@
     {
       "displayName": "Trondheim kommune, Miljøenheten",
       "id": "trondheimkommunemiljoenheten-476d58",
-      "locationSet": {"include": ["no"]},
+      "locationSet": {
+        "include": [
+          "no"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Trondheim kommune, Miljøenheten"
@@ -7490,7 +9149,11 @@
     {
       "displayName": "True Kare",
       "id": "truekare-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "True Kare"
@@ -7499,7 +9162,11 @@
     {
       "displayName": "Turmstrom",
       "id": "turmstrom-3f60da",
-      "locationSet": {"include": ["at"]},
+      "locationSet": {
+        "include": [
+          "at"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Turmstrom"
@@ -7508,7 +9175,11 @@
     {
       "displayName": "UAB Ignitis",
       "id": "uabignitis-467e3c",
-      "locationSet": {"include": ["lt"]},
+      "locationSet": {
+        "include": [
+          "lt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "UAB Ignitis",
@@ -7518,7 +9189,11 @@
     {
       "displayName": "Ubeeqo",
       "id": "ubeeqo-c22d3a",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Ubeeqo",
@@ -7526,18 +9201,13 @@
       }
     },
     {
-      "displayName": "Überlandwerk Groß-Gerau GmbH",
-      "id": "uberlandwerkgrossgeraugmbh-1299a8",
-      "locationSet": {"include": ["de"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Überlandwerk Groß-Gerau GmbH"
-      }
-    },
-    {
       "displayName": "Ucharge",
       "id": "ucharge-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Ucharge"
@@ -7547,7 +9217,9 @@
       "displayName": "UEM",
       "id": "uem-4dd58e",
       "locationSet": {
-        "include": ["fr-ges.geojson"]
+        "include": [
+          "fr-ges.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7558,7 +9230,11 @@
     {
       "displayName": "Umbria Energy",
       "id": "umbriaenergy-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Umbria Energy"
@@ -7567,7 +9243,11 @@
     {
       "displayName": "Umeå Energi",
       "id": "umeaenergi-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Umeå Energi",
@@ -7577,7 +9257,12 @@
     {
       "displayName": "Uno-X",
       "id": "unox-285e25",
-      "locationSet": {"include": ["dk", "no"]},
+      "locationSet": {
+        "include": [
+          "dk",
+          "no"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Uno-X",
@@ -7587,7 +9272,11 @@
     {
       "displayName": "Uppsala parkerings AB",
       "id": "uppsalaparkeringsab-c9e89f",
-      "locationSet": {"include": ["se"]},
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Uppsala parkerings AB"
@@ -7596,7 +9285,11 @@
     {
       "displayName": "UTE",
       "id": "ute-dde172",
-      "locationSet": {"include": ["uy"]},
+      "locationSet": {
+        "include": [
+          "uy"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "UTE",
@@ -7606,7 +9299,11 @@
     {
       "displayName": "V-MARKT",
       "id": "vmarkt-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "V-MARKT",
@@ -7614,25 +9311,13 @@
       }
     },
     {
-      "displayName": "Vattenfall InCharge",
-      "id": "vattenfallincharge-648812",
-      "locationSet": {
-        "include": ["gb", "nl", "se"]
-      },
-      "matchNames": ["incharge", "vattenfall"],
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "Vattenfall InCharge",
-        "brand:wikidata": "Q71041027",
-        "name": "Vattenfall InCharge",
-        "operator": "Vattenfall InCharge",
-        "operator:wikidata": "Q71041027"
-      }
-    },
-    {
       "displayName": "Vattenvall",
       "id": "vattenvall-fa6152",
-      "locationSet": {"include": ["nl"]},
+      "locationSet": {
+        "include": [
+          "nl"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Vattenvall"
@@ -7641,7 +9326,11 @@
     {
       "displayName": "Vector",
       "id": "vector-9850e1",
-      "locationSet": {"include": ["nz"]},
+      "locationSet": {
+        "include": [
+          "nz"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Vector",
@@ -7651,7 +9340,12 @@
     {
       "displayName": "VendElectric",
       "id": "vendelectric-f6fe0b",
-      "locationSet": {"include": ["gb", "ie"]},
+      "locationSet": {
+        "include": [
+          "gb",
+          "ie"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "VendElectric"
@@ -7661,7 +9355,9 @@
       "displayName": "Vereinigte Stadtwerke",
       "id": "vereinigtestadtwerke-cf3cf5",
       "locationSet": {
-        "include": ["de-sh.geojson"]
+        "include": [
+          "de-sh.geojson"
+        ]
       },
       "matchNames": [
         "vereinigte stadtwerke gmbh"
@@ -7675,7 +9371,11 @@
     {
       "displayName": "VGS mbH",
       "id": "vgsmbh-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "VGS mbH"
@@ -7684,7 +9384,11 @@
     {
       "displayName": "Viesgo",
       "id": "viesgo-97d7cf",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {
+        "include": [
+          "es"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Viesgo",
@@ -7695,9 +9399,13 @@
       "displayName": "Ville de Saint-Louis",
       "id": "villedesaintlouis-4dd58e",
       "locationSet": {
-        "include": ["fr-ges.geojson"]
+        "include": [
+          "fr-ges.geojson"
+        ]
       },
-      "matchNames": ["saint-louis"],
+      "matchNames": [
+        "saint-louis"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Ville de Saint-Louis",
@@ -7707,31 +9415,27 @@
     {
       "displayName": "VinFast",
       "id": "vinfast-2da5cb",
-      "locationSet": {"include": ["vn"]},
+      "locationSet": {
+        "include": [
+          "vn"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "VinFast"
       }
     },
     {
-      "displayName": "VIRTA",
-      "id": "virta-e80d25",
-      "locationSet": {"include": ["fi"]},
-      "matchNames": ["liikennevirta oy"],
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "VIRTA",
-        "brand:wikidata": "Q97205884",
-        "name": "VIRTA",
-        "operator": "VIRTA",
-        "operator:wikidata": "Q97205884"
-      }
-    },
-    {
       "displayName": "vkw vlotte",
       "id": "vkwvlotte-3f60da",
-      "locationSet": {"include": ["at"]},
-      "matchNames": ["vlotte"],
+      "locationSet": {
+        "include": [
+          "at"
+        ]
+      },
+      "matchNames": [
+        "vlotte"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "vkw vlotte",
@@ -7741,7 +9445,11 @@
     {
       "displayName": "Volkswagen",
       "id": "volkswagen-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Volkswagen",
@@ -7751,7 +9459,11 @@
     {
       "displayName": "Volta",
       "id": "volta-994ed4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Volta",
@@ -7761,7 +9473,11 @@
     {
       "displayName": "VOLTRUN",
       "id": "voltrun-f274f9",
-      "locationSet": {"include": ["tr"]},
+      "locationSet": {
+        "include": [
+          "tr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "VOLTRUN"
@@ -7770,7 +9486,11 @@
     {
       "displayName": "Vолна",
       "id": "16e62d-18ef61",
-      "locationSet": {"include": ["ru"]},
+      "locationSet": {
+        "include": [
+          "ru"
+        ]
+      },
       "note": "ISO 3166-2 RU-VGG",
       "tags": {
         "amenity": "charging_station",
@@ -7780,8 +9500,14 @@
     {
       "displayName": "WAAT",
       "id": "waat-170e94",
-      "locationSet": {"include": ["fx"]},
-      "matchNames": ["waat sas"],
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
+      "matchNames": [
+        "waat sas"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "WAAT"
@@ -7790,7 +9516,11 @@
     {
       "displayName": "wallbe",
       "id": "wallbe-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "wallbe"
@@ -7799,8 +9529,14 @@
     {
       "displayName": "Waybler",
       "id": "waybler-c9e89f",
-      "locationSet": {"include": ["se"]},
-      "matchNames": ["cacharge"],
+      "locationSet": {
+        "include": [
+          "se"
+        ]
+      },
+      "matchNames": [
+        "cacharge"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Waybler",
@@ -7808,21 +9544,13 @@
       }
     },
     {
-      "displayName": "We Drive Solar",
-      "id": "wedrivesolar-fa6152",
-      "locationSet": {"include": ["nl"]},
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "We Drive Solar",
-        "brand:wikidata": "Q127260037",
-        "operator": "We Drive Solar",
-        "operator:wikidata": "Q127260037"
-      }
-    },
-    {
       "displayName": "WEL Networks",
       "id": "welnetworks-9850e1",
-      "locationSet": {"include": ["nz"]},
+      "locationSet": {
+        "include": [
+          "nz"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "network": "OpenLoop",
@@ -7835,7 +9563,9 @@
       "displayName": "Wels Strom E-Mobil",
       "id": "welsstromemobil-f73649",
       "locationSet": {
-        "include": ["at-4.geojson"]
+        "include": [
+          "at-4.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7845,7 +9575,11 @@
     {
       "displayName": "WEMAG",
       "id": "wemag-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "WEMAG",
@@ -7855,7 +9589,12 @@
     {
       "displayName": "Wenea",
       "id": "wenea-417ce7",
-      "locationSet": {"include": ["es", "gb"]},
+      "locationSet": {
+        "include": [
+          "es",
+          "gb"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Wenea",
@@ -7865,7 +9604,11 @@
     {
       "displayName": "westenergie",
       "id": "westenergie-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "westenergie",
@@ -7875,7 +9618,11 @@
     {
       "displayName": "Westenergie Metering GmbH",
       "id": "westenergiemeteringgmbh-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Westenergie Metering GmbH"
@@ -7885,7 +9632,9 @@
       "displayName": "Westfalen AG",
       "id": "westfalenag-fcc3c2",
       "locationSet": {
-        "include": ["de-nw.geojson"]
+        "include": [
+          "de-nw.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7896,7 +9645,11 @@
     {
       "displayName": "Westfalen Weser Ladeservice",
       "id": "westfalenweserladeservice-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "matchNames": [
         "westfalen weser",
         "westfalen weser energie",
@@ -7911,7 +9664,11 @@
     {
       "displayName": "Whole Foods",
       "id": "wholefoods-994ed4",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Whole Foods",
@@ -7921,8 +9678,14 @@
     {
       "displayName": "Wien Energie",
       "id": "wienenergie-3f60da",
-      "locationSet": {"include": ["at"]},
-      "matchNames": ["wien energie gmbh"],
+      "locationSet": {
+        "include": [
+          "at"
+        ]
+      },
+      "matchNames": [
+        "wien energie gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Wien Energie",
@@ -7933,7 +9696,9 @@
       "displayName": "WiiiZ",
       "id": "izivia-5e108d",
       "locationSet": {
-        "include": ["fr-pac.geojson"]
+        "include": [
+          "fr-pac.geojson"
+        ]
       },
       "tags": {
         "amenity": "charging_station",
@@ -7946,8 +9711,14 @@
     {
       "displayName": "Wirelane",
       "id": "wirelane-1299a8",
-      "locationSet": {"include": ["de"]},
-      "matchNames": ["wirelane gmbh"],
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
+      "matchNames": [
+        "wirelane gmbh"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Wirelane",
@@ -7957,7 +9728,11 @@
     {
       "displayName": "Wowplug",
       "id": "wowplug-a1285d",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": {
+        "include": [
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Wowplug"
@@ -7966,7 +9741,11 @@
     {
       "displayName": "WVV",
       "id": "wvv-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "matchNames": [
         "würzburger versorgungs- und verkehrs-gmbh"
       ],
@@ -7979,8 +9758,14 @@
     {
       "displayName": "Z Energy",
       "id": "zenergy-9850e1",
-      "locationSet": {"include": ["nz"]},
-      "matchNames": ["z"],
+      "locationSet": {
+        "include": [
+          "nz"
+        ]
+      },
+      "matchNames": [
+        "z"
+      ],
       "tags": {
         "amenity": "charging_station",
         "network": "Z Energy",
@@ -7993,9 +9778,13 @@
       "displayName": "ZDiTM Lublin",
       "id": "zditmlublin-a7df86",
       "locationSet": {
-        "include": ["pl-06.geojson"]
+        "include": [
+          "pl-06.geojson"
+        ]
       },
-      "matchNames": ["ztm lublin"],
+      "matchNames": [
+        "ztm lublin"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "ZDiTM Lublin",
@@ -8006,9 +9795,13 @@
       "displayName": "ZEAG Energie",
       "id": "zeagenergie-6bc1fb",
       "locationSet": {
-        "include": ["de-bw.geojson"]
+        "include": [
+          "de-bw.geojson"
+        ]
       },
-      "matchNames": ["zeag"],
+      "matchNames": [
+        "zeag"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "ZEAG Energie",
@@ -8018,7 +9811,11 @@
     {
       "displayName": "ZEBORNE",
       "id": "zeborne-170e94",
-      "locationSet": {"include": ["fx"]},
+      "locationSet": {
+        "include": [
+          "fx"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ZEBORNE"
@@ -8027,7 +9824,11 @@
     {
       "displayName": "ZES",
       "id": "zes-f274f9",
-      "locationSet": {"include": ["tr"]},
+      "locationSet": {
+        "include": [
+          "tr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ZES",
@@ -8035,19 +9836,13 @@
       }
     },
     {
-      "displayName": "Zest",
-      "id": "zest-0793ce",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Zest",
-        "operator:wikidata": "Q122871256"
-      }
-    },
-    {
       "displayName": "Zeus",
       "id": "zeus-2c5517",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {
+        "include": [
+          "it"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Zeus"
@@ -8057,9 +9852,13 @@
       "displayName": "ZTM Warszawa",
       "id": "ztmwarszawa-003b26",
       "locationSet": {
-        "include": ["pl-14.geojson"]
+        "include": [
+          "pl-14.geojson"
+        ]
       },
-      "matchNames": ["ztm"],
+      "matchNames": [
+        "ztm"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "ZTM Warszawa",
@@ -8069,7 +9868,12 @@
     {
       "displayName": "Zunder",
       "id": "zunder-3948da",
-      "locationSet": {"include": ["es", "pt"]},
+      "locationSet": {
+        "include": [
+          "es",
+          "pt"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Zunder",
@@ -8079,7 +9883,11 @@
     {
       "displayName": "Zwickau",
       "id": "zwickau-1299a8",
-      "locationSet": {"include": ["de"]},
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Zwickau",
@@ -8087,9 +9895,101 @@
       }
     },
     {
+      "displayName": "Àrea Metropolitana de Barcelona",
+      "id": "areametropolitanadebarcelona-f58b3e",
+      "locationSet": {
+        "include": [
+          "es-b.geojson"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Àrea Metropolitana de Barcelona",
+        "operator:short": "AMB",
+        "operator:wikidata": "Q4859869"
+      }
+    },
+    {
+      "displayName": "Électricité de France",
+      "id": "electricitedefrance-c22d3a",
+      "locationSet": {
+        "include": [
+          "001"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Électricité de France",
+        "operator:short": "EDF",
+        "operator:wikidata": "Q274591"
+      }
+    },
+    {
+      "displayName": "Ísorka",
+      "id": "isorka-8fcd5a",
+      "locationSet": {
+        "include": [
+          "is"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Ísorka",
+        "operator:wikidata": "Q127783906"
+      }
+    },
+    {
+      "displayName": "ÖAMTC",
+      "id": "oamtc-3f60da",
+      "locationSet": {
+        "include": [
+          "at"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "ÖAMTC",
+        "operator:wikidata": "Q306057"
+      }
+    },
+    {
+      "displayName": "Überlandwerk Groß-Gerau GmbH",
+      "id": "uberlandwerkgrossgeraugmbh-1299a8",
+      "locationSet": {
+        "include": [
+          "de"
+        ]
+      },
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Überlandwerk Groß-Gerau GmbH"
+      }
+    },
+    {
+      "displayName": "ČEZ",
+      "id": "cez-f67a50",
+      "locationSet": {
+        "include": [
+          "cz"
+        ]
+      },
+      "matchNames": [
+        "čez (ccs/chademo/mennekes type2)"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "ČEZ",
+        "operator:wikidata": "Q336735"
+      }
+    },
+    {
       "displayName": "ΑΒ Βασιλόπουλος",
       "id": "1f0d32-e68869",
-      "locationSet": {"include": ["gr"]},
+      "locationSet": {
+        "include": [
+          "gr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ΑΒ Βασιλόπουλος"
@@ -8098,8 +9998,14 @@
     {
       "displayName": "Γαλαξίας",
       "id": "443698-e68869",
-      "locationSet": {"include": ["gr"]},
-      "matchNames": ["γαλαξίας supermarket"],
+      "locationSet": {
+        "include": [
+          "gr"
+        ]
+      },
+      "matchNames": [
+        "γαλαξίας supermarket"
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Γαλαξίας",
@@ -8109,7 +10015,11 @@
     {
       "displayName": "ΔΕΗ",
       "id": "788cf3-e68869",
-      "locationSet": {"include": ["gr"]},
+      "locationSet": {
+        "include": [
+          "gr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ΔΕΗ",
@@ -8119,7 +10029,11 @@
     {
       "displayName": "ΔΕΗ blue",
       "id": "3ef695-e68869",
-      "locationSet": {"include": ["gr"]},
+      "locationSet": {
+        "include": [
+          "gr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ΔΕΗ blue"
@@ -8128,7 +10042,11 @@
     {
       "displayName": "Μασούτης",
       "id": "8c5a72-e68869",
-      "locationSet": {"include": ["gr"]},
+      "locationSet": {
+        "include": [
+          "gr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Μασούτης",
@@ -8138,7 +10056,11 @@
     {
       "displayName": "Σκλαβενίτης",
       "id": "46ef11-e68869",
-      "locationSet": {"include": ["gr"]},
+      "locationSet": {
+        "include": [
+          "gr"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Σκλαβενίτης",
@@ -8148,7 +10070,11 @@
     {
       "displayName": "АО \"Сетевая компания\"",
       "id": "e19896-18ef61",
-      "locationSet": {"include": ["ru"]},
+      "locationSet": {
+        "include": [
+          "ru"
+        ]
+      },
       "note": "ISO 3166-2 RU-TA",
       "tags": {
         "amenity": "charging_station",
@@ -8159,7 +10085,11 @@
     {
       "displayName": "Белтелеком",
       "id": "672155-20a807",
-      "locationSet": {"include": ["by"]},
+      "locationSet": {
+        "include": [
+          "by"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Белтелеком"
@@ -8174,7 +10104,9 @@
           "ru-spe.geojson"
         ]
       },
-      "matchNames": ["пао \"ленэнерго\""],
+      "matchNames": [
+        "пао \"ленэнерго\""
+      ],
       "tags": {
         "amenity": "charging_station",
         "operator": "Ленэнерго",
@@ -8184,7 +10116,11 @@
     {
       "displayName": "Мосэнерго",
       "id": "1e6fb1-18ef61",
-      "locationSet": {"include": ["ru"]},
+      "locationSet": {
+        "include": [
+          "ru"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Мосэнерго",
@@ -8194,7 +10130,11 @@
     {
       "displayName": "Одеська міська рада",
       "id": "09a705-a6c3f2",
-      "locationSet": {"include": ["ua"]},
+      "locationSet": {
+        "include": [
+          "ua"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Одеська міська рада",
@@ -8204,7 +10144,11 @@
     {
       "displayName": "ПО «Белоруснефть»",
       "id": "ab4fd9-20a807",
-      "locationSet": {"include": ["by"]},
+      "locationSet": {
+        "include": [
+          "by"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "ПО «Белоруснефть»"
@@ -8213,7 +10157,11 @@
     {
       "displayName": "Пункт Е",
       "id": "59d85b-18ef61",
-      "locationSet": {"include": ["ru"]},
+      "locationSet": {
+        "include": [
+          "ru"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Пункт Е"
@@ -8222,7 +10170,11 @@
     {
       "displayName": "Россети",
       "id": "rosseti-18ef61",
-      "locationSet": {"include": ["ru"]},
+      "locationSet": {
+        "include": [
+          "ru"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Россети",
@@ -8234,7 +10186,11 @@
     {
       "displayName": "РУП \"Белоруснефть-Гомельоблнефтепродукт\"",
       "id": "026cd5-20a807",
-      "locationSet": {"include": ["by"]},
+      "locationSet": {
+        "include": [
+          "by"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "РУП \"Белоруснефть-Гомельоблнефтепродукт\""
@@ -8243,7 +10199,11 @@
     {
       "displayName": "РУП \"Белоруснефть-Минскавтозаправка\"",
       "id": "44a84d-20a807",
-      "locationSet": {"include": ["by"]},
+      "locationSet": {
+        "include": [
+          "by"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "РУП \"Белоруснефть-Минскавтозаправка\""
@@ -8252,7 +10212,11 @@
     {
       "displayName": "РусГидро",
       "id": "70aabc-18ef61",
-      "locationSet": {"include": ["ru"]},
+      "locationSet": {
+        "include": [
+          "ru"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "РусГидро",
@@ -8262,35 +10226,24 @@
     {
       "displayName": "Столичен електротранспорт",
       "id": "28c7ea-befeeb",
-      "locationSet": {"include": ["bg"]},
+      "locationSet": {
+        "include": [
+          "bg"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "Столичен електротранспорт"
       }
     },
     {
-      "displayName": "国家电网",
-      "id": "stategridcorporationofchina-c785ca",
-      "locationSet": {"include": ["cn"]},
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "国家电网",
-        "brand:en": "State Grid",
-        "brand:wikidata": "Q209078",
-        "brand:zh": "国家电网",
-        "name": "国家电网",
-        "name:en": "State Grid",
-        "name:zh": "国家电网",
-        "operator": "国家电网有限公司",
-        "operator:en": "State Grid Corporation of China",
-        "operator:wikidata": "Q209078",
-        "operator:zh": "国家电网有限公司"
-      }
-    },
-    {
       "displayName": "小兔充充",
       "id": "bunnypower-c785ca",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {
+        "include": [
+          "cn"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "小兔充充",
@@ -8300,33 +10253,13 @@
       }
     },
     {
-      "displayName": "東光高岳",
-      "id": "takaokatoko-631cd5",
-      "locationSet": {
-        "include": [
-          "jp-12.geojson",
-          "jp-13.geojson"
-        ]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "東光高岳",
-        "brand:en": "Takaoka Toko",
-        "brand:ja": "東光高岳",
-        "brand:wikidata": "Q17220263",
-        "name": "東光高岳",
-        "name:en": "Takaoka Toko",
-        "name:ja": "東光高岳",
-        "operator": "東光高岳",
-        "operator:en": "Takaoka Toko",
-        "operator:ja": "東光高岳",
-        "operator:wikidata": "Q17220263"
-      }
-    },
-    {
       "displayName": "睿能創意股份有限公司",
       "id": "d4b35c-265fde",
-      "locationSet": {"include": ["tw"]},
+      "locationSet": {
+        "include": [
+          "tw"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "睿能創意股份有限公司"
@@ -8335,7 +10268,11 @@
     {
       "displayName": "英屬開曼群島商睿能新動力股份有限公司台灣分公司",
       "id": "66d0d4-265fde",
-      "locationSet": {"include": ["tw"]},
+      "locationSet": {
+        "include": [
+          "tw"
+        ]
+      },
       "tags": {
         "amenity": "charging_station",
         "operator": "英屬開曼群島商睿能新動力股份有限公司台灣分公司"


### PR DESCRIPTION
Following on from https://github.com/osmlab/name-suggestion-index/issues/11030 

I Merged about 50 charge station operators into brand where they had both tags

Also/alongside

added missing brand where it was an obvious known brand

applegreen Electric
E.On Drive (renamed too)
Elecktra
Electrify America
ev connect
evyve
fastned
geniepoint
gridserve
Mercedes benz
Osprey
podpoint
porsche
TotalEnergies
zest

added missing operator

Ionity
mer
Nio Power to non-chinese  nio power, nio power Destination, nio swap

updated countries
applegreen electric added us
be.ev updated to gb
bp pulse added us

excluded us, au, nz, gb from BP
(BP pulse is teh brand in these countries)

removed e.on danmark

