### PR TITLE
add wikidata value to Korean bus network

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -25019,7 +25019,6 @@
       "displayName": "천안시 시내버스",
       "id": "bf6076-776068",
       "locationSet": {"include": ["kr"]},
-      "note": "",
       "tags": {
         "network": "천안시 시내버스",
         "network:ko": "천안시 시내버스",


### PR DESCRIPTION
added `network:wikidata=*` tags to some Korean bus networks and changed the name of '천안시' properly.