### PR TITLE
Removed Italy from INPS brand in government.json

### DIFF
--- a/data/brands/office/government.json
+++ b/data/brands/office/government.json
@@ -106,7 +106,7 @@
     {
       "displayName": "INPS",
       "id": "inps-36a710",
-      "locationSet": {"include": ["it", "ml"]},
+      "locationSet": {"include": ["ml"]},
       "tags": {
         "brand": "INPS",
         "name": "INPS",


### PR DESCRIPTION
I removed Italy from INPS brand (inps-36a710) because we have the correct preset in operator/* side (istitutonazionaledellaprevidenzasociale-52677d).

We need to complete the preset for the Mali institute "Institut National de Prévoyance Sociale".