### PR TITLE
Doughnut Time split into Rodeo Doughnuts

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -2867,14 +2867,13 @@
     {
       "displayName": "Doughnut Time",
       "id": "doughnuttime-1abd07",
-      "locationSet": {"include": ["gb-eng"]},
+      "locationSet": {"include": ["de", "gb"]},
       "tags": {
         "amenity": "fast_food",
         "brand": "Doughnut Time",
         "brand:wikidata": "Q117286917",
         "cuisine": "donut",
         "name": "Doughnut Time",
-        "takeaway": "yes"
       }
     },
     {
@@ -9087,6 +9086,16 @@
         "name": "Robin's Donuts",
         "short_name": "Robin's",
         "takeaway": "yes"
+      }
+    },    {
+      "displayName": "Rodeo Doughnuts",
+      "locationSet": {"include": ["gb-eng"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Rodeo Doughnuts",
+        "brand:wikidata": "",
+        "cuisine": "donut",
+        "name": "Rodeo Doughnuts",
       }
     },
     {

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -9093,7 +9093,7 @@
       "tags": {
         "amenity": "fast_food",
         "brand": "Rodeo Doughnuts",
-        "brand:wikidata": "",
+        "brand:wikidata": "Q140723445",
         "cuisine": "donut",
         "name": "Rodeo Doughnuts",
       }


### PR DESCRIPTION
https://doughnuttime.co.uk/pages/locations - Although Wikidata calls it a British brand https://rodeo.co.uk/pages/doughnut-stores

Some details on the split:
https://taylortalksvegan.co.uk/2025/03/31/doughnut-time-rebranded-to-rodeo-doughnuts/ https://inquisitiveminds.bristows.com/post/102jxoo/doughnot-forget-about-your-franchisees