### PR TITLE
Extend Dollarama to Australia.

### DIFF
--- a/data/brands/shop/variety_store.json
+++ b/data/brands/shop/variety_store.json
@@ -278,7 +278,7 @@
     {
       "displayName": "Dollarama",
       "id": "dollarama-f36c63",
-      "locationSet": {"include": ["ca"]},
+      "locationSet": {"include": ["ca", "au"]},
       "tags": {
         "brand": "Dollarama",
         "brand:wikidata": "Q3033947",


### PR DESCRIPTION
Dollarama will start to replace The Reject Shop over the next couple of years.   
Start by making Dollarama available in Australia, but don't start forcing it over TRS yet.   

Source: https://au.finance.yahoo.com/news/the-reject-shop-changes-name-after-44-years-in-259-million-takeover-to-rival-kmart-222433537.html