### PR TITLE
Add wikidata to Kosan Gas amenity=vending_machine.

### DIFF
--- a/data/brands/amenity/vending_machine.json
+++ b/data/brands/amenity/vending_machine.json
@@ -892,7 +892,9 @@
       "tags": {
         "amenity": "vending_machine",
         "brand": "Kosan Gas",
-        "name": "Kosan Gas",
+        "brand:wikidata": "Q138029964",
+        "operator": "Kosan Gas",
+        "operator:wikidata": "Kosan Gas",
         "vending": "gas"
       }
     },


### PR DESCRIPTION
I added a wikidata ID to the brand. I also removed the `name=Kosan Gas`, since the vending machines don't have names just a brand/operator like car charging stations.