### PR TITLE
Update "The Gym Group" preset

### DIFF
--- a/data/brands/leisure/fitness_centre.json
+++ b/data/brands/leisure/fitness_centre.json
@@ -1615,12 +1615,12 @@
       "displayName": "The Gym",
       "id": "thegym-2770cb",
       "locationSet": {"include": ["gb"]},
-      "matchNames": ["the gym group"],
+      "matchNames": ["the gym"],
       "tags": {
-        "brand": "The Gym",
+        "brand": "The Gym Group",
         "brand:wikidata": "Q48815022",
         "leisure": "fitness_centre",
-        "name": "The Gym"
+        "name": "The Gym Group"
       }
     },
     {


### PR DESCRIPTION
I believe that the external branding on The Gym Group's premises has changed from "The Gym" to "The Gym Group", so I think the latter should now be used as the name=* tag in OSM. (See the logo change documented in https://en.wikipedia.org/wiki/The_Gym_Group and the outdoor view of e.g. https://www.thegymgroup.com/find-a-gym/west-london-gyms/greenford/ .)

Equally the company running the gyms is called "The Gym Group", and this is the name of the Wikipedia and Wikidata articles, hence I think this should be the brand=* tag too.