### PR TITLE
revert Aida cafe locationSet

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -272,12 +272,7 @@
     {
       "displayName": "Aida",
       "id": "aida-706eba",
-      "locationSet": {
-        "include": [
-          "at-3.geojson",
-          "at-9.geojson"
-        ]
-      },
+      "locationSet": {"include": ["at"]},
       "tags": {
         "amenity": "cafe",
         "brand": "Aida",


### PR DESCRIPTION
I limited the locationSet in #11636, however, I missed that there are Aidas outside of the specified set, so this PR reverts it to the whole of Austria again.