### PR TITLE
Add swimming pools and community centers for City of Houston

### DIFF
--- a/data/operators/amenity/community_centre.json
+++ b/data/operators/amenity/community_centre.json
@@ -250,6 +250,20 @@
       }
     },
     {
+      "displayName": "City of Houston Swimming Pool",
+      "id": "cityofhouston-1d14a3",
+      "locationSet": { "include": ["us-tx.geojson"] },
+      "tags": {
+        "amenity": "community_centre",
+        "operator": "Houston Parks and Recreation Department",
+        "operator:short": "HPARD",
+        "operator:type": "government",
+        "operator:wikidata": "Q115018877",
+        "owner": "City of Houston",
+        "owner:wikidata": "Q16555"
+      }
+    },
+    {
       "displayName": "City of Kitchener",
       "id": "cityofkitchener-6e645e",
       "locationSet": {


### PR DESCRIPTION
This adds a new file useful for non-branded municipal pools, and also the community centers for City of Houston

* Website for pools, https://www.houstontx.gov/parks/swimming.html
* Website for community centers, https://www.houstontx.gov/parks/communitycenters/index.html