### PR TITLE
[JP] Fix Wikidata QID for prefectural flags

### DIFF
--- a/data/flags/man_made/flagpole.json
+++ b/data/flags/man_made/flagpole.json
@@ -3036,7 +3036,7 @@
         "flag:name": "青森県旗",
         "flag:name:en": "Flag of Aomori Prefecture",
         "flag:type": "regional",
-        "flag:wikidata": "Q116096085",
+        "flag:wikidata": "Q7751423",
         "man_made": "flagpole",
         "subject": "青森県",
         "subject:en": "Aomori Prefecture",
@@ -3396,11 +3396,11 @@
         "flag:name": "京都府旗",
         "flag:name:en": "Flag of Kyoto Prefecture",
         "flag:type": "regional",
-        "flag:wikidata": "Q5718596",
+        "flag:wikidata": "Q10883252",
         "man_made": "flagpole",
         "subject": "京都府",
         "subject:en": "Kyoto Prefecture",
-        "subject:wikidata": "Q34600"
+        "subject:wikidata": "Q120730"
       }
     },
     {


### PR DESCRIPTION
Aomori and Kyoto flags are mistakenly pointed to the municipal flags of the cities with the same name.

Fixup: https://github.com/osmlab/name-suggestion-index/pull/11139