### PR TITLE
fix: use Q99525174 for Power

### DIFF
--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -1347,7 +1347,7 @@
       },
       "tags": {
         "brand": "Power",
-        "brand:wikidata": "Q20857751",
+        "brand:wikidata": "Q99525174",
         "name": "Power",
         "shop": "electronics"
       }


### PR DESCRIPTION
Not sure how to solve this. If there should be duplicate entries for each country with their own wikidata ID, or if I should do as I did in this PR by moving it to be the international entity 

Q20857751 is the DK entity 
Q137773608 is the NO entity
Q99525174 is the international entity owning all the sub country entities