### PR TITLE
Update tags for Toronto subway

### DIFF
--- a/data/transit/route/subway.json
+++ b/data/transit/route/subway.json
@@ -908,7 +908,7 @@
         "network": "TTC",
         "network:metro": "Toronto subway",
         "network:metro:wikidata": "Q20379",
-        "network:wikidata": "Q6612865"
+        "network:wikidata": "Q6612865",
         "operator": "Toronto Transit Commission",
         "operator:short": "TTC",
         "operator:wikidata": "Q17978",


### PR DESCRIPTION
This updates the tag preset for Toronto subway, moving "Toronto subway" to network:metro and its associated Wikidata to network:metro:wikidata, making TTC the network value (in line with other transit modes under the Toronto Transit Commission such as its buses and streetcars/trams which have been using network=TTC for long). This follows up a similar change completed for Calgary Transit's CTrain light rail transit (LRT) network (part of #11462), which moves the system branding under network:metro.