### PR TITLE
split Kooperativa

### DIFF
--- a/data/brands/office/insurance.json
+++ b/data/brands/office/insurance.json
@@ -14,6 +14,16 @@
   },
   "items": [
     {
+      "displayName": "Kooperativa (Slovensko)",
+      "locationSet": {"include": ["sk"]},
+      "tags": {
+        "brand": "Kooperativa",
+        "brand:wikidata": "Q96129121",
+        "name": "Kooperativa",
+        "office": "insurance"
+      }
+    },
+    {
       "displayName": "RBP, zdravotní pojišťovna",
       "locationSet": {"include": ["cz"]},
       "tags": {
@@ -1686,9 +1696,9 @@
       }
     },
     {
-      "displayName": "Kooperativa",
+      "displayName": "Kooperativa (Česko)",
       "id": "kooperativa-98fcf6",
-      "locationSet": {"include": ["cz", "sk"]},
+      "locationSet": {"include": ["cz"]},
       "tags": {
         "brand": "Kooperativa",
         "brand:wikidata": "Q16742113",


### PR DESCRIPTION
Kooperativa insurance companies in Czech republic and Slovakia are different brands and each company has own logo.

issue #10400 