### PR TITLE
[JP] Update vending_machine brand for Pokka Sapporo

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -1879,7 +1879,7 @@
         "name": "ポッカサッポロ",
         "name:en": "Pokka Sapporo",
         "name:ja": "ポッカサッポロ",
-        "vending": "water;food"
+        "vending": "drink"
       }
     },
     {


### PR DESCRIPTION
I propose to modify ポッカサッポロ (Pokka Sapporo) vending machines entry because typical Pokka Sapporo vending machines sell only drinks[^1] as the other beverage company brands.

Somebody might want to use vending=food for canned soup (e.g. corn, potato or tomato soup), which is a popular item sold in drink vendors in Japan. But keeping it here is inconsistent because vending machines of the other brands such as Coca-Cola, Suntry and DyDo also sells soup.

[^1]: https://commons.wikimedia.org/wiki/Category:Pokka_Sapporo_vending_machines