### PR TITLE
Supercor duplicated

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -8195,17 +8195,6 @@
       }
     },
     {
-      "displayName": "Supercor",
-      "id": "supercor-d9bffc",
-      "locationSet": {"include": ["es", "pt"]},
-      "tags": {
-        "brand": "Supercor",
-        "brand:wikidata": "Q6135841",
-        "name": "Supercor",
-        "shop": "supermarket"
-      }
-    },
-    {
       "displayName": "SuperDino",
       "id": "superdino-0513f1",
       "locationSet": {"include": ["es"]},


### PR DESCRIPTION
Brand Supercor is duplicated, both as a [convenience](https://github.com/osmlab/name-suggestion-index/blob/main/data/brands/shop/convenience.json#L5594-L5603) and as a supermarket. This last one is wrong, therefore is removed