### PR TITLE
Add bookstore chains

### DIFF
--- a/data/brands/shop/books.json
+++ b/data/brands/shop/books.json
@@ -24,7 +24,7 @@
     {
       "displayName": "Kosmas",
       "locationSet": {"include": ["cz"]},
-      "matchNames": ["knihkupectví kosmas", *kosmas knihkupectví"],
+      "matchNames": ["knihkupectví kosmas", "kosmas knihkupectví"],
       "tags": {
         "brand": "Kosmas",
         "brand:wikidata": "Q56433594",


### PR DESCRIPTION
Add bookstore chains in Czech Republic, each with more than 30 locations.