### PR TITLE
update/add suggestions for things owned by Christchurch City Council and subsidiaries

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -3330,10 +3330,20 @@
       }
     },
     {
+      "displayName": "Banque populaire Grand Ouest",
+      "id": "banquepopulairegrandouest-b30a91",
+      "locationSet": {"include": ["fx"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "Banque populaire Grand Ouest",
+        "brand:wikidata": "Q56653727",
+        "name": "Banque populaire Grand Ouest"
+      }
+    },
+    {
       "displayName": "Banque Populaire البنك الشعبي",
-      "id": "banquepopulaire-4fc013",
-      "locationSet": {
-        "include": ["ma"]},
+      "id": "banquepopulaire-11534a",
+      "locationSet": {"include": ["ma"]},
       "tags": {
         "amenity": "bank",
         "brand": "Banque Populaire البنك الشعبي",
@@ -3343,17 +3353,6 @@
         "name": "Banque Populaire البنك الشعبي",
         "name:ar": "البنك الشعبي",
         "name:fr": "Banque Populaire"
-      }
-    },
-    {
-      "displayName": "Banque populaire Grand Ouest",
-      "id": "banquepopulairegrandouest-b30a91",
-      "locationSet": {"include": ["fx"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Banque populaire Grand Ouest",
-        "brand:wikidata": "Q56653727",
-        "name": "Banque populaire Grand Ouest"
       }
     },
     {
@@ -5017,6 +5016,7 @@
     },
     {
       "displayName": "Chaabi Bank",
+      "id": "chaabibank-e8e7ce",
       "locationSet": {
         "include": ["be", "de", "es", "it", "nl"]
       },

--- a/data/operators/amenity/bicycle_parking.json
+++ b/data/operators/amenity/bicycle_parking.json
@@ -57,21 +57,18 @@
     },
     {
       "displayName": "Christchurch City Council",
-      "id": "christchurchcitycouncil-f7c9d2",
+      "id": "christchurchcitycouncil-8e0182",
       "locationSet": {
         "include": ["nz-can.geojson"]
       },
-      "matchNames": [
-        "christchurch city council",
-        "ccc"
-      ],
+      "matchNames": ["ccc"],
       "tags": {
-        "amenity": "bicycle_parking",
-        "operator": "Christchurch City Council",
-        "operator:wikidata": "Q5109064",
-        "operator:type": "government",
         "access": "yes",
-        "fee": "no"
+        "amenity": "bicycle_parking",
+        "fee": "no",
+        "operator": "Christchurch City Council",
+        "operator:type": "government",
+        "operator:wikidata": "Q5109064"
       }
     },
     {

--- a/data/operators/amenity/community_centre.json
+++ b/data/operators/amenity/community_centre.json
@@ -222,14 +222,10 @@
     },
     {
       "displayName": "Christchurch City Council",
-      "id": "christchurchcitycouncil-0b187f",
+      "id": "christchurchcitycouncil-33697f",
       "locationSet": {
         "include": ["nz-can.geojson"]
       },
-      "matchNames": [
-        "christchurch city council",
-        "ccc"
-      ],
       "tags": {
         "amenity": "community_centre",
         "operator": "Christchurch City Council",

--- a/data/operators/amenity/drinking_water.json
+++ b/data/operators/amenity/drinking_water.json
@@ -346,17 +346,14 @@
       "locationSet": {
         "include": ["nz-can.geojson"]
       },
-      "matchNames": [
-        "christchurch city council",
-        "ccc"
-      ],
+      "matchNames": ["ccc"],
       "tags": {
-        "amenity": "drinking_water",
-        "operator": "Christchurch City Council",
-        "operator:wikidata": "Q5109064",
-        "operator:type": "government",
         "access": "yes",
-        "fee": "no"
+        "amenity": "drinking_water",
+        "fee": "no",
+        "operator": "Christchurch City Council",
+        "operator:type": "government",
+        "operator:wikidata": "Q5109064"
       }
     },
     {

--- a/data/operators/amenity/library.json
+++ b/data/operators/amenity/library.json
@@ -746,14 +746,10 @@
     },
     {
       "displayName": "Christchurch City Council",
-      "id": "christchurchcitycouncil-0b187f",
+      "id": "christchurchcitycouncil-796869",
       "locationSet": {
         "include": ["nz-can.geojson"]
       },
-      "matchNames": [
-        "christchurch city council",
-        "ccc"
-      ],
       "tags": {
         "amenity": "library",
         "operator": "Christchurch City Council",

--- a/data/operators/leisure/park.json
+++ b/data/operators/leisure/park.json
@@ -876,16 +876,13 @@
     },
     {
       "displayName": "Christchurch City Council",
-      "id": "christchurchcitycouncil-0b187f",
+      "id": "christchurchcitycouncil-b93ce4",
       "locationSet": {
         "include": ["nz-can.geojson"]
       },
-      "matchNames": [
-        "christchurch city council",
-        "ccc"
-      ],
       "tags": {
         "amenity": "park",
+        "leisure": "park",
         "operator": "Christchurch City Council",
         "operator:short": "CCC",
         "operator:type": "government",

--- a/data/operators/leisure/sports_centre.json
+++ b/data/operators/leisure/sports_centre.json
@@ -1,20 +1,18 @@
 {
   "properties": {
-    "path": "operators/leisure/sports_centre"
+    "path": "operators/leisure/sports_centre",
+    "exclude": {"generic": ["^sports centre$"]}
   },
   "items": [
     {
       "displayName": "Christchurch City Council",
-      "id": "christchurchcitycouncil-0b187f",
+      "id": "christchurchcitycouncil-d479de",
       "locationSet": {
         "include": ["nz-can.geojson"]
       },
-      "matchNames": [
-        "christchurch city council",
-        "ccc"
-      ],
       "tags": {
         "amenity": "sports_centre",
+        "leisure": "sports_centre",
         "operator": "Christchurch City Council",
         "operator:short": "CCC",
         "operator:type": "government",

--- a/data/operators/man_made/pumping_station.json
+++ b/data/operators/man_made/pumping_station.json
@@ -15,16 +15,13 @@
     },
     {
       "displayName": "Christchurch City Council",
-      "id": "christchurchcitycouncil-0b187f",
+      "id": "christchurchcitycouncil-f4dd85",
       "locationSet": {
         "include": ["nz-can.geojson"]
       },
-      "matchNames": [
-        "christchurch city council",
-        "ccc"
-      ],
       "tags": {
         "amenity": "pumping_station",
+        "man_made": "pumping_station",
         "operator": "Christchurch City Council",
         "operator:short": "CCC",
         "operator:type": "government",

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -6687,22 +6687,21 @@
     },
     {
       "displayName": "Orion New Zealand",
-      "id": "orionnewzealand-737a3a",
+      "id": "orionnewzealand-52a2ec",
       "locationSet": {
         "include": ["nz-can.geojson"]
       },
       "matchNames": [
-        "orion",
-        "orion nz",
-        "orion new zealand",
-        "orion new zealand limited",
         "ccc",
-        "christchurch city council"
+        "christchurch city council",
+        "orion",
+        "orion new zealand limited",
+        "orion nz"
       ],
       "tags": {
         "operator": "Orion New Zealand",
-        "operator:wikidata": "Q7102789",
         "operator:type": "public",
+        "operator:wikidata": "Q7102789",
         "power": "line"
       }
     },

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -8048,22 +8048,21 @@
     },
     {
       "displayName": "Orion New Zealand",
-      "id": "orionnewzealand-8d74a7",
+      "id": "orionnewzealand-e516d3",
       "locationSet": {
         "include": ["nz-can.geojson"]
       },
       "matchNames": [
-        "orion",
-        "orion nz",
-        "orion new zealand",
-        "orion new zealand limited",
         "ccc",
-        "christchurch city council"
+        "christchurch city council",
+        "orion",
+        "orion new zealand limited",
+        "orion nz"
       ],
       "tags": {
         "operator": "Orion New Zealand",
-        "operator:wikidata": "Q7102789",
         "operator:type": "public",
+        "operator:wikidata": "Q7102789",
         "power": "substation"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-suggestion-index",
-  "version": "6.0.20250615",
+  "version": "6.0.20250616",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-suggestion-index",
-      "version": "6.0.20250615",
+      "version": "6.0.20250616",
       "license": "BSD-3-Clause",
       "dependencies": {
         "diacritics": "^1.3.0",


### PR DESCRIPTION
Some tweaks and updates for things owned/operated by CCC.

I have expanded the `matchNames` for both to make it more likely to match. For Orion, I have also updated it such that if some says a substation is operated by `Christchurch City Council` or `CCC`, it will instead recommend Orion. Orion is owned by the council.