### PR TITLE
Add Café Local

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -938,6 +938,18 @@
       }
     },
     {
+      "displayName": "Café Local",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "amenity": "cafe",
+        "brand": "Café Local",
+        "brand:wikidata": "Q27825961",
+        "cuisine": "coffee_shop",
+        "name": "Café Local",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Café OMA",
       "id": "cafeoma-6b7f50",
       "locationSet": {"include": ["co"]},


### PR DESCRIPTION
Alternative branding of Pumpkin.

I didn't know if we should rename, or add a second (as I've currently done) or...?

See:
https://en.wikipedia.org/wiki/Pumpkin_Caf%C3%A9_Shop
https://www.wikidata.org/wiki/Q27825961 - Already been updated by others.
https://tpt.amey.co.uk/news/all-change-at-havant-as-ssp-continue-cafe-local-conversions/
