### PR TITLE
Add Tembici Colombia bicycle rental entry

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -3969,6 +3969,7 @@
         "brand:wikidata": "Q137163067",
         "operator": "M1 Transportes Sustentaveis Sucursal Colombia LTDA",
         "operator:wikidata": "Q137163064"
+      }
     },
     {
       "displayName": "TBike",


### PR DESCRIPTION
Service back in operation since [september 2025](https://www.instagram.com/p/DPMuu5wCYiJ/), around [300 stations](https://tembici.com.co/en/) across Bogotá.