### PR TITLE
Blank out short_name and offical_name in templates when name is also removed

### DIFF
--- a/data/brands/advertising/totem.json
+++ b/data/brands/advertising/totem.json
@@ -9,10 +9,13 @@
       "templateSource": "brands/amenity/fuel",
       "templateTags": {
         "advertising": "totem",
+        "alt_name": "",
         "amenity": "",
         "brand": "{source.tags.brand}",
         "brand:wikidata": "{source.tags.brand:wikidata}",
-        "name": ""
+        "name": "",
+        "official_name": "",
+        "short_name": ""
       }
     }
   ]

--- a/data/operators/amenity/post_box.json
+++ b/data/operators/amenity/post_box.json
@@ -26,6 +26,7 @@
       "templateTags": {
         "amenity": "post_box",
         "name": "",
+        "official_name": "",
         "operator": "{source.tags.brand}",
         "operator:wikidata": "{source.tags.brand:wikidata}",
         "shop": ""
@@ -47,8 +48,10 @@
       ],
       "templateSource": "operators/amenity/post_office",
       "templateTags": {
+        "alt_name": "",
         "amenity": "post_box",
         "name": "",
+        "official_name": "",
         "shop": ""
       }
     },


### PR DESCRIPTION
We currently end up with some weird entries eg alt_name on post boxes, and no name.