### PR TITLE
Add Laser Quest brand for UK

### DIFF
--- a/data/brands/leisure/sports_centre.json
+++ b/data/brands/leisure/sports_centre.json
@@ -276,6 +276,18 @@
       }
     },
     {
+      "displayName": "Laser Quest",
+      "id": "laserquest-2b43d7",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "Laser Quest",
+        "brand:wikidata": "Q6493011",
+        "leisure": "sports_centre",
+        "name": "Laser Quest",
+        "sport": "laser_tag"
+      }
+    },
+    {
       "displayName": "Le Five",
       "id": "lefive-b9c700",
       "locationSet": {"include": ["fr", "us"]},


### PR DESCRIPTION
- There are enough locations on https://laserquest.co.uk/locations/ to meet notability requirement
- id generated with `bun run build`
- Confirmed changes built and linted with `bun run all`