### PR TITLE
Updating Bosch eBike Systems to only be in Europe

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -114,7 +114,7 @@
       "displayName": "Bosch eBike Systems",
       "id": "boschebikesystems-67e574",
       "locationSet": {
-        "include": ["001"],
+        "include": ["150"],
         "exclude": ["no"]
       },
       "matchNames": ["robert bosch gmbh"],


### PR DESCRIPTION
According to Overpass, the only stations of these exist in Europe, code 150.

https://overpass-turbo.eu/s/29Io