### PR TITLE
Refactor loop usage to comply with Sonar rule S1751

### DIFF
--- a/lib/idgen.js
+++ b/lib/idgen.js
@@ -67,10 +67,12 @@ export function idgen(item, tkv, locationID) {
           if (ex.test(key)) keylist.push(key);
         });
 
-        for ( let j = 0; j < keylist.length; j++ ) {
-          const message = simplify(item.tags[keylist[j]]);
-          name = crypto.createHash('md5').update(message).digest('hex').slice(0, 6);
-          break;
+        if (keylist.length > 0) {
+          const message = simplify(item.tags[keylist[0]]);
+          name = crypto.createHash('md5')
+               .update(message)
+               .digest('hex')
+               .slice(0, 6);
         }
 
         if (name) break;


### PR DESCRIPTION
### What kind of change does this PR introduce?
- Code refactor for better readability and maintainability.
- Removed unnecessary for loop with unconditional break.

### Why was this change needed?
- The original loop only executed once due to an unconditional break.
- Sonar flagged this as a violation of rule javascript:S1751 (loops should not contain more than a single break/continue).
- Refactoring improves code clarity and eliminates the Sonar warning.

### Other information:
- Replaced loop with direct access to the first element of keylist.
- No functional impact — behavior remains the same.