### PR TITLE
Add Brödernas, O'Learys restaurant brands

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -1113,6 +1113,7 @@
     },
     {
       "displayName": "Brödernas",
+      "id": "brodernas-45c141",
       "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "restaurant",
@@ -5529,6 +5530,7 @@
     },
     {
       "displayName": "O'Learys",
+      "id": "olearys-d05cca",
       "locationSet": {
         "include": [
           "ae",


### PR DESCRIPTION
The location set for O'Learys is based on the countries having restaurants listed in olearys.com and olearys.club (For some reason the website for the Baltic countries is in a separate site). Note that some of the countries listed only have a single O'Learys though, often in an airport.