### PR TITLE
Update Boseh in bicycle rental

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -985,8 +985,8 @@
         "network": "Boseh",
         "network:wikidata": "Q56392276",
         "operator": "Boseh",
-        "operator:type": "private",
-        "operator:wikidata": "Q56392276"
+        "operator:type": "government",
+        "operator:wikidata": "Q135037597"
       }
     },
     {


### PR DESCRIPTION
Boseh is ran by UPT Angkutan Dinas Perhubungan Kota Bandung, a local government's department in Bandung City. So it is a government operator, not a private entity. The Wikidata item is for Dinas Perhubungan Kota Bandung (parent organization) since creating UPT Angkutan is a bit unnecessary right now.