### PR TITLE
move chemists from amenity=pharmacy to shop=chemist

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -3766,22 +3766,6 @@
       }
     },
     {
-      "displayName": "V・ドラッグ",
-      "id": "vdrug-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "V・ドラッグ",
-        "brand:en": "V・Drug",
-        "brand:ja": "V・ドラッグ",
-        "brand:wikidata": "Q11367334",
-        "healthcare": "pharmacy",
-        "name": "V・ドラッグ",
-        "name:en": "V・Drug",
-        "name:ja": "V・ドラッグ"
-      }
-    },
-    {
       "displayName": "Vaga Pharm",
       "id": "vagapharm-447e41",
       "locationSet": {"include": ["am"]},
@@ -5658,56 +5642,6 @@
       }
     },
     {
-      "displayName": "ウエルシア薬局",
-      "id": "welcia-650eee",
-      "locationSet": {"include": ["jp"]},
-      "matchNames": ["ウェルシア", "ウエルシア", "ハックドラッグ"],
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "welcia",
-        "brand:en": "welcia",
-        "brand:ja": "ウエルシア薬局",
-        "brand:wikidata": "Q11288687",
-        "healthcare": "pharmacy",
-        "name": "ウエルシア薬局",
-        "name:en": "Welcia",
-        "name:ja": "ウエルシア薬局"
-      }
-    },
-    {
-      "displayName": "ウェルパーク",
-      "id": "welpark-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "ウェルパーク",
-        "brand:en": "Welpark",
-        "brand:ja": "ウェルパーク",
-        "brand:wikidata": "Q11288610",
-        "healthcare": "pharmacy",
-        "name": "ウェルパーク",
-        "name:en": "Welpark",
-        "name:ja": "ウェルパーク"
-      }
-    },
-    {
-      "displayName": "オーエスドラッグ",
-      "id": "osdrug-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "alt_name": "OSドラッグ",
-        "amenity": "pharmacy",
-        "brand": "オーエスドラッグ",
-        "brand:en": "OS Drug",
-        "brand:ja": "オーエスドラッグ",
-        "brand:wikidata": "Q11407223",
-        "healthcare": "pharmacy",
-        "name": "オーエスドラッグ",
-        "name:en": "OS Drug",
-        "name:ja": "オーエスドラッグ"
-      }
-    },
-    {
       "displayName": "オレンジ薬局",
       "id": "1eb4d5-650eee",
       "locationSet": {"include": ["jp"]},
@@ -5718,38 +5652,6 @@
         "healthcare": "pharmacy",
         "name": "オレンジ薬局",
         "name:ja": "オレンジ薬局"
-      }
-    },
-    {
-      "displayName": "カワチ薬品",
-      "id": "cawachi-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "カワチ薬品",
-        "brand:en": "Cawachi",
-        "brand:ja": "カワチ薬品",
-        "brand:wikidata": "Q11295397",
-        "healthcare": "pharmacy",
-        "name": "カワチ薬品",
-        "name:en": "Cawachi",
-        "name:ja": "カワチ薬品"
-      }
-    },
-    {
-      "displayName": "キリン堂",
-      "id": "kirindo-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "キリン堂",
-        "brand:en": "Kirindo",
-        "brand:ja": "キリン堂",
-        "brand:wikidata": "Q130612731",
-        "healthcare": "pharmacy",
-        "name": "キリン堂",
-        "name:en": "Kirindo",
-        "name:ja": "キリン堂"
       }
     },
     {
@@ -5770,108 +5672,6 @@
       }
     },
     {
-      "displayName": "クスリのアオキ",
-      "id": "kusurinoaoki-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "クスリのアオキ",
-        "brand:en": "Kusuri no Aoki",
-        "brand:ja": "クスリのアオキ",
-        "brand:wikidata": "Q11298661",
-        "healthcare": "pharmacy",
-        "name": "クスリのアオキ",
-        "name:en": "Kusuri no Aoki",
-        "name:ja": "クスリのアオキ"
-      }
-    },
-    {
-      "displayName": "くすりの福太郎",
-      "id": "kusurinofukutaro-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "くすりの福太郎",
-        "brand:en": "Kusurino FUKUTARO",
-        "brand:ja": "くすりの福太郎",
-        "brand:wikidata": "Q17214460",
-        "healthcare": "pharmacy",
-        "name": "くすりの福太郎",
-        "name:en": "Kusurino Fukutaro",
-        "name:ja": "くすりの福太郎"
-      }
-    },
-    {
-      "displayName": "クリエイトSD",
-      "id": "createsd-650eee",
-      "locationSet": {"include": ["jp"]},
-      "matchNames": ["クリエイト"],
-      "tags": {
-        "alt_name": "薬CREATE",
-        "alt_name:ja": "薬クリエイト",
-        "amenity": "pharmacy",
-        "brand": "クリエイトSD",
-        "brand:en": "Create SD",
-        "brand:ja": "クリエイトSD",
-        "brand:wikidata": "Q117337754",
-        "healthcare": "pharmacy",
-        "name": "クリエイトSD",
-        "name:en": "Create SD",
-        "name:ja": "クリエイトSD"
-      }
-    },
-    {
-      "displayName": "クリエイト薬局",
-      "id": "createpharmacy-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "クリエイト薬局",
-        "brand:en": "Create Pharmacy",
-        "brand:ja": "クリエイト薬局",
-        "brand:wikidata": "Q115682176",
-        "healthcare": "pharmacy",
-        "name": "クリエイト薬局",
-        "name:en": "Create Pharmacy",
-        "name:ja": "クリエイト薬局"
-      }
-    },
-    {
-      "displayName": "コクミン",
-      "id": "kokumin-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "コクミン",
-        "brand:en": "Kokumin",
-        "brand:ja": "コクミン",
-        "brand:wikidata": "Q11301923",
-        "healthcare": "pharmacy",
-        "name": "コクミン",
-        "name:en": "Kokumin",
-        "name:ja": "コクミン",
-        "official_name": "コクミンドラッグ",
-        "official_name:en": "Kokumin Drug",
-        "official_name:ja": "コクミンドラッグ"
-      }
-    },
-    {
-      "displayName": "ココカラファイン",
-      "id": "cocokarafine-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "ココカラファイン",
-        "brand:en": "Cocokara Fine",
-        "brand:ja": "ココカラファイン",
-        "brand:wikidata": "Q11301948",
-        "healthcare": "pharmacy",
-        "name": "ココカラファイン",
-        "name:en": "Cocokara Fine",
-        "name:ja": "ココカラファイン"
-      }
-    },
-    {
       "displayName": "さくら薬局",
       "id": "sakurapharmacy-650eee",
       "locationSet": {"include": ["jp"]},
@@ -5888,102 +5688,6 @@
       }
     },
     {
-      "displayName": "サツドラ",
-      "id": "satudora-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "alt_name": "サッポロドラッグストアー",
-        "alt_name:en": "Sapporo Drug Store",
-        "alt_name:ja": "サッポロドラッグストアー",
-        "amenity": "pharmacy",
-        "brand": "サツドラ",
-        "brand:en": "SATUDORA",
-        "brand:ja": "サツドラ",
-        "brand:wikidata": "Q11304804",
-        "healthcare": "pharmacy",
-        "name": "サツドラ",
-        "name:en": "Satudora",
-        "name:ja": "サツドラ"
-      }
-    },
-    {
-      "displayName": "サンドラッグ",
-      "id": "sundrug-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "サンドラッグ",
-        "brand:en": "Sundrug",
-        "brand:ja": "サンドラッグ",
-        "brand:wikidata": "Q11305867",
-        "healthcare": "pharmacy",
-        "name": "サンドラッグ",
-        "name:en": "Sundrug",
-        "name:ja": "サンドラッグ"
-      }
-    },
-    {
-      "displayName": "スーパードラッグひまわり",
-      "id": "superdrughimawari-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "スーパードラッグひまわり",
-        "brand:en": "Super Drug Himawari",
-        "brand:ja": "スーパードラッグひまわり",
-        "brand:wikidata": "Q119871355",
-        "healthcare": "pharmacy",
-        "name": "スーパードラッグひまわり",
-        "name:en": "Super Drug Himawari",
-        "name:ja": "スーパードラッグひまわり"
-      }
-    },
-    {
-      "displayName": "スギ薬局",
-      "id": "sugipharmacy-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "スギ薬局",
-        "brand:en": "Sugi Pharmacy",
-        "brand:ja": "スギ薬局",
-        "brand:wikidata": "Q11311460",
-        "healthcare": "pharmacy",
-        "name": "スギ薬局",
-        "name:en": "Sugi Pharmacy",
-        "name:ja": "スギ薬局"
-      }
-    },
-    {
-      "displayName": "セイジョー",
-      "id": "seijo-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "セイジョー",
-        "brand:en": "Seijo",
-        "brand:ja": "セイジョー",
-        "brand:wikidata": "Q11314133",
-        "healthcare": "pharmacy",
-        "name": "セイジョー",
-        "name:en": "Seijo",
-        "name:ja": "セイジョー"
-      }
-    },
-    {
-      "displayName": "セイムス",
-      "id": "ca047a-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "セイムス",
-        "brand:ja": "セイムス",
-        "healthcare": "pharmacy",
-        "name": "セイムス",
-        "name:ja": "セイムス"
-      }
-    },
-    {
       "displayName": "そうごう薬局",
       "id": "531aeb-650eee",
       "locationSet": {"include": ["jp"]},
@@ -5994,88 +5698,6 @@
         "healthcare": "pharmacy",
         "name": "そうごう薬局",
         "name:ja": "そうごう薬局"
-      }
-    },
-    {
-      "displayName": "ダイコクドラッグ",
-      "id": "daikokudrug-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "ダイコクドラッグ",
-        "brand:en": "Daikoku Drug",
-        "brand:ja": "ダイコクドラッグ",
-        "brand:wikidata": "Q11316754",
-        "healthcare": "pharmacy",
-        "name": "ダイコクドラッグ",
-        "name:en": "Daikoku Drug",
-        "name:ja": "ダイコクドラッグ"
-      }
-    },
-    {
-      "displayName": "ツルハドラッグ",
-      "id": "tsuruha-650eee",
-      "locationSet": {"include": ["jp"]},
-      "matchNames": ["tsuruha drug"],
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "ツルハドラッグ",
-        "brand:en": "Tsuruha",
-        "brand:ja": "ツルハドラッグ",
-        "brand:wikidata": "Q11318826",
-        "healthcare": "pharmacy",
-        "name": "ツルハドラッグ",
-        "name:en": "Tsuruha",
-        "name:ja": "ツルハドラッグ"
-      }
-    },
-    {
-      "displayName": "トモズ",
-      "id": "tomods-650eee",
-      "locationSet": {"include": ["jp"]},
-      "matchNames": ["トモズエキスプレス"],
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "トモズ",
-        "brand:en": "Tomod's",
-        "brand:ja": "トモズ",
-        "brand:wikidata": "Q7820097",
-        "healthcare": "pharmacy",
-        "name": "トモズ",
-        "name:en": "Tomod's",
-        "name:ja": "トモズ"
-      }
-    },
-    {
-      "displayName": "ドラッグイレブン",
-      "id": "drugeleven-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "ドラッグイレブン",
-        "brand:en": "Drug Eleven",
-        "brand:ja": "ドラッグイレブン",
-        "brand:wikidata": "Q11323075",
-        "healthcare": "pharmacy",
-        "name": "ドラッグイレブン",
-        "name:en": "Drug Eleven",
-        "name:ja": "ドラッグイレブン"
-      }
-    },
-    {
-      "displayName": "ドラッグセイムス",
-      "id": "drugseims-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "ドラッグセイムス",
-        "brand:en": "Seims",
-        "brand:ja": "ドラッグセイムス",
-        "brand:wikidata": "Q11456137",
-        "healthcare": "pharmacy",
-        "name": "ドラッグセイムス",
-        "name:en": "Drug Seims",
-        "name:ja": "ドラッグセイムス"
       }
     },
     {
@@ -6095,22 +5717,6 @@
       }
     },
     {
-      "displayName": "ぱぱす",
-      "id": "papasu-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "ぱぱす",
-        "brand:en": "Papasu",
-        "brand:ja": "ぱぱす",
-        "brand:wikidata": "Q11276061",
-        "healthcare": "pharmacy",
-        "name": "ぱぱす",
-        "name:en": "Papasu",
-        "name:ja": "ぱぱす"
-      }
-    },
-    {
       "displayName": "ひまわり薬局",
       "id": "himawaripharmacy-650eee",
       "locationSet": {"include": ["jp"]},
@@ -6123,22 +5729,6 @@
         "name": "ひまわり薬局",
         "name:en": "Himawari Pharmacy",
         "name:ja": "ひまわり薬局"
-      }
-    },
-    {
-      "displayName": "フィットケアデポ",
-      "id": "fitcaredepot-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "Fit Care DEPOT",
-        "brand:en": "Fit Care DEPOT",
-        "brand:ja": "フィットケアデポ",
-        "brand:wikidata": "Q121625030",
-        "healthcare": "pharmacy",
-        "name": "フィットケアデポ",
-        "name:en": "Fit Care DEPOT",
-        "name:ja": "フィットケアデポ"
       }
     },
     {
@@ -6155,25 +5745,6 @@
         "name": "ププレひまわり薬局",
         "name:en": "Pupule Himawari Pharmacy",
         "name:ja": "ププレひまわり薬局"
-      }
-    },
-    {
-      "displayName": "マツモトキヨシ",
-      "id": "matsumotokiyoshi-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "マツモトキヨシ",
-        "brand:en": "Matsumoto Kiyoshi",
-        "brand:ja": "マツモトキヨシ",
-        "brand:wikidata": "Q8014776",
-        "healthcare": "pharmacy",
-        "name": "マツモトキヨシ",
-        "name:en": "Matsumoto Kiyoshi",
-        "name:ja": "マツモトキヨシ",
-        "short_name": "マツキヨ",
-        "short_name:en": "Matsukiyo",
-        "short_name:ja": "マツキヨ"
       }
     },
     {
@@ -6317,22 +5888,6 @@
       }
     },
     {
-      "displayName": "杏林堂",
-      "id": "kyorindo-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "杏林堂",
-        "brand:en": "Kyorindo",
-        "brand:ja": "杏林堂",
-        "brand:wikidata": "Q11522605",
-        "healthcare": "pharmacy",
-        "name": "杏林堂",
-        "name:en": "Kyorindo",
-        "name:ja": "杏林堂"
-      }
-    },
-    {
       "displayName": "松本清",
       "id": "matsumotokiyoshi-9d8b4e",
       "locationSet": {"include": ["tw"]},
@@ -6414,38 +5969,6 @@
         "name": "老百姓大药房",
         "name:en": "LBX Pharmacy",
         "name:zh": "老百姓大药房"
-      }
-    },
-    {
-      "displayName": "薬王堂",
-      "id": "yakuodo-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "薬王堂",
-        "brand:en": "Yakuodo",
-        "brand:ja": "薬王堂",
-        "brand:wikidata": "Q11622485",
-        "healthcare": "pharmacy",
-        "name": "薬王堂",
-        "name:en": "Yakuodo",
-        "name:ja": "薬王堂"
-      }
-    },
-    {
-      "displayName": "調剤薬局ツルハドラッグ",
-      "id": "pharmacytsuruha-650eee",
-      "locationSet": {"include": ["jp"]},
-      "tags": {
-        "amenity": "pharmacy",
-        "brand": "ツルハドラッグ",
-        "brand:en": "Tsuruha",
-        "brand:ja": "ツルハドラッグ",
-        "brand:wikidata": "Q114891238",
-        "healthcare": "pharmacy",
-        "name": "調剤薬局ツルハドラッグ",
-        "name:en": "Pharmacy Tsuruha",
-        "name:ja": "調剤薬局ツルハドラッグ"
       }
     },
     {

--- a/data/brands/shop/chemist.json
+++ b/data/brands/shop/chemist.json
@@ -792,6 +792,150 @@
       }
     },
     {
+      "displayName": "V・ドラッグ",
+      "id": "vdrug-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "V・ドラッグ",
+        "brand:en": "V・Drug",
+        "brand:ja": "V・ドラッグ",
+        "brand:wikidata": "Q11367334",
+        "name": "V・ドラッグ",
+        "name:en": "V・Drug",
+        "name:ja": "V・ドラッグ"
+      }
+    },
+    {
+      "displayName": "ウェルパーク",
+      "id": "welpark-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "ウェルパーク",
+        "brand:en": "Welpark",
+        "brand:ja": "ウェルパーク",
+        "brand:wikidata": "Q11288610",
+        "name": "ウェルパーク",
+        "name:en": "Welpark",
+        "name:ja": "ウェルパーク"
+      }
+    },
+     {
+      "displayName": "キリン堂",
+      "id": "kirindo-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "キリン堂",
+        "brand:en": "Kirindo",
+        "brand:ja": "キリン堂",
+        "brand:wikidata": "Q130612731",
+        "name": "キリン堂",
+        "name:en": "Kirindo",
+        "name:ja": "キリン堂"
+      }
+    },
+    {
+      "displayName": "クリエイトSD",
+      "id": "createsd-650eee",
+      "locationSet": {"include": ["jp"]},
+      "matchNames": ["クリエイト"],
+      "tags": {
+        "alt_name": "薬CREATE",
+        "alt_name:ja": "薬クリエイト",
+        "brand": "クリエイトSD",
+        "brand:en": "Create SD",
+        "brand:ja": "クリエイトSD",
+        "brand:wikidata": "Q117337754",
+        "name": "クリエイトSD",
+        "name:en": "Create SD",
+        "name:ja": "クリエイトSD",
+        "shop": "chemist",
+      }
+    },
+    {
+      "displayName": "コクミン",
+      "id": "kokumin-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "コクミン",
+        "brand:en": "Kokumin",
+        "brand:ja": "コクミン",
+        "brand:wikidata": "Q11301923",
+        "name": "コクミン",
+        "name:en": "Kokumin",
+        "name:ja": "コクミン",
+        "official_name": "コクミンドラッグ",
+        "official_name:en": "Kokumin Drug",
+        "official_name:ja": "コクミンドラッグ"
+      }
+    },
+   {
+      "displayName": "ココカラファイン",
+      "id": "cocokarafine-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "ココカラファイン",
+        "brand:en": "Cocokara Fine",
+        "brand:ja": "ココカラファイン",
+        "brand:wikidata": "Q11301948",
+        "name": "ココカラファイン",
+        "name:en": "Cocokara Fine",
+        "name:ja": "ココカラファイン"
+      }
+    },
+    {
+      "displayName": "サツドラ",
+      "id": "satudora-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "alt_name": "サッポロドラッグストアー",
+        "alt_name:en": "Sapporo Drug Store",
+        "alt_name:ja": "サッポロドラッグストアー",
+        "brand": "サツドラ",
+        "brand:en": "SATSUDORA",
+        "brand:ja": "サツドラ",
+        "brand:wikidata": "Q11304804",
+        "shop": "chemist",
+        "name": "サツドラ",
+        "name:en": "Satsudora",
+        "name:ja": "サツドラ"
+      }
+    },
+    {
+      "displayName": "サンドラッグ",
+      "id": "sundrug-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "サンドラッグ",
+        "brand:en": "Sundrug",
+        "brand:ja": "サンドラッグ",
+        "brand:wikidata": "Q11305867",
+        "shop": "chemist",
+        "name": "サンドラッグ",
+        "name:en": "Sundrug",
+        "name:ja": "サンドラッグ"
+      }
+    },
+    {
+      "displayName": "スーパードラッグひまわり",
+      "id": "superdrughimawari-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "スーパードラッグひまわり",
+        "brand:en": "Super Drug Himawari",
+        "brand:ja": "スーパードラッグひまわり",
+        "brand:wikidata": "Q119871355",
+        "name": "スーパードラッグひまわり",
+        "name:en": "Super Drug Himawari",
+        "name:ja": "スーパードラッグひまわり"
+      }
+    },
+    {
       "displayName": "スギ薬局",
       "id": "sugipharmacy-a211ef",
       "locationSet": {"include": ["jp"]},
@@ -800,10 +944,270 @@
         "brand:en": "Sugi Pharmacy",
         "brand:ja": "スギ薬局",
         "brand:wikidata": "Q11311460",
-        "healthcare": "pharmacy",
         "name": "スギ薬局",
         "name:en": "Sugi Pharmacy",
         "name:ja": "スギ薬局",
+        "shop": "chemist"
+      }
+    },
+    {
+      "displayName": "セイジョー",
+      "id": "seijo-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "セイジョー",
+        "brand:en": "Seijo",
+        "brand:ja": "セイジョー",
+        "brand:wikidata": "Q11314133",
+        "shop": "chemist",
+        "name": "セイジョー",
+        "name:en": "Seijo",
+        "name:ja": "セイジョー"
+      }
+    },
+    {
+      "displayName": "セイムス",
+      "id": "ca047a-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "セイムス",
+        "brand:ja": "セイムス",
+        "brand:en": "Seims",
+        "name": "セイムス",
+        "name:ja": "セイムス",
+        "name:en": "Seims"
+      }
+    },
+    {
+      "displayName": "ダイコクドラッグ",
+      "id": "daikokudrug-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "ダイコクドラッグ",
+        "brand:en": "Daikoku Drug",
+        "brand:ja": "ダイコクドラッグ",
+        "brand:wikidata": "Q11316754",
+        "name": "ダイコクドラッグ",
+        "name:en": "Daikoku Drug",
+        "name:ja": "ダイコクドラッグ"
+      }
+    },
+    {
+      "displayName": "ツルハドラッグ",
+      "id": "tsuruha-650eee",
+      "locationSet": {"include": ["jp"]},
+      "matchNames": ["tsuruha drug"],
+      "tags": {
+        "shop": "chemist",
+        "brand": "ツルハドラッグ",
+        "brand:en": "Tsuruha",
+        "brand:ja": "ツルハドラッグ",
+        "brand:wikidata": "Q11318826",
+        "name": "ツルハドラッグ",
+        "name:en": "Tsuruha",
+        "name:ja": "ツルハドラッグ"
+      }
+    },
+    {
+      "displayName": "トモズ",
+      "id": "tomods-650eee",
+      "locationSet": {"include": ["jp"]},
+      "matchNames": ["トモズエキスプレス"],
+      "tags": {
+        "shop": "chemist",
+        "brand": "トモズ",
+        "brand:en": "Tomod's",
+        "brand:ja": "トモズ",
+        "brand:wikidata": "Q7820097",
+        "name": "トモズ",
+        "name:en": "Tomod's",
+        "name:ja": "トモズ"
+      }
+    },
+    {
+      "displayName": "ドラッグイレブン",
+      "id": "drugeleven-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "ドラッグイレブン",
+        "brand:en": "Drug Eleven",
+        "brand:ja": "ドラッグイレブン",
+        "brand:wikidata": "Q11323075",
+        "name": "ドラッグイレブン",
+        "name:en": "Drug Eleven",
+        "name:ja": "ドラッグイレブン"
+      }
+    },
+    {
+      "displayName": "ぱぱす",
+      "id": "papasu-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "ぱぱす",
+        "brand:en": "Papasu",
+        "brand:ja": "ぱぱす",
+        "brand:wikidata": "Q11276061",
+        "name": "ぱぱす",
+        "name:en": "Papasu",
+        "name:ja": "ぱぱす"
+      }
+    },
+    {
+      "displayName": "フィットケアデポ",
+      "id": "fitcaredepot-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "Fit Care DEPOT",
+        "brand:en": "Fit Care DEPOT",
+        "brand:ja": "フィットケアデポ",
+        "brand:wikidata": "Q121625030",
+        "name": "フィットケアデポ",
+        "name:en": "Fit Care DEPOT",
+        "name:ja": "フィットケアデポ"
+      }
+    },
+    {
+      "displayName": "マツモトキヨシ",
+      "id": "matsumotokiyoshi-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "マツモトキヨシ",
+        "brand:en": "Matsumoto Kiyoshi",
+        "brand:ja": "マツモトキヨシ",
+        "brand:wikidata": "Q8014776",
+        "name": "マツモトキヨシ",
+        "name:en": "Matsumoto Kiyoshi",
+        "name:ja": "マツモトキヨシ",
+        "short_name": "マツキヨ",
+        "short_name:en": "Matsukiyo",
+        "short_name:ja": "マツキヨ"
+      }
+    },
+    {
+      "displayName": "杏林堂",
+      "id": "kyorindo-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "杏林堂",
+        "brand:en": "Kyorindo",
+        "brand:ja": "杏林堂",
+        "brand:wikidata": "Q11522605",
+        "name": "杏林堂",
+        "name:en": "Kyorindo",
+        "name:ja": "杏林堂"
+      }
+    },
+    {
+      "displayName": "薬王堂",
+      "id": "yakuodo-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "薬王堂",
+        "brand:en": "Yakuodo",
+        "brand:ja": "薬王堂",
+        "brand:wikidata": "Q11622485",
+        "name": "薬王堂",
+        "name:en": "Yakuodo",
+        "name:ja": "薬王堂"
+      }
+    },
+    {
+      "displayName": "ウエルシア薬局",
+      "id": "welcia-650eee",
+      "locationSet": {"include": ["jp"]},
+      "matchNames": ["ウェルシア", "ウエルシア", "ハックドラッグ"],
+      "tags": {
+        "shop": "chemist",
+        "brand": "welcia",
+        "brand:en": "welcia",
+        "brand:ja": "ウエルシア薬局",
+        "brand:wikidata": "Q11288687",
+        "name": "ウエルシア薬局",
+        "name:en": "Welcia",
+        "name:ja": "ウエルシア薬局"
+      }
+    },
+    {
+      "displayName": "オーエスドラッグ",
+      "id": "osdrug-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "alt_name": "OSドラッグ",
+        "shop": "chemist",
+        "brand": "オーエスドラッグ",
+        "brand:en": "OS Drug",
+        "brand:ja": "オーエスドラッグ",
+        "brand:wikidata": "Q11407223",
+        "name": "オーエスドラッグ",
+        "name:en": "OS Drug",
+        "name:ja": "オーエスドラッグ"
+      }
+    },
+    {
+      "displayName": "カワチ薬品",
+      "id": "cawachi-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "カワチ薬品",
+        "brand:en": "Cawachi",
+        "brand:ja": "カワチ薬品",
+        "brand:wikidata": "Q11295397",
+        "name": "カワチ薬品",
+        "name:en": "Cawachi",
+        "name:ja": "カワチ薬品"
+      }
+    },
+    {
+      "displayName": "クスリのアオキ",
+      "id": "kusurinoaoki-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "クスリのアオキ",
+        "brand:en": "Kusuri no Aoki",
+        "brand:ja": "クスリのアオキ",
+        "brand:wikidata": "Q11298661",
+        "name": "クスリのアオキ",
+        "name:en": "Kusuri no Aoki",
+        "name:ja": "クスリのアオキ",
+        "shop": "chemist"
+      }
+    },
+    {
+      "displayName": "クリエイト薬局",
+      "id": "createpharmacy-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "shop": "chemist",
+        "brand": "クリエイト薬局",
+        "brand:en": "Create Pharmacy",
+        "brand:ja": "クリエイト薬局",
+        "brand:wikidata": "Q115682176",
+        "name": "クリエイト薬局",
+        "name:en": "Create Pharmacy",
+        "name:ja": "クリエイト薬局"
+      }
+    },
+    {
+      "displayName": "くすりの福太郎",
+      "id": "kusurinofukutaro-650eee",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "くすりの福太郎",
+        "brand:en": "Kusurino FUKUTARO",
+        "brand:ja": "くすりの福太郎",
+        "brand:wikidata": "Q17214460",
+        "name": "くすりの福太郎",
+        "name:en": "Kusurino Fukutaro",
+        "name:ja": "くすりの福太郎",
         "shop": "chemist"
       }
     },


### PR DESCRIPTION
all of these stores were wrongly categorized as pharmacies when they are actually chemists. The amenity=pharmacy for Japan that are left only fill prescriptions and don't sell food or other things a shop=chemist might.