### PR TITLE
Fix typo in brand name for Tzomet Sfarim

### DIFF
--- a/data/brands/shop/books.json
+++ b/data/brands/shop/books.json
@@ -1389,7 +1389,7 @@
         "brand:he": "צומת ספרים",
         "brand:wikidata": "Q6743833",
         "name": "צומת ספרים",
-        "name:en": "Tzomet Sfarm",
+        "name:en": "Tzomet Sfarim",
         "name:he": "צומת ספרים",
         "shop": "books"
       }


### PR DESCRIPTION
The value for the `name:en` tag was missing an 'i', although it exists in the `brand:en` tag.
I fixed it to avoid false warnings in OSM iD editor that suggest "fixing" mapped elements with an incorrect name.