### PR TITLE
Refined Oredoo from 001 to 9 countries

### DIFF
--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -578,7 +578,7 @@
     {
       "displayName": "Ooredoo",
       "id": "ooredoo-33bf96",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["dz", "id", "iq", "kw", "mv", "om", "ps", "qa", "tn"]},
       "tags": {
         "brand": "Ooredoo",
         "brand:wikidata": "Q919935",


### PR DESCRIPTION
Ooredoo only operates in 9 countries, don't know why it was 001.
https://en.wikipedia.org/wiki/Ooredoo