### PR TITLE
Add cafe & fast_food in China

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -55,6 +55,28 @@
       }
     },
     {
+      "displayName": "1点点",
+      "id": "alittletea-3300f4",
+      "locationSet": {"include": ["cn"]},
+      "matchNames": ["一点点"],
+      "tags": {
+        "amenity": "cafe",
+        "brand": "1点点",
+        "brand:en": "ALittle Tea",
+        "brand:wikidata": "Q106926258",
+        "brand:zh": "1点点",
+        "brand:zh-Hans": "1点点",
+        "brand:zh-Hant": "1點點",
+        "cuisine": "bubble_tea",
+        "name": "1点点",
+        "name:en": "ALittle Tea",
+        "name:zh": "1点点",
+        "name:zh-Hans": "1点点",
+        "name:zh-Hant": "1點點",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "365",
       "id": "365-4351d9",
       "locationSet": {"include": ["es"]},
@@ -127,6 +149,31 @@
         "brand:wikidata": "Q118480682",
         "cuisine": "coffee_shop;vietnamese",
         "name": "7 Leaves Cafe",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "7分甜",
+      "id": "sweet7-823e31",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "tags": {
+        "amenity": "cafe",
+        "brand": "7分甜",
+        "brand:en": "Sweet7",
+        "brand:wikidata": "Q108117854",
+        "brand:zh": "7分甜",
+        "brand:zh-Hans": "7分甜",
+        "brand:zh-Hant": "7分甜",
+        "cuisine": "bubble_tea",
+        "delivery": "yes",
+        "name": "7分甜",
+        "name:en": "Sweet7",
+        "name:zh": "7分甜",
+        "name:zh-Hans": "7分甜",
+        "name:zh-Hant": "7分甜",
         "takeaway": "yes"
       }
     },
@@ -6255,23 +6302,6 @@
       }
     },
     {
-      "displayName": "一点点",
-      "id": "alittletea-3300f4",
-      "locationSet": {"include": ["cn"]},
-      "tags": {
-        "amenity": "cafe",
-        "brand": "一点点",
-        "brand:en": "alittle-tea",
-        "brand:wikidata": "Q106926258",
-        "brand:zh": "一点点",
-        "cuisine": "bubble_tea",
-        "name": "一点点",
-        "name:en": "alittle-tea",
-        "name:zh": "一点点",
-        "takeaway": "yes"
-      }
-    },
-    {
       "displayName": "一芳水果茶",
       "id": "yifangtea-bd86e2",
       "locationSet": {
@@ -6532,18 +6562,43 @@
       }
     },
     {
+      "displayName": "卡旺卡",
+      "id": "comewonka-823e31",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "tags": {
+        "amenity": "cafe",
+        "brand": "卡旺卡",
+        "brand:en": "Come Wonka",
+        "brand:wikidata": "Q135655177",
+        "brand:zh": "卡旺卡",
+        "brand:zh-Hans": "卡旺卡",
+        "brand:zh-Hant": "卡旺卡",
+        "cuisine": "bubble_tea",
+        "delivery": "yes",
+        "name": "卡旺卡",
+        "name:en": "Come Wonka",
+        "name:zh": "卡旺卡",
+        "name:zh-Hans": "卡旺卡",
+        "name:zh-Hant": "卡旺卡",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "古茗",
       "id": "goodme-3300f4",
       "locationSet": {"include": ["cn"]},
       "tags": {
         "amenity": "cafe",
         "brand": "古茗",
-        "brand:en": "Goodme",
+        "brand:en": "Good me",
         "brand:wikidata": "Q101500324",
         "brand:zh": "古茗",
-        "cuisine": "ice_cream;bubble_tea",
+        "cuisine": "bubble_tea",
         "name": "古茗",
-        "name:en": "Goodme",
+        "name:en": "Good me",
         "name:zh": "古茗",
         "takeaway": "yes"
       }
@@ -6898,17 +6953,26 @@
     },
     {
       "displayName": "幸运咖",
-      "id": "luckycup-3300f4",
-      "locationSet": {"include": ["cn"]},
+      "id": "luckycup-823e31",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
       "tags": {
         "amenity": "cafe",
         "brand": "幸运咖",
         "brand:en": "Lucky Cup",
+        "brand:wikidata": "Q135657515",
         "brand:zh": "幸运咖",
+        "brand:zh-Hans": "幸运咖",
+        "brand:zh-Hant": "幸運咖",
         "cuisine": "coffee_shop",
+        "delivery": "yes",
         "name": "幸运咖",
         "name:en": "Lucky Cup",
         "name:zh": "幸运咖",
+        "name:zh-Hans": "幸运咖",
+        "name:zh-Hant": "幸運咖",
         "takeaway": "yes"
       }
     },
@@ -7155,6 +7219,29 @@
       }
     },
     {
+      "displayName": "爷爷不泡茶",
+      "id": "noyeyenotea-823e31",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "tags": {
+        "amenity": "cafe",
+        "brand": "爷爷不泡茶",
+        "brand:en": "No Yeye No Tea",
+        "brand:wikidata": "Q135657533",
+        "brand:zh-Hans": "爷爷不泡茶",
+        "brand:zh-Hant": "爺爺不泡茶",
+        "cuisine": "bubble_tea",
+        "delivery": "yes",
+        "name": "爷爷不泡茶",
+        "name:en": "No Yeye No Tea",
+        "name:zh-Hans": "爷爷不泡茶",
+        "name:zh-Hant": "爺爺不泡茶",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "珈琲館",
       "id": "kohikan-0cf217",
       "locationSet": {"include": ["jp"]},
@@ -7224,6 +7311,56 @@
         "name": "瑞幸咖啡",
         "name:en": "Luckin Coffee",
         "name:zh": "瑞幸咖啡",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "甘茶度",
+      "id": "tealand-823e31",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "tags": {
+        "amenity": "cafe",
+        "brand": "甘茶度",
+        "brand:en": "Tea Land",
+        "brand:wikidata": "Q135652058",
+        "brand:zh": "甘茶度",
+        "brand:zh-Hans": "甘茶度",
+        "brand:zh-Hant": "甘茶度",
+        "cuisine": "bubble_tea;ice_cream",
+        "delivery": "yes",
+        "name": "甘茶度",
+        "name:en": "Tea Land",
+        "name:zh": "甘茶度",
+        "name:zh-Hans": "甘茶度",
+        "name:zh-Hant": "甘茶度",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "甜啦啦",
+      "id": "tianlala-823e31",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "tags": {
+        "amenity": "cafe",
+        "brand": "甜啦啦",
+        "brand:en": "Tianlala",
+        "brand:wikidata": "Q135652058",
+        "brand:zh": "甜啦啦",
+        "brand:zh-Hans": "甜啦啦",
+        "brand:zh-Hant": "甜啦啦",
+        "cuisine": "bubble_tea;ice_cream",
+        "delivery": "yes",
+        "name": "甜啦啦",
+        "name:en": "Tianlala",
+        "name:zh": "甜啦啦",
+        "name:zh-Hans": "甜啦啦",
+        "name:zh-Hant": "甜啦啦",
         "takeaway": "yes"
       }
     },
@@ -7300,6 +7437,29 @@
       }
     },
     {
+      "displayName": "肯悦咖啡",
+      "id": "kcoffee-823e31",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "tags": {
+        "amenity": "cafe",
+        "brand": "肯悦咖啡",
+        "brand:en": "KCOFFEE",
+        "brand:wikidata": "Q135678114",
+        "brand:zh-Hans": "肯悦咖啡",
+        "brand:zh-Hant": "肯悅咖啡",
+        "cuisine": "coffee_shop",
+        "delivery": "yes",
+        "name": "肯悦咖啡",
+        "name:en": "KCOFFEE",
+        "name:zh-Hans": "肯悦咖啡",
+        "name:zh-Hant": "肯悅咖啡",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "茶星人 E.Tea",
       "id": "etea-59dcf2",
       "locationSet": {"include": ["hk"]},
@@ -7360,7 +7520,7 @@
     },
     {
       "displayName": "茶百道",
-      "id": "chabaidao-bd86e2",
+      "id": "chapanda-bd86e2",
       "locationSet": {
         "include": ["cn"],
         "exclude": ["hk"]
@@ -7368,12 +7528,12 @@
       "tags": {
         "amenity": "cafe",
         "brand": "茶百道",
-        "brand:en": "chabaidao",
+        "brand:en": "ChaPanda",
         "brand:wikidata": "Q108165952",
         "brand:zh": "茶百道",
         "cuisine": "bubble_tea",
         "name": "茶百道",
-        "name:en": "chabaidao",
+        "name:en": "ChaPanda",
         "name:zh": "茶百道",
         "takeaway": "yes"
       }
@@ -7465,12 +7625,12 @@
         "brand:en": "Mixue Ice Cream & Tea",
         "brand:wikidata": "Q107406476",
         "brand:zh": "蜜雪冰城",
-        "brand:zh-Latn-pinyin": "Mixue Bingcheng",
+        "brand:zh-Latn-pinyin": "Mìxuě Bīngchéng",
         "cuisine": "ice_cream;bubble_tea",
         "name": "蜜雪冰城",
         "name:en": "Mixue Ice Cream & Tea",
         "name:zh": "蜜雪冰城",
-        "name:zh-Latn-pinyin": "Mixue Bingcheng",
+        "name:zh-Latn-pinyin": "Mìxuě Bīngchéng",
         "takeaway": "yes"
       }
     },
@@ -7485,12 +7645,12 @@
         "brand:en": "Mixue Ice Cream & Tea",
         "brand:wikidata": "Q107406476",
         "brand:zh": "蜜雪冰城",
-        "brand:zh-Latn-pinyin": "Mixue Bingcheng",
+        "brand:zh-Latn-pinyin": "Mìxuě Bīngchéng",
         "cuisine": "ice_cream;bubble_tea",
         "name": "蜜雪冰城 Mixue Ice Cream & Tea",
         "name:en": "Mixue Ice Cream & Tea",
         "name:zh": "蜜雪冰城",
-        "name:zh-Latn-pinyin": "Mixue Bingcheng",
+        "name:zh-Latn-pinyin": "Mìxuě Bīngchéng",
         "takeaway": "yes"
       }
     },

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -9907,7 +9907,7 @@
     },
     {
       "displayName": "Taco Bell",
-      "id": "tacobell-d22c36",
+      "id": "tacobell-d1feac",
       "locationSet": {
         "include": [
           "ae",
@@ -9918,7 +9918,6 @@
           "br",
           "ca",
           "cl",
-          "cn",
           "co",
           "cr",
           "cy",
@@ -13708,6 +13707,50 @@
       }
     },
     {
+      "displayName": "塔可钟",
+      "id": "tacobell-19ae3c",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "塔可钟",
+        "brand:en": "Taco Bell",
+        "brand:wikidata": "Q752941",
+        "brand:zh-Hans": "塔可钟",
+        "brand:zh-Hant": "塔可鐘",
+        "cuisine": "tex-mex",
+        "delivery": "yes",
+        "name": "塔可钟",
+        "name:en": "Taco Bell",
+        "name:zh-Hans": "塔可钟",
+        "name:zh-Hant": "塔可鐘",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "塔斯汀",
+      "id": "tastien-19ae3c",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "塔斯汀",
+        "brand:en": "Tastien",
+        "brand:wikidata": "Q117191831",
+        "brand:zh": "塔斯汀",
+        "cuisine": "burger",
+        "delivery": "yes",
+        "name": "塔斯汀",
+        "name:en": "Tastien",
+        "name:zh": "塔斯汀",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "大家乐",
       "id": "cafedecoral-19ae3c",
       "locationSet": {
@@ -13842,6 +13885,30 @@
         "name": "富士そば",
         "name:en": "Fuji Soba",
         "name:ja": "富士そば",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "尊宝比萨",
+      "id": "championpizza-19ae3c",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "matchNames": ["尊宝", "尊宝披萨"],
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "尊宝比萨",
+        "brand:en": "Champion Pizza",
+        "brand:wikidata": "Q135167309",
+        "brand:zh-Hans": "尊宝比萨",
+        "brand:zh-Hant": "尊寶比薩",
+        "cuisine": "pizza",
+        "delivery": "yes",
+        "name": "尊宝比萨",
+        "name:en": "Champion Pizza",
+        "name:zh-Hans": "尊宝比萨",
+        "name:zh-Hant": "尊寶比薩",
         "takeaway": "yes"
       }
     },
@@ -14197,12 +14264,12 @@
       "tags": {
         "amenity": "fast_food",
         "brand": "正新鸡排",
-        "brand:en": "ZHENGXIN CHICKEN STEAK",
+        "brand:en": "Zhengxin Chicken Steak",
         "brand:wikidata": "Q104093084",
         "brand:zh": "正新鸡排",
         "cuisine": "chicken_steak",
         "name": "正新鸡排",
-        "name:en": "ZHENGXIN CHICKEN STEAK",
+        "name:en": "Zhengxin Chicken Steak",
         "name:zh": "正新鸡排",
         "takeaway": "yes"
       }
@@ -14258,6 +14325,30 @@
         "name:zh": "漢堡王",
         "operator": "家城股份有限公司",
         "ref:vatin": "TW23309178",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "玛格利塔",
+      "id": "magrittapizza-19ae3c",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "matchNames": ["玛格丽塔"],
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "玛格利塔",
+        "brand:en": "Magritta Pizza",
+        "brand:wikidata": "Q135652045",
+        "brand:zh-Hans": "玛格利塔",
+        "brand:zh-Hant": "瑪格利塔",
+        "cuisine": "pizza",
+        "delivery": "yes",
+        "name": "玛格利塔",
+        "name:en": "Magritta Pizza",
+        "name:zh-Hans": "玛格利塔",
+        "name:zh-Hant": "瑪格利塔",
         "takeaway": "yes"
       }
     },
@@ -14347,6 +14438,31 @@
         "name": "築地銀だこ Gindaco",
         "name:en": "Gindaco",
         "name:ja": "築地銀だこ",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "米村拌饭",
+      "id": "micunbibimbap-19ae3c",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "米村拌饭",
+        "brand:en": "Micun Bibimbap",
+        "brand:ko": "미촌 비빔밥",
+        "brand:wikidata": "Q135677988",
+        "brand:zh-Hans": "米村拌饭",
+        "brand:zh-Hant": "米村拌飯",
+        "cuisine": "korean",
+        "delivery": "yes",
+        "name": "米村拌饭",
+        "name:en": "Micun Bibimbap",
+        "name:ko": "미촌 비빔밥",
+        "name:zh-Hans": "米村拌饭",
+        "name:zh-Hant": "米村拌飯",
         "takeaway": "yes"
       }
     },
@@ -14555,6 +14671,31 @@
         "name:en": "Fat Daddy American Fried Chicken",
         "name:zh": "胖老爹美式炸雞",
         "takeaway": "only"
+      }
+    },
+    {
+      "displayName": "芝根芝底",
+      "id": "zipizza-19ae3c",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "芝根芝底",
+        "brand:en": "Zi Pizza",
+        "brand:wikidata": "Q135677957",
+        "brand:zh": "芝根芝底",
+        "brand:zh-Hans": "芝根芝底",
+        "brand:zh-Hant": "芝根芝底",
+        "cuisine": "pizza",
+        "delivery": "yes",
+        "name": "芝根芝底",
+        "name:en": "Zi Pizza",
+        "name:zh": "芝根芝底",
+        "name:zh-Hans": "芝根芝底",
+        "name:zh-Hant": "芝根芝底",
+        "takeaway": "yes"
       }
     },
     {


### PR DESCRIPTION
### New
| Name |  | Number |
| - | - | - |
| 塔斯汀 | Tastien | 9647+ |
| 尊宝比萨 | Champion Pizza | 2900+ |
| 玛格利塔 | Magritta Pizza | 600+ |
| 芝根芝底 | Zi Pizza | 1200+ |
| 米村拌饭 | Micun Bibimbap | 1863+ |
| 甜啦啦 | Tianlala | 8000+ |
| 甘茶度 | Tea Land | 3000+ |
| 爷爷不泡茶 | No Yeye No Tea | 2500+ |
| 7分甜 | Sweet7 | 2000- |
| 卡旺卡 | Tianlala | 277+ |
| 幸运咖 | Lucky Cup | 7100+ |
| 肯悦咖啡 | KCOFFEE | 1300+ |

### Changes
蜜雪冰城: Corrected `zh-Latn-pinyin` to a tonal spelling
古茗: Removed `cuisine`=`ice_cream` because it is not sold as a single item. Added missing spaces in `name:en`.