### PR TITLE
Rename 'Nicolas' to 'Maison Nicolas' in JSON

### DIFF
--- a/data/brands/shop/alcohol.json
+++ b/data/brands/shop/alcohol.json
@@ -644,15 +644,16 @@
       }
     },
     {
-      "displayName": "Nicolas",
+      "displayName": "Maison Nicolas",
       "id": "nicolas-44f3b7",
       "locationSet": {
         "include": ["be", "fr", "gb", "ma"]
       },
       "tags": {
-        "brand": "Nicolas",
+        "brand": "Maison Nicolas",
         "brand:wikidata": "Q3340012",
-        "name": "Nicolas",
+        "name": "Maison Nicolas",
+        "old_name": "Nicolas",
         "shop": "alcohol"
       }
     },


### PR DESCRIPTION
fix issue #11600 

OpenStreetMap France Discussion Forum : https://forum.openstreetmap.fr/t/le-reseau-de-cavistes-nicolas-devient-maison-nicolas/39265

I didn't change the ID. I don't know if it's necessary, and  I think it's automatic.

I don't think it's necessary to use `matchNames`.