### PR TITLE
Merge subway network

### DIFF
--- a/data/transit/route/subway.json
+++ b/data/transit/route/subway.json
@@ -917,9 +917,10 @@
         "include": ["at-9.geojson"]
       },
       "tags": {
-        "network": "U-Bahn Wien",
-        "network:wikidata": "Q209400",
+        "network": "VOR",
+        "network:wikidata": "Q2516485",
         "operator": "Wiener Linien",
+        "operator:short": "WL",
         "operator:wikidata": "Q668849",
         "route": "subway"
       }


### PR DESCRIPTION
The subway doesn't have its own network.
See also https://c.osm.org/t/135462 and https://ptna.openstreetmap.de/results/AT/AT-VOR-Analysis.html#notconsiderednetworks 