### PR TITLE
Add "Full lineup Value" vending machine brand

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -620,6 +620,18 @@
       }
     },
     {
+      "displayName": "Full lineup Value",
+      "id": "fulllineupvalue-bf11a2",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "vending_machine",
+        "brand": "Full lineup Value",
+        "brand:wikidata": "Q135298109",
+        "name": "Full lineup Value",
+        "vending": "drinks"
+      }
+    },
+    {
       "displayName": "Glacier Water",
       "id": "glacierwater-7e3927",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Add entry for "Full lineup Value" vending machine brand owned by FV Japan (Coca-Cola Bottlers Japan subsidiary) but operated by other group companies. These machines sell drinks from Coca-Cola and other manufacturers including Kirin, Asahi, and Pokka-Sapporo.

I have no data on the number of deployed "Full lineup Value" machines, but there are more than 10 of them just around my house, and the company operates nationwide.

Tagging note: Those machines are often mistagged as brand=Coca-Cola due to "Coke ON" payment acceptance logos.