### PR TITLE
Removed duplicate "ma" from total-389b37, kept in totalenergies-ff2f90

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6635,7 +6635,7 @@
       "displayName": "Total طوطال",
       "id": "total-389b37",
       "locationSet": {
-        "include": ["dj", "er", "ma"]
+        "include": ["dj", "er"]
       },
       "tags": {
         "amenity": "fuel",


### PR DESCRIPTION
Morocco was present in both total-389b37 (which seems to be an entry with the old name (Total) that was kept on the NSI for Morocco, Algeria and Eritrea) and totalenergies-ff2f90.

I removed it from the former and kept it in the latter. Gas stations here are branded "TotalEnergies", just like the rest of the world. Have no idea about Algeria and Eritrea so I did not move them.