### PR TITLE
Modify locationSet for Penový raj

### DIFF
--- a/data/brands/amenity/car_wash.json
+++ b/data/brands/amenity/car_wash.json
@@ -517,7 +517,7 @@
     {
       "displayName": "Penový raj",
       "id": "penovyraj-3482c3",
-      "locationSet": {"include": ["cz", "sk"]},
+      "locationSet": {"include": ["sk"]},
       "tags": {
         "amenity": "car_wash",
         "brand": "Penový raj",


### PR DESCRIPTION
Car washes in the Czech republic have slightly different name and only 5 locations.