### PR TITLE
fixed 'Göteborgs stad' to 'Göteborgs Stad'

### DIFF
--- a/data/operators/amenity/community_centre.json
+++ b/data/operators/amenity/community_centre.json
@@ -408,12 +408,12 @@
       }
     },
     {
-      "displayName": "Göteborgs stad",
+      "displayName": "Göteborgs Stad",
       "id": "goteborgsstad-57685d",
       "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "community_centre",
-        "operator": "Göteborgs stad",
+        "operator": "Göteborgs Stad",
         "operator:type": "government",
         "operator:wikidata": "Q52502"
       }

--- a/data/operators/amenity/social_facility.json
+++ b/data/operators/amenity/social_facility.json
@@ -950,12 +950,12 @@
       }
     },
     {
-      "displayName": "Göteborgs stad",
+      "displayName": "Göteborgs Stad",
       "id": "goteborgsstad-0c56f6",
       "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "social_facility",
-        "operator": "Göteborgs stad",
+        "operator": "Göteborgs Stad",
         "operator:type": "government",
         "operator:wikidata": "Q52502"
       }


### PR DESCRIPTION
'Göteborgs Stad' is the official name of the city: https://goteborg.se. It is also the more popular tag with 817 uses (https://taginfo.openstreetmap.org/tags/operator=G%C3%B6teborgs%20Stad) while 'stad' has zero: https://taginfo.openstreetmap.org/tags/operator=G%C3%B6teborgs%20stad