### PR TITLE
[JP] Add brand entry for Fami Locker

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -1301,6 +1301,23 @@
       }
     },
     {
+      "displayName": "ファミロッカー",
+      "id": "familocker-83187c",
+      "locationSet": {"include": ["ja"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "ファミロッカー",
+        "brand:en": "Fami Locker",
+        "brand:ja": "ファミロッカー",
+        "brand:wikidata": "Q135552919",
+        "name": "ファミロッカー",
+        "name:en": "Fami Locker",
+        "name:ja": "ファミロッカー",
+        "parcel_mail_in": "yes",
+        "parcel_pickup": "yes"
+      }
+    },
+    {
       "displayName": "丰巢",
       "id": "hivebox-a0c60b",
       "locationSet": {


### PR DESCRIPTION
ファミロッカー (Fami Locker) is a parcel-locker service operated by FamilyMart in Japan. Lockers of the brand are installed at selected FamilyMart stores in the Greater Tokyo Area at the moment (~1000 stores[^1]).

A photo of the locker is available on [wikidata].

[wikidata]: https://www.wikidata.org/wiki/Q135552919
[^1]: https://www.family.co.jp/services/delivery/locker/shop_list.html