### PR TITLE
Updating NIO EV Infrastructure locationSet

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -643,7 +643,7 @@
       "id": "niopowercharger-9dbcd7",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["us"]
+        "exclude": ["cn", "us"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -661,7 +661,7 @@
       "id": "niopowerdestination-9dbcd7",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["us"]
+        "exclude": ["cn", "us"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -679,7 +679,7 @@
       "id": "niopowerswap-9dbcd7",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["us"]
+        "exclude": ["cn", "us"]
       },
       "tags": {
         "amenity": "charging_station",

--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -643,7 +643,7 @@
       "id": "niopowercharger-9dbcd7",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["cn"]
+        "exclude": ["us"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -661,7 +661,7 @@
       "id": "niopowerdestination-9dbcd7",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["cn"]
+        "exclude": ["us"]
       },
       "tags": {
         "amenity": "charging_station",
@@ -679,7 +679,7 @@
       "id": "niopowerswap-9dbcd7",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["cn"]
+        "exclude": ["us"]
       },
       "tags": {
         "amenity": "charging_station",


### PR DESCRIPTION
NIO primarily sells in China, which their brand websites show, so I have removed "exclude" cn. In addition, they are not present in the US due to political decisions and economic tariffs so I have added "us" to "exclude".

https://www.onvo.cn/map

https://chargermap.eu.nio.com/pe/h5/static/chargermap?channel=official