### PR TITLE
Fixed spelling of Calida

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -1844,7 +1844,7 @@
       }
     },
     {
-      "displayName": "CALIDA",
+      "displayName": "Calida",
       "id": "calida-758685",
       "locationSet": {
         "include": [
@@ -1858,9 +1858,9 @@
         ]
       },
       "tags": {
-        "brand": "CALIDA",
+        "brand": "Calida",
         "brand:wikidata": "Q693344",
-        "name": "CALIDA",
+        "name": "Calida",
         "shop": "clothes"
       }
     },


### PR DESCRIPTION
Fixed spelling of Calida (underwear brand): no all-caps according to https://wiki.openstreetmap.org/wiki/Names#Proper_name_spelling (it is not an initialism)