### PR TITLE
Update social_facility.json

### DIFF
--- a/data/brands/amenity/social_facility.json
+++ b/data/brands/amenity/social_facility.json
@@ -49,6 +49,19 @@
         "name": "Arbeiterwohlfahrt"
       }
     },
+     {
+      "displayName": "Centro de Referência Especializado de Assistência Social CREAS",
+      "id": "Centrodereferênciaespecializadodeassistênciasocial-233ba4",
+      "locationSet": {"include": ["br"]},
+      "tags": {
+        "amenity": "social_facility",
+        "social_facility": "outreach",
+        "brand": "Centro de Referência Especializado de Assistência Social CREAS",
+        "brand:wikidata": "Q130315297",
+        "name": "Centro de Referência Especializado de Assistência Social"
+         "social_facility:for": "abused"
+      }
+    },
     {
       "displayName": "Bahnhofsmission",
       "id": "bahnhofsmission-da0ff2",


### PR DESCRIPTION
CREAS, or Specialized Social Assistance Reference Center, is a public unit of social assistance policy that offers specialized services to families and individuals in situations of personal and social risk, with violation of rights.

query with the number of points and areas mapped with the tag amenity=social_facility in Brazil. https://overpass-turbo.eu/s/267L

https://www.wikidata.org/wiki/Q130315297