### PR TITLE
[JP] Add parking brand entry for SAN Park

### DIFF
--- a/data/brands/amenity/parking.json
+++ b/data/brands/amenity/parking.json
@@ -56,6 +56,22 @@
       }
     },
     {
+      "displayName": "SANパーク",
+      "id": "sanpark-9f17fa",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "parking",
+        "brand": "SANパーク",
+        "brand:en": "SAN Park",
+        "brand:ja": "SANパーク",
+        "brand:wikidata": "Q135285806",
+        "fee": "yes",
+        "name": "SANパーク",
+        "name:en": "SAN Park",
+        "name:ja": "SANパーク"
+      }
+    },
+    {
       "displayName": "俥亭停車",
       "id": "youparking-1fcc49",
       "locationSet": {"include": ["tw"]},


### PR DESCRIPTION
サンパーク (SAN Park) is a franchised brand of pay parking in Japan, that mainly operates in the Greater Tokyo Area and some areas in Western Japan.

The franchise has 1000+ locations in Tokyo Metropolis alone, according to its official site[^1]. A photo is available on [wikidata].

[wikidata]: https://www.wikidata.org/wiki/Q135285806
[^1]: https://sanpark.jp/search/all/?pref=-&kw=%E6%9D%B1%E4%BA%AC%E9%83%BD&x=37&y=18