### PR TITLE
Update fast_food.json add Turkish fast food chain Etiler Marmaris

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -15064,10 +15064,10 @@
       "locationSet": {"include": ["tr"]},
       "tags": {
         "amenity": "fast_food",
-        "brand": " Etiler Marmaris ",
+        "brand": "Etiler Marmaris",
         "brand:wikidata": "Q136088046",
-       "cuisine": "kebab",
-        "name": " Etiler Marmaris",
+        "cuisine": "kebab",
+        "name": "Etiler Marmaris",
         "takeaway": "yes"
       }
     }


### PR DESCRIPTION
Etiler Marmaris is a Turkish fast food chain. As of 2025, Etiler Marmaris operates 60 branches across 10 provinces in Turkey. website: https://etilermarmaris.com.tr/ Q-Code available (Q136088046)