### PR TITLE
use ETS as network=* for Edmonton LRT

### DIFF
--- a/data/transit/route/light_rail.json
+++ b/data/transit/route/light_rail.json
@@ -132,7 +132,8 @@
       },
       "matchNames": [
         "edmonton transit system",
-        "ets",
+        "edmonton transit service",      
+        "edmonton lrt",
       ],
       "tags": {
         "network": "ETS",


### PR DESCRIPTION
this changes the network value for the Edmonton LRT preset to ETS, and also removes operator tags to account for one line and associated infrastructure not directly operated by ETS.