### PR TITLE
Update houseware.json - Remove countries from Blokker ("be")

### DIFF
--- a/data/brands/shop/houseware.json
+++ b/data/brands/shop/houseware.json
@@ -129,7 +129,7 @@
     {
       "displayName": "Blokker",
       "id": "blokker-a48b12",
-      "locationSet": {"include": ["be", "nl"]},
+      "locationSet": {"include": ["nl"]},
       "matchTags": ["shop/furniture"],
       "tags": {
         "brand": "Blokker",


### PR DESCRIPTION
Blokker itself [no longer operates in Belgium -nor Luxembourg-](https://en.wikipedia.org/wiki/Blokker_(store)#New_ownership).