### PR TITLE
[shop/truck][shop/truck_repair] change Wikidata for Mercedes-Benz Trucks and add repair

### DIFF
--- a/data/brands/shop/truck.json
+++ b/data/brands/shop/truck.json
@@ -147,7 +147,7 @@
       "matchTags": ["shop/car"],
       "tags": {
         "brand": "Mercedes-Benz Trucks",
-        "brand:wikidata": "Q1586306",
+        "brand:wikidata": "Q36008",
         "name": "Mercedes-Benz Trucks",
         "shop": "truck"
       }

--- a/data/brands/shop/truck_repair.json
+++ b/data/brands/shop/truck_repair.json
@@ -197,6 +197,16 @@
         "name": "Volvo Trucks",
         "shop": "truck_repair"
       }
+    },
+    {
+      "displayName": "Mercedes-Benz Trucks",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "Mercedes-Benz Trucks",
+        "brand:wikidata": "Q36008",
+        "name": "Mercedes-Benz Trucks",
+        "shop": "truck_repair"
+      }
     }
   ]
 }


### PR DESCRIPTION
Previous wikidata is a list of Mercedes-Benz trucks ([Q1586306](https://www.wikidata.org/wiki/Q1586306)), it's probably better to link nsi entry to just Mercedes-Benz ([Q36008](https://www.wikidata.org/wiki/Q36008)).