### PR TITLE
Add Robin Oil

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -30,6 +30,16 @@
     }
   },
   "items": [
+        {
+      "displayName": "Robin Oil",
+      "locationSet": {"include": ["cz"]},
+      "tags": {
+        "amenity": "fuel",
+        "brand": "Robin Oil",
+        "brand:wikidata": "Q133453886",
+        "name": "Robin Oil"
+      }
+    },
     {
       "displayName": "1-2-3",
       "id": "123-67b972",


### PR DESCRIPTION
Added new fuel brand 'Robin Oil' with more than 50 locations in Czech republic.