### PR TITLE
Updating name of 85°C Bakery Cafe

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -178,7 +178,7 @@
       }
     },
     {
-      "displayName": "85°C",
+      "displayName": "85°C Bakery Cafe",
       "id": "ef3f02-07c6ab",
       "locationSet": {"include": ["au", "us"]},
       "matchNames": [
@@ -189,15 +189,16 @@
         "85°c bakery cafe",
         "85c bakery cafe",
         "85c daily cafe",
-        "85oc"
+        "85oc",
+        "85C"
       ],
       "tags": {
-        "alt_name": "85C",
+        "alt_name": "85°C",
         "amenity": "cafe",
-        "brand": "85°C",
+        "brand": "85°C Bakery Cafe",
         "brand:wikidata": "Q4644852",
         "cuisine": "coffee_shop;chinese",
-        "name": "85°C",
+        "name": "85°C Bakery Cafe",
         "takeaway": "yes"
       }
     },


### PR DESCRIPTION
Addresses #11223, website uses both 85°C and full 85°C Bakery Cafe, signage uses 85°C Bakery Cafe.

https://www.85cbakerycafe.com/about/#why-85c