### PR TITLE
[JP] Add prep_school brand for Nichinoken

### DIFF
--- a/data/brands/amenity/prep_school.json
+++ b/data/brands/amenity/prep_school.json
@@ -361,6 +361,21 @@
       }
     },
     {
+      "displayName": "日能研",
+      "id": "nichinoken-cae330",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "prep_school",
+        "brand": "日能研",
+        "brand:en": "Nichinoken",
+        "brand:ja": "日能研",
+        "brand:wikidata": "Q11510273",
+        "name": "日能研",
+        "name:en": "Nichinoken",
+        "name:ja": "日能研"
+      }
+    },
+    {
       "displayName": "旭川練成会",
       "id": "asahikawarenseikai-cae330",
       "locationSet": {"include": ["jp"]},


### PR DESCRIPTION
日能研 (Nichinoken) is a network of cram schools (preparatory schools for high school entrance exam) in Japan. There are 100+ schools[^1] nationwide and these schools are operated by regional Nichonoken companies under the same brand.

[^1]: https://www.nichinoken.co.jp/branch/