### PR TITLE
fix Aida cafe name and extra info

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -282,8 +282,7 @@
         "amenity": "cafe",
         "brand": "Aida",
         "brand:wikidata": "Q794636",
-        "cuisine": "coffee_shop;cake;pastry",
-        "drink:espresso": "yes",
+        "cuisine": "coffee_shop;pastry",
         "name": "Aida",
         "takeaway": "yes"
       }


### PR DESCRIPTION
Hi,

I fixed the name of this coffee house chain (source: I have been going to Aida for 20+ years). Aïda, (with a diaeresis) is not actually used beyond the logo, and that is technically Ɑïdɑ according to [Wikipedia](https://de.wikipedia.org/wiki/Aida_(Unternehmen)).

Thanks!
C