### PR TITLE
Update brand name for Bancontact CASH

### DIFF
--- a/data/brands/amenity/atm.json
+++ b/data/brands/amenity/atm.json
@@ -105,12 +105,13 @@
       }
     },
     {
-      "displayName": "Bancontact CASH",
+      "displayName": "CASH",
       "id": "bancontactcash-8a4913",
       "locationSet": {"include": ["be"]},
+      "matchNames": ["bancontact cash"],
       "tags": {
         "amenity": "atm",
-        "brand": "Bancontact CASH",
+        "brand": "CASH",
         "brand:wikidata": "Q112875867",
         "operator": "Batopin",
         "operator:wikidata": "Q97142699"


### PR DESCRIPTION
The brand name used by Bancontact CASH is nowadays CASH. See their website https://cash.be/nl and https://www.wikidata.org/wiki/Q112875867