### PR TITLE
Update vending_machine.json with brand Doggyslide (ch)

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -2044,6 +2044,17 @@
         "operator:zh": "維他奶國際",
         "vending": "drinks"
       }
-    }
+    },
+    {
+      "displayName": "Doggyslide",
+      "locationSet": {"include": ["ch"]},
+      "tags": {
+        "amenity": "vending_machine",
+        "vending": "excrement_bags",
+        "bin": "yes",
+        "brand": "Doggyslide",
+        "brand:wikidata": "Q136408155"
+      }
+    } 
   ]
 }


### PR DESCRIPTION
Update vending_machine.json with brand Doggyslide (ch) - a Swiss company selling waste bins and dog toilets.