### PR TITLE
Split Rhaetian Railway and S-Bahn Chur

### DIFF
--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -1989,7 +1989,7 @@
     },
     {
       "displayName": "RhB",
-      "id": "rhb-0c66c7",
+      "id": "rhb-0c66c8",
       "locationSet": {
         "include": [
           "ch-gr.geojson",
@@ -1998,6 +1998,16 @@
       },
       "tags": {
         "network": "RhB",
+        "network:wikidata": "Q135619095",
+        "route": "train"
+      }
+    },
+    {
+      "displayName": "S-Bahn Chur",
+      "id": "sbahnchur-0c66c7",
+      "locationSet": {"include": ["ch-gr.geojson"]},
+      "tags": {
+        "network": "S-Bahn Chur",
         "network:wikidata": "Q2204412",
         "route": "train"
       }


### PR DESCRIPTION
So far, relations with `route=train` and `network=RhB` (Rhätische Bahn/Rhaetian Railway) suggested `network:wikidata=Q2204412`. However, [`Q2204412`](https://www.wikidata.org/wiki/Q2204412) only represents a subset of the network covered by RhB which are the S1 and S2 commuter rail services that comprise the (small) [S-Bahn Chur network](https://en.wikipedia.org/wiki/Chur_S-Bahn).

This PR is supposed to
* change the wikidata item in `data/transit/route/train.json` for the main Rhaetian Railway network to [`Q135619095`](https://www.wikidata.org/wiki/Q135619095)
* create a new entry in `data/transit/route/train.json` for the S-Bahn Chur network which uses the pre-existing Wikidata item at [`Q2204412`](https://www.wikidata.org/wiki/Q2204412).

Resources:
https://en.wikipedia.org/wiki/Rhaetian_Railway
https://en.wikipedia.org/wiki/Chur_S-Bahn
https://www.rhb.ch/en/service-souvenirs/rail-network