### PR TITLE
Update Mega PX Mart

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -12278,6 +12278,21 @@
       }
     },
     {
+      "displayName": "大全聯",
+      "id": "megapxmart-14223e",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "大全聯",
+        "brand:en": "Mega Pxmart",
+        "brand:wikidata": "Q135550746",
+        "brand:zh": "大全聯",
+        "name": "大全聯",
+        "name:en": "Mega Pxmart",
+        "name:zh": "大全聯",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "大张超市",
       "id": "dazhang-eda947",
       "locationSet": {"include": ["cn"]},
@@ -12306,21 +12321,6 @@
         "name": "大润发",
         "name:en": "RT-Mart",
         "name:zh": "大润发",
-        "shop": "supermarket"
-      }
-    },
-    {
-      "displayName": "大潤發",
-      "id": "rtmart-14223e",
-      "locationSet": {"include": ["tw"]},
-      "tags": {
-        "brand": "大潤發",
-        "brand:en": "RT-Mart",
-        "brand:wikidata": "Q7277802",
-        "brand:zh": "大潤發",
-        "name": "大潤發",
-        "name:en": "RT-Mart",
-        "name:zh": "大潤發",
         "shop": "supermarket"
       }
     },


### PR DESCRIPTION
The RT-Mart in Taiwan is acquired by the supermarket operator PX Mart in 2022. In August 1, 2025, all stores were renamed to "MEGA PX MART" and the original company was merged into the PX Mart parent company in July.

This PR will update it, and as the `name:en` of PX Mart is `Pxmart`, this PR uses `name:en=Mega Pxmart`. It will also update the Wikidata item to a newly created one.