### PR TITLE
Updated PubliBike Velospot

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -3271,7 +3271,7 @@
         "brand": "PubliBike Velospot",
         "brand:wikidata": "Q138003595",
         "network": "Agglo Fribourg-Freiburg",
-        "operator": "PubliBike SA",
+        "operator": "PubliBike AG",
         "operator:type": "private",
         "operator:wikidata": "Q3555363"
       }
@@ -3287,7 +3287,7 @@
         "brand": "PubliBike Velospot",
         "brand:wikidata": "Q138003595",
         "network": "Lugano-Malcantone",
-        "operator": "PubliBike SA",
+        "operator": "PubliBike AG",
         "operator:type": "private",
         "operator:wikidata": "Q3555363"
       }
@@ -3303,7 +3303,7 @@
         "brand": "PubliBike Velospot",
         "brand:wikidata": "Q138003595",
         "network": "Région de Nyon",
-        "operator": "PubliBike SA",
+        "operator": "PubliBike AG",
         "operator:type": "private",
         "operator:wikidata": "Q3555363"
       }
@@ -3319,7 +3319,7 @@
         "brand": "PubliBike Velospot",
         "brand:wikidata": "Q138003595",
         "network": "Sierre",
-        "operator": "PubliBike SA",
+        "operator": "PubliBike AG",
         "operator:type": "private",
         "operator:wikidata": "Q3555363"
       }
@@ -3335,7 +3335,7 @@
         "brand": "PubliBike Velospot",
         "brand:wikidata": "Q138003595",
         "network": "Sion",
-        "operator": "PubliBike SA",
+        "operator": "PubliBike AG",
         "operator:type": "private",
         "operator:wikidata": "Q3555363"
       }


### PR DESCRIPTION
Updated PubliBike Velospot:

- new brand name: PubliBike → PubliBike Velospot
- official company name: PubliBike SA (in French) / PubliBike AG (in German)
- removed discontinued service in Lausanne
- new network name in Bern: Velo Bern → Velo Region Bern