### PR TITLE
Add Tobacco DC

### DIFF
--- a/data/brands/shop/tobacco.json
+++ b/data/brands/shop/tobacco.json
@@ -15,6 +15,21 @@
   },
   "items": [
     {
+      "displayName": "Tobacco DC",
+      "locationSet": {"include": ["cz"]},
+      "matchNames": ["trafika tobacco dc"],
+      "matchTags": [
+        "shop/newsagent"
+      ],
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Tobacco DC",
+        "brand:wikidata": "Q137939456",
+        "name": "Tobacco DC",
+        "shop": "tobacco"
+      }
+    },
+    {
       "displayName": "20 грамм",
       "id": "0b3858-0cd077",
       "locationSet": {"include": ["ru"]},


### PR DESCRIPTION
Add tobacco brand with more than 40 locations.