### PR TITLE
Add ION Hotels entry to hotel.json

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -2085,6 +2085,24 @@
       }
     },
     {
+      "displayName": "ION Hotels",
+      "locationSet": {"include": ["142", "150"]},
+      "matchNames": [
+        "ion hotel",
+        "ion",
+        "ion hótel ehf",
+        "ion hótels",
+        "ion hótel"
+      ],
+      "tags": {
+        "brand": "ION Hotels",
+        "brand:wikidata": "Q137530068",
+        "operator": "ION Hótel",
+        "operator:wikidata": "Q137530068",
+        "tourism": "hotel"
+      }
+    },
+    {
       "displayName": "Itsy by Treebo",
       "id": "itsybytreebo-b22a38",
       "locationSet": {"include": ["in"]},


### PR DESCRIPTION
Adds the ION Hotels chain to OSM Name Suggestion Index, which includes multiple branches labeled with descriptions of either the location or the vibe (or marketing strategy) the branch is aiming for.