### PR TITLE
Include Central Luzon and CALABARZON regions for LTFRB NCR preset

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -10149,7 +10149,7 @@
     },
     {
       "displayName": "LTFRB National Capital Region",
-      "locationSet": {"include": ["ph-00.geojson"]},
+      "locationSet": {"include": ["ph-00.geojson", "ph-03.geojson", "ph-40.geojson"]},
       "matchNames": [
         "metro manila city bus",
         "metro manila pub",


### PR DESCRIPTION
This extends the LTFRB NCR preset to include Central Luzon and CALABARZON regions since some routes under the LTFRB NCR office cross into provinces belonging to those regions, specifically Bulacan (PH-BUL), Rizal (PH-RIZ), Laguna (PH-LAG) and Cavite (PH-CAV). Since there is currently no defined geofences for Cavite and Rizal, the preset will use the wider region as a stopgap until the missing province geofences are added.