### PR TITLE
Update car_sharing.json

### DIFF
--- a/data/brands/amenity/car_sharing.json
+++ b/data/brands/amenity/car_sharing.json
@@ -169,7 +169,7 @@
         "amenity": "car_sharing",
         "brand": "teilAuto",
         "brand:wikidata": "Q2400658",
-        "operator": "Mobility Center GmbH",
+        "operator": "teilAuto eG",
         "operator:type": "private"
       }
     },


### PR DESCRIPTION
Mobility Center GmbH is now called teilAuto eG