### PR TITLE
Updates Warhammer wikidata id

### DIFF
--- a/data/brands/shop/games.json
+++ b/data/brands/shop/games.json
@@ -47,7 +47,7 @@
       "matchNames": ["games workshop"],
       "tags": {
         "brand": "Warhammer",
-        "brand:wikidata": "Q587270",
+        "brand:wikidata": "Q136613133",
         "name": "Warhammer",
         "shop": "games"
       }


### PR DESCRIPTION
The Wikidata ID pointed to the games workshop, which worked in the past because it was called that.
But then it was renamed to Warhammer, and so I've created a new wikidata item for the chainstore.