### PR TITLE
Adding IONNA EV Charging station that now meets eligibility criteria

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -525,6 +525,23 @@
       }
     },
     {
+      "displayName": "IONNA",
+      "locationSet": {
+        "include": ["us"]
+      },
+      "matchNames": [
+        "Rechargery",
+        "Rechargery Relay",
+        "Rechargery @",
+        "Rechargery Beacon"
+      ],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "IONNA",
+        "brand:wikidata": "Q124528707"
+      }
+    },
+    {
       "displayName": "Ionity",
       "id": "ionity-b625d6",
       "locationSet": {"include": ["150"]},


### PR DESCRIPTION
Adding IONNA now that they have been expanding in the past few months and show no sign of stopping. All the Places now shows 39 stations on the official website, with PlugShare showing many more under construction.

https://alltheplaces-data.openaddresses.io/runs/2025-08-09-13-32-21/output/ionna_us.geojson