### PR TITLE
Added country to Espressolab

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -1923,7 +1923,7 @@
     {
       "displayName": "Espressolab",
       "id": "espressolab-e2a804",
-      "locationSet": {"include": ["tr"]},
+      "locationSet": {"include": ["ma", "tr"]},
       "tags": {
         "amenity": "cafe",
         "brand": "Espressolab",


### PR DESCRIPTION
Added "ma" as a country to Espressolab, which has more than 10 branches in Morocco. See [list of stores](https://en.espressolab.com/stores/) and ctrl+F "Morocco" or "Casablanca". They also have takeaway, and they also display only "Espressolab" on their storefront (see an example in Casablanca below).

![image](https://github.com/user-attachments/assets/ee9ec7bc-c68a-4b11-922f-4f6c55b88c32)
