### PR TITLE
Add Annabella supermarket chain

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -475,6 +475,16 @@
       }
     },
     {
+      "displayName": "Annabella",
+      "locationSet": {"include": ["ro"]},
+      "tags": {
+        "brand": "Annabella",
+        "brand:wikidata": "Q127785313",
+        "name": "Annabella",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Ara",
       "id": "ara-271a34",
       "locationSet": {"include": ["co"]},


### PR DESCRIPTION
Annabella it's a Romanian supermarkets chain with more than 100 stores across the country.

Wikidata item: https://www.wikidata.org/wiki/Q127785313

Stores map: https://www.annabella.ro/magazine/harta/