### PR TITLE
Add AVIS association office

### DIFF
--- a/data/brands/office/association.json
+++ b/data/brands/office/association.json
@@ -86,6 +86,17 @@
       }
     },
     {
+      "displayName": "AVIS",
+      "id": "avis-7fa950",
+      "locationSet": {"include": ["it"]},
+      "tags": {
+        "brand": "AVIS",
+        "brand:wikidata": "Q3627251",
+        "name": "AVIS",
+        "office": "association"
+      }
+    },
+    {
       "displayName": "BUND",
       "id": "bund-496920",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
Following up on https://github.com/osmlab/name-suggestion-index/pull/11070/ , beyond blood donation centers AVIS also has some regular offices