### PR TITLE
[NL] Migrating telecom providers from shop=mobile_phone to shop=telecommunication

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -442,17 +442,6 @@
       }
     },
     {
-      "displayName": "KPN",
-      "id": "kpn-c7ad94",
-      "locationSet": {"include": ["nl"]},
-      "tags": {
-        "brand": "KPN",
-        "brand:wikidata": "Q338633",
-        "name": "KPN",
-        "shop": "mobile_phone"
-      }
-    },
-    {
       "displayName": "lifecell",
       "id": "lifecell-985251",
       "locationSet": {"include": ["ua"]},
@@ -672,17 +661,6 @@
         "brand": "O2",
         "brand:wikidata": "Q1759255",
         "name": "O2",
-        "shop": "mobile_phone"
-      }
-    },
-    {
-      "displayName": "Odido",
-      "id": "odido-c7ad94",
-      "locationSet": {"include": ["nl"]},
-      "tags": {
-        "brand": "Odido",
-        "brand:wikidata": "Q28406140",
-        "name": "Odido",
         "shop": "mobile_phone"
       }
     },

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -97,6 +97,28 @@
       }
     },
     {
+      "displayName": "KPN",
+      "id": "kpn-c7ad94",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "KPN",
+        "brand:wikidata": "Q338633",
+        "name": "KPN",
+        "shop": "telecommunication"
+      }
+    },
+    {
+      "displayName": "Odido",
+      "id": "odido-c7ad94",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "Odido",
+        "brand:wikidata": "Q28406140",
+        "name": "Odido",
+        "shop": "telecommunication"
+      }
+    },
+    {
       "displayName": "A1 (Северна Македонија)",
       "id": "a1-5455f4",
       "locationSet": {"include": ["mk"]},


### PR DESCRIPTION
This PR migrates Dutch telecom operators KPN and Odido from `shop=mobile_phone` to `shop=telecommunication`.

See community discussion: https://community.openstreetmap.org/t/kpn-odido-and-vodafone-shop-mobile-phone-to-shop-telecommunication/135102
[Tag:shop=mobile_phone](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dmobile_phone)
[Tag:shop=telecommunication](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dtelecommunication)