### PR TITLE
Fix ecars brand

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -339,18 +339,14 @@
     },
     {
       "displayName": "ESB ecars",
-      "id": "ebsecars-e9c107",
+      "id": "esbecars-e9c107",
       "locationSet": {
         "include": ["gb-nir", "ie"]
       },
-      "matchNames": [
-        "ecarni",
-        "esb",
-        "esb ecars"
-      ],
+      "matchNames": ["ecarni", "esb"],
       "tags": {
         "amenity": "charging_station",
-        "brand": "EBS ecars",
+        "brand": "ESB ecars",
         "brand:wikidata": "Q134882112",
         "operator": "ESB Group",
         "operator:wikidata": "Q3050566"


### PR DESCRIPTION
#11036 turned it from "ecars" -> "EBS ecars", however the acronym is actually "ESB" https://esb.ie/what-we-do/ecars