### PR TITLE
Change Dutch parcel locker names, add two entries

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6274,7 +6274,7 @@
       "tags": {
         "amenity": "fuel",
         "brand": "Tamoil Express",
-        "brand:wikidata": "Q706793",
+        "brand:wikidata": "Q124658477",
         "name": "Tamoil Express"
       }
     },

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -271,6 +271,17 @@
       }
     },
     {
+      "displayName": "DHL",
+      "id": "dhl-476b76",
+      "locationSet": {"include": ["nl"]},
+      "matchNames": ["dhl pakketautomaat"],
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "DHL",
+        "brand:wikidata": "Q132858576"
+      }
+    },
+    {
       "displayName": "DHL BOX 24/7",
       "id": "dhlbox247-ce4e28",
       "locationSet": {"include": ["pl"]},
@@ -311,17 +322,6 @@
         "brand": "Paketbox",
         "brand:wikidata": "Q2046604",
         "name": "DHL Paketbox"
-      }
-    },
-    {
-      "displayName": "DHL Pakketautomaat",
-      "id": "dhlpakketautomaat-476b76",
-      "locationSet": {"include": ["nl"]},
-      "tags": {
-        "amenity": "parcel_locker",
-        "brand": "DHL",
-        "brand:wikidata": "Q132858576",
-        "name": "DHL Pakketautomaat"
       }
     },
     {
@@ -935,14 +935,14 @@
       }
     },
     {
-      "displayName": "PostNL Pakketautomaat",
-      "id": "postnlpakketautomaat-476b76",
+      "displayName": "PostNL",
+      "id": "postnl-476b76",
       "locationSet": {"include": ["nl"]},
+      "matchNames": ["postnl pakketautomaat"],
       "tags": {
         "amenity": "parcel_locker",
         "brand": "PostNL",
         "brand:wikidata": "Q5921598",
-        "name": "PostNL Pakketautomaat",
         "operator": "PostNL",
         "operator:wikidata": "Q5921598"
       }

--- a/data/brands/shop/bicycle.json
+++ b/data/brands/shop/bicycle.json
@@ -139,6 +139,17 @@
       }
     },
     {
+      "displayName": "Fiets & Service",
+      "id": "fietsandservice-a0a74d",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "Fiets & Service",
+        "brand:wikidata": "Q134972535",
+        "name": "Fiets & Service",
+        "shop": "bicycle"
+      }
+    },
+    {
       "displayName": "Fietsenwinkel.nl",
       "id": "fietsenwinkelnl-a0a74d",
       "locationSet": {"include": ["nl"]},

--- a/data/brands/shop/interior_decoration.json
+++ b/data/brands/shop/interior_decoration.json
@@ -113,6 +113,17 @@
       }
     },
     {
+      "displayName": "Decokay",
+      "id": "decokay-b0e1d1",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "Decokay",
+        "brand:wikidata": "Q134972480",
+        "name": "Decokay",
+        "shop": "interior_decoration"
+      }
+    },
+    {
       "displayName": "Demmoksi",
       "id": "demmoksi-9e51b3",
       "locationSet": {"include": ["ru"]},


### PR DESCRIPTION
Removes the "pakketautomaat" text from two entries, which can be seen as descriptive rather than being part of the brand. Also added entries for Fiets & Service and Decokay, plus changed the Tamoil Express entry to the separate Wikidata identifier (#11025).