### PR TITLE
Add Form Factory

### DIFF
--- a/data/brands/leisure/fitness_centre.json
+++ b/data/brands/leisure/fitness_centre.json
@@ -14,6 +14,17 @@
   },
   "items": [
     {
+      "displayName": "Form Factory",
+      "locationSet": {"include": ["cz"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Form Factory",
+        "brand:wikidata": "Q136752478",
+        "leisure": "fitness_centre",
+        "name": "Form Factory"
+      }
+    },
+    {
       "displayName": "[solidcore]",
       "id": "solidcore-809afb",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Add fitness centre chain with more than 30 locations in Czech Republic, sometimes with local name.