### PR TITLE
Update PH-LTFRB presets

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -10097,7 +10097,7 @@
     },
     {
       "displayName": "LTFRB Cordillera Administrative Region",
-      "locationSet": {"include": ["ph-15"]},
+      "locationSet": {"include": ["ph-15.geojson"]},
       "matchNames": [
         "baguio city jeepney",
         "baguio city puj",
@@ -10105,6 +10105,7 @@
       ],
       "tags": {
         "network": "LTFRB Cordillera Administrative Region",
+        "network:short": "LTFRB CAR",
         "network:wikidata": "Q6483998",
         "route": "bus"
       }
@@ -10125,7 +10126,7 @@
     },
     {
       "displayName": "LTFRB National Capital Region",
-      "locationSet": {"include": ["ph-00"]},
+      "locationSet": {"include": ["ph-00.geojson"]},
       "matchNames": [
         "metro manila city bus",
         "metro manila pub",
@@ -10143,7 +10144,7 @@
     },
     {
       "displayName": "LTFRB Negros Island Region",
-      "locationSet": {"include": ["ph-nir"]},
+      "locationSet": {"include": ["ph-nir.geojson"]},
       "matchNames": [
         "bacolod city",
         "bacolod city jeepney",
@@ -10159,7 +10160,7 @@
     },
     {
       "displayName": "LTFRB Region III",
-      "locationSet": {"include": ["ph-03"]},
+      "locationSet": {"include": ["ph-03.geojson"]},
       "matchNames": [
         "central luzon",
         "ph central luzon"
@@ -10172,7 +10173,7 @@
     },
     {
       "displayName": "LTFRB Region IV-A",
-      "locationSet": {"include": ["ph-40"]},
+      "locationSet": {"include": ["ph-40.geojson"]},
       "matchNames": [
         "batangas city jeepney",
         "batangss city puj",
@@ -10187,7 +10188,7 @@
     },
     {
       "displayName": "LTFRB Region VI",
-      "locationSet": {"include": ["ph-06"]},
+      "locationSet": {"include": ["ph-06.geojson"]},
       "matchNames": [
         "iloilo city",
         "western visayas",
@@ -10201,7 +10202,7 @@
     },
     {
       "displayName": "LTFRB Region VII",
-      "locationSet": {"include": ["ph-07"]},
+      "locationSet": {"include": ["ph-07.geojson"]},
       "matchNames": [
         "central visayas",
         "metro cebu city bus",
@@ -10218,7 +10219,7 @@
     },
     {
       "displayName": "LTFRB Region XI",
-      "locationSet": {"include": ["ph-11"]},
+      "locationSet": {"include": ["ph-11.geojson"]},
       "matchNames": [
         "davao",
         "davao city bus",


### PR DESCRIPTION
Update tagging for Philippine LTFRB network tags, replacing the current PUB and PUJ values applying nationwide with geofenced regional values (e.g. LTFRB National Capital Region) covering most bus routes as well as jeepneys, and a Inter-Regional Inter-Provincial value to cover long-distance provincial bus routes (e.g. Manila to Baguio). This does not merge the presets for UV Express and Premium Point-to-Point (P2P) buses, which will remain as-is.

For regional networks (covering provincial bus routes not crossing regional boundaries, city buses and jeepneys), these ones will be supported based on current local and regional bus network mapping. Name matching is also provided to handle routes and stops still tagged with legacy values such as PH:[region]:[locale]:
- Metro Manila (National Capital Region)
- Cordillera Administrative Region
- Negros Island Region
- Central Luzon (Region III)
- CALABARZON (Region IV-A)
- Western Visayas (Region VI)
- Central Visayas (Region VII)
- Davao Region (Region XI)