### PR TITLE
Update houseware.json - Add Allesz

### DIFF
--- a/data/brands/shop/houseware.json
+++ b/data/brands/shop/houseware.json
@@ -55,6 +55,17 @@
       }
     },
     {
+      "displayName": "Allesz",
+      "locationSet": {"include": ["nl"]},
+      "matchTags": ["shop/furniture"],
+      "tags": {
+        "brand": "Allesz",
+        "brand:wikidata": "Q136703522",
+        "name": "Allesz",
+        "shop": "houseware"
+      }
+    },
+    {
       "displayName": "At Home",
       "id": "athome-d77d08",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
(cc'd A67-A67)

---

Sidenote: Blokker itself [no longer operates in Belgium -nor Luxembourg-](https://en.wikipedia.org/wiki/Blokker_(store)#New_ownership). This can be changed separately.
(Allesz does not have any shops there -nor in Suriname- at least for now)