### PR TITLE
Changed BMCE Bank to Bank of Africa after rebranding

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -3938,24 +3938,24 @@
       }
     },
     {
-      "displayName": "BMCE Bank (البنك المغربي للتجارة الخارجية)",
+      "displayName": "Bank of Africa ⵍⴱⴰⵏⴽ ⵏ ⴰⴼⵔⵉⵇⵢⴰ بنك أفريقيا",
       "id": "bmcebank-11534a",
       "locationSet": {"include": ["ma"]},
       "matchNames": [
         "bmce",
-        "bmce bank البنك المغربي للتجارة الخارجية"
+        "bmce bank البنك المغربي للتجارة الخارجية",
+        "البنك المغربي للتجارة الخارجية"
       ],
       "tags": {
         "amenity": "bank",
-        "brand": "BMCE Bank",
-        "brand:ar": "البنك المغربي للتجارة الخارجية",
-        "brand:en": "BMCE Bank",
+        "brand": "Bank of Africa ⵍⴱⴰⵏⴽ ⵏ ⴰⴼⵔⵉⵇⵢⴰ بنك أفريقيا",
+        "brand:ar": "بنك أفريقيا",
+        "brand:fr": "Bank of Africa",
         "brand:wikidata": "Q2300433",
-        "name:ar": "البنك المغربي للتجارة الخارجية",
-        "name:en": "BMCE Bank",
-        "official_name": "البنك المغربي للتجارة الخارجية",
-        "official_name:ar": "البنك المغربي للتجارة الخارجية",
-        "official_name:en": "Moroccan Bank of Foreign Commerce"
+        "brand:zgh": "ⵍⴱⴰⵏⴽ ⵏ ⴰⴼⵔⵉⵇⵢⴰ",
+        "name:ar": "بنك أفريقيا",
+        "name:fr": "Bank of Africa",
+        "name:zgh": "ⵍⴱⴰⵏⴽ ⵏ ⴰⴼⵔⵉⵇⵢⴰ"
       }
     },
     {


### PR DESCRIPTION
In 2020, BMCE Bank [rebranded](https://www.leconomiste.com/flash-infos/bmce-bank-africa-devient-officiellement-bank-africa) into Bank of Africa.

In Morocco, the [convention about business names](https://wiki.openstreetmap.org/wiki/Morocco#Place/business_names) is to follow the on the ground rule, e.g. the name should reflect the languages displayed (French, Arabic, Tamazight, 2 of them or even the 3 of them). In this case, Bank of Africa displays the 3 languages on its front (see image below). Hence, I added the 3 languages to the name.
![image](https://github.com/user-attachments/assets/a952fb57-b707-4043-918e-680720614e25)