### PR TITLE
Preserve names on Do it Best

### DIFF
--- a/data/brands/shop/hardware.json
+++ b/data/brands/shop/hardware.json
@@ -132,6 +132,7 @@
         "do it best hardware",
         "do it center"
       ],
+      "preserveTags": ["^name"],
       "tags": {
         "brand": "Do it Best",
         "brand:wikidata": "Q5286067",


### PR DESCRIPTION
Do it Best is a [weakly branded co-op chain](https://github.com/osmlab/name-suggestion-index/issues/5500#issuecomment-943095957) that doesn’t enforce member locations’ naming at all. Some members call their locations “Do it Best” or “Do it Center”, others keep just the “Do it” and drop the “Best”, and still others don’t include the chain in their names at all, relegating the branding to a logo beside the actual name. I used to frequent a [McCabe Do it Center](https://www.openstreetmap.org/node/256828030) but only knew it was part of that small local chain. I never knew Do it Best is a national chain until seeing the logo in a [Barton’s Do it Center](https://www.openstreetmap.org/way/71338163) thousands of miles away.

Each member is essentially its own chain, but few are big enough to warrant a separate entry in NSI as with Caterpillar (#5647). Instead, we can let mappers indicate the name more manually. The Do it Best logo is still applicable to even the lightly branded members anyways.