### PR TITLE
Added Arabica Coffee Shop for Turkey

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -317,7 +317,7 @@
         "brand:wikidata": "Q115987749",
         "cuisine": "coffee_shop",
         "name": "Arabica",
-        "official_name": "Arabica Coffee House"
+        "official_name": "Arabica Coffee House",
         "takeaway": "yes"
       }
     },


### PR DESCRIPTION
Arabica is a Turkish coffeehouse company. Not to be confused with '% Arabica'

Arabica Website: [https://arabicacoffee.com.tr/](https://arabicacoffee.com.tr/)