### PR TITLE
Update car.json for a new brand Mahindra & Mahindra

### DIFF
--- a/data/brands/shop/car.json
+++ b/data/brands/shop/car.json
@@ -1772,6 +1772,20 @@
         "name:zh-Hans": "雷克萨斯",
         "shop": "car"
       }
-    }
+    },{
+   "displayName": "Mahindra & Mahindra",
+   "locationSet": {
+       "include": [
+           "001"
+       ]
+   },
+   "tags": {
+       "brand": "Mahindra & Mahindra",
+       "brand:wikidata": "Q848059",
+       "name": "Mahindra & Mahindra", 
+       "alt_name": "Mahindra",
+       "shop": "car"
+   }
+}
   ]
 }


### PR DESCRIPTION
Update car.json for new brand of Indian multinational automobile manufacturer

Adding new brand for shop=car called Mahindra & Mahindra

Mahindra and Mahindra, a prominent automotive company has a widespread global presence in regions like APAC, Africa & Middle East, and South Central America. Its footprint spans across Australia, Bangladesh, Bhutan, Indonesia, New Zealand, Nepal, Sri Lanka, UAE, Kenya, Mozambique, Morocco, South Africa, Tunisia, Chile, Guatemala, and Peru.

The official brand name is Mahindra & Mahindra. However, in common usage, especially in marketing related to their automotive products, the brand is often shortened simply to Mahindra for ease and simplicity.

https://www.wikidata.org/wiki/Q848059
https://www.mahindra.com/our-business/automotive