### PR TITLE
Add Meilleurtaux to office=financial data

### DIFF
--- a/data/brands/office/financial.json
+++ b/data/brands/office/financial.json
@@ -159,6 +159,18 @@
         "office": "financial",
         "operator": "Premista"
       }
+    },
+    {
+      "displayName": "Meilleurtaux",
+      "id": "meilleurtaux-1791d3",
+      "locationSet": {"include": ["fx"]},
+      "matchNames": ["Meilleurtaux.com"],
+      "tags": {
+        "brand": "Meilleurtaux",
+        "brand:wikidata": "Q3304699",
+        "name": "Meilleurtaux",
+        "office": "financial"
+      }
     }
   ]
 }


### PR DESCRIPTION
Adding French financial service brand with 350 offices as of today (see [official website](https://www.meilleurtaux.com/a-propos-de-meilleurtaux/toutes-nos-agences-en-france/nos-agences-de-courtage.html))
- fx code as only Metropolitan France
- category is aligned with existing competitors like Cafpi and Vousfinancer