### PR TITLE
Update Transports Urbans de Sabadell

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -2876,13 +2876,19 @@
       }
     },
     {
-      "displayName": "Bus de Sabadell",
+      "displayName": "Transports Urbans de Sabadell",
       "id": "busdesabadell-b0a08c",
       "locationSet": {
         "include": ["es-b.geojson"]
       },
+      "matchNames": [
+        "tus",
+      ],
       "tags": {
-        "network": "Bus de Sabadell",
+        "network": "Transports Urbans de Sabadell",
+        "network:short": "TUS",
+        "network:wikidata": "Q39080976",
+        "operator": "TUS, SCCL",
         "route": "bus"
       }
     },


### PR DESCRIPTION
Updating bus network in Sabadell with Wikidata ID and correct name.