### PR TITLE
Add TRAID charity shop

### DIFF
--- a/data/brands/shop/charity.json
+++ b/data/brands/shop/charity.json
@@ -603,6 +603,16 @@
       }
     },
     {
+      "displayName": "TRAID",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "TRAID",
+        "brand:wikidata": "Q109717195",
+        "name": "TRAID",
+        "shop": "charity"
+      }
+    },
+    {
       "displayName": "Vincent's",
       "id": "vincents-bbdeed",
       "locationSet": {"include": ["ie"]},


### PR DESCRIPTION
Whilst they probably technically don't meet the notability requirements with only twelve stores, we've got their recycling bins in the system already, so this is all it takes to add the shops too:
https://traid.org.uk/shop-at-traid/