### PR TITLE
[JP] Add parking operator entry for COIN PARK

### DIFF
--- a/data/operators/amenity/parking.json
+++ b/data/operators/amenity/parking.json
@@ -1091,6 +1091,27 @@
       }
     },
     {
+      "displayName": "コインパーク",
+      "id": "coinpark-a16317",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "parking",
+        "brand": "コインパーク",
+        "brand:en": "COIN PARK",
+        "brand:ja": "コインパーク",
+        "brand:wikidata": "Q135274141",
+        "fee": "yes",
+        "name": "コインパーク",
+        "name:en": "COIN PARK",
+        "name:ja": "コインパーク",
+        "operator": "コインパーク",
+        "operator:en": "COIN PARK",
+        "operator:ja": "コインパーク",
+        "operator:type": "private",
+        "operator:wikidata": "Q135274149"
+      }
+    },
+    {
       "displayName": "タイムズ",
       "id": "times24-a16317",
       "locationSet": {"include": ["jp"]},


### PR DESCRIPTION
コインパーク (COIN PARK) runs pay parking lots in Japan under the brand "COIN PARK". It operates mainly in the Greater Tokyo Area and the other urban areas such as Osaka.

There 900+ locations in Tokyo Metropolis alone[^1]. A photo is available on [wikidata].

[wikidata]: https://www.wikidata.org/wiki/Q135274141
[^1]: https://www.coinpark.info/parking/tokyo/
[^2]: https://www.coinpark.info/parking/kanagawa/