### PR TITLE
Excluding the US from Porsche Charging Stations

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -743,7 +743,7 @@
       "id": "porsche-67e574",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["no"]
+        "exclude": ["no", "us"]
       },
       "tags": {
         "amenity": "charging_station",


### PR DESCRIPTION
According to the Porsche website, they have partnership agreements with Electrify America, and open access with brands like ChargePoint and IONNA in the US, but I cannot find any reference to a Porsche charging station beyond private, in-home destination chargers which would not rise to the level of inclusion in NSI.

https://porsche-production.discover.chargetrip.com