### PR TITLE
change ownership type to government

### DIFF
--- a/data/operators/amenity/library.json
+++ b/data/operators/amenity/library.json
@@ -1344,7 +1344,7 @@
         "amenity": "library",
         "operator": "Houston Public Library",
         "operator:short": "HPL",
-        "operator:type": "public",
+        "operator:type": "government",
         "operator:wikidata": "Q1647690"
       }
     },


### PR DESCRIPTION
fix ownership type of Houston Public Library. The library is owned by the city and controlled by the city.