### PR TITLE
fix brand and name mismatch

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -4281,7 +4281,7 @@
       "tags": {
         "alt_name": "Habit Burger Grill",
         "amenity": "fast_food",
-        "brand": "Habit Burger Grill",
+        "brand": "Habit Burger & Grill",
         "brand:wikidata": "Q18158741",
         "cuisine": "burger",
         "name": "Habit Burger & Grill",


### PR DESCRIPTION
Harmonizes the `brand` tag to match the `name` tag for Habit Burger & Grill, keeping it consistent with the title at its [Wikidata](https://www.wikidata.org/wiki/Q18158741) and [Wikipedia](https://en.wikipedia.org/wiki/Habit_Burger_%26_Grill) entries.