### PR TITLE
Vintage Cellars replaced by Liquorland Cellars in AU

### DIFF
--- a/data/brands/shop/alcohol.json
+++ b/data/brands/shop/alcohol.json
@@ -527,6 +527,16 @@
       }
     },
     {
+      "displayName": "Liquorland Cellars",
+      "locationSet": {"include": ["au"]},
+      "tags": {
+        "brand": "Liquorland Cellars",
+        "brand:wikidata": "Q137190282",
+        "name": "Liquorland Cellars",
+        "shop": "alcohol"
+      }
+    },
+    {
       "displayName": "LiquorShop Checkers",
       "id": "liquorshopcheckers-7eb0a3",
       "locationSet": {
@@ -953,17 +963,6 @@
         "brand": "Vinmonopolet",
         "brand:wikidata": "Q1740534",
         "name": "Vinmonopolet",
-        "shop": "alcohol"
-      }
-    },
-    {
-      "displayName": "Vintage Cellars",
-      "id": "vintagecellars-cb3c62",
-      "locationSet": {"include": ["au"]},
-      "tags": {
-        "brand": "Vintage Cellars",
-        "brand:wikidata": "Q7932815",
-        "name": "Vintage Cellars",
         "shop": "alcohol"
       }
     },


### PR DESCRIPTION
in Australia, the Vintage Cellars brand was retired, all stores have now been rebranded into either "Liquorland Cellars" or "Liquorland".

The Liquorland brand already exists, so in this change I've removed the now retired "Vintage Cellars" and added the new "Liquorland Cellars" brand.