### PR TITLE
[GR] Migrating telecom providers from shop=mobile_phone to shop=telecommunication

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -246,17 +246,6 @@
       }
     },
     {
-      "displayName": "Cosmote",
-      "id": "cosmote-d5175a",
-      "locationSet": {"include": ["gr"]},
-      "tags": {
-        "brand": "Cosmote",
-        "brand:wikidata": "Q1136203",
-        "name": "Cosmote",
-        "shop": "mobile_phone"
-      }
-    },
-    {
       "displayName": "Cricket Wireless",
       "id": "cricketwireless-ce3e5c",
       "locationSet": {"include": ["us"]},
@@ -632,22 +621,6 @@
         "brand": "NOS",
         "brand:wikidata": "Q136331",
         "name": "NOS",
-        "shop": "mobile_phone"
-      }
-    },
-    {
-      "displayName": "Nova",
-      "id": "nova-d5175a",
-      "locationSet": {"include": ["gr"]},
-      "matchNames": [
-        "nova greece",
-        "wind",
-        "wind hellas"
-      ],
-      "tags": {
-        "brand": "Nova",
-        "brand:wikidata": "Q1608689",
-        "name": "Nova",
         "shop": "mobile_phone"
       }
     },

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -49,6 +49,33 @@
       }
     },
     {
+      "displayName": "Cosmote",
+      "id": "cosmote-d5175a",
+      "locationSet": {"include": ["gr"]},
+      "tags": {
+        "brand": "Cosmote",
+        "brand:wikidata": "Q1136203",
+        "name": "Cosmote",
+        "shop": "telecommunication"
+      }
+    },
+    {
+      "displayName": "Nova",
+      "id": "nova-d5175a",
+      "locationSet": {"include": ["gr"]},
+      "matchNames": [
+        "nova greece",
+        "wind",
+        "wind hellas"
+      ],
+      "tags": {
+        "brand": "Nova",
+        "brand:wikidata": "Q1608689",
+        "name": "Nova",
+        "shop": "telecommunication"
+      }
+    },
+    {
       "displayName": "A1",
       "id": "a1-5b3624",
       "locationSet": {


### PR DESCRIPTION
This PR migrates Greek telecom operators Cosmote, Nova (and Vodafone in [commit ba864ea](https://github.com/osmlab/name-suggestion-index/commit/ba864ea5f58268219944dd618ddb45cc12d052fe)) from `shop=mobile_phone` to `shop=telecommunication`.

See community discussion: https://community.openstreetmap.org/t/cosmote-vodafone-and-nova-shop-mobile-phone-to-shop-telecommunication/135105
[Tag:shop=mobile_phone](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dmobile_phone)
[Tag:shop=telecommunication](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dtelecommunication)