### PR TITLE
Add Sport 24 (shop/sports)

### DIFF
--- a/data/brands/shop/sports.json
+++ b/data/brands/shop/sports.json
@@ -949,6 +949,7 @@
       "tags": {
         "brand": "Sport 24",
         "brand:wikidata": "Q121503172",
+        "name": "Sport 24",
         "shop": "sports"
       }
     },


### PR DESCRIPTION
Current known locations from ATP: https://alltheplaces-data.openaddresses.io/map.html?show=https%3A%2F%2Falltheplaces-data.openaddresses.io%2Fruns%2F2025-08-30-13-32-10%2Foutput%2Fsport24.geojson