### PR TITLE
Add french diy shops (4 new, 1 updated)

### DIFF
--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -572,6 +572,16 @@
       }
     },
     {
+      "displayName": "Frans Bonhomme",
+      "locationSet": {"include": ["fx"]},
+      "tags": {
+        "brand": "Frans Bonhomme",
+        "brand:wikidata": "Q124014148",
+        "name": "Frans Bonhomme",
+        "shop": "doityourself"
+      }
+    },
+    {
       "displayName": "Gamma",
       "id": "gamma-29070e",
       "locationSet": {"include": ["be", "nl"]},


### PR DESCRIPTION
Added
- CEDEO: 450 shops (source: https://www.cedeo.fr/nos-agences)
- La Plateforme du Bâtiment: 69 shops (source: https://www.laplateforme.com/depot/liste)
- Samse: 88 shops (source: https://www.samse.fr/agences)
- Frans Bonhomme: 400 shops (source: https://www.fransbonhomme.fr/store-finder)

Updated
- Screwfix: also in France (source: https://www.screwfix.fr/comptoirs-screwfix)