### PR TITLE
Update Dulux paint.json

### DIFF
--- a/data/brands/shop/paint.json
+++ b/data/brands/shop/paint.json
@@ -137,14 +137,14 @@
       }
     },
     {
-      "displayName": "Dulux Paints",
+      "displayName": "Dulux",
       "id": "duluxpaints-573ec1",
       "locationSet": {"include": ["001"]},
       "matchNames": ["dulux"],
       "tags": {
-        "brand": "Dulux Paints",
+        "brand": "Dulux",
         "brand:wikidata": "Q50921",
-        "name": "Dulux Paints",
+        "name": "Dulux",
         "shop": "paint"
       }
     },


### PR DESCRIPTION
update brand Dulux Paint to Dulux for AUS as per Wikidata and official website, because Dulux Paint is the name of the product https://www.dulux.com.au/specifier/products/, https://www.dulux.com.au/about-us/ Dulux (Q50921)