### PR TITLE
Duplicate entry for TUS

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -2889,15 +2889,6 @@
       }
     },
     {
-      "displayName": "Bus de Sabadell",
-      "id": "busdesabadell-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "Bus de Sabadell",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "Bus Faial",
       "id": "busfaial-f2b810",
       "locationSet": {"include": ["pt-20"]},


### PR DESCRIPTION
From https://github.com/osmlab/name-suggestion-index/pull/11530, the entry `busdesabadell-a45453` is a duplicate.