### PR TITLE
Update bus networks in Slovakia

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -29,6 +29,28 @@
   },
   "items": [
     {
+      "displayName": "MHD Hlohovec",
+      "locationSet": {"include": ["sk"]},
+      "tags": {
+        "network": "MHD Hlohovec",
+        "network:wikidata": "Q110521790",
+        "operator": "Arriva Trnava",
+        "operator:wikidata": "Q131698585",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "MHD Senica",
+      "locationSet": {"include": ["sk"]},
+      "tags": {
+        "network": "MHD Senica",
+        "network:wikidata": "Q107782592",
+        "operator": "Arriva Trnava",
+        "operator:wikidata": "Q131698585",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "A-Welle",
       "id": "awelle-ba16da",
       "locationSet": {"include": ["ch"]},
@@ -7974,7 +7996,8 @@
       "locationSet": {"include": ["sk"]},
       "note": "ISO 3166-2 SK-KI, SK-PV",
       "tags": {
-        "network": "IDS Východ",
+        "network": "Integrovaný dopravný systém IDS Východ",
+        "network:short": "IDS Východ",
         "network:wikidata": "Q105226836",
         "route": "bus"
       }
@@ -10798,6 +10821,7 @@
         "network": "Mestský bus",
         "network:wikidata": "Q12771417",
         "operator": "Arriva Trnava",
+        "operator:wikidata": "Q131698585",
         "route": "bus"
       }
     },
@@ -11347,7 +11371,8 @@
       "tags": {
         "network": "MHD Košice",
         "network:wikidata": "Q104904552",
-        "operator": "DPMK",
+        "operator": "Dopravný podnik mesta Košice",
+        "operator:short": "DPMK",
         "operator:wikidata": "Q2265496",
         "route": "bus"
       }
@@ -11395,7 +11420,8 @@
       "tags": {
         "network": "MHD Michalovce",
         "network:wikidata": "Q131400264",
-        "operator": "DZS – MK TRANS",
+        "operator": "DZS - M.K.Trans",
+        "operator:wikidata": "Q135479224",
         "route": "bus"
       }
     },
@@ -11422,6 +11448,8 @@
       "tags": {
         "network": "MHD Nitra",
         "network:wikidata": "Q12771415",
+        "operator": "Transdev",
+        "operator:wikidata": "Q135073012",
         "route": "bus"
       }
     },
@@ -11445,6 +11473,8 @@
       "tags": {
         "network": "MHD Piešťany",
         "network:wikidata": "Q110521796",
+        "operator": "Arriva Trnava",
+        "operator:wikidata": "Q131698585",
         "route": "bus"
       }
     },
@@ -11467,7 +11497,9 @@
       "tags": {
         "network": "MHD Poprad",
         "network:wikidata": "Q107782589",
-        "operator": "SAD Poprad",
+        "operator": "Slovenská autobusová doprava Poprad",
+        "operator:short": "SAD Poprad",
+        "operator:wikidata": "Q131812204",
         "route": "bus"
       }
     },
@@ -11480,6 +11512,9 @@
         "network": "MHD Považská Bystrica",
         "network:short": "MHD PB",
         "network:wikidata": "Q131784849",
+        "operator": "Dopravný podnik mesta Považská Bystrica",
+        "operator:short": "DPMPB",
+        "operator:wikidata": "Q131784803",
         "route": "bus"
       }
     },
@@ -11493,6 +11528,7 @@
         "network:wikidata": "Q131400368",
         "operator": "Dopravný podnik mesta Prešov",
         "operator:short": "DPMP",
+        "operator:wikidata": "Q131702272",
         "route": "bus"
       }
     },
@@ -16183,19 +16219,6 @@
         "network": "SacRT",
         "network:wikidata": "Q7397015",
         "operator": "Sacramento Regional Transit District",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "SAD Žilina",
-      "id": "sadzilina-0c8a8c",
-      "locationSet": {
-        "include": ["cz-80.geojson", "sk"]
-      },
-      "note": "ISO 3166-2 SK-ZI",
-      "tags": {
-        "network": "SAD Žilina",
-        "network:wikidata": "Q12776241",
         "route": "bus"
       }
     },


### PR DESCRIPTION
Updated full names, operators and wikidata. Added 2 networks and removed SAD Žilina network that has been merged into IDS Plus network.