### PR TITLE
Add cafe, fast_food, convenience, greengrocer in China

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -76,11 +76,12 @@
       "id": "alittletea-3300f4",
       "locationSet": {"include": ["cn"]},
       "matchNames": ["一点点"],
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "1点点",
         "brand:en": "ALittle Tea",
-        "brand:wikidata": "Q106926258",
+        "brand:wikidata": "Q136345714",
         "brand:zh": "1点点",
         "brand:zh-Hans": "1点点",
         "brand:zh-Hant": "1點點",
@@ -177,6 +178,7 @@
         "include": ["cn"],
         "exclude": ["hk", "mo"]
       },
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "7分甜",
@@ -6616,6 +6618,7 @@
         "include": ["cn"],
         "exclude": ["hk", "mo"]
       },
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "卡旺卡",
@@ -6638,6 +6641,7 @@
       "displayName": "古茗",
       "id": "goodme-3300f4",
       "locationSet": {"include": ["cn"]},
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "古茗",
@@ -6735,6 +6739,7 @@
         "include": ["cn"],
         "exclude": ["hk", "mo"]
       },
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "喜茶",
@@ -6928,18 +6933,18 @@
     },
     {
       "displayName": "奈雪的茶",
-      "id": "nayuki-3300f4",
+      "id": "naisnow-3300f4",
       "locationSet": {"include": ["cn"]},
       "matchNames": ["奈雪", "奈雪の茶"],
       "tags": {
         "amenity": "cafe",
         "brand": "奈雪的茶",
-        "brand:en": "Nayuki",
+        "brand:en": "NaiSnow",
         "brand:wikidata": "Q107351710",
         "brand:zh": "奈雪的茶",
         "cuisine": "bubble_tea",
         "name": "奈雪的茶",
-        "name:en": "Nayuki",
+        "name:en": "NaiSnow",
         "name:zh": "奈雪的茶",
         "takeaway": "yes"
       }
@@ -7046,18 +7051,27 @@
     },
     {
       "displayName": "快乐柠檬",
-      "id": "happylemon-aa349e",
-      "locationSet": {"include": ["cn", "tw"]},
+      "id": "happylemon-823e31",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "快乐柠檬",
         "brand:en": "Happy Lemon",
         "brand:wikidata": "Q109968422",
         "brand:zh": "快乐柠檬",
+        "brand:zh-Hans": "快乐柠檬",
+        "brand:zh-Hant": "快樂檸檬",
         "cuisine": "bubble_tea",
+        "delivery": "yes",
         "name": "快乐柠檬",
         "name:en": "Happy Lemon",
         "name:zh": "快乐柠檬",
+        "name:zh-Hans": "快乐柠檬",
+        "name:zh-Hant": "快樂檸檬",
         "takeaway": "yes"
       }
     },
@@ -7075,6 +7089,25 @@
         "name": "快可立",
         "name:en": "Quickly",
         "name:zh": "快可立",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "快樂檸檬",
+      "id": "happylemon-7d270d",
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "amenity": "cafe",
+        "brand": "快樂檸檬",
+        "brand:en": "Happy Lemon",
+        "brand:wikidata": "Q109968422",
+        "brand:zh-Hans": "快乐柠檬",
+        "brand:zh-Hant": "快樂檸檬",
+        "cuisine": "bubble_tea",
+        "name": "快樂檸檬",
+        "name:en": "Happy Lemon",
+        "name:zh-Hans": "快乐柠檬",
+        "name:zh-Hant": "快樂檸檬",
         "takeaway": "yes"
       }
     },
@@ -7232,19 +7265,48 @@
       }
     },
     {
+      "displayName": "柠季",
+      "id": "ningji-823e31",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "matchTags": ["shop/beverages"],
+      "tags": {
+        "amenity": "cafe",
+        "brand": "柠季",
+        "brand:en": "Ningji",
+        "brand:wikidata": "Q136334059",
+        "brand:zh-Hans": "柠季",
+        "brand:zh-Hant": "檸季",
+        "cuisine": "bubble_tea",
+        "delivery": "yes",
+        "name": "柠季",
+        "name:en": "Ningji",
+        "name:zh-Hans": "柠季",
+        "name:zh-Hant": "檸季",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "沪上阿姨",
       "id": "aunteajenny-3300f4",
       "locationSet": {"include": ["cn"]},
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "沪上阿姨",
-        "brand:en": "AUNTEA JENNY",
+        "brand:en": "Auntea Jenny",
         "brand:wikidata": "Q108165945",
         "brand:zh": "沪上阿姨",
+        "brand:zh-Hans": "沪上阿姨",
+        "brand:zh-Hant": "滬上阿姨",
         "cuisine": "bubble_tea",
         "name": "沪上阿姨",
-        "name:en": "AUNTEA JENNY",
+        "name:en": "Auntea Jenny",
         "name:zh": "沪上阿姨",
+        "name:zh-Hans": "沪上阿姨",
+        "name:zh-Hant": "滬上阿姨",
         "takeaway": "yes"
       }
     },
@@ -7273,11 +7335,12 @@
         "include": ["cn"],
         "exclude": ["hk", "mo"]
       },
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "爷爷不泡茶",
         "brand:en": "No Yeye No Tea",
-        "brand:wikidata": "Q135657533",
+        "brand:wikidata": "Q136243117",
         "brand:zh-Hans": "爷爷不泡茶",
         "brand:zh-Hant": "爺爺不泡茶",
         "cuisine": "bubble_tea",
@@ -7369,6 +7432,7 @@
         "include": ["cn"],
         "exclude": ["hk", "mo"]
       },
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "甘茶度",
@@ -7394,6 +7458,7 @@
         "include": ["cn"],
         "exclude": ["hk", "mo"]
       },
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "甜啦啦",
@@ -7434,6 +7499,7 @@
       "displayName": "益禾堂",
       "id": "yhtang-3300f4",
       "locationSet": {"include": ["cn"]},
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "益禾堂",
@@ -7573,6 +7639,7 @@
         "include": ["cn"],
         "exclude": ["hk"]
       },
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "茶百道",
@@ -7626,6 +7693,7 @@
       "displayName": "茶颜悦色",
       "id": "sexytea-3300f4",
       "locationSet": {"include": ["cn"]},
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "茶颜悦色",
@@ -7667,6 +7735,7 @@
         "include": ["cn"],
         "exclude": ["hk"]
       },
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "蜜雪冰城",
@@ -7824,6 +7893,7 @@
         "include": ["cn"],
         "exclude": ["hk", "mo"]
       },
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "贡茶",
@@ -7860,6 +7930,32 @@
       }
     },
     {
+      "displayName": "巡茶",
+      "id": "supertea-823e31",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "matchTags": ["shop/beverages"],
+      "tags": {
+        "amenity": "cafe",
+        "brand": "巡茶",
+        "brand:en": "Supertea",
+        "brand:wikidata": "Q136334472",
+        "brand:zh": "巡茶",
+        "brand:zh-Hans": "巡茶",
+        "brand:zh-Hant": "巡茶",
+        "cuisine": "bubble_tea",
+        "delivery": "yes",
+        "name": "巡茶",
+        "name:en": "Supertea",
+        "name:zh": "巡茶",
+        "name:zh-Hans": "巡茶",
+        "name:zh-Hant": "巡茶",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "迷客夏",
       "id": "milkshop-7d270d",
       "locationSet": {"include": ["tw"]},
@@ -7884,6 +7980,7 @@
         "include": ["cn"],
         "exclude": ["hk", "mo"]
       },
+      "matchTags": ["shop/beverages"],
       "tags": {
         "amenity": "cafe",
         "brand": "霸王茶姬",

--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -7283,6 +7283,7 @@
         "delivery": "yes",
         "name": "柠季",
         "name:en": "Ningji",
+        "name:zh": "柠季",
         "name:zh-Hans": "柠季",
         "name:zh-Hant": "檸季",
         "takeaway": "yes"

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -276,6 +276,7 @@
     },
     {
       "displayName": "All'Antico Vinaio",
+      "id": "allanticovinaio-6b6fb0",
       "locationSet": {
         "include": ["ae", "gb-eng", "it", "us"]
       },
@@ -13607,6 +13608,27 @@
       }
     },
     {
+      "displayName": "临榆炸鸡腿",
+      "id": "6f7bab-19ae3c",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "临榆炸鸡腿",
+        "brand:wikidata": "Q136192743",
+        "brand:zh-Hans": "临榆炸鸡腿",
+        "brand:zh-Hant": "臨榆炸雞腿",
+        "cuisine": "fried_chicken",
+        "delivery": "yes",
+        "name": "临榆炸鸡腿",
+        "name:zh-Hans": "临榆炸鸡腿",
+        "name:zh-Hant": "臨榆炸雞腿",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "丸亀製麺",
       "id": "marugameseimen-f9a382",
       "locationSet": {
@@ -13822,6 +13844,29 @@
       }
     },
     {
+      "displayName": "喜姐炸串",
+      "id": "5fb15a-19ae3c",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "喜姐炸串",
+        "brand:wikidata": "Q136401501",
+        "brand:zh": "喜姐炸串",
+        "brand:zh-Hans": "喜姐炸串",
+        "brand:zh-Hant": "喜姐炸串",
+        "cuisine": "fried_skewers",
+        "delivery": "yes",
+        "name": "喜姐炸串",
+        "name:zh": "喜姐炸串",
+        "name:zh-Hans": "喜姐炸串",
+        "name:zh-Hant": "喜姐炸串",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "塔可钟",
       "id": "tacobell-19ae3c",
       "locationSet": {
@@ -13925,6 +13970,31 @@
         "name:zh": "大快活",
         "name:zh-Hans": "大快活",
         "name:zh-Hant": "大快活",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "夸父炸串",
+      "id": "kuafood-19ae3c",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "夸父炸串",
+        "brand:en": "Kuafood",
+        "brand:wikidata": "Q136402151",
+        "brand:zh": "夸父炸串",
+        "brand:zh-Hans": "夸父炸串",
+        "brand:zh-Hant": "夸父炸串",
+        "cuisine": "fried_skewers",
+        "delivery": "yes",
+        "name": "夸父炸串",
+        "name:en": "Kuafood",
+        "name:zh": "夸父炸串",
+        "name:zh-Hans": "夸父炸串",
+        "name:zh-Hant": "夸父炸串",
         "takeaway": "yes"
       }
     },
@@ -14827,7 +14897,7 @@
         "brand:zh": "芝根芝底",
         "brand:zh-Hans": "芝根芝底",
         "brand:zh-Hant": "芝根芝底",
-        "cuisine": "pizza",
+        "cuisine": "pizza;pasta",
         "delivery": "yes",
         "name": "芝根芝底",
         "name:en": "Zi Pizza",

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -13623,6 +13623,7 @@
         "cuisine": "fried_chicken",
         "delivery": "yes",
         "name": "临榆炸鸡腿",
+        "name:zh": "临榆炸鸡腿",
         "name:zh-Hans": "临榆炸鸡腿",
         "name:zh-Hant": "臨榆炸雞腿",
         "takeaway": "yes"

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -8802,6 +8802,7 @@
         "brand:zh-Hant": "鄰幾",
         "name": "邻几",
         "name:en": "Good Spot",
+        "name:zh": "邻几",
         "name:zh-Hans": "邻几",
         "name:zh-Hant": "鄰幾",
         "shop": "convenience"

--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -4099,8 +4099,10 @@
     },
     {
       "displayName": "My Auchan",
-      "id": "myauchan-f3ab02",
-      "locationSet": {"include": ["fx", "pt", "ro"]},
+      "id": "myauchan-5dd5a6",
+      "locationSet": {
+        "include": ["fx", "pt", "ro"]
+      },
       "matchTags": ["shop/supermarket"],
       "tags": {
         "brand": "My Auchan",
@@ -5226,8 +5228,19 @@
     },
     {
       "displayName": "Shoprite Mini",
-      "id": "shopritemini-c7b713",
-      "locationSet": {"include": ["za", "zm", "ls", "sz", "ao", "bw", "mz", "na"]},
+      "id": "shopritemini-65248a",
+      "locationSet": {
+        "include": [
+          "ao",
+          "bw",
+          "ls",
+          "mz",
+          "na",
+          "sz",
+          "za",
+          "zm"
+        ]
+      },
       "tags": {
         "brand": "Shoprite Mini",
         "brand:wikidata": "Q1857639",
@@ -8605,6 +8618,29 @@
       }
     },
     {
+      "displayName": "新力有家",
+      "id": "uhome-9729f7",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "matchNames": ["有家便利店"],
+      "tags": {
+        "brand": "新力有家",
+        "brand:en": "U-Home",
+        "brand:wikidata": "Q136192169",
+        "brand:zh": "新力有家",
+        "brand:zh-Hans": "新力有家",
+        "brand:zh-Hant": "新力有家",
+        "name": "新力有家",
+        "name:en": "U-Home",
+        "name:zh": "新力有家",
+        "name:zh-Hans": "新力有家",
+        "name:zh-Hant": "新力有家",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "易客来",
       "id": "intolife-da9ca7",
       "locationSet": {"include": ["cn"]},
@@ -8670,17 +8706,23 @@
     },
     {
       "displayName": "罗森",
-      "id": "lawson-da9ca7",
-      "locationSet": {"include": ["cn"]},
+      "id": "lawson-9729f7",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
       "tags": {
         "brand": "罗森",
-        "brand:en": "LAWSON",
+        "brand:en": "Lawson",
         "brand:wikidata": "Q1557223",
         "brand:zh": "罗森",
+        "brand:zh-Hans": "罗森",
+        "brand:zh-Hant": "羅森",
         "name": "罗森",
         "name:en": "Lawson",
         "name:zh": "罗森",
-        "operator": "罗森（中国）投资有限公司",
+        "name:zh-Hans": "罗森",
+        "name:zh-Hant": "羅森",
         "shop": "convenience"
       }
     },
@@ -8742,6 +8784,26 @@
         "name": "蝦皮店到店",
         "name:en": "Shopee Xpress",
         "name:zh": "蝦皮店到店",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "邻几",
+      "id": "goodspot-9729f7",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "tags": {
+        "brand": "邻几",
+        "brand:en": "Good Spot",
+        "brand:wikidata": "Q136192152",
+        "brand:zh-Hans": "邻几",
+        "brand:zh-Hant": "鄰幾",
+        "name": "邻几",
+        "name:en": "Good Spot",
+        "name:zh-Hans": "邻几",
+        "name:zh-Hant": "鄰幾",
         "shop": "convenience"
       }
     },

--- a/data/brands/shop/greengrocer.json
+++ b/data/brands/shop/greengrocer.json
@@ -208,6 +208,7 @@
         "delivery": "yes",
         "name": "鲜丰水果",
         "name:en": "Xianfeng Fruit",
+        "name:zh": "鲜丰水果",
         "name:zh-Hans": "鲜丰水果",
         "name:zh-Hant": "鮮豐水果",
         "shop": "greengrocer"

--- a/data/brands/shop/greengrocer.json
+++ b/data/brands/shop/greengrocer.json
@@ -191,6 +191,27 @@
         "name:zh": "钱大妈",
         "shop": "greengrocer"
       }
+    },
+    {
+      "displayName": "鲜丰水果",
+      "id": "xianfengfruit-c3a176",
+      "locationSet": {
+        "include": ["cn"],
+        "exclude": ["hk", "mo"]
+      },
+      "tags": {
+        "brand": "鲜丰水果",
+        "brand:en": "Xianfeng Fruit",
+        "brand:wikidata": "Q136192256",
+        "brand:zh-Hans": "鲜丰水果",
+        "brand:zh-Hant": "鮮豐水果",
+        "delivery": "yes",
+        "name": "鲜丰水果",
+        "name:en": "Xianfeng Fruit",
+        "name:zh-Hans": "鲜丰水果",
+        "name:zh-Hant": "鮮豐水果",
+        "shop": "greengrocer"
+      }
     }
   ]
 }


### PR DESCRIPTION
### New
| Name | Number |
| - | - |
| 喜姐炸串 | 2500+ |
| 夸父炸串 | 2000+ |
| 临渝炸鸡腿 | 5000+ |
| 柠季 | 3000+ |
| 巡茶 | 3000+ |
| 鲜丰水果 | 2400+ |
| 邻几 | 1400+ |
| 新力有家 | 800+ |

### Changes
* Add matchTag `shop/beverages` to non-coffee shops cafe. This is a common tag because the Chinese translation of cafe does not include non-coffee shops cafe.
* Separated the Wikidata value for "ALittle Tea". This brand is not directly related to the Taiwanese and mainland Chinese "50 Lan", which are three separate companies.
* Updated 奈雪的茶's English name, renaming to naisnow.
* Separated the Taiwanese version of Happy Lemon due to different tagging schemes.
* Removed the `operator` field from Lawson, as franchised stores should not have the same operator value.