### PR TITLE
Added British Columbia car repair chain

### DIFF
--- a/data/brands/shop/car_repair.json
+++ b/data/brands/shop/car_repair.json
@@ -1752,12 +1752,12 @@
     },
     {
       "displayName": "Budget Brake & Muffler Auto Centres",
-      "locationSet": {"ca-bc.geojson"},
+      "locationSet": {"include": ["ca-bc.geojson"]},
       "matchNames": ["Budget Brake"],
       "tags": {
-        "brand": "Budget Brake and Muffler Auto Centres",
+        "brand": "Budget Brake & Muffler Auto Centres",
         "brand:wikidata": "Q135205842",
-        "name": "Budget Brake and Muffler Auto Centres",
+        "name": "Budget Brake & Muffler Auto Centres",
         "shop": "car_repair"
       }
     }

--- a/data/brands/shop/car_repair.json
+++ b/data/brands/shop/car_repair.json
@@ -1749,6 +1749,17 @@
         "name:zh": "歐特耐養護中心",
         "shop": "car_repair"
       }
+    },
+    {
+      "displayName": "Budget Brake & Muffler Auto Centres",
+      "locationSet": {"ca-bc.geojson"},
+      "matchNames": ["Budget Brake"],
+      "tags": {
+        "brand": "Budget Brake and Muffler Auto Centres",
+        "brand:wikidata": "Q135205842",
+        "name": "Budget Brake and Muffler Auto Centres",
+        "shop": "car_repair"
+      }
     }
   ]
 }


### PR DESCRIPTION
I am somewhat hesitant regarding the use of "and" vs "&". The official website uses "and" but signage uses "&".

OSM default to "on the ground truth" but also "If the name can be spelled without an abbreviation, then don't abbreviate it".

I see many other car repair chains in the NSI have used "&".

I have used "and" but will accept if this project's maintainers prefer "&".

Thanks.