### PR TITLE
[FR] Migrating telecom providers from shop=mobile_phone to shop=telecommunication

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -164,17 +164,6 @@
       }
     },
     {
-      "displayName": "Bouygues Telecom",
-      "id": "bouyguestelecom-f6fe9a",
-      "locationSet": {"include": ["fr"]},
-      "tags": {
-        "brand": "Bouygues Telecom",
-        "brand:wikidata": "Q581438",
-        "name": "Bouygues Telecom",
-        "shop": "mobile_phone"
-      }
-    },
-    {
       "displayName": "Carphone Warehouse",
       "id": "carphonewarehouse-eb0c8f",
       "locationSet": {"include": ["by", "gb"]},
@@ -331,17 +320,6 @@
         "brand": "Fido",
         "brand:wikidata": "Q3071471",
         "name": "Fido",
-        "shop": "mobile_phone"
-      }
-    },
-    {
-      "displayName": "Free",
-      "id": "free-f6fe9a",
-      "locationSet": {"include": ["fr"]},
-      "tags": {
-        "brand": "Free",
-        "brand:wikidata": "Q2467627",
-        "name": "Free",
         "shop": "mobile_phone"
       }
     },
@@ -853,18 +831,6 @@
         "brand": "Safaricom",
         "brand:wikidata": "Q7398410",
         "name": "Safaricom",
-        "shop": "mobile_phone"
-      }
-    },
-    {
-      "displayName": "SFR",
-      "id": "sfr-ba7290",
-      "locationSet": {"include": ["fr", "lu"]},
-      "matchNames": ["espace sfr"],
-      "tags": {
-        "brand": "SFR",
-        "brand:wikidata": "Q218765",
-        "name": "SFR",
         "shop": "mobile_phone"
       }
     },


### PR DESCRIPTION
This PR migrates French telecom operators Bouygues, Free and SFR from shop=mobile_phone to shop=telecommunication.

See community discussion: https://forum.openstreetmap.fr/t/orange-sfr-bouygues-free-shop-mobile-phone-a-shop-telecommunication/37163
[Tag:shop=mobile_phone](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dmobile_phone)
[Tag:shop=telecommunication](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dtelecommunication)