### PR TITLE
Add two Dutch brands

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6274,7 +6274,7 @@
       "tags": {
         "amenity": "fuel",
         "brand": "Tamoil Express",
-        "brand:wikidata": "Q706793",
+        "brand:wikidata": "Q124658477",
         "name": "Tamoil Express"
       }
     },

--- a/data/brands/shop/bicycle.json
+++ b/data/brands/shop/bicycle.json
@@ -139,6 +139,17 @@
       }
     },
     {
+      "displayName": "Fiets & Service",
+      "id": "fietsandservice-a0a74d",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "Fiets & Service",
+        "brand:wikidata": "Q134972535",
+        "name": "Fiets & Service",
+        "shop": "bicycle"
+      }
+    },
+    {
       "displayName": "Fietsenwinkel.nl",
       "id": "fietsenwinkelnl-a0a74d",
       "locationSet": {"include": ["nl"]},

--- a/data/brands/shop/interior_decoration.json
+++ b/data/brands/shop/interior_decoration.json
@@ -113,6 +113,17 @@
       }
     },
     {
+      "displayName": "Decokay",
+      "id": "decokay-b0e1d1",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "Decokay",
+        "brand:wikidata": "Q134972480",
+        "name": "Decokay",
+        "shop": "interior_decoration"
+      }
+    },
+    {
       "displayName": "Demmoksi",
       "id": "demmoksi-9e51b3",
       "locationSet": {"include": ["ru"]},


### PR DESCRIPTION
Split off from #11071

Added entries for Fiets & Service and Decokay, plus changed the Tamoil Express entry to the separate Wikidata identifier (#11025).