### PR TITLE
[JP] Remove telephone operator NTT Osaka Branch

### DIFF
--- a/data/operators/amenity/telephone.json
+++ b/data/operators/amenity/telephone.json
@@ -355,17 +355,6 @@
       }
     },
     {
-      "displayName": "NTT大阪支店",
-      "id": "9b5070-944417",
-      "locationSet": {
-        "include": ["jp-27.geojson"]
-      },
-      "tags": {
-        "amenity": "telephone",
-        "operator": "NTT大阪支店"
-      }
-    },
-    {
       "displayName": "NTT東日本",
       "id": "nippontelegraphandtelephoneeast-a6a893",
       "locationSet": {


### PR DESCRIPTION
大阪支店 (Osaka branch office) of NTT West does not exist anymore, and its former operation area is now covered by 関西支店 (Kansan branch office)[^1].

I think it's better to just remove this entry for now to prevent mistagging, until someone wants to map telephone booths with their operating branch office information.

[^1]: https://www.ntt-west.co.jp/corporate/branch/