### PR TITLE
Switzerland: Add Blackout clothing store chain

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -1204,6 +1204,16 @@
       }
     },
     {
+      "displayName": "Blackout",
+      "locationSet": {"include": ["ch"]},
+      "tags": {
+        "brand": "Blackout",
+        "brand:wikidata": "Q118074688",
+        "name": "Blackout",
+        "shop": "clothes"
+      }
+    },    
+    {
       "displayName": "Blackstore",
       "id": "blackstore-4a3e29",
       "locationSet": {"include": ["fr"]},


### PR DESCRIPTION
In the course of fixing some POIs mentioned in https://community.openstreetmap.org/t/vogele-shoes-pois-loschen/132208 I found out that the https://www.blackout.ch/ shops are missing from NSI.