### PR TITLE
Implement badenovaNETZE rebranding

### DIFF
--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -1005,14 +1005,14 @@
       }
     },
     {
-      "displayName": "bnNETZE",
+      "displayName": "badenovaNETZE",
       "id": "bnnetze-dda049",
       "locationSet": {
         "include": ["de-bw.geojson"]
       },
-      "matchNames": ["bnnetze gmbh"],
+      "matchNames": ["bnnetze gmbh", "bnnetze", "badenovanetze gmbh"],
       "tags": {
-        "operator": "bnNETZE",
+        "operator": "badenovaNETZE",
         "operator:wikidata": "Q57712950",
         "power": "substation"
       }


### PR DESCRIPTION
TL;DR bnNETZE rebranded to badenovaNETZE in 2023 and this is my best-effort attempt to update the database accordingly.

1. I hope that this catches all existing spellings of former "bnNETZE", so that a rename is recommended. I hope that this is what the `"matchNames"` list is for.
2. The [Wikidata Entry](https://www.wikidata.org/wiki/Q57712950) mentions 2 ids: `bnnetze-dda049` and `bnnetze-645c81`, where the latter is specifically for `power=transformer`, but when I searched for this entry it wasn't there, so I assume it is auto-generated based on `power=substation`?
3. Also should IDs ever get updated? So should `bnnetze-dda049` get changed to `badenovanetze-dda049`? I don't think so, that's why I left it as-is.
4. A small caveat, I don't know where nsi does source its logos from. If it's from wikidata, then the current wikidata entry doesn't have the new logo yet, because it isn't on wikimedia commons yet, the wikipedia page has the up-to-date logo though: https://de.wikipedia.org/wiki/Badenova_Netze

Thanks in advance for your help.