### PR TITLE
Update Stromnetz Hamburg replacement

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -3414,6 +3414,16 @@
       }
     },
     {
+      "displayName": "Hamburger Energiewerke",
+      "id": "stromnetzhamburg-43ccfe",
+      "locationSet": {"include": ["de-hh.geojson"]},
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "HEnW Mobil",
+        "operator:wikidata": "Q107336926"
+      }
+    },
+    {
       "displayName": "Helen",
       "id": "helen-e80d25",
       "locationSet": {"include": ["fi"]},
@@ -7046,18 +7056,6 @@
         "amenity": "charging_station",
         "operator": "STAWAG",
         "operator:wikidata": "Q2328404"
-      }
-    },
-    {
-      "displayName": "Stromnetz Hamburg",
-      "id": "stromnetzhamburg-43ccfe",
-      "locationSet": {
-        "include": ["de-hh.geojson"]
-      },
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "Stromnetz Hamburg",
-        "operator:wikidata": "Q18028215"
       }
     },
     {

--- a/data/operators/man_made/street_cabinet.json
+++ b/data/operators/man_made/street_cabinet.json
@@ -1823,6 +1823,18 @@
       }
     },
     {
+      "displayName": "Hamburger Energienetze",
+      "id": "stromnetzhamburg-c70552",
+      "locationSet": {
+        "include": ["de-hh.geojson"]
+      },
+      "tags": {
+        "man_made": "street_cabinet",
+        "operator": "Hamburger Energienetze",
+        "operator:wikidata": "Q130127016"
+      }
+    },
+    {
       "displayName": "Harz Energie Netz",
       "id": "harzenergienetz-1aee73",
       "locationSet": {
@@ -3925,18 +3937,6 @@
         "man_made": "street_cabinet",
         "operator": "Stromnetz Berlin",
         "operator:wikidata": "Q110255475"
-      }
-    },
-    {
-      "displayName": "Stromnetz Hamburg",
-      "id": "stromnetzhamburg-c70552",
-      "locationSet": {
-        "include": ["de-hh.geojson"]
-      },
-      "tags": {
-        "man_made": "street_cabinet",
-        "operator": "Stromnetz Hamburg",
-        "operator:wikidata": "Q18028215"
       }
     },
     {

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -4543,6 +4543,17 @@
       }
     },
     {
+      "displayName": "Hamburger Energienetze",
+      "id": "stromnetzhamburg-840ea0",
+      "locationSet": {"include": ["de-hh.geojson"]},
+      "matchNames": ["hamburger energienetze gmbh"],
+      "tags": {
+        "operator": "Hamburger Energienetze",
+        "operator:wikidata": "Q130127016",
+        "power": "line"
+      }
+    },
+    {
       "displayName": "Hammerfest Energi Nett",
       "id": "hammerfestenerginett-e0b869",
       "locationSet": {"include": ["no"]},
@@ -8421,19 +8432,6 @@
       "tags": {
         "operator": "Stromnetz Berlin",
         "operator:wikidata": "Q110255475",
-        "power": "line"
-      }
-    },
-    {
-      "displayName": "Stromnetz Hamburg",
-      "id": "stromnetzhamburg-840ea0",
-      "locationSet": {
-        "include": ["de-hh.geojson"]
-      },
-      "matchNames": ["stromnetz hamburg gmbh"],
-      "tags": {
-        "operator": "Stromnetz Hamburg",
-        "operator:wikidata": "Q18028215",
         "power": "line"
       }
     },

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -5402,6 +5402,19 @@
       }
     },
     {
+      "displayName": "Hamburger Energienetze",
+      "id": "stromnetzhamburg-de1365",
+      "locationSet": {
+        "include": ["de-hh.geojson"]
+      },
+      "matchNames": ["hamburger energienetze gmbh"],
+      "tags": {
+        "operator": "Hamburger Energienetze",
+        "operator:wikidata": "Q130127016",
+        "power": "substation"
+      }
+    },
+    {
       "displayName": "HanseWerk",
       "id": "hansewerk-7ff171",
       "locationSet": {"include": ["de"]},
@@ -11009,19 +11022,6 @@
       "tags": {
         "operator": "Stromnetz Berlin",
         "operator:wikidata": "Q110255475",
-        "power": "substation"
-      }
-    },
-    {
-      "displayName": "Stromnetz Hamburg",
-      "id": "stromnetzhamburg-de1365",
-      "locationSet": {
-        "include": ["de-hh.geojson"]
-      },
-      "matchNames": ["stromnetz hamburg gmbh"],
-      "tags": {
-        "operator": "Stromnetz Hamburg",
-        "operator:wikidata": "Q18028215",
         "power": "substation"
       }
     },

--- a/data/operators/route/power.json
+++ b/data/operators/route/power.json
@@ -450,6 +450,19 @@
       }
     },
     {
+      "displayName": "Hamburger Energienetze",
+      "id": "stromnetzhamburg-227083",
+      "locationSet": {
+        "include": ["de-hh.geojson"]
+      },
+      "matchNames": ["hamburger energienetze gmbh"],
+      "tags": {
+        "operator": "Hamburger Energienetze",
+        "operator:wikidata": "Q130127016",
+        "route": "power"
+      }
+    },
+    {
       "displayName": "Hydro-Québec",
       "id": "hydroquebec-f5644d",
       "locationSet": {
@@ -773,19 +786,6 @@
       "tags": {
         "operator": "Stromnetz Berlin",
         "operator:wikidata": "Q110255475",
-        "route": "power"
-      }
-    },
-    {
-      "displayName": "Stromnetz Hamburg",
-      "id": "stromnetzhamburg-227083",
-      "locationSet": {
-        "include": ["de-hh.geojson"]
-      },
-      "matchNames": ["stromnetz hamburg gmbh"],
-      "tags": {
-        "operator": "Stromnetz Hamburg",
-        "operator:wikidata": "Q18028215",
         "route": "power"
       }
     },


### PR DESCRIPTION
Stromnetz Hamburg doesnt exist as an entity anymore, there is Hamburger Energiewerke and Hamburger Energienetze now.