### PR TITLE
Separated Banque Populaire entries

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -3330,22 +3330,35 @@
       }
     },
     {
-      "displayName": "Banque Populaire (البنك الشعبي)",
+      "displayName": "Banque Populaire البنك الشعبي",
       "id": "banquepopulaire-4fc013",
       "locationSet": {
-        "include": ["de", "es", "it", "ma", "nl"]
+        "include": ["ma"]
+      "tags": {
+        "amenity": "bank",
+        "brand": "Banque Populaire البنك الشعبي",
+        "brand:ar": "البنك الشعبي",
+        "brand:fr": "Banque Populaire",
+        "brand:wikidata": "Q2883441",
+        "name": "Banque Populaire البنك الشعبي"
+        "name:ar": "البنك الشعبي",
+        "name:fr": "Banque Populaire"
+      }
+    },
+    {
+      "displayName": "Chaabi Bank",
+      "locationSet": {
+        "include": ["be", "de", "es", "it", "nl"]
       },
       "matchNames": [
-        "banque populaire البنك الشعبي"
+        "banque populaire",
+        "البنك الشعبي"
       ],
       "tags": {
         "amenity": "bank",
-        "brand": "Banque Populaire",
-        "brand:ar": "البنك الشعبي",
-        "brand:en": "Banque Populaire",
-        "brand:wikidata": "Q2883441",
-        "name:ar": "البنك الشعبي",
-        "name:en": "Banque Populaire"
+        "brand": "Chaabi Bank",
+        "brand:wikidata": "Q24938960",
+        "name": "Chaabi Bank"
       }
     },
     {


### PR DESCRIPTION
Banque Populaire is the second largest Moroccan bank.

![image](https://github.com/user-attachments/assets/17b01e4b-4569-4c28-b932-239aa27a810d)

It has a subsidiary in Europe which operates in Spain, France, Belgium, the Netherlands, Italy and Germany, but as a separate entity with a completely different name: Chaabi Bank (see image below of Chaabi Bank in Paris).

![image](https://github.com/user-attachments/assets/50647e7a-371b-48e0-8699-fe7b334bf95f)


On the NSI, both the Moroccan entity and the European entity were under one single entry. I separated them by updating the Moroccan entry (Banque Populaire) and adding the European entry (Chaabi Bank). They already have separate Wikidata entries.