### PR TITLE
Rename cuisine tag `hotpot` to `hot_pot`

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -3066,7 +3066,7 @@
         "brand:en": "Haidilao Hot Pot",
         "brand:wikidata": "Q5638920",
         "brand:zh": "海底捞火锅",
-        "cuisine": "chinese;hotpot",
+        "cuisine": "chinese;hot_pot",
         "name": "Haidilao Hot Pot",
         "name:en": "Haidilao Hot Pot",
         "name:zh": "海底捞火锅"
@@ -3183,7 +3183,7 @@
         "brand:en": "Happy Lamb Hot Pot",
         "brand:wikidata": "Q123091978",
         "brand:zh": "快乐小羊",
-        "cuisine": "mongolian;hotpot",
+        "cuisine": "mongolian;hot_pot",
         "name": "Happy Lamb Hot Pot",
         "name:en": "Happy Lamb Hot Pot",
         "name:zh": "快乐小羊"
@@ -3384,7 +3384,7 @@
         "amenity": "restaurant",
         "brand": "HOT POT Buffet",
         "brand:wikidata": "Q125919341",
-        "cuisine": "hotpot;chinese",
+        "cuisine": "chinese;hot_pot",
         "name": "HOT POT Buffet"
       }
     },
@@ -4268,7 +4268,7 @@
         "brand:en": "LITTLE SHEEP",
         "brand:wikidata": "Q5976467",
         "brand:zh": "小肥羊",
-        "cuisine": "chinese;hotpot",
+        "cuisine": "chinese;hot_pot",
         "name": "LITTLE SHEEP",
         "name:en": "LITTLE SHEEP",
         "name:zh": "小肥羊"
@@ -5019,7 +5019,7 @@
         "amenity": "restaurant",
         "brand": "Mo-Mo Paradise",
         "brand:wikidata": "Q126369578",
-        "cuisine": "japanese;hotpot",
+        "cuisine": "japanese;hot_pot",
         "name": "Mo-Mo Paradise"
       }
     },
@@ -5294,7 +5294,7 @@
         "brand:en": "Nice To Meet You Hot Pot",
         "brand:wikidata": "Q123093094",
         "brand:zh": "那年遇见串串",
-        "cuisine": "chinese;hotpot",
+        "cuisine": "chinese;hot_pot",
         "name": "Nice To Meet You Hot Pot",
         "name:en": "Nice To Meet You Hot Pot",
         "name:zh": "那年遇见串串"
@@ -6818,7 +6818,7 @@
         "brand:en": "XiaoLongKan",
         "brand:wikidata": "Q108212427",
         "brand:zh": "小龙坎火锅",
-        "cuisine": "chinese;hotpot",
+        "cuisine": "chinese;hot_pot",
         "name": "Shoo Loong Kan",
         "name:en": "Shoo Loong Kan",
         "name:zh": "小龙坎火锅"
@@ -8128,7 +8128,7 @@
         "brand:en": "XiaoLongKan",
         "brand:wikidata": "Q108212427",
         "brand:zh": "小龙坎火锅",
-        "cuisine": "chinese;hotpot",
+        "cuisine": "chinese;hot_pot",
         "name": "XiaoLongKan",
         "name:en": "XiaoLongKan",
         "name:zh": "小龙坎火锅"
@@ -9161,7 +9161,7 @@
         "brand:en": "Dong Lai Shun",
         "brand:wikidata": "Q10870490",
         "brand:zh": "东来顺",
-        "cuisine": "chinese;hotpot",
+        "cuisine": "chinese;hot_pot",
         "diet:halal": "only",
         "name": "东来顺",
         "name:en": "Dong Lai Shun",
@@ -9280,7 +9280,7 @@
         "brand:en": "6owl door",
         "brand:wikidata": "Q131688921",
         "brand:zh": "六扇門時尚湯鍋",
-        "cuisine": "hotpot",
+        "cuisine": "hot_pot",
         "diet:vegetarian": "yes",
         "name": "六扇門時尚湯鍋",
         "name:en": "6owl door",
@@ -9333,7 +9333,7 @@
         "brand:en": "Chien Yen Shabu Shabu",
         "brand:wikidata": "Q67936077",
         "brand:zh": "千葉火鍋",
-        "cuisine": "japanese;hotpot",
+        "cuisine": "japanese;hot_pot",
         "name": "千葉火鍋",
         "name:en": "Chien Yen Shabu Shabu",
         "name:zh": "千葉火鍋"
@@ -9850,7 +9850,7 @@
         "brand:en": "LITTLE SHEEP",
         "brand:wikidata": "Q5976467",
         "brand:zh": "小肥羊",
-        "cuisine": "chinese;hotpot",
+        "cuisine": "chinese;hot_pot",
         "name": "小肥羊",
         "name:en": "LITTLE SHEEP",
         "name:zh": "小肥羊"
@@ -9867,7 +9867,7 @@
         "brand:en": "XiaoLongKan",
         "brand:wikidata": "Q108212427",
         "brand:zh": "小龙坎火锅",
-        "cuisine": "chinese;hotpot",
+        "cuisine": "chinese;hot_pot",
         "name": "小龙坎火锅",
         "name:en": "XiaoLongKan",
         "name:zh": "小龙坎火锅"
@@ -10072,7 +10072,7 @@
         "brand:en": "Happy Lamb Hot Pot",
         "brand:wikidata": "Q123091978",
         "brand:zh": "快乐小羊",
-        "cuisine": "mongolian;hotpot",
+        "cuisine": "mongolian;hot_pot",
         "name": "快乐小羊",
         "name:en": "Happy Lamb Hot Pot",
         "name:zh": "快乐小羊"
@@ -10332,7 +10332,7 @@
         "brand:zh": "海底捞火锅",
         "brand:zh-Hans": "海底捞火锅",
         "brand:zh-Hant": "海底撈火鍋",
-        "cuisine": "chinese;hotpot",
+        "cuisine": "chinese;hot_pot",
         "name": "海底捞火锅",
         "name:en": "Haidilao Hot Pot",
         "name:zh": "海底捞火锅",
@@ -10352,7 +10352,7 @@
         "brand:zh": "海底撈火鍋",
         "brand:zh-Hans": "海底捞火锅",
         "brand:zh-Hant": "海底撈火鍋",
-        "cuisine": "chinese;hotpot",
+        "cuisine": "chinese;hot_pot",
         "name": "海底撈火鍋",
         "name:en": "Haidilao Hot Pot",
         "name:zh": "海底撈火鍋",
@@ -10373,7 +10373,7 @@
         "brand:zh": "海底撈火鍋",
         "brand:zh-Hans": "海底捞火锅",
         "brand:zh-Hant": "海底撈火鍋",
-        "cuisine": "chinese;hotpot",
+        "cuisine": "chinese;hot_pot",
         "name": "海底撈火鍋 Haidilao Hot Pot",
         "name:en": "Haidilao Hot Pot",
         "name:zh": "海底撈火鍋",
@@ -10718,7 +10718,7 @@
         "brand:en": "Shi Erguo",
         "brand:wikidata": "Q108056247",
         "brand:zh": "石二鍋",
-        "cuisine": "hotpot",
+        "cuisine": "hot_pot",
         "name": "石二鍋",
         "name:en": "Shi Erguo",
         "name:zh": "石二鍋",
@@ -10758,7 +10758,7 @@
         "brand:en": "Jhujian shabu",
         "brand:wikidata": "Q80214451",
         "brand:zh": "築間幸福鍋物",
-        "cuisine": "hotpot",
+        "cuisine": "hot_pot",
         "name": "築間幸福鍋物",
         "name:en": "Jhujian shabu",
         "name:zh": "築間幸福鍋物",
@@ -11095,7 +11095,7 @@
         "brand:en": "CYGNET",
         "brand:wikidata": "Q108212568",
         "brand:zh": "重庆小天鹅火锅",
-        "cuisine": "chinese;hotpot",
+        "cuisine": "chinese;hot_pot",
         "name": "重庆小天鹅火锅",
         "name:en": "CYGNET",
         "name:zh": "重庆小天鹅火锅"
@@ -11112,7 +11112,7 @@
         "brand:en": "Chien Tu Hot Pot",
         "brand:wikidata": "Q109344533",
         "brand:zh": "錢都涮涮鍋",
-        "cuisine": "hotpot",
+        "cuisine": "hot_pot",
         "name": "錢都涮涮鍋",
         "name:en": "Chien Tu Hot Pot",
         "name:zh": "錢都涮涮鍋"


### PR DESCRIPTION
The phrase "[Hot pot](https://en.wikipedia.org/wiki/Hot_pot)", like "Hot dog", should alway be used with an whitespace. The informal `hotpot` tag should be deprecated, and existing usages should be changed to `hot_pot`