### PR TITLE
Add pharmacy brands

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -33,6 +33,80 @@
   },
   "items": [
     {
+      "displayName": "Alphega lékárna",
+      "locationSet": {"include": ["cz"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "Alphega lékárna",
+        "brand:wikidata": "Q136759253",
+        "healthcare": "pharmacy",
+        "name": "Alphega lékárna"
+      }
+    },
+    {
+      "displayName": "Družstvo lékáren",
+      "locationSet": {"include": ["cz"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "Družstvo lékáren",
+        "brand:wikidata": "Q136759298",
+        "healthcare": "pharmacy",
+        "name": "Družstvo lékáren"
+      }
+    },
+    {
+      "displayName": "Lékárna IPC",
+      "locationSet": {"include": ["cz"]},
+      "matchNames": ["ipc"],
+      "preserveTags": ["^name"],
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "Lékárna IPC",
+        "brand:wikidata": "Q136759343",
+        "healthcare": "pharmacy",
+        "name": "Lékárna IPC"
+      }
+    },
+    {
+      "displayName": "Magistra",
+      "locationSet": {"include": ["cz"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "Magistra",
+        "brand:wikidata": "Q128990890",
+        "healthcare": "pharmacy",
+        "name": "Magistra"
+      }
+    },
+    {
+      "displayName": "Moje lékárna",
+      "locationSet": {"include": ["cz"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "Moje lékárna",
+        "brand:wikidata": "Q127690464",
+        "healthcare": "pharmacy",
+        "name": "Moje lékárna"
+      }
+    },
+    {
+      "displayName": "PharmaPoint",
+      "locationSet": {"include": ["cz"]},
+      "matchNames": ["pharmapoint lékárna"],
+      "preserveTags": ["^name"],
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "PharmaPoint",
+        "brand:wikidata": "Q136759425",
+        "healthcare": "pharmacy",
+        "name": "PharmaPoint"
+      }
+    },
+    {
       "displayName": "1 Соціальна Аптека",
       "id": "06361d-996e17",
       "locationSet": {"include": ["ua"]},


### PR DESCRIPTION
Add pharmacy chains in Czech Republic, each with more than 30 locations and sometimes with a local name.