### PR TITLE
Add Univerexport (RS) as convenience store

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -6074,6 +6074,21 @@
       }
     },
     {
+      "displayName": "Univerexport",
+      "id": "univer-fji3e2",
+      "locationSet": {"include": ["rs"]},
+      "matchNames": [
+        "univereksport",
+        "универекспорт"
+      ],
+      "tags": {
+        "brand": "Univerexport",
+        "brand:wikidata": "Q12747294",
+        "name": "Univerexport",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "US Market",
       "id": "usmarket-f1e40b",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Univerexport can be a convenience store (example: [1](https://www.openstreetmap.org/node/9329529177))