### PR TITLE
Added Inwi (telecom shop)

### DIFF
--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -373,6 +373,16 @@
       }
     },
     {
+      "displayName": "Inwi",
+      "locationSet": {"include": ["ma"]},
+      "tags": {
+        "brand": "Inwi",
+        "brand:wikidata": "Q1388949",
+        "name": "Inwi",
+        "shop": "telecommunication"
+      }
+    },
+    {
       "displayName": "Magenta",
       "id": "magenta-a73137",
       "locationSet": {"include": ["at"]},


### PR DESCRIPTION
Third largest telecom provider in Morocco. Around 380 shops in the country.
![image](https://github.com/user-attachments/assets/b711e5e0-e8cb-4178-a4e7-d1666a9f4559)
