### PR TITLE
Drop cuisine=vegetarian

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -14555,7 +14555,7 @@
         "brand:en": "FJ Veggie",
         "brand:wikidata": "Q130458837",
         "brand:zh": "芳珍蔬食",
-        "cuisine": "vegetarian",
+        "diet:vegetarian": "yes",
         "name": "芳珍蔬食",
         "name:en": "FJ Veggie",
         "name:zh": "芳珍蔬食",

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -2151,7 +2151,8 @@
         "amenity": "restaurant",
         "brand": "De Beren",
         "brand:wikidata": "Q57076079",
-        "cuisine": "burger;chicken;grill;vegetarian",
+        "cuisine": "burger;chicken;grill",
+        "diet:vegetarian": "yes",
         "name": "De Beren"
       }
     },


### PR DESCRIPTION
`cuisine=vegetarian` is strongly discouraged in favour of `diet:vegetarian=*`, and has basically [no usage](https://taginfo.openstreetmap.org/keys/cuisine#values) due to people cleaning it up. We shouldn't have it.