### PR TITLE
Add Solo Oil

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6124,6 +6124,18 @@
       }
     },
     {
+      "displayName": "Solo Oil",
+      "id": "solo-9ed9c0",
+      "locationSet": {"include": ["au"]},
+      "matchNames": ["solo oil"],
+      "tags": {
+        "amenity": "fuel",
+        "brand": "Solo Oil",
+        "brand:wikidata": "Q115517074",
+        "name": "Solo Oil"
+      }
+    },
+    {
       "displayName": "Sonangol",
       "id": "sonangol-a1d251",
       "locationSet": {"include": ["ao"]},


### PR DESCRIPTION
[Q115517074](https://www.wikidata.org/wiki/Q115517074); formerly part of Liberty Oil (Australia)
