### PR TITLE
Add Bria and Camella residence brands

### DIFF
--- a/data/brands/landuse/residential.json
+++ b/data/brands/landuse/residential.json
@@ -46,12 +46,51 @@
       }
     },
     {
+      "displayName": "Bria Flats",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "brand": "Bria Flats",
+        "landuse": "residential",
+        "residential": "apartments"
+      }
+    },
+    {
+      "displayName": "Bria Homes",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "brand": "Bria Homes",
+        "brand:wikidata": "Q136476367",
+        "landuse": "residential",
+        "residential": "single_family"
+      }
+    },
+    {
       "displayName": "Camden",
       "id": "camden-4e5c5e",
       "locationSet": {"include": ["us"]},
       "tags": {
         "brand": "Camden",
         "brand:wikidata": "Q5025803",
+        "landuse": "residential",
+        "residential": "apartments"
+      }
+    },
+    {
+      "displayName": "Camella",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "brand": "Camella",
+        "brand:wikidata": "Q105438953",
+        "landuse": "residential",
+        "residential": "single_family"
+      }
+    },
+    {
+      "displayName": "Camella Manors",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "brand": "Camella Manors",
+        "brand:wikidata": "Q136477278",
         "landuse": "residential",
         "residential": "apartments"
       }


### PR DESCRIPTION
Added the Bria Homes and Camella brands of single-family residential subdivisions, and the Bria Flats and Camella Manors brands of condominiums.

The Bria brands' developer, Bria Homes, Inc., is a subsidiary of Villar Land Holdings Corp. (formerly Golden MV Holdings, Inc.), while the Camella brands are developed by Camella, Inc., a subsidiary of another company owned by the same family (Vista Land and Lifescapes, Inc.).

I modeled the tags after the existing brand suggestions for American subdivisions and condos.

### Relevant links:

- [residential land areas in the Philippines with Bria on the name tag](https://overpass-turbo.eu/s/2dsU)
- [residential land areas in the Philippines with Camella on the name tag](https://overpass-turbo.eu/s/2dsT)
- [discussion of rejected `developer=` tag proposal](https://community.openstreetmap.org/t/rfc-feature-proposal-developer/131594)
    - `developer=Camella Homes` was [used as an example](https://community.openstreetmap.org/t/rfc-feature-proposal-developer/131594/25) of its de facto usage