### PR TITLE
Add 'sg' to locationSet include for TOMORO Coffee

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -4782,7 +4782,7 @@
       "displayName": "TOMORO Coffee",
       "id": "tomorocoffee-f6b874",
       "locationSet": {
-        "include": ["ch", "id", "ph"]
+        "include": ["ch", "cn", "id", "ph", "sg"]
       },
       "tags": {
         "amenity": "cafe",


### PR DESCRIPTION
- Add Singapore to TOMORO Coffee's operating area.

Source: https://www.worldcoffeeportal.com/news/indonesias-tomoro-coffee-makes-singapore-debut-with-university-store/