### PR TITLE
[MA] Fixed typo in Afriquia

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -131,18 +131,18 @@
       }
     },
     {
-      "displayName": "Afriquia أفريقيا",
+      "displayName": "Afriquia افريقيا",
       "id": "afriquia-144a57",
       "locationSet": {"include": ["ma"]},
       "tags": {
         "amenity": "fuel",
-        "brand": "Afriquia أفريقيا",
-        "brand:ar": "أفريقيا",
-        "brand:en": "Afriquia",
+        "brand": "Afriquia افريقيا",
+        "brand:ar": "افريقيا",
+        "brand:fr": "Afriquia",
         "brand:wikidata": "Q56300032",
-        "name": "Afriquia أفريقيا",
-        "name:ar": "أفريقيا",
-        "name:en": "Afriquia"
+        "name": "Afriquia افريقيا",
+        "name:ar": "افريقيا",
+        "name:fr": "Afriquia"
       }
     },
     {


### PR DESCRIPTION
Afriquia's brand name in Arabic is افريقيا, not أفريقيا. It basically doesn't have the little thing on top of the ا (see logo). It's a small mistake but better be correct nevertheless.
<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/faac37a4-1214-4f96-9bd5-52470aa2d952" />

I also changed name:en and brand:en to name:fr and brand:fr, because French is the language used in the country, not English. "Afriquia" itself isn't even an English word.