### PR TITLE
Add initial military operators category (landuse=military)

### DIFF
--- a/data/operators/landuse/military.json
+++ b/data/operators/landuse/military.json
@@ -24,7 +24,7 @@
         "landuse": "military",
         "military_service": "army",
         "operator": "Australian Army",
-        "operator:wikidata": "Q122191"
+        "operator:wikidata": "Q781360"
       }
     },
     {
@@ -68,7 +68,7 @@
         "landuse": "military",
         "military_service": "intelligence",
         "operator": "Central Intelligence Agency",
-        "operator:wikidata": "Q206613"
+        "operator:wikidata": "Q37230"
       }
     },
     {
@@ -169,7 +169,7 @@
         "landuse": "military",
         "military_service": "gendarmerie",
         "operator": "Guardia di Finanza",
-        "operator:wikidata": "Q54853"
+        "operator:wikidata": "Q1552861"
       }
     },
     {
@@ -268,7 +268,7 @@
         "military_service": "navy",
         "operator": "海上自衛隊",
         "operator:en": "Japan Maritime Self-Defense Force",
-        "operator:wikidata": "Q830306"
+        "operator:wikidata": "Q731647"
       }
     },
     {
@@ -303,7 +303,7 @@
         "landuse": "military",
         "military_service": "intelligence",
         "operator": "National Security Agency",
-        "operator:wikidata": "Q180057"
+        "operator:wikidata": "Q121194"
       }
     },
     {
@@ -347,7 +347,7 @@
         "landuse": "military",
         "military_service": "air_force",
         "operator": "Royal Air Force",
-        "operator:wikidata": "Q222596"
+        "operator:wikidata": "Q165862"
       }
     },
     {
@@ -371,7 +371,7 @@
         "landuse": "military",
         "military_service": "navy",
         "operator": "Royal Australian Navy",
-        "operator:wikidata": "Q122190"
+        "operator:wikidata": "Q741691"
       }
     },
     {
@@ -433,7 +433,7 @@
         "landuse": "military",
         "military_service": "coast_guard",
         "operator": "United States Coast Guard",
-        "operator:wikidata": "Q11222"
+        "operator:wikidata": "Q11224"
       }
     },
     {


### PR DESCRIPTION
# Add military.json to define military operators and their attributes

I have always been interested in creating a map of all the military bases in the world, organized by country. For that, you need good data.

That is why I propose adding `landuse=military` to the NSI. This is just an initial step to get the ball rolling. I welcome discussion about the choices I've made, and I am sure there are some errors in this first attempt at creating this new category.

I've started with all the operators that have around 10 uses in Taginfo.

I also have some issues that need solutions, and I would like to hear your thoughts on them:

- Arma dei Carabinieri – also in police.json
- Gendarmerie nationale – also in police.json
- United States Army Corps of Engineers – also in protected_areas.json
- Guardia Costiera – also in police.json
- Guardia Civil – also in police.json

We can move them here or keep them in their current files. Additionally, I'm still debating whether the gendarmerie should be classified as a police force or a military force, as they serve in this capacity in some countries and others.

I hope this is something we want to add to the NSI.
Any feedback or suggestions for improvement are welcome.

