### PR TITLE
Updating Hunt Brothers Pizza to be takeaway only

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -4652,7 +4652,7 @@
         "brand:wikidata": "Q5943909",
         "cuisine": "pizza",
         "name": "Hunt Brothers Pizza",
-        "takeaway": "yes"
+        "takeaway": "only"
       }
     },
     {


### PR DESCRIPTION
Hunt Brothers Pizza instructs customers to "Look for Hunt Brothers Pizza inside convenience stores and corner markets." These locations are only used for pick-up / takeaway, the OSM wiki states the correct tag for this is takeaway=only.

https://www.huntbrotherspizza.com/locations/
https://osm.wiki/wiki/Key:takeaway