### PR TITLE
All'Antico Vinaio

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -275,6 +275,20 @@
       }
     },
     {
+      "displayName": "All'Antico Vinaio",
+      "locationSet": {
+        "include": ["gb-eng", "it", "us"]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "All'Antico Vinaio",
+        "brand:wikidata": "Q136350648",
+        "cuisine": "sandwich",
+        "name": "All'Antico Vinaio",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Aloha Poké",
       "id": "alohapoke-34e6e8",
       "locationSet": {"include": ["es"]},

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -277,7 +277,7 @@
     {
       "displayName": "All'Antico Vinaio",
       "locationSet": {
-        "include": ["gb-eng", "it", "us"]
+        "include": ["ae", "gb-eng", "it", "us"]
       },
       "tags": {
         "amenity": "fast_food",


### PR DESCRIPTION
Add the Italian sandwich shop brand, All'Antico Vinaio, which has locations in Italy, New York, Los Angeles, Las Vegas, and London