### PR TITLE
Update brand name of Hangry Joe's to include 'Wings'

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -4414,7 +4414,7 @@
       }
     },
     {
-      "displayName": "Hangry Joe's Hot Chicken",
+      "displayName": "Hangry Joe's Hot Chicken & Wings",
       "id": "hangryjoeshotchicken-10afbb",
       "locationSet": {
         "include": [
@@ -4447,10 +4447,10 @@
       "matchNames": ["hangry joe's"],
       "tags": {
         "amenity": "fast_food",
-        "brand": "Hangry Joe's Hot Chicken",
+        "brand": "Hangry Joe's Hot Chicken & Wings",
         "brand:wikidata": "Q131378216",
         "cuisine": "chicken",
-        "name": "Hangry Joe's Hot Chicken",
+        "name": "Hangry Joe's Hot Chicken & Wings",
         "takeaway": "yes"
       }
     },


### PR DESCRIPTION
Updates brand name to match what's written on their logo and sign over restaurant.
https://hangryjoes.com/wp-content/uploads/2024/12/Hangry-Joes-Circle-Logo-Micah-1200-200x200.png