### PR TITLE
Update supermarket.json

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -31,6 +31,21 @@
   },
   "items": [
     {
+      "displayName": "大全聯", 
+      "locationSet": {"include": ["tw"]},
+      "tags": {
+        "brand": "大全聯",
+        "brand:en": "Mega PX Mart",
+        "brand:wikidata": "Q135550746",
+        "brand:zh": "大全聯",
+        "name": "大全聯",
+        "name:en": "Mega PX Mart",
+        "name:zh": "大全聯",
+        "shop": "supermarket"
+      }
+    },
+    
+    {
       "displayName": "365discount",
       "id": "365discount-072052",
       "locationSet": {"include": ["dk"]},


### PR DESCRIPTION
Mega PX Mart is the new name for RT Mart locations. 

https://www.pxmart.com.tw/mega/store-locations/store-list/pxmart-mega
https://www.icrt.com.tw/info_details.php?mlevel1=6&mlevel2=13&news_id=286944&reUrlAddr=L25ld3NfZGF0YWJhc2UucGhwPyZwYWdlPTUwNjI=
https://www.wikidata.org/wiki/Q135550746
https://logos.fandom.com/wiki/Mega_PX_Mart#:~:text=Mega%20PX%20Mart%20%7C%20Logopedia%20%7C%20Fandom,Official%20website