### PR TITLE
Upgrade vegetarian tag for De Beren restaurant

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -2179,7 +2179,7 @@
         "brand": "De Beren",
         "brand:wikidata": "Q57076079",
         "cuisine": "burger;chicken;grill",
-        "diet:vegetarian": "yes"
+        "diet:vegetarian": "yes",
         "name": "De Beren"
       }
     },


### PR DESCRIPTION
`cuisine=vegetarian` has been replaced with `diet:vegetarian=*`

https://wiki.openstreetmap.org/wiki/Key:diet:vegetarian

Closes #11313 