### PR TITLE
Enhance Republic of Türkiye Ministry of National Education

### DIFF
--- a/data/operators/amenity/school.json
+++ b/data/operators/amenity/school.json
@@ -31498,7 +31498,7 @@
         "operator": "Millî Eğitim Bakanlığı",
         "operator:en": "Ministry of National Education",
         "operator:short": "MEB",
-        "operator:type": "public",
+        "operator:type": "government",
         "operator:tr": "Millî Eğitim Bakanlığı",
         "operator:wikidata": "Q1359675"
       }


### PR DESCRIPTION
It had a typo (i vs î) and it was missing the `operator:en` tag.
Those tags are fixed using the data from the [wikipedia page](https://en.wikipedia.org/wiki/Ministry_of_National_Education_(Turkey)).