### PR TITLE
brand/amenity/atm: Add VIEW ALTTE

### DIFF
--- a/data/brands/amenity/atm.json
+++ b/data/brands/amenity/atm.json
@@ -528,10 +528,10 @@
       "locationSet": {"include": ["jp"]},
       "tags": {
         "amenity": "atm",
-        "brand": "VIEW ALTTE",
+        "brand": "ビューアルッテ",
         "brand:ja": "ビューアルッテ",
         "brand:wikidata": "Q11330938",
-        "name": "VIEW ALTTE",
+        "name": "ビューアルッテ",
         "name:ja": "ビューアルッテ",
         "operator": "ビューカード",
         "operator:en": "Viewcard",


### PR DESCRIPTION
VIEW ALTTE is a brand of ATMs operated in Japan by the non-bank credit card issuer Viewcard, a subsidiary of JR East. The ATMs are located at the major train stations of JR East (300+ locations).

ref: https://www.jreast.co.jp/card/guide/atm/