### PR TITLE
Added Morocco to Caribou Coffee locationset

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -1097,7 +1097,7 @@
       "displayName": "Caribou Coffee",
       "id": "cariboucoffee-d73092",
       "locationSet": {
-        "include": ["ba", "tr", "us"]
+        "include": ["ba", "ma", "tr", "us"]
       },
       "tags": {
         "amenity": "cafe",


### PR DESCRIPTION
Caribou Coffee has opened 11 stores in Morocco (see [list of stores](https://www.cariboucoffee.com/around-the-world/)). I added "ma" to its locationset.

2 other items exist in Arabic, but I did not add "ma" there as the storefronts only display "Caribou Coffee" here.