### PR TITLE
change GameStop for EB Games in Canada

### DIFF
--- a/data/brands/shop/video_games.json
+++ b/data/brands/shop/video_games.json
@@ -33,6 +33,21 @@
       }
     },
     {
+      "displayName": "EB Games (Canada)",
+      "id": "ebgames-3d1279",
+      "locationSet": {"include": ["ca"]},
+      "matchNames": [
+        "electronics boutique / eb games",
+        "gamestop"
+      ],
+      "tags": {
+        "brand": "EB Games",
+        "brand:wikidata": "Q135656622",
+        "name": "EB Games",
+        "shop": "video_games"
+      }
+    },
+    {
       "displayName": "EB Games (Oceania)",
       "id": "ebgames-be6d96",
       "locationSet": {"include": ["au", "nz"]},
@@ -70,10 +85,10 @@
     },
     {
       "displayName": "GameStop",
-      "id": "gamestop-e24f8b",
+      "id": "gamestop-62b0bb",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["au", "nz"]
+        "exclude": ["au", "ca", "nz"]
       },
       "matchNames": [
         "eb games",


### PR DESCRIPTION
GameStop sold it's Canadian operations and rebranded itself back to EB Games