### PR TITLE
Update tyres.json by removing Continental AG

### DIFF
--- a/data/brands/shop/tyres.json
+++ b/data/brands/shop/tyres.json
@@ -131,17 +131,6 @@
       }
     },
     {
-      "displayName": "Continental AG",
-      "id": "continentalag-1d5291",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "brand": "Continental AG",
-        "brand:wikidata": "Q163241",
-        "name": "Continental AG",
-        "shop": "tyres"
-      }
-    },
-    {
       "displayName": "Cooper Tire & Rubber Company",
       "id": "coopertireandrubbercompany-db574d",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Continental do not have physical locations. 

Below is an example of dealer locator - only not branded locations: https://continentaltire.com/Store-finder

This is same situation as for brands: Michelin or Pirelli (https://github.com/osmlab/name-suggestion-index/pull/10346)