### PR TITLE
[CA] Added WingsUp!

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -210,7 +210,7 @@
         "amenity": "fast_food",
         "brand": "WingsUp!",
         "brand:wikidata": "Q137167877",
-        "cuisine": "",
+        "cuisine": "wings",
         "delivery": "yes",
         "name": "WingsUp!",
         "takeaway": "yes"


### PR DESCRIPTION
Closes #10281

Canadian chicken (wings) fast food chain
38 open locations and 2 coming soon according to https://wingsup.com/Locations

[Asked on the Canadian forum](https://community.openstreetmap.org/t/wingsup-cuisine-chicken-or-cuisine-wings/138727) is I should tag it with `cuisine=chicken` or `cuisine=wings`.