### PR TITLE
Remove Banco Casino

### DIFF
--- a/data/brands/amenity/casino.json
+++ b/data/brands/amenity/casino.json
@@ -5,17 +5,6 @@
   },
   "items": [
     {
-      "displayName": "BANCO CASINO",
-      "id": "bancocasino-efca36",
-      "locationSet": {"include": ["cz", "sk"]},
-      "tags": {
-        "amenity": "casino",
-        "brand": "BANCO CASINO",
-        "brand:wikidata": "Q58555038",
-        "name": "BANCO CASINO"
-      }
-    },
-    {
       "displayName": "Codere",
       "id": "codere-3dfd07",
       "locationSet": {


### PR DESCRIPTION
Only 4 locations in Slovakia and Czech Republic.