### PR TITLE
brands/amenity/prep_school: Add Toshin High School

### DIFF
--- a/data/brands/amenity/prep_school.json
+++ b/data/brands/amenity/prep_school.json
@@ -443,6 +443,21 @@
       }
     },
     {
+      "displayName": "東進ハイスクール",
+      "id": "toshinhighschool-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "東進ハイスクール",
+        "brand:en": "Toshin High School",
+        "brand:ja": "東進ハイスクール",
+        "brand:wikidata": "Q11528409",
+        "name": "東進ハイスクール",
+        "name:en": "Toshin High School",
+        "name:ja": "東進ハイスクール"
+      }
+    },
+    {
       "displayName": "東進衛星予備校",
       "id": "toshineiseiyobiko-cae330",
       "locationSet": {"include": ["jp"]},
@@ -451,7 +466,6 @@
         "brand": "東進衛星予備校",
         "brand:en": "Toshin Eisei Yobiko",
         "brand:ja": "東進衛星予備校",
-        "brand:wikidata": "Q11528409",
         "name": "東進衛星予備校",
         "name:en": "Toshin Eisei Yobiko",
         "name:ja": "東進衛星予備校"


### PR DESCRIPTION
東進ハイスクール (Toshin High School) is a brand of prep schools for colleges, operated by Nagase in Japan. ~100 schools are located mainly in the Kanto region.

東進衛星予備校 (Toshin Eisei Yobiko) is a franchised brand of prep schools, and is operated nationwide by franchisees (~1,000 schools).

Wikidata Q11528409 is for Toshin High School, thus removed from Toshin Eisei Yobiko.