### PR TITLE
Add Toastmasters

### DIFF
--- a/data/brands/club/toastmasters.json
+++ b/data/brands/club/toastmasters.json
@@ -1,0 +1,21 @@
+{
+  "properties": {
+    "path": "brands/club/toastmasters",
+  },
+  "items": [
+    {
+      "displayName": "Toastmasters International",
+      "id": "toastmastersinternational-6f1e7c",
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "brand": "Toastmasters International",
+        "brand:wikidata": "Q917036",
+        "club": "toastmasters"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add Toastmasters as a tag. Toastmasters was founded in 1924, as per the [2025 finical report](https://www.toastmasters.org/about/annual-financial-reports) there are 265,000 members spread across 149 countries and 13,833 active clubs currently in operation which does make this brand notable enough to be included. Based on taginfo.osm.org the following clubs are listed

- Bonn International Toastmasters
- Toastmasters Torres Novas
- Airpark Chatter Toastmasters Club
- Innisfail Toastmasters Club
- HSR Toastmasters
- Toastmasters Sokrates Toruń
- Toastmasters Düsseldorf
- Auckland West Toastmasters
- Brașov Toastmasters Club
- Toastmasters Club of Pune-West

Which should be enough to add it to the name suggestion index