### PR TITLE
Update department_store.json

### DIFF
--- a/brands/shop/department_store.json
+++ b/brands/shop/department_store.json
@@ -415,6 +415,19 @@
       }
     },
     {
+      "displayName": "Hart",
+      "id": "hart-01xs1m",
+      "locationSet": {"include": ["ca"]},
+       "oldid": "shop/department_store|Hart",
+      "tags": {
+        "brand": "Hart",
+        "brand:wikidata": "Q5674252",
+        "brand:wikipedia": "en:Hart Stores",
+        "name": "Hart",
+        "shop": "department_store"
+      }
+    },
+    {
       "displayName": "Harvey Norman",
       "id": "harveynorman-2e4a6e",
       "locationSet": {"include": ["au", "nz"]},
@@ -836,6 +849,19 @@
         "brand:wikipedia": "en:Ross Stores",
         "name": "Ross",
         "official_name": "Ross Dress for Less",
+        "shop": "department_store"
+      }
+    },
+    {
+      "displayName": "Rossy",
+      "id": "rossy-02vzky6",
+      "locationSet": {"include": ["ca"]},
+      "oldid": "shop/department_store|Rossy",
+      "tags": {
+        "brand": "Rossy",
+        "brand:wikidata": "Q17042064",
+        "brand:wikipedia": "en:Rossy",
+        "name": "Rossy",
         "shop": "department_store"
       }
     },


### PR DESCRIPTION
Added two Canadian department store chains, Hart and Rossy. Hart has 130 locations total, and Rossy has around 80 locations total. Not all locations are currently listed on Open Street Map. 