### PR TITLE
Update MultiVlaai entry in bakery to a pastry shops

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -1842,17 +1842,6 @@
       }
     },
     {
-      "displayName": "MultiVlaai",
-      "id": "multivlaai-8eaf6b",
-      "locationSet": {"include": ["nl"]},
-      "tags": {
-        "brand": "MultiVlaai",
-        "brand:wikidata": "Q5439846",
-        "name": "MultiVlaai",
-        "shop": "bakery"
-      }
-    },
-    {
       "displayName": "Musmanni",
       "id": "musmanni-8b7146",
       "locationSet": {"include": ["cr"]},

--- a/data/brands/shop/pastry.json
+++ b/data/brands/shop/pastry.json
@@ -29,6 +29,17 @@
       }
     },
     {
+      "displayName": "MultiVlaai",
+      "id": "multivlaai-8eaf6b",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "MultiVlaai",
+        "brand:wikidata": "Q5439846",
+        "name": "MultiVlaai",
+        "shop": "pastry"
+      }
+    },
+    {
       "displayName": "Buns From Home",
       "id": "bunsfromhome-68933a",
       "locationSet": {


### PR DESCRIPTION
According to the [Dutch osm forums](https://community.openstreetmap.org/t/nsi-feedback-topic/131133/19), Multivlaai mainly sells cakes (or more specifically a Limburgse Vlaai). And so pastry is more appropriate for this establishment, as you can't buy any bread there.