### PR TITLE
Crumbl Cookies is also in Canada

### DIFF
--- a/data/brands/shop/pastry.json
+++ b/data/brands/shop/pastry.json
@@ -108,7 +108,7 @@
     {
       "displayName": "Crumbl Cookies",
       "id": "crumblcookies-64e364",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["us", "ca"]},
       "tags": {
         "brand": "Crumbl Cookies",
         "brand:wikidata": "Q106924414",


### PR DESCRIPTION
https://crumblcookies.ca/stores shows 25 locations in four provinces in Canada