### PR TITLE
Fixed location for Brown's Chicken

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -1147,7 +1147,7 @@
     {
       "displayName": "Brown's Chicken",
       "id": "brownschicken-dbdcb8",
-      "locationSet": {"include": ["il"]},
+      "locationSet": {"include": ["us-il.geojson"]},
       "tags": {
         "amenity": "fast_food",
         "brand": "Brown's Chicken",


### PR DESCRIPTION
`locationSet` was set to `il` (Israel) instead of `us-il.geojson` (Illinois - USA).