### PR TITLE
Add two laser hair removal chains

### DIFF
--- a/data/brands/shop/beauty.json
+++ b/data/brands/shop/beauty.json
@@ -661,6 +661,38 @@
       }
     },
     {
+      "displayName": "Láserum",
+      "id": "laserum",
+      "locationSet": {"include": ["es", "pt"]},
+      "tags": {
+        "beauty": "hair_removal",
+        "brand": "Láserum",
+        "name": "Láserum",
+        "brand:wikidata": "Q126736478",
+        "shop": "beauty"
+      }
+    },
+    
+    {
+      "displayName": "No+vello",
+      "id": "nomasvello",
+      "locationSet": {"include": [
+        "es", "hr", "ro",
+        "gb", "it", "pt",
+        "de", "ba", "br",
+        "bg", "md", "me",
+        "rs", "si", "se"
+      ]},
+      "tags": {
+        "beauty": "hair_removal",
+        "brand": "No+vello",
+        "name": "No+vello",
+        "alt_name": "Nomasvello",
+        "brand:wikidata": "Q127603433",
+        "shop": "beauty"
+      }
+    },
+    {
       "displayName": "Персона",
       "id": "persona-ac8d4a",
       "locationSet": {"include": ["ru"]},


### PR DESCRIPTION
Láserum with 250+ locations in Spain and Portugal, and No+vello with over 1000 locations around Europe and South America.