### PR TITLE
Add a bunch of Colombian power operators

### DIFF
--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -10555,6 +10555,136 @@
         "operator:zh": "魏桥创业",
         "power": "line"
       }
+    },
+    {
+      "displayName": "Celsia",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Celsia",
+        "operator:wikidata": "Q113303365",
+        "power": "line"
+      }
+    },
+    {
+      "displayName": "Centrales Eléctricas de Norte de Santander",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Centrales Eléctricas de Norte de Santander",
+        "operator:short": "CENS",
+        "operator:wikidata": "Q33326890",
+        "power": "line"
+      }
+    },
+    {
+      "displayName": "Electrificadora de Santander",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Electrificadora de Santander",
+        "operator:short": "ESSA",
+        "operator:wikidata": "Q5829022",
+        "power": "line"
+      }
+    },
+    {
+      "displayName": "Electrificadora del Meta",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Electrificadora del Meta",
+        "operator:short": "EMSA",
+        "operator:wikidata": "Q131370261",
+        "power": "line"
+      }
+    },
+    {
+      "displayName": "Empresas Públicas de Medellín",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Empresas Públicas de Medellín",
+        "operator:short": "EPM",
+        "operator:wikidata": "Q3053381",
+        "power": "line"
+      }
+    },
+    {
+      "displayName": "Empresa de Energía de Boyacá",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Empresa de Energía de Boyacá",
+        "operator:short": "EBSA",
+        "operator:wikidata": "Q131302600",
+        "power": "line"
+      }
+    },
+    {
+      "displayName": "Empresas Municipales de Cali",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Empresas Municipales de Cali",
+        "operator:short": "EMCALI",
+        "operator:wikidata": "Q3053375",
+        "power": "line"
+      }
+    },
+    {
+      "displayName": "Centrales Eléctricas de Nariño",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Centrales Eléctricas de Nariño",
+        "operator:short": "CEDENAR",
+        "operator:wikidata": "Q114802463",
+        "power": "line"
+      }
+    },
+    {
+      "displayName": "Compañía Energética de Occidente",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Compañía Energética de Occidente",
+        "operator:short": "CEO",
+        "operator:wikidata": "Q132187084",
+        "power": "line"
+      }
+    },
+    {
+      "displayName": "Desarrollo Electrico Suria",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags":{
+        "operator": "Desarrollo Electrico Suria",
+        "operator:short": "Delsur",
+        "operator:wikidata": "Q137299304",
+        "power": "line"
+      }
+    },
+    {
+      "displayName": "Enlaza",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Enlaza",
+        "operator:wikidata": "Q137299319",
+        "power": "line"
+      }
     }
   ]
 }

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -15321,6 +15321,124 @@
         "operator:zh-Hant": "香港電燈有限公司",
         "power": "substation"
       }
+    },
+    {
+      "displayName": "Celsia",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Celsia",
+        "operator:wikidata": "Q113303365",
+        "power": "substation"
+      }
+    },
+    {
+      "displayName": "Centrales Eléctricas de Norte de Santander",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Centrales Eléctricas de Norte de Santander",
+        "operator:short": "CENS",
+        "operator:wikidata": "Q33326890",
+        "power": "substation"
+      }
+    },
+    {
+      "displayName": "Electrificadora de Santander",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Electrificadora de Santander",
+        "operator:short": "ESSA",
+        "operator:wikidata": "Q5829022",
+        "power": "substation"
+      }
+    },
+    {
+      "displayName": "Electrificadora del Meta",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Electrificadora del Meta",
+        "operator:short": "EMSA",
+        "operator:wikidata": "Q131370261",
+        "power": "substation"
+      }
+    },
+    {
+      "displayName": "Empresa de Energía de Boyacá",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Empresa de Energía de Boyacá",
+        "operator:short": "EBSA",
+        "operator:wikidata": "Q131302600",
+        "power": "substation"
+      }
+    },
+    {
+      "displayName": "Empresas Municipales de Cali",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Empresas Municipales de Cali",
+        "operator:short": "EMCALI",
+        "operator:wikidata": "Q3053375",
+        "power": "substation"
+      }
+    },
+    {
+      "displayName": "Centrales Eléctricas de Nariño",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Centrales Eléctricas de Nariño",
+        "operator:short": "CEDENAR",
+        "operator:wikidata": "Q114802463",
+        "power": "substation"
+      }
+    },
+    {
+      "displayName": "Compañía Energética de Occidente",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Compañía Energética de Occidente",
+        "operator:short": "CEO",
+        "operator:wikidata": "Q132187084",
+        "power": "substation"
+      }
+    },
+    {
+      "displayName": "Desarrollo Electrico Suria",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags":{
+        "operator": "Desarrollo Electrico Suria",
+        "operator:short": "Delsur",
+        "operator:wikidata": "Q137299304",
+        "power": "substation"
+      }
+    },
+    {
+      "displayName": "Enlaza",
+      "locationSet": {
+        "include": ["co"]
+      },
+      "tags": {
+        "operator": "Enlaza",
+        "operator:wikidata": "Q137299319",
+        "power": "substation"
+      }
     }
   ]
 }


### PR DESCRIPTION
This is based on the work done here: https://wiki.openstreetmap.org/wiki/Power_networks/Colombia

We don't have subdivisions for Colombia and in some cases the regions served by power operators don't exactly match administrative regions, so I've scoped all these nationally for the moment.