### PR TITLE
Edit INPS and add INAIL Italian government operators

### DIFF
--- a/data/operators/office/government.json
+++ b/data/operators/office/government.json
@@ -1039,7 +1039,7 @@
       "locationSet": {"include": ["it"]},
       "tags": {
         "name": "INPS",
-        "government": "social_welfare".
+        "government": "social_welfare",
         "office": "government",
         "operator": "Istituto Nazionale della Previdenza Sociale",
         "operator:short": "INPS",


### PR DESCRIPTION
INPS and INAIL are social security and welfare officies in Italy.

I changed the display name of "Istituto Nazionale della Previdenza Sociale" with "INPS" because it's more common one.

OSM discussion here: https://community.openstreetmap.org/t/inps-inail-e-motorizzazione/126874

Ps. I will not put "Motorizzazione" operator now because the Wikidata item it's referring the Italian authority but the Wikipedia article not. And there are not a single entity (or website), every Italian province have their structure.