### PR TITLE
Update fuel.json for new brand Gazprom Neft

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -8960,6 +8960,8 @@
    },
    "tags": {
        "brand": "Газпром Нефть",
+       "brand:ru": "Газпром Нефть",
+       "brand:en": "Gazprom Neft",
        "brand:wikidata": "Q1461799",
        "name": "Газпром Нефть",
        "name:ru": "Газпром Нефть",


### PR DESCRIPTION
Update fuel.json for the third largest oil producer in Russia and a subsidiary of Gazprom

Adding new brand for amenity=fuel called Gazprom Neft


https://www.wikidata.org/wiki/Q1461799
https://www.gazprom-neft.ru/
https://www.gazprom-neft.com/