### PR TITLE
[UA] Migrating telecom providers from shop=mobile_phone to shop=telecommunication

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -453,23 +453,6 @@
       }
     },
     {
-      "displayName": "lifecell",
-      "id": "lifecell-985251",
-      "locationSet": {"include": ["ua"]},
-      "matchNames": [
-        "life:)",
-        "лайф",
-        "лайфселл",
-        "магазин lifecell"
-      ],
-      "tags": {
-        "brand": "lifecell",
-        "brand:wikidata": "Q1936895",
-        "name": "lifecell",
-        "shop": "mobile_phone"
-      }
-    },
-    {
       "displayName": "Mega device",
       "id": "megadevice-2a48ca",
       "locationSet": {"include": ["bg"]},
@@ -1666,26 +1649,6 @@
         "brand": "Жжук",
         "brand:wikidata": "Q25435027",
         "name": "Жжук",
-        "shop": "mobile_phone"
-      }
-    },
-    {
-      "displayName": "Київстар",
-      "id": "kyivstar-985251",
-      "locationSet": {"include": ["ua"]},
-      "matchNames": [
-        "beeline",
-        "білайн",
-        "центр обслуговування абонентів київстар"
-      ],
-      "tags": {
-        "brand": "Київстар",
-        "brand:en": "Kyivstar",
-        "brand:uk": "Київстар",
-        "brand:wikidata": "Q2288463",
-        "name": "Київстар",
-        "name:en": "Kyivstar",
-        "name:uk": "Київстар",
         "shop": "mobile_phone"
       }
     },

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -67,6 +67,43 @@
       }
     },
     {
+      "displayName": "Київстар",
+      "id": "kyivstar-985251",
+      "locationSet": {"include": ["ua"]},
+      "matchNames": [
+        "beeline",
+        "білайн",
+        "центр обслуговування абонентів київстар"
+      ],
+      "tags": {
+        "brand": "Київстар",
+        "brand:en": "Kyivstar",
+        "brand:uk": "Київстар",
+        "brand:wikidata": "Q2288463",
+        "name": "Київстар",
+        "name:en": "Kyivstar",
+        "name:uk": "Київстар",
+        "shop": "telecommunication"
+      }
+    },
+    {
+      "displayName": "lifecell",
+      "id": "lifecell-985251",
+      "locationSet": {"include": ["ua"]},
+      "matchNames": [
+        "life:)",
+        "лайф",
+        "лайфселл",
+        "магазин lifecell"
+      ],
+      "tags": {
+        "brand": "lifecell",
+        "brand:wikidata": "Q1936895",
+        "name": "lifecell",
+        "shop": "telecommunication"
+      }
+    },
+    {
       "displayName": "A1 (Srbija)",
       "id": "a1-ba40c7",
       "locationSet": {"include": ["rs"]},


### PR DESCRIPTION
This PR migrates Ukrainian telecom operators Kyivstar and Lifecell from `shop=mobile_phone` to `shop=telecommunication`.

See community discussion: https://community.openstreetmap.org/t/kyivstar-vodafone-and-lifecell-shop-mobile-phone-to-shop-telecommunication/135104
[Tag:shop=mobile_phone](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dmobile_phone)
[Tag:shop=telecommunication](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dtelecommunication)