### PR TITLE
Update school.json

### DIFF
--- a/data/operators/amenity/school.json
+++ b/data/operators/amenity/school.json
@@ -17786,7 +17786,7 @@
       "tags": {
         "amenity": "school",
         "operator": "Elk Island Catholic Schools",
-        "operator:type": "religious",
+        "operator:type": "public",
         "operator:wikidata": "Q17508700"
       }
     },
@@ -17799,7 +17799,8 @@
       "tags": {
         "amenity": "school",
         "operator": "Elk Island Public Schools",
-        "operator:type": "public"
+        "operator:type": "public",
+        "operator:wikidata": "Q17508703"
       }
     },
     {


### PR DESCRIPTION
adds missing Wikidata for Elk Island Public Schools and corrects operator type for Elk Island Catholic Schools (Alberta Catholic separate school districts should be also operator:type=public).