### PR TITLE
Changing Gogoro locationSet to Taiwan-only

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -466,10 +466,7 @@
     {
       "displayName": "Gogoro 電池交換站",
       "id": "62c656-67e574",
-      "locationSet": {
-        "include": ["001"],
-        "exclude": ["no"]
-      },
+      "locationSet": {"include": ["tw"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "Gogoro 電池交換站",


### PR DESCRIPTION
According to their website, https://www.gogoro.com/findus/ , Gogoro is only located in Taiwan.