### PR TITLE
Updating the name of BP Pulse to match capitalization on website and signs.

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "displayName": "BP Pulse",
+      "displayName": "bp pulse",
       "id": "bppulse-36ec13",
       "locationSet": {
         "include": ["au", "gb", "nz", "us"]
@@ -139,9 +139,9 @@
       ],
       "tags": {
         "amenity": "charging_station",
-        "brand": "BP Pulse",
+        "brand": "bp pulse",
         "brand:wikidata": "Q39057719",
-        "operator": "BP Pulse",
+        "operator": "bp pulse",
         "operator:wikidata": "Q39057719"
       }
     },


### PR DESCRIPTION
Changing the tags and name of BP Pulse to bp pulse, to match the branding of the stations present online and on signs.

Please see the bp pulse website where all mentions of the brand are in lowercase: https://www.bppulse.com/en-us/public-ev-charging

Also included on signage including up to the gigahub:

<img width="1240" height="827" alt="image" src="https://github.com/user-attachments/assets/011bb160-dd00-4dc8-872a-de4a9ecea766" />


![](https://image.chitra.live/api/v1/wps/425a17e/e68f7f61-1c4c-4314-8fdd-5b828562f8e5/13/R5-0717-679x419.jpg)
