### PR TITLE
Fastned is now in France, Italy, Switzerland

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -409,7 +409,7 @@
       "displayName": "Fastned",
       "id": "fastned-b69337",
       "locationSet": {
-        "include": ["be", "de", "gb", "nl"]
+        "include": ["be", "de", "gb", "nl", "fr", "it", "ch"]
       },
       "tags": {
         "amenity": "charging_station",


### PR DESCRIPTION
Source: https://www.fastnedcharging.com/fr/emplacements