### PR TITLE
Add Swedish estate agent brands

### DIFF
--- a/data/brands/office/estate_agent.json
+++ b/data/brands/office/estate_agent.json
@@ -171,6 +171,16 @@
       }
     },
     {
+      "displayName": "Bjurfors",
+      "locationSet": {"include": ["se"]},
+      "tags": {
+        "brand": "Bjurfors",
+        "brand:wikidata": "Q64210847",
+        "name": "Bjurfors",
+        "office": "estate_agent"
+      }
+    },
+    {
       "displayName": "Bradleys",
       "id": "bradleys-aa448d",
       "locationSet": {"include": ["gb"]},
@@ -434,6 +444,17 @@
       }
     },
     {
+      "displayName": "Erik Olsson",
+      "locationSet": {"include": ["se"]},
+      "matchNames": ["erik olsson fastighetsförmedling"],
+      "tags": {
+        "brand": "Erik Olsson",
+        "brand:wikidata": "Q10487677",
+        "name": "Erik Olsson",
+        "office": "estate_agent"
+      }
+    },
+    {
       "displayName": "eXp Realty",
       "id": "exprealty-0f7192",
       "locationSet": {"include": ["ca", "us"]},
@@ -452,6 +473,16 @@
         "brand": "FALC Immobilien",
         "brand:wikidata": "Q107983152",
         "name": "FALC Immobilien",
+        "office": "estate_agent"
+      }
+    },
+    {
+      "displayName": "Fastighetsbyrån",
+      "locationSet": {"include": ["se"]},
+      "tags": {
+        "brand": "Fastighetsbyrån",
+        "brand:wikidata": "Q10494294",
+        "name": "Fastighetsbyrån",
         "office": "estate_agent"
       }
     },
@@ -659,6 +690,16 @@
       }
     },
     {
+      "displayName": "HusmanHagberg",
+      "locationSet": {"include": ["se"]},
+      "tags": {
+        "brand": "HusmanHagberg",
+        "brand:wikidata": "Q130239920",
+        "name": "HusmanHagberg",
+        "office": "estate_agent"
+      }
+    },
+    {
       "displayName": "Jellis Craig",
       "id": "jelliscraig-f2ceb3",
       "locationSet": {
@@ -764,6 +805,17 @@
       }
     },
     {
+      "displayName": "LF Fastighetsförmedling",
+      "locationSet": {"include": ["se"]},
+      "matchNames": ["länsförsäkringar fastighetsförmedling"],
+      "tags": {
+        "brand": "LF Fastighetsförmedling",
+        "brand:wikidata": "Q49101381",
+        "name": "LF Fastighetsförmedling",
+        "office": "estate_agent"
+      }
+    },
+    {
       "displayName": "LJ Hooker",
       "id": "ljhooker-08bb13",
       "locationSet": {"include": ["001"]},
@@ -782,6 +834,26 @@
         "brand": "Long & Foster Real Estate",
         "brand:wikidata": "Q6672178",
         "name": "Long & Foster",
+        "office": "estate_agent"
+      }
+    },
+    {
+      "displayName": "Mäklarhuset",
+      "locationSet": {"include": ["se"]},
+      "tags": {
+        "brand": "Mäklarhuset",
+        "brand:wikidata": "Q10593121",
+        "name": "Mäklarhuset",
+        "office": "estate_agent"
+      }
+    },
+    {
+      "displayName": "Mäklarringen",
+      "locationSet": {"include": ["se"]},
+      "tags": {
+        "brand": "Mäklarringen",
+        "brand:wikidata": "Q18292443",
+        "name": "Mäklarringen",
         "office": "estate_agent"
       }
     },
@@ -1064,6 +1136,16 @@
       }
     },
     {
+      "displayName": "SkandiaMäklarna",
+      "locationSet": {"include": ["se"]},
+      "tags": {
+        "brand": "SkandiaMäklarna",
+        "brand:wikidata": "Q10669682",
+        "name": "SkandiaMäklarna",
+        "office": "estate_agent"
+      }
+    },
+    {
       "displayName": "Square Habitat",
       "id": "squarehabitat-b7bc37",
       "locationSet": {"include": ["fx"]},
@@ -1127,6 +1209,16 @@
         "brand": "Strutt & Parker",
         "brand:wikidata": "Q7625458",
         "name": "Strutt & Parker",
+        "office": "estate_agent"
+      }
+    },
+    {
+      "displayName": "Svensk Fastighetsförmedling",
+      "locationSet": {"include": ["se"]},
+      "tags": {
+        "brand": "Svensk Fastighetsförmedling",
+        "brand:wikidata": "Q10684799",
+        "name": "Svensk Fastighetsförmedling",
         "office": "estate_agent"
       }
     },


### PR DESCRIPTION
Add several Swedish estate agent brands:
* Bjurfors
* Erik Olsson
* Fastighetsbyrån
* HusmanHagberg
* LF Fastighetsförmedling
* Mäklarhuset
* Mäklarringen
* SkandiaMäklarna
* Svensk Fastighetsförmedling