### PR TITLE
Update bicycle_rental network name

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -502,14 +502,14 @@
       }
     },
     {
-      "displayName": "Bicloo",
+      "displayName": "Naolib Vélo",
       "id": "bicloo-fb0739",
       "locationSet": {"include": [[-1.6, 47.2]]},
       "tags": {
         "amenity": "bicycle_rental",
-        "brand": "Bicloo",
+        "brand": "Naolib Vélo",
         "brand:wikidata": "Q2901638",
-        "network": "Bicloo",
+        "network": "Naolib Vélo",
         "network:wikidata": "Q2901638",
         "operator": "Cyclocity",
         "operator:type": "private",


### PR DESCRIPTION
Hello,

Nantes (France) bicycle rental network has changed its name from "Bicloo" to "Naolib Vélo".
