### PR TITLE
Fix Tenya QID

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -13087,7 +13087,7 @@
         "brand": "てんや",
         "brand:en": "Tenya",
         "brand:ja": "てんや",
-        "brand:wikidata": "Q11319830",
+        "brand:wikidata": "Q124282698",
         "cuisine": "fries",
         "name": "てんや",
         "name:en": "Tenya",


### PR DESCRIPTION
Tenya entrie's QID was set to the former operating company, and the entry was incorrectly marked as dissolved.

This PR replaces the brand:wikidata with the QID for the brand.