### PR TITLE
Veneta Cucine is also present in Metropolitan France

### DIFF
--- a/data/brands/shop/kitchen.json
+++ b/data/brands/shop/kitchen.json
@@ -418,7 +418,7 @@
     {
       "displayName": "Veneta Cucine",
       "id": "venetacucine-266f5b",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {"include": ["fx", "it"]},
       "tags": {
         "brand": "Veneta Cucine",
         "brand:wikidata": "Q136439356",


### PR DESCRIPTION
See also store locator in the official website https://venetacucine.fr/store-locator/