### PR TITLE
Update branding for Moss

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -7409,6 +7409,7 @@
         "clothes": "men",
         "name": "Moss",
         "alt_name": "Moss Bros",
+        "matchNames": ["Moss Bros"],
         "shop": "clothes"
       }
     },

--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -7398,16 +7398,17 @@
       }
     },
     {
-      "displayName": "Moss Bros",
+      "displayName": "Moss",
       "id": "mossbros-b36645",
       "locationSet": {
         "include": ["ae", "gb", "gg", "je"]
       },
       "tags": {
-        "brand": "Moss Bros",
+        "brand": "Moss",
         "brand:wikidata": "Q6916538",
         "clothes": "men",
-        "name": "Moss Bros",
+        "name": "Moss",
+        "alt_name": "Moss Bros",
         "shop": "clothes"
       }
     },

--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -7400,6 +7400,7 @@
     {
       "displayName": "Moss",
       "id": "mossbros-b36645",
+      "matchNames": ["Moss Bros"],
       "locationSet": {
         "include": ["ae", "gb", "gg", "je"]
       },
@@ -7409,7 +7410,6 @@
         "clothes": "men",
         "name": "Moss",
         "alt_name": "Moss Bros",
-        "matchNames": ["Moss Bros"],
         "shop": "clothes"
       }
     },


### PR DESCRIPTION
Brand changed from "Moss Bros" to "Moss" in 2023
https://www.moss.co.uk/about-us