### PR TITLE
Fixed Société Générale bank name in Morocco

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -12357,23 +12357,24 @@
       }
     },
     {
-      "displayName": "Société Générale (الشركة العامة)",
+      "displayName": "Société Générale الشركة العامة",
       "id": "576e54-11534a",
       "locationSet": {"include": ["ma"]},
       "matchNames": [
         "société générale",
         "société générale سوسيتيه جنرال",
-        "سوسيتيه جنرال"
+        "سوسيتيه جنرال",
+        "الشركة العامة"
       ],
       "tags": {
         "amenity": "bank",
-        "brand": "Société générale Maroc الشركة العامة",
+        "brand": "Société Générale الشركة العامة",
         "brand:ar": "الشركة العامة",
-        "brand:fr": "Société générale Maroc",
+        "brand:fr": "Société Générale",
         "brand:wikidata": "Q3488352",
-        "name": "Société générale Maroc الشركة العامة",
+        "name": "Société Générale الشركة العامة",
         "name:ar": "الشركة العامة",
-        "name:fr": "Société générale Maroc"
+        "name:fr": "Société Générale"
       }
     },
     {


### PR DESCRIPTION
Fixed name of Société Générale in Morocco. It's not called "Société générale Maroc" but simply "Société Générale".

![image](https://github.com/user-attachments/assets/b16b0ece-ce44-4ba4-8f03-2e51baf6c251)
