### PR TITLE
Stop suggesting Banco Santander in Portugal

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -2199,7 +2199,7 @@
       "id": "bancosantander-77aaa4",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["de", "gb", "pl", "us"]
+        "exclude": ["de", "gb", "pl", "pt", "us"]
       },
       "matchNames": [
         "banco santander banespa",


### PR DESCRIPTION
There's a separate rule for Portugal, so exclude Portugal from the catch-all rule.