### PR TITLE
Update car_sharing.json

### DIFF
--- a/data/operators/amenity/car_sharing.json
+++ b/data/operators/amenity/car_sharing.json
@@ -597,7 +597,7 @@
     },
     {
       "displayName": "teilAuto eG",
-      "locationSet": {"include": ["de-th.json", "de-sn.json", "de-st.json"]},
+      "locationSet": {"include": ["de-th.geojson", "de-sn.geojson", "de-st.geojson"]},
       "matchNames": ["Mobility Center GmbH"],
       "tags": {
         "amenity": "car_sharing",


### PR DESCRIPTION
Mobility Center GmbH is now called teilAuto eG

Source: https://teilauto.net/impressum

> Mit Eintragung in das Genossenschaftsregister am 30.9.2025 wurde der Formwechsel der Mobility Center GmbH in eine eingetragene Genossenschaft (teilAuto eG) nach §§ 251–257 UmwG vollzogen.

(Follow-up for commit d7324df3d which only updated brand but not operator)