### PR TITLE
Add Železničná spoločnosť Slovensko ticket shop

### DIFF
--- a/data/brands/shop/ticket.json
+++ b/data/brands/shop/ticket.json
@@ -27,7 +27,6 @@
         "operator:type": "public",
         "operator:wikidata": "Q393557",
         "shop": "ticket"
-        "tickets:public_transport": "only",
       }
     },
     {


### PR DESCRIPTION
Add ticket shop with more than 100 locations, sometimes with different name.