### PR TITLE
Wikidata items and locationSet of some bus networks in Spain

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -16668,8 +16668,12 @@
       "locationSet": {
         "include": ["es-v.geojson"]
       },
+      "matchNames": [
+        "SUV"
+      ],
       "tags": {
         "network": "Servei Urbà de Viatgers",
+        "network:wikidata": "Q136088674",
         "operator": "Autos Vallduxense",
         "operator:short": "AVSA",
         "route": "bus"
@@ -20131,7 +20135,11 @@
         "include": [
           "es-a.geojson",
           "es-cs.geojson",
-          "es-v.geojson"
+          "es-v.geojson",
+          "es-te.geojson",
+          "es-ab.geojson",
+          "es-cu.geojson",
+          "es-mu.geojson"
         ]
       },
       "tags": {
@@ -20159,8 +20167,9 @@
       },
       "tags": {
         "network": "Transport Urbà de Castelló",
-        "network:short": "TUCS",
-        "route": "bus"
+        "network:short": "TUCs",
+        "route": "bus",
+        "network:wikidata": "Q10747168",
       }
     },
     {


### PR DESCRIPTION
* Added Wikidata item for Servei Urbà de Viatgers and Transport Urbà de Castelló
* Updated `locationSet` of Transport Públic Generalitat Valenciana to include covered bordering regions