### PR TITLE
Add tags to two bus networks in Poland

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -13750,7 +13750,7 @@
       "tags": {
         "network": "Otwockie Przewozy Gminno-Powiatowe",
         "network:short": "OPGP",
-        "network:wikidata": "Q136485442"
+        "network:wikidata": "Q136485442",
         "route": "bus"
       }
     },


### PR DESCRIPTION
Add tags: network:short to "Otwockie Przewozy Gminno-Powiatowe"; network:wikidata to "Otwockie Przewozy Gminno-Powiatowe" and "PKS Grójec"