### PR TITLE
added missing name tag on previous commit

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -2645,6 +2645,7 @@
         "brand:fr": "Bank of Africa",
         "brand:wikidata": "Q2300433",
         "brand:zgh": "ⵍⴱⴰⵏⴽ ⵏ ⴰⴼⵔⵉⵇⵢⴰ",
+        "name": "Bank of Africa ⵍⴱⴰⵏⴽ ⵏ ⴰⴼⵔⵉⵇⵢⴰ بنك أفريقيا",
         "name:ar": "بنك أفريقيا",
         "name:fr": "Bank of Africa",
         "name:zgh": "ⵍⴱⴰⵏⴽ ⵏ ⴰⴼⵔⵉⵇⵢⴰ"


### PR DESCRIPTION
In my [previous commit ](https://github.com/osmlab/name-suggestion-index/pull/11053)I added the `name:ar`, `name:fr` and `name:zgh` but I forgot the main `name` tag with the 3 languages. I fixed it.