### PR TITLE
Add Ptáček

### DIFF
--- a/data/brands/shop/trade.json
+++ b/data/brands/shop/trade.json
@@ -7,6 +7,17 @@
   },
   "items": [
     {
+      "displayName": "Ptáček",
+      "locationSet": {"include": ["cz", "sk"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Ptáček",
+        "brand:wikidata": "Q58195153",
+        "name": "Ptáček",
+        "shop": "trade",
+      }
+    },
+    {
       "displayName": "84 Lumber",
       "id": "84lumber-4e950c",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
About 140 locations in Czech Republic and Slovakia, mostly with local name.