### PR TITLE
add hotel brand Elite Hotels of Sweden

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -4672,6 +4672,16 @@
         "operator:zh": "長榮集團",
         "tourism": "hotel"
       }
-    }
+    },
+  {
+      "displayName": "Elite Hotels of Sweden",
+      "locationSet": {"include": ["se"]},
+      "tags": {
+        "brand": " Elite Hotels of Sweden ",
+        "brand:wikidata": " Q10481573",
+        "name": " Elite Hotels of Sweden ",
+        "tourism": "hotel"
+      }
+    }  
   ]
 }


### PR DESCRIPTION
add hotel brand Elite Hotels of Sweden.
It is Sweden's largest family-owned hotel group.
As of 2025, Elite Hotels operates 26 hotels in Sweden. name 'Elite Hotels of Sweden' is more common than name 'Elite Hotels' - this is also reflected in Wikidata.

Wesite: https://www.elite.se/en/hotels/
Q-Code: Q10481573