### PR TITLE
[IT] Migrating telecom providers from shop=mobile_phone to shop=telecommunication

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -47,16 +47,6 @@
       }
     },
     {
-      "displayName": "A1 prodajno mesto",
-      "id": "a1prodajnomesto-6945ea",
-      "locationSet": {"include": ["rs"]},
-      "tags": {
-        "brand": "A1 prodajno mesto",
-        "name": "A1 prodajno mesto",
-        "shop": "mobile_phone"
-      }
-    },
-    {
       "displayName": "TIM",
       "id": "tim-a66d78",
       "locationSet": {

--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -57,6 +57,19 @@
       }
     },
     {
+      "displayName": "TIM",
+      "id": "tim-a66d78",
+      "locationSet": {
+        "include": ["br"]
+      },
+      "tags": {
+        "brand": "TIM",
+        "brand:wikidata": "Q1120617",
+        "name": "TIM",
+        "shop": "mobile_phone"
+      }
+    },
+    {
       "displayName": "Airtel",
       "id": "airtel-62d34e",
       "locationSet": {"include": ["202", "in"]},

--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -386,18 +386,6 @@
       }
     },
     {
-      "displayName": "Iliad",
-      "id": "iliad-c4d7ba",
-      "locationSet": {"include": ["it"]},
-      "matchNames": ["iliad store"],
-      "tags": {
-        "brand": "Iliad",
-        "brand:wikidata": "Q55433734",
-        "name": "Iliad",
-        "shop": "mobile_phone"
-      }
-    },
-    {
       "displayName": "iPlace",
       "id": "iplace-1b1a0a",
       "locationSet": {"include": ["br", "uy"]},
@@ -1195,19 +1183,6 @@
       }
     },
     {
-      "displayName": "TIM",
-      "id": "tim-a66d78",
-      "locationSet": {
-        "include": ["br", "it", "sm"]
-      },
-      "tags": {
-        "brand": "TIM",
-        "brand:wikidata": "Q1120617",
-        "name": "TIM",
-        "shop": "mobile_phone"
-      }
-    },
-    {
       "displayName": "Total by Verizon",
       "id": "totalbyverizon-ce3e5c",
       "locationSet": {"include": ["us"]},
@@ -1512,18 +1487,6 @@
         "brand": "WIFI_ETECSA",
         "brand:wikidata": "Q490323",
         "name": "WIFI_ETECSA",
-        "shop": "mobile_phone"
-      }
-    },
-    {
-      "displayName": "Wind Tre",
-      "id": "windtre-c4d7ba",
-      "locationSet": {"include": ["it"]},
-      "matchNames": ["wind"],
-      "tags": {
-        "brand": "Wind Tre",
-        "brand:wikidata": "Q28119223",
-        "name": "Wind Tre",
         "shop": "mobile_phone"
       }
     },

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -127,6 +127,8 @@
         "brand:wikidata": "Q499342",
         "name": "Fastweb",
         "shop": "telecommunication"
+      }
+    },
     {
       "displayName": "A1 (България)",
       "id": "a1-5ceaa9",

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -120,6 +120,14 @@
       }
     },
     {
+      "displayName": "Fastweb",
+      "locationSet": {"include": ["it"]},
+      "tags": {
+        "brand": "Fastweb",
+        "brand:wikidata": "Q499342",
+        "name": "Fastweb",
+        "shop": "telecommunication"
+    {
       "displayName": "A1 (България)",
       "id": "a1-5ceaa9",
       "locationSet": {"include": ["bg"]},

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -83,6 +83,43 @@
       }
     },
     {
+      "displayName": "Iliad",
+      "id": "iliad-c4d7ba",
+      "locationSet": {"include": ["it"]},
+      "matchNames": ["iliad store"],
+      "tags": {
+        "brand": "Iliad",
+        "brand:wikidata": "Q55433734",
+        "name": "Iliad",
+        "shop": "telecommunication"
+      }
+    },
+    {
+      "displayName": "TIM",
+      "id": "tim-a66d78",
+      "locationSet": {
+        "include": ["br", "it", "sm"]
+      },
+      "tags": {
+        "brand": "TIM",
+        "brand:wikidata": "Q1120617",
+        "name": "TIM",
+        "shop": "telecommunication"
+      }
+    },
+    {
+      "displayName": "Wind Tre",
+      "id": "windtre-c4d7ba",
+      "locationSet": {"include": ["it"]},
+      "matchNames": ["wind"],
+      "tags": {
+        "brand": "Wind Tre",
+        "brand:wikidata": "Q28119223",
+        "name": "Wind Tre",
+        "shop": "telecommunication"
+      }
+    },
+    {
       "displayName": "A1 (България)",
       "id": "a1-5ceaa9",
       "locationSet": {"include": ["bg"]},

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -96,9 +96,8 @@
     },
     {
       "displayName": "TIM",
-      "id": "tim-a66d78",
       "locationSet": {
-        "include": ["br", "it", "sm"]
+        "include": ["it", "sm"]
       },
       "tags": {
         "brand": "TIM",


### PR DESCRIPTION
This PR migrates Italian telecom operators Iliad, TIM, Wind Tre (and Vodafone in [commit cf59786](https://github.com/osmlab/name-suggestion-index/commit/cf59786cbdeff4c1f1a8fadd521d3da7c7e1715e) from `shop=mobile_phone` to `shop=telecommunication`.

It also adds Fastweb ([Wikidata](https://www.wikidata.org/wiki/Q499342), [website](https://www.fastweb.it/)), with 40 locations according to [store locator](https://www.fastweb.it/negozi/?from=menu).

See community discussion: https://community.openstreetmap.org/t/vodafone-tim-windtre-and-iliad-shop-mobile-phone-to-shop-telecommunication/135100
[Tag:shop=mobile_phone](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dmobile_phone)
[Tag:shop=telecommunication](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dtelecommunication)