### PR TITLE
Put SNCF Voyageurs as the french railway operator

### DIFF
--- a/data/operators/amenity/drinking_water.json
+++ b/data/operators/amenity/drinking_water.json
@@ -1221,20 +1221,10 @@
       }
     },
     {
-      "displayName": "SNCF",
-      "id": "sncf-02ca9b",
-      "locationSet": {"include": ["fx"]},
-      "tags": {
-        "amenity": "drinking_water",
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646"
-      }
-    },
-    {
       "displayName": "SNCF Gares & Connexions",
       "id": "sncfgaresandconnexions-02ca9b",
       "locationSet": {"include": ["fx"]},
-      "matchNames": ["sncf gares et connexions"],
+      "matchNames": ["sncf", "sncf gares et connexions"],
       "tags": {
         "amenity": "drinking_water",
         "operator": "SNCF Gares & Connexions",

--- a/data/operators/amenity/toilets.json
+++ b/data/operators/amenity/toilets.json
@@ -1338,13 +1338,13 @@
       }
     },
     {
-      "displayName": "SNCF",
-      "id": "sncf-73fc0c",
+      "displayName": "SNCF Gares & Connexions",
+      "id": "sncfgaresandconnexions-73fc0c",
       "locationSet": {"include": ["fx"]},
       "tags": {
         "amenity": "toilets",
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646"
+        "operator": "SNCF Gares & Connexions",
+        "operator:wikidata": "Q3098278"
       }
     },
     {

--- a/data/operators/route/railway.json
+++ b/data/operators/route/railway.json
@@ -601,16 +601,6 @@
       }
     },
     {
-      "displayName": "SNCF",
-      "id": "sncf-ced9a9",
-      "locationSet": {"include": ["fx"]},
-      "tags": {
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646",
-        "route": "railway"
-      }
-    },
-    {
       "displayName": "SNCF Réseau",
       "id": "sncfreseau-ced9a9",
       "locationSet": {"include": ["fx"]},

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -939,7 +939,8 @@
       "tags": {
         "network": "Intercités",
         "network:wikidata": "Q1968198",
-        "operator": "SNCF",
+        "operator": "SNCF Voyageurs",
+        "operator:wikidata": "Q93090957",
         "route": "train"
       }
     },
@@ -2324,8 +2325,8 @@
       "tags": {
         "network": "TER Auvergne-Rhône-Alpes",
         "network:wikidata": "Q41585492",
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646",
+        "operator": "SNCF Voyageurs",
+        "operator:wikidata": "Q93090957",
         "route": "train"
       }
     },
@@ -2342,8 +2343,22 @@
       "tags": {
         "network": "TER Bourgogne-Franche-Comté",
         "network:wikidata": "Q43082620",
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646",
+        "operator": "SNCF Voyageurs",
+        "operator:wikidata": "Q93090957",
+        "route": "train"
+      }
+    },
+    {
+      "displayName": "TER Bourgogne-Ouest-Nivernais",
+      "id": "terbourgogneouestnivernais-75a404",
+      "locationSet": {
+        "include": ["fr-bfc.geojson"]
+      },
+      "tags": {
+        "network": "TER Bourgogne-Ouest-Nivernais",
+        "network:wikidata": "Q43082620",
+        "operator": "SNCF Voyageurs Bourgogne Ouest",
+        "operator:wikidata": "Q93090957",
         "route": "train"
       }
     },
@@ -2356,8 +2371,8 @@
       "tags": {
         "network": "TER Bretagne",
         "network:wikidata": "Q975369",
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646",
+        "operator": "SNCF Voyageurs",
+        "operator:wikidata": "Q93090957",
         "route": "train"
       }
     },
@@ -2371,8 +2386,8 @@
       "tags": {
         "network": "TER Centre – Val de Loire",
         "network:wikidata": "Q912775",
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646",
+        "operator": "SNCF Voyageurs",
+        "operator:wikidata": "Q93090957",
         "route": "train"
       }
     },
@@ -2385,8 +2400,8 @@
       "tags": {
         "network": "TER Grand Est",
         "network:wikidata": "Q37800073",
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646",
+        "operator": "SNCF Voyageurs",
+        "operator:wikidata": "Q93090957",
         "route": "train"
       }
     },
@@ -2399,8 +2414,22 @@
       "tags": {
         "network": "TER Hauts-de-France",
         "network:wikidata": "Q38223166",
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646",
+        "operator": "SNCF Voyageurs",
+        "operator:wikidata": "Q93090957",
+        "route": "train"
+      }
+    },
+    {
+      "displayName": "TER Hauts-de-France Étoile d'Amiens",
+      "id": "terhautsdefranceetoiledamiens-6daada",
+      "locationSet": {
+        "include": ["fr-hdf.geojson"]
+      },
+      "tags": {
+        "network": "TER Hauts-de-France Étoile d'Amiens",
+        "network:wikidata": "Q38223166",
+        "operator": "SNCF Voyageurs Étoile d'Amiens",
+        "operator:wikidata": "Q93090957",
         "route": "train"
       }
     },
@@ -2413,8 +2442,8 @@
       "tags": {
         "network": "TER Normandie",
         "network:wikidata": "Q30740754",
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646",
+        "operator": "SNCF Voyageurs",
+        "operator:wikidata": "Q93090957",
         "route": "train"
       }
     },
@@ -2427,8 +2456,8 @@
       "tags": {
         "network": "TER Nouvelle-Aquitaine",
         "network:wikidata": "Q47519663",
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646",
+        "operator": "SNCF Voyageurs",
+        "operator:wikidata": "Q93090957",
         "route": "train"
       }
     },
@@ -2445,8 +2474,8 @@
       "tags": {
         "network": "TER Occitanie",
         "network:wikidata": "Q37941081",
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646",
+        "operator": "SNCF Voyageurs",
+        "operator:wikidata": "Q93090957",
         "route": "train"
       }
     },
@@ -2459,13 +2488,27 @@
       "tags": {
         "network": "TER Pays de la Loire",
         "network:wikidata": "Q3512113",
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646",
+        "operator": "SNCF Voyageurs",
+        "operator:wikidata": "Q93090957",
         "route": "train"
       }
     },
     {
-      "displayName": "TER Provence-Alpes-Côte d'Azur",
+      "displayName": "TER Pays de la Loire Loire Océan",
+      "id": "terpaysdelaloireloireocean-04c37d",
+      "locationSet": {
+        "include": ["fr-pdl.geojson"]
+      },
+      "tags": {
+        "network": "TER Pays de la Loire Loire Océan",
+        "network:wikidata": "Q3512113",
+        "operator": "SNCF Voyageurs Loire Océan",
+        "operator:wikidata": "Q93090957",
+        "route": "train"
+      }
+    },
+    {
+      "displayName": "TER ZOU!",
       "id": "terprovencealpescotedazur-89ac8f",
       "locationSet": {
         "include": ["fr-pac.geojson"]
@@ -2473,8 +2516,22 @@
       "tags": {
         "network": "TER Provence-Alpes-Côte d'Azur",
         "network:wikidata": "Q3512123",
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646",
+        "operator": "SNCF Voyageurs",
+        "operator:wikidata": "Q93090957",
+        "route": "train"
+      }
+    },
+    {
+      "displayName": "TER ZOU! Étoile de Nice",
+      "id": "terprovencealpescotedazuretoiledenice-89ac8f",
+      "locationSet": {
+        "include": ["fr-pac.geojson"]
+      },
+      "tags": {
+        "network": "TER Provence-Alpes-Côte d'Azur Étoile de Nice",
+        "network:wikidata": "Q3512123",
+        "operator": "SNCF Voyageurs Sud Azur",
+        "operator:wikidata": "Q93090957",
         "route": "train"
       }
     },
@@ -2498,8 +2555,8 @@
       "tags": {
         "network": "TGV",
         "network:wikidata": "Q129337",
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646",
+        "operator": "SNCF Voyageurs",
+        "operator:wikidata": "Q93090957",
         "route": "train"
       }
     },
@@ -2511,8 +2568,8 @@
       "tags": {
         "network": "TGV InOui",
         "network:wikidata": "Q30754613",
-        "operator": "SNCF",
-        "operator:wikidata": "Q13646",
+        "operator": "SNCF Voyageurs",
+        "operator:wikidata": "Q93090957",
         "route": "train"
       }
     },


### PR DESCRIPTION
Since 2020, the french national railway company "SNCF" splitted in different companies: *SNCF Réseau* manages the network, *SNCF Gares & Connexions* manages the stations and *SNCF Voyageurs* is exploiting trains.

Furthermore, the political choice is to split *SNCF Voyageurs* into smaller companies to run a small network (eg: *SNCF Voyageurs Étoile d'Amiens* for regional lines around Amiens). I don't know how to manage it properly, I just added the new companies in the data file.