### PR TITLE
Add various telecom/data_center brands

### DIFF
--- a/data/operators/telecom/data_center.json
+++ b/data/operators/telecom/data_center.json
@@ -6,6 +6,17 @@
   },
   "items": [
     {
+      "displayName": "Aligned Data Centers",
+      "id": "aligneddatacenters-918717",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "name": "Aligned Data Centers",
+        "operator": "Aligned Data Centers",
+        "operator:wikidata": "Q136332540",
+        "telecom": "data_center"
+      }
+    },
+    {
       "displayName": "Amazon Web Services",
       "id": "amazonwebservices-918717",
       "locationSet": {"include": ["001"]},
@@ -49,6 +60,17 @@
       }
     },
     {
+      "displayName": "CDC",
+      "id": "cdc-78d901",
+      "locationSet": {"include": ["au", "nz"]},
+      "tags": {
+        "name": "CDC",
+        "operator": "CDC",
+        "operator:wikidata": "Q136333394",
+        "telecom": "data_center"
+      }
+    },
+    {
       "displayName": "Centersquare",
       "id": "centersquare-918717",
       "locationSet": {"include": ["001"]},
@@ -68,6 +90,39 @@
         "name": "Cloudflare",
         "operator": "Cloudflare",
         "operator:wikidata": "Q4778915",
+        "telecom": "data_center"
+      }
+    },
+    {
+      "displayName": "CloudHQ",
+      "id": "cloudhq-918717",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "name": "CloudHQ",
+        "operator": "CloudHQ",
+        "operator:wikidata": "Q136332516",
+        "telecom": "data_center"
+      }
+    },
+    {
+      "displayName": "Cologix",
+      "id": "cologix-0f9444",
+      "locationSet": {"include": ["ca", "us"]},
+      "tags": {
+        "name": "Cologix",
+        "operator": "Cologix",
+        "operator:wikidata": "Q18348355",
+        "telecom": "data_center"
+      }
+    },
+    {
+      "displayName": "Compass Datacenters",
+      "id": "compassdatacenters-918717",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "name": "Compass Datacenters",
+        "operator": "Compass Datacenters",
+        "operator:wikidata": "Q87613064",
         "telecom": "data_center"
       }
     },
@@ -99,6 +154,17 @@
         "name": "Cyxtera",
         "operator": "Cyxtera",
         "operator:wikidata": "Q111143924",
+        "telecom": "data_center"
+      }
+    },
+    {
+      "displayName": "DataBank",
+      "id": "databank-73d34b",
+      "locationSet": {"include": ["gb", "us"]},
+      "tags": {
+        "name": "DataBank",
+        "operator": "DataBank",
+        "operator:wikidata": "Q117314439",
         "telecom": "data_center"
       }
     },
@@ -163,6 +229,17 @@
       }
     },
     {
+      "displayName": "Evocative",
+      "id": "evocative-251dd4",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "name": "Evocative",
+        "operator": "Evocative",
+        "operator:wikidata": "Q136332656",
+        "telecom": "data_center"
+      }
+    },
+    {
       "displayName": "Fastly",
       "id": "fastly-918717",
       "locationSet": {"include": ["001"]},
@@ -197,6 +274,17 @@
       }
     },
     {
+      "displayName": "H5 Data Centers",
+      "id": "h5datacenters-251dd4",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "name": "H5 Data Centers",
+        "operator": "H5 Data Centers",
+        "operator:wikidata": "Q136332488",
+        "telecom": "data_center"
+      }
+    },
+    {
       "displayName": "Interxion",
       "id": "interxion-918717",
       "locationSet": {"include": ["001"]},
@@ -204,6 +292,17 @@
         "name": "Interxion",
         "operator": "Interxion",
         "operator:wikidata": "Q685641",
+        "telecom": "data_center"
+      }
+    },
+    {
+      "displayName": "Iron Mountain",
+      "id": "ironmountain-918717",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "name": "Iron Mountain",
+        "operator": "Iron Mountain",
+        "operator:wikidata": "Q1673079",
         "telecom": "data_center"
       }
     },
@@ -220,6 +319,17 @@
         "name": "Lumen",
         "operator": "Lumen Technologies",
         "operator:wikidata": "Q5063092",
+        "telecom": "data_center"
+      }
+    },
+    {
+      "displayName": "Menlo Digital",
+      "id": "menlodigital-251dd4",
+      "locationSet": {"include": ["us"]},
+      "tags": {
+        "name": "Menlo Digital",
+        "operator": "Menlo Digital",
+        "operator:wikidata": "Q136332694",
         "telecom": "data_center"
       }
     },
@@ -276,6 +386,17 @@
         "name": "NTT",
         "operator": "NTT",
         "operator:wikidata": "Q1054787",
+        "telecom": "data_center"
+      }
+    },
+    {
+      "displayName": "OVHcloud",
+      "id": "ovhcloud-918717",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "name": "OVHcloud",
+        "operator": "OVHcloud",
+        "operator:wikidata": "Q568183",
         "telecom": "data_center"
       }
     },


### PR DESCRIPTION
Add CDC (telecom/data_center)
Locations listed at https://cdc.com/locations/

Add OVHcloud (telecom/data_center)
Locations listed at https://www.ovhcloud.com/en-au/about-us/global-infrastructure/regions/

Add Menlo Digital (telecom/data_center)
Locations listed at https://menlo-digital.com/data-centers/

Add Iron Mountain (telecom/data_center)
Locations listed at https://www.ironmountain.com/data-centers/locations

Add DataBank (telecom/data_center)
Locations listed at https://www.databank.com/data-centers/

Add Evocative (telecom/data_center)
Locations listed at https://evocative.com/data-centers/

Add H5 Data Centers (telecom/data_center)
Locations listed at https://h5datacenters.com/data-centers.html

Add Compass Datacenters (telecom/data_center)
Locations listed at https://www.compassdatacenters.com/data-center-markets/

Add Cologix (telecom/data_center)
Locations listed at https://cologix.com/data-centers/

Add CloudHQ (telecom/data_center)
Locations listed at https://cloudhq.com/campuses/

Add Aligned Data Centers (telecom/data_center)
Locations listed at https://aligneddc.com/locations/