### PR TITLE
Add Trojan Energy

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -938,7 +938,6 @@
     },
     {
       "displayName": "Trojan Energy",
-      "id": "",
       "locationSet": {"include": ["gb"]},
       "matchNames": [
         "trojan.energy",


### PR DESCRIPTION
I don't know if we want AON ( https://trojan.energy/aon ) and Hub ( https://trojan.energy/ev-charger-locations/ ) as separate sub brands?