### PR TITLE
Adding some new EV charging brands

### DIFF
--- a/data/brands/amenity/pub.json
+++ b/data/brands/amenity/pub.json
@@ -667,8 +667,11 @@
         "amenity": "pub",
         "brand": "庄や",
         "brand:ja": "庄や",
+        "brand:en": "Shoya",
         "name": "庄や",
-        "name:ja": "庄や"
+        "name:ja": "庄や",
+        "name:en": "Shoya",
+        "brand:wikidata": "Q122964078",
       }
     },
     {
@@ -694,8 +697,11 @@
         "amenity": "pub",
         "brand": "目利きの銀次",
         "brand:ja": "目利きの銀次",
+        "brand:en": "Mekiki-no-Ginji",
         "name": "目利きの銀次",
-        "name:ja": "目利きの銀次"
+        "name:ja": "目利きの銀次",
+        "name:en": "Mekiki-no-Ginji",
+        "brand:wikidata": "Q109653557",
       }
     },
     {

--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -4668,6 +4668,7 @@
       "displayName": "Hackett London",
       "id": "hackettlondon-3937bd",
       "locationSet": {"include": ["001"]},
+      "matchNames": ["hackett"],
       "tags": {
         "brand": "Hackett London",
         "brand:wikidata": "Q1136426",


### PR DESCRIPTION
Number of stations in the US according to the United States Department of Energy for notability purposes:

Loop - 915
EvGateway - 405
Shell Recharge - 1556
NovaCHARGE - 287
ampUp - approx. 2000 (retail operators)
SWTCH - 493
opconnect - 351