### PR TITLE
Make RBC Royal Bank local-language aware.

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -11183,10 +11183,13 @@
       }
     },
     {
-      "displayName": "RBC",
-      "id": "rbc-e1345b",
-      "locationSet": {"include": ["ca"]},
+      "displayName": "RBC Banque Royale",
+      "id": "rbcbanqueroyale-ff5d57",
+      "locationSet": {
+        "include": ["ca-qc.geojson"]
+      },
       "matchNames": [
+        "banque royale",
         "hsbc",
         "hsbc bank canada",
         "rbc financial group",
@@ -11198,7 +11201,33 @@
         "brand:en": "RBC Royal Bank",
         "brand:fr": "RBC Banque Royale",
         "brand:wikidata": "Q735261",
-        "name": "RBC",
+        "name": "RBC Banque Royale",
+        "name:en": "RBC Royal Bank",
+        "name:fr": "RBC Banque Royale",
+        "official_name": "Royal Bank of Canada"
+      }
+    },
+    {
+      "displayName": "RBC Royal Bank",
+      "id": "rbcroyalbank-9178f2",
+      "locationSet": {
+        "include": ["ca"],
+        "exclude": ["ca-qc.geojson"]
+      },
+      "matchNames": [
+        "banque royale",
+        "hsbc",
+        "hsbc bank canada",
+        "rbc financial group",
+        "royal bank"
+      ],
+      "tags": {
+        "amenity": "bank",
+        "brand": "RBC",
+        "brand:en": "RBC Royal Bank",
+        "brand:fr": "RBC Banque Royale",
+        "brand:wikidata": "Q735261",
+        "name": "RBC Royal Bank",
         "name:en": "RBC Royal Bank",
         "name:fr": "RBC Banque Royale",
         "official_name": "Royal Bank of Canada"


### PR DESCRIPTION
Ensure `name` matches either `name:fr` (in Quebec) or `name:en` (in the rest of Canada) so that OSM guidelines are followed, keeping the Osmose QA tool happy.

Originally filed as a bug on iD:

https://github.com/openstreetmap/iD/issues/11226