### PR TITLE
[amenity/charging_station] added Elektro Profi

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -857,6 +857,19 @@
       }
     },
     {
+      "displayName": "Elektro Profi",
+      "id": "elektroprofi-39fea5",
+      "locationSet": {"include": ["hu"]},
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Elektro Profi",
+        "brand:wikidata": "Q137696853",
+        "name": "Elektro Profi",
+        "operator": "Elektro Profi Mobility Kft.",
+        "operator:wikidata": "Q137696853"
+      }
+    },
+    {
       "displayName": "Mobiliti",
       "id": "mobiliti-39fea5",
       "locationSet": {"include": ["hu"]},


### PR DESCRIPTION
Added Elektro Profi to the list of `amenity=charging_station` suggestions, the company and its network operates in Hungary.