### PR TITLE
Update preset for WKD

### DIFF
--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -3250,14 +3250,19 @@
       }
     },
     {
-      "displayName": "WKD",
+      "displayName": "Warszawska Kolej Dojazdowa",
       "id": "wkd-8d7802",
       "locationSet": {
         "include": ["pl-14.geojson"]
       },
+      "matchNames": ["WKD"],
       "tags": {
-        "network": "WKD",
+        "network": "Warszawska Kolej Dojazdowa",
+        "network:short": "WKD",
         "network:wikidata": "Q773832",
+        "operator": "Warszawska Kolej Dojazdowa",
+        "operator:short": "WKD",
+        "operator:wikidata": "Q137943194",
         "route": "train"
       }
     },


### PR DESCRIPTION
Changed `WKD` to the full name `Warszawska Kolej Dojazdowa`. \
Also added `network:short=WKD` and appropriate `operator` tags to the preset.

According to [OSM Tag History](https://taghistory.raifer.tech/?#***/network/Warszawska%20Kolej%20Dojazdowa&***/network/WKD), the longer variant is more prevalent in the OSM data for over 3 years now, despite the current preset featuring the shorter one.