### PR TITLE
Added File Market for Turkey

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -2917,6 +2917,16 @@
       }
     },
     {
+      "displayName": "File Market",
+      "locationSet": {"include": ["tr"]},
+      "tags": {
+        "brand": "File Market",
+        "brand:wikidata": "Q112228237",
+        "name": "File Market",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Fix Price",
       "id": "fixprice-be42a4",
       "locationSet": {


### PR DESCRIPTION
File Market is a Turkish supermarket chain. Here is the [Wikidata entry.](https://www.wikidata.org/wiki/Q112228237)