### PR TITLE
adds a new charging station brand "DiDi Charging"（滴滴充电）

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -1528,7 +1528,7 @@
       "displayName": "滴滴充电",
       "id": "didi-07dd34",
       "locationSet": {"include": ["cn"],"exclude":["hk","mo"]},
-      "matchNames": ["小桔充电","滴滴充电"]
+      "matchNames": ["小桔充电"],
       "tags": {
         "amenity": "charging_station",
         "brand": "滴滴充电",


### PR DESCRIPTION
This pull request adds a new charging station brand to the dataset for China. The main change is the inclusion of "滴滴充电" (DiDi Charging) with relevant metadata and historical names.

**Brand data updates:**

* Added a new entry for the "滴滴充电" (DiDi Charging) charging station brand, including its English and Chinese names, Wikidata reference, and former names ("小桔充电"/"Orange Charging"). (`data/brands/amenity/charging_station.json`)