### PR TITLE
Add Mobil pro vás

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -10,6 +10,17 @@
   },
   "items": [
     {
+      "displayName": "Mobil pro vás",
+      "locationSet": {"include": ["cz"]},
+      "matchNames": ["mobilprovas"],
+      "tags": {
+        "brand": "Mobil pro vás",
+        "brand:wikidata": "Q135993719",
+        "name": "Mobil pro vás",
+        "shop": "mobile_phone"
+      }
+    },
+    {
       "displayName": "2degrees",
       "id": "2degrees-5219b0",
       "locationSet": {"include": ["nz"]},


### PR DESCRIPTION
Add Czech mobile phone chain store with 17 locations.