### PR TITLE
Added Maroc Telecom (telecom shop)

### DIFF
--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -396,6 +396,20 @@
       }
     },
     {
+      "displayName": "Maroc Telecom اتصالات المغرب",
+      "locationSet": {"include": ["ma"]},
+      "tags": {
+        "brand": "Maroc Telecom اتصالات المغرب",
+        "brand:fr": "Maroc Telecom",
+        "brand:ar": "اتصالات المغرب",
+        "brand:wikidata": "Q2299942",
+        "name": "Maroc Telecom اتصالات المغرب",
+        "name:fr": "Maroc Telecom",
+        "name:ar": "اتصالات المغرب",
+        "shop": "telecommunication"
+      }
+    },
+    {
       "displayName": "Maxis",
       "id": "maxis-c82acb",
       "locationSet": {"include": ["my"]},


### PR DESCRIPTION
Largest telecom provider in Morocco, more than 400 shops.
![image](https://github.com/user-attachments/assets/f9fc6e14-d8ad-44c9-a4cf-d0154f47749c)
