### PR TITLE
fix Komunálna poisťovňa name

### DIFF
--- a/data/brands/office/insurance.json
+++ b/data/brands/office/insurance.json
@@ -1659,13 +1659,13 @@
       }
     },
     {
-      "displayName": "KOMUNÁLNA poisťovňa",
+      "displayName": "Komunálna poisťovňa",
       "id": "komunalnapoistovna-780b74",
       "locationSet": {"include": ["sk"]},
       "tags": {
-        "brand": "KOMUNÁLNA poisťovňa",
+        "brand": "Komunálna poisťovňa",
         "brand:wikidata": "Q96129040",
-        "name": "KOMUNÁLNA poisťovňa",
+        "name": "Komunálna poisťovňa",
         "office": "insurance"
       }
     },

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -854,13 +854,13 @@
       }
     },
     {
-      "displayName": "ID ŽK (Slovensko)",
-      "id": "integrovanadopravazilinskehokraja-b6707b",
+      "displayName": "IDS PLUS",
+      "id": "integrovanydopravnysystemplus-b6707b",
       "locationSet": {"include": ["sk"]},
       "note": "ISO 3166-2 SK-ZI",
       "tags": {
-        "network": "Integrovaná doprava Žilinského kraja",
-        "network:short": "ID ŽK",
+        "network": "Integrovaný dopravný systém PLUS",
+        "network:short": "IDS PLUS",
         "network:wikidata": "Q105957236",
         "route": "train"
       }


### PR DESCRIPTION
Changed spelling according to https://wiki.openstreetmap.org/wiki/Names#Proper_name_spelling.