### PR TITLE
[Londis GB and IE] Remove name

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -3362,7 +3362,6 @@
       "tags": {
         "brand": "Londis",
         "brand:wikidata": "Q21015800",
-        "name": "Londis",
         "shop": "convenience"
       }
     },
@@ -3373,7 +3372,6 @@
       "tags": {
         "brand": "Londis",
         "brand:wikidata": "Q21008564",
-        "name": "Londis",
         "shop": "convenience"
       }
     },

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -3359,11 +3359,11 @@
       "displayName": "Londis (Ireland)",
       "id": "londis-cb4625",
       "locationSet": {"include": ["ie"]},
+      "preserveTags": ["^name"],
       "tags": {
         "brand": "Londis",
         "brand:wikidata": "Q21015800",
         "name": "Londis",
-        "preserveTags": ["^name"],
         "shop": "convenience"
       }
     },
@@ -3371,11 +3371,11 @@
       "displayName": "Londis (UK)",
       "id": "londis-232829",
       "locationSet": {"include": ["gb"]},
+      "preserveTags": ["^name"],
       "tags": {
         "brand": "Londis",
         "brand:wikidata": "Q21008564",
         "name": "Londis",
-        "preserveTags": ["^name"],
         "shop": "convenience"
       }
     },

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -3375,7 +3375,7 @@
         "brand": "Londis",
         "brand:wikidata": "Q21008564",
         "name": "Londis",
-        "preserveTags": ["^name"]
+        "preserveTags": ["^name"],
         "shop": "convenience"
       }
     },

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -3362,6 +3362,8 @@
       "tags": {
         "brand": "Londis",
         "brand:wikidata": "Q21015800",
+        "name": "Londis",
+        "preserveTags": ["^name"],
         "shop": "convenience"
       }
     },
@@ -3372,6 +3374,8 @@
       "tags": {
         "brand": "Londis",
         "brand:wikidata": "Q21008564",
+        "name": "Londis",
+        "preserveTags": ["^name"]
         "shop": "convenience"
       }
     },


### PR DESCRIPTION
I'd like it to be an option to add the name of the shop for Londis as many of them have a name. Eg https://hisdeedsaredust.com/tmp/20250907T1223-londis.jpg

