### PR TITLE
Remove pakketautomaat text from DHL and PostNL entries

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -271,6 +271,17 @@
       }
     },
     {
+      "displayName": "DHL",
+      "id": "dhl-476b76",
+      "locationSet": {"include": ["nl"]},
+      "matchNames": ["dhl pakketautomaat"],
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "DHL",
+        "brand:wikidata": "Q132858576"
+      }
+    },
+    {
       "displayName": "DHL BOX 24/7",
       "id": "dhlbox247-ce4e28",
       "locationSet": {"include": ["pl"]},
@@ -311,17 +322,6 @@
         "brand": "Paketbox",
         "brand:wikidata": "Q2046604",
         "name": "DHL Paketbox"
-      }
-    },
-    {
-      "displayName": "DHL Pakketautomaat",
-      "id": "dhlpakketautomaat-476b76",
-      "locationSet": {"include": ["nl"]},
-      "tags": {
-        "amenity": "parcel_locker",
-        "brand": "DHL",
-        "brand:wikidata": "Q132858576",
-        "name": "DHL Pakketautomaat"
       }
     },
     {
@@ -935,14 +935,14 @@
       }
     },
     {
-      "displayName": "PostNL Pakketautomaat",
-      "id": "postnlpakketautomaat-476b76",
+      "displayName": "PostNL",
+      "id": "postnl-476b76",
       "locationSet": {"include": ["nl"]},
+      "matchNames": ["postnl pakketautomaat"],
       "tags": {
         "amenity": "parcel_locker",
         "brand": "PostNL",
         "brand:wikidata": "Q5921598",
-        "name": "PostNL Pakketautomaat",
         "operator": "PostNL",
         "operator:wikidata": "Q5921598"
       }

--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -278,7 +278,7 @@
       "tags": {
         "amenity": "parcel_locker",
         "brand": "DHL",
-        "brand:wikidata": "Q132858576"
+        "brand:wikidata": "Q489815"
       }
     },
     {
@@ -942,9 +942,7 @@
       "tags": {
         "amenity": "parcel_locker",
         "brand": "PostNL",
-        "brand:wikidata": "Q5921598",
-        "operator": "PostNL",
-        "operator:wikidata": "Q5921598"
+        "brand:wikidata": "Q5921598"
       }
     },
     {


### PR DESCRIPTION
Split off from #11071.

Removes the "pakketautomaat" text from two entries, which can be seen as descriptive rather than being part of the brand. Draft for now, waiting for more community feedback