### PR TITLE
Adding and updating school operators in Southernwestern British Columbia

### DIFF
--- a/data/operators/amenity/school.json
+++ b/data/operators/amenity/school.json
@@ -56380,7 +56380,7 @@
         "amenity": "school",
         "operator": "School District Number 44 (North Vancouver)",
         "operator:short": "North Vancouver School District",
-        "operator:abbr": "NVSD"
+        "operator:abbr": "NVSD",
         "operator:type": "public",
         "operator:wikidata": "Q7432191"
       }


### PR DESCRIPTION
Updated existing entries and added missing entries for schools operated in the Lower Mainland. Several school districts use a different operating name than their official name so I captured both names, as well as any acronyms.

I may have over specified the matchnames. I anticipate many different names to be tried by mappers so tried to consider several variations. I included in the matchnames their operating name (tagged as operator:short) since I am not sure if it would be suggested by default.