### PR TITLE
Update hotel.json add hotel brand Original by Sokos Hotels

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -4954,6 +4954,17 @@
         "operator:zh": "長榮集團",
         "tourism": "hotel"
       }
+    },
+    {
+      "displayName": "Original by Sokos Hotels",
+      "locationSet": {"include": ["fi", "ee"]},
+      "tags": {
+        "brand": "Original by Sokos Hotels ",
+        "brand:wikidata": "Q136158784",
+        "name": " Original by Sokos Hotels ",
+        "official_name": "Original by Sokos Hotels",
+        "tourism": "hotel"
+      }
     }
   ]
 }


### PR DESCRIPTION
creation of new PR  (first created PR editing of json file was not possible due to unclear reason). website: https://www.sokoshotels.fi/
31 locations available under this brand (owned by Sokos Hotel) - other brands of this Hotel group have to less location (under 30 locations)