### PR TITLE
Add Annabella convenience shop as well

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -521,6 +521,16 @@
       }
     },
     {
+      "displayName": "Annabella",
+      "locationSet": {"include": ["ro"]},
+      "tags": {
+        "brand": "Annabella",
+        "brand:wikidata": "Q127785313",
+        "name": "Annabella",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "APlus (Sunoco)",
       "id": "aplus-f1e40b",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Annabella operates both supermaket and convenience store. It also takes over some "Profi Go" shops that are minimarkets, so it's better to have this brand for both categories of stores.