### PR TITLE
[shop/motorcycles] change BMW to BMW Motorrad

### DIFF
--- a/data/brands/shop/motorcycle.json
+++ b/data/brands/shop/motorcycle.json
@@ -24,9 +24,9 @@
       "id": "bmw-7610a8",
       "locationSet": {"include": ["001"]},
       "tags": {
-        "brand": "BMW",
+        "brand": "BMW Motorrad",
         "brand:wikidata": "Q249173",
-        "name": "BMW",
+        "name": "BMW Motorrad",
         "shop": "motorcycle"
       }
     },


### PR DESCRIPTION
BMW brands their stores as BWM Motorrad, e.g. [example](https://www.google.com/maps/place/Van+Harten+BMW+Motorrad/@52.181734,5.4265611,19z/data=!4m6!3m5!1s0x47c6441fa80494ad:0x93c32465c87890fa!8m2!3d52.1816234!4d5.427689!16s%2Fg%2F1tj56_12?hl=en&entry=ttu&g_ep=EgoyMDI1MTIwOS4wIKXMDSoASAFQAw%3D%3D).
Also this aligns name more with Wikidata https://www.wikidata.org/wiki/Q249173.
OSM has only 193 POIs with this brand:wikidata (https://taginfo.openstreetmap.org/tags/brand%3Awikidata=Q249173) so I hope this change is fine.