### PR TITLE
Add Super Star Car Wash to car_wash.json

### DIFF
--- a/data/brands/amenity/car_wash.json
+++ b/data/brands/amenity/car_wash.json
@@ -599,11 +599,10 @@
     },
     {
       "displayName": "Super Star Car Wash",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us-az.geojson","us-ca.geojson","us-co.geojson","us-tx.geojson"]},
       "tags": {
         "amenity": "car_wash",
         "brand": "Super Star Car Wash",
-        "brand:website": "https://www.superstarcarwashaz.com",
         "brand:wikidata": "Q132156104",
         "name": "Super Star Car Wash"
       }


### PR DESCRIPTION
Found this missing while creating https://www.openstreetmap.org/way/1411265276 . According to their website we probably can add

vacuum=yes
vacuum:fee=no
compressed_air=yes

as they say they are normally included with their service.

Others that could be included but are dynamic values:

opening_hours:url (not posting the full open+close time clearly per site page). self_service (only some sites offer their 'full service') automated=yes (not sure if the 'full service' ones have any options not using automation; if not then yes is correct (excludes manual interior vacuum and such))