### PR TITLE
More Best Western/BWH brands

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -21,6 +21,18 @@
   },
   "items": [
     {
+      "displayName": "@HOME",
+      "id": "home-779ccb",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "@HOME",
+        "brand:wikidata": "Q135249100",
+        "name": "@HOME",
+        "official_name": "@HOME by Best Western",
+        "tourism": "hotel"
+      }
+    },
+    {
       "displayName": "7天酒店",
       "id": "7daysinn-af4cd2",
       "locationSet": {"include": ["cn"]},
@@ -1242,6 +1254,18 @@
         "brand": "Exe Hotels",
         "brand:wikidata": "Q30880716",
         "name": "Exe",
+        "tourism": "hotel"
+      }
+    },
+    {
+      "displayName": "Executive Residency",
+      "id": "executiveresidency-779ccb",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "Executive Residency",
+        "brand:wikidata": "Q135249087",
+        "name": "Executive Residency",
+        "official_name": "Executive Residency by Best Western",
         "tourism": "hotel"
       }
     },

--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "path": "brands/tourism/hotel",
-    "preserveTags": ["^name"],
+    "preserveTags": ["^name", "^official_name"],
     "exclude": {
       "generic": [
         "^(commercial )?hotel$",
@@ -111,7 +111,7 @@
       "matchNames": ["aiden hotel"],
       "tags": {
         "brand": "Aiden",
-        "brand:wikidata": "Q830334",
+        "brand:wikidata": "Q135247220",
         "name": "Aiden",
         "official_name": "Aiden by Best Western",
         "tourism": "hotel"
@@ -552,7 +552,7 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "Best Western Premier",
-        "brand:wikidata": "Q830334",
+        "brand:wikidata": "Q135248460",
         "name": "Best Western Premier",
         "tourism": "hotel"
       }
@@ -630,7 +630,7 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "BW Premier Collection",
-        "brand:wikidata": "Q830334",
+        "brand:wikidata": "Q135248830",
         "name": "BW Premier Collection",
         "tourism": "hotel"
       }
@@ -641,7 +641,7 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "BW Signature Collection",
-        "brand:wikidata": "Q830334",
+        "brand:wikidata": "Q135249021",
         "name": "BW Signature Collection",
         "tourism": "hotel"
       }
@@ -1418,7 +1418,7 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "Glo",
-        "brand:wikidata": "Q830334",
+        "brand:wikidata": "Q135249046",
         "name": "Glo",
         "official_name": "Glo Best Western",
         "tourism": "hotel"
@@ -4128,7 +4128,7 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "Vib",
-        "brand:wikidata": "Q830334",
+        "brand:wikidata": "Q135249054",
         "name": "Vib",
         "official_name": "Vib Best Western",
         "tourism": "hotel"

--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -3642,6 +3642,118 @@
       }
     },
     {
+      "displayName": "SureStay",
+      "id": "surestay-c355a5",
+      "locationSet": {
+        "include": [
+          "au",
+          "ca",
+          "de",
+          "fr",
+          "gb",
+          "in",
+          "it",
+          "la",
+          "no",
+          "se",
+          "th",
+          "us"
+        ]
+      },
+      "matchNames": ["surestay hotels"],
+      "tags": {
+        "brand": "SureStay",
+        "brand:wikidata": "Q135246628",
+        "name": "SureStay",
+        "official_name": "SureStay by Best Western",
+        "tourism": "hotel"
+      }
+    },
+    {
+      "displayName": "SureStay Collection",
+      "id": "surestaycollection-c355a5",
+      "locationSet": {
+        "include": [
+          "au",
+          "ca",
+          "de",
+          "fr",
+          "gb",
+          "in",
+          "it",
+          "la",
+          "no",
+          "se",
+          "th",
+          "us"
+        ]
+      },
+      "matchNames": [
+        "surestay collection hotels"
+      ],
+      "tags": {
+        "brand": "SureStay Collection",
+        "brand:wikidata": "Q135246644",
+        "name": "SureStay Collection",
+        "official_name": "SureStay Collection by Best Western",
+        "tourism": "hotel"
+      }
+    },
+    {
+      "displayName": "SureStay Plus",
+      "id": "surestayplus-c355a5",
+      "locationSet": {
+        "include": [
+          "au",
+          "ca",
+          "de",
+          "fr",
+          "gb",
+          "in",
+          "it",
+          "la",
+          "no",
+          "se",
+          "th",
+          "us"
+        ]
+      },
+      "tags": {
+        "brand": "SureStay Plus",
+        "brand:wikidata": "Q135246640",
+        "name": "SureStay Plus",
+        "official_name": "SureStay Plus by Best Western",
+        "tourism": "hotel"
+      }
+    },
+    {
+      "displayName": "SureStay Studio",
+      "id": "surestaystudio-c355a5",
+      "locationSet": {
+        "include": [
+          "au",
+          "ca",
+          "de",
+          "fr",
+          "gb",
+          "in",
+          "it",
+          "la",
+          "no",
+          "se",
+          "th",
+          "us"
+        ]
+      },
+      "tags": {
+        "brand": "SureStay Studio",
+        "brand:wikidata": "Q135246687",
+        "name": "SureStay Studio",
+        "official_name": "SureStay Studio by Best Western",
+        "tourism": "hotel"
+      }
+    },
+    {
       "displayName": "Swiss-Belhotel",
       "id": "swissbelhotel-779ccb",
       "locationSet": {"include": ["001"]},

--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -4362,6 +4362,17 @@
       }
     },
     {
+      "displayName": "WorldHotels",
+      "id": "worldhotel-779ccb",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "WorldHotels",
+        "brand:wikidata": "Q135246666",
+        "name": "Worldhotel",
+        "tourism": "hotel"
+      }
+    },
+    {
       "displayName": "WorldMark",
       "id": "worldmarkbywyndham-6ac210",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Added the rest of the hotel chains by BWH Hotels, including SureStay and WorldHotels. (I didn’t distinguish the various classes of WorldHotels since it isn’t clear to me whether anything besides booking sites distinguish them.) Updated the Wikidata tags of various existing Best Western brands to stop overloading [Q830334](https://www.wikidata.org/wiki/Q830334), especially since some of them have very different branding.