### PR TITLE
Add preserveTags for 'De Echte Bakker' brand

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -750,6 +750,7 @@
     {
       "displayName": "De Echte Bakker",
       "id": "deechtebakker-8eaf6b",
+      "preserveTags": ["^name"],
       "locationSet": {"include": ["nl"]},
       "tags": {
         "brand": "De Echte Bakker",


### PR DESCRIPTION
De Echte Bakker is a suffix for the name of the baker.

So it would be Simon, De Echte Bakker (translated Simon, real baker) 

De echte bakker is a shortened form of the real bakkers guild