### PR TITLE
Add missing Max Mara Fashion Group brands

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -11819,7 +11819,7 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "Weekend Max Mara",
-        "brand:wikidata": "Q1151774",
+        "brand:wikidata": "Q136159038",
         "clothes": "women",
         "name": "Weekend Max Mara",
         "shop": "clothes"


### PR DESCRIPTION
Refer to https://github.com/alltheplaces/alltheplaces/pull/14202 for a GeoJSON file of locations of all stores in Max Mara Fashion Group retail chains.