### PR TITLE
Update hotel.json update country scope for hotel brand Days Inn

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -993,12 +993,18 @@
       "id": "daysinn-6df761",
       "locationSet": {
         "include": [
+          "ar",
+          "az",
+          "br",
           "ca",
           "ch",
           "cn",
+          "de",
           "gb",
+          "gu",
           "id",
           "in",
+          "jo",
           "kr",
           "mx",
           "my",
@@ -1006,6 +1012,7 @@
           "sg",
           "sn",
           "th",
+          "tr",
           "us"
         ]
       },


### PR DESCRIPTION
according to official website: https://www.wyndhamhotels.com/en-uk/days-inn/locations Brazil, Argentina, Jordan, Turkey, Germany, Azerbaijan, Guam are missing in NSI and 'ch' (Switzerland) and 'sg' (Singapore) are superfluous (no Days Inn Hotels in these 2 countries) and need to be removed.