### PR TITLE
Petrolina pcharge charging stations

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -918,6 +918,17 @@
       }
     },
     {
+      "displayName": "pcharge",
+      "id": "pcharge-1f324c",
+      "locationSet": {"include": ["cy"]},
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "pcharge",
+        "operator": "Petrolina",
+        "operator:wikidata": "Q17013948"
+      }
+    },
+    {
       "displayName": "Plugit",
       "id": "plugit-4d533b",
       "locationSet": {"include": ["fi"]},


### PR DESCRIPTION
Petrolina's charging stations brand, Cyprus.
https://www.pcharge.com.cy/en/home