### PR TITLE
update capitalisation of Geers brand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ node_modules/
 
 .DS_Store
 .vscode
-.idea
 npm-debug.log
 lerna-debug.log
 package-lock.json


### PR DESCRIPTION
Geers is not an acronym. If it is spelled all-caps, it is done so just for the purpose of increasing the visibility of the brand name in text. Neither [Wikidata](https://www.wikidata.org/wiki/Q1497707) nor [Wikipedia](https://de.wikipedia.org/wiki/Geers_H%C3%B6rakustik) found it warranted to apply an all-caps spelling.