### PR TITLE
MA - Société Générale rebranded as Saham Bank

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -12196,6 +12196,13 @@
     {
       "displayName": "Saham Bank سهام بنك",
       "locationSet": {"include": ["ma"]},
+      "matchNames": [
+        "société générale سوسيتيه جنرال",
+        "سوسيتيه جنرال",
+        "société générale",
+        "société générale الشركة العامة",
+        "الشركة العامة"
+      ],
       "tags": {
         "amenity": "bank",
         "brand": "Saham Bank سهام بنك",


### PR DESCRIPTION
In Morocco, Société Générale was bought by Saham and was rebranded Saham Bank ([source](https://maroc-diplomatique.net/la-societe-generale-maroc-devient-saham-bank/)). They display the name in French and Arabic (see image below). I updated the names accordingly.

<img width="400" height="225" alt="image" src="https://github.com/user-attachments/assets/eb1894bd-c151-4f97-93c7-f923d1574811" />
