### PR TITLE
Add Craig's Cookies

### DIFF
--- a/data/brands/shop/pastry.json
+++ b/data/brands/shop/pastry.json
@@ -106,6 +106,17 @@
       }
     },
     {
+      "displayName": "Craig's Cookies",
+      "id": "craigscookies-349785",
+      "locationSet": {"include": ["ca"]},
+      "tags": {
+        "brand": "Craig's Cookies",
+        "brand:wikidata": "Q137660411",
+        "name": "Craig's Cookies",
+        "shop": "pastry"
+      }
+    },
+    {
       "displayName": "Crumbl Cookies",
       "id": "crumblcookies-64e364",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
22 locations

List of stores: https://craigscookies.com/pages/find-us

Clickable Wikidata: https://www.wikidata.org/wiki/Q137660411

I based the `id` on the OSM ID of their first store location (https://www.openstreetmap.org/node/6389349785/history/1) but feel free to change if necessary