### PR TITLE
Add öklo (Austrian composting toilet brand)

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -3791,10 +3791,10 @@
     },
     {
       "displayName": "Quickly",
-      "id": "quickly-fb11e8",
+      "id": "quickly-92c4b0",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["tw", "bg"]
+        "exclude": ["bg", "tw"]
       },
       "tags": {
         "amenity": "cafe",

--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -156,7 +156,7 @@
     },
     {
       "displayName": "bp pulse",
-      "id": "bppulse-36ec13",
+      "id": "bppulse-ac8b5c",
       "locationSet": {
         "include": ["au", "gb", "nl", "nz", "us"]
       },
@@ -337,7 +337,7 @@
     },
     {
       "displayName": "Electra",
-      "id": "electra-08a288",
+      "id": "electra-5e7209",
       "locationSet": {
         "include": [
           "at",
@@ -1470,26 +1470,6 @@
       }
     },
     {
-      "displayName": "国家电网",
-      "id": "stategrid-07dd34",
-      "locationSet": {"include": ["cn"]},
-      "matchNames": ["中国国家电网"],
-      "tags": {
-        "amenity": "charging_station",
-        "brand": "国家电网",
-        "brand:en": "State Grid",
-        "brand:wikidata": "Q209078",
-        "brand:zh": "国家电网",
-        "name": "国家电网",
-        "name:en": "State Grid",
-        "name:zh": "国家电网",
-        "operator": "国家电网有限公司",
-        "operator:en": "State Grid Corporation of China",
-        "operator:wikidata": "Q209078",
-        "operator:zh": "国家电网有限公司"
-      }
-    },
-    {
       "displayName": "南方电网",
       "id": "southernpowergrid-07dd34",
       "locationSet": {"include": ["cn"]},
@@ -1507,6 +1487,26 @@
         "operator:en": "Southern Power Grid",
         "operator:wikidata": "Q209039",
         "operator:zh": "南方电网有限公司"
+      }
+    },
+    {
+      "displayName": "国家电网",
+      "id": "stategrid-07dd34",
+      "locationSet": {"include": ["cn"]},
+      "matchNames": ["中国国家电网"],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "国家电网",
+        "brand:en": "State Grid",
+        "brand:wikidata": "Q209078",
+        "brand:zh": "国家电网",
+        "name": "国家电网",
+        "name:en": "State Grid",
+        "name:zh": "国家电网",
+        "operator": "国家电网有限公司",
+        "operator:en": "State Grid Corporation of China",
+        "operator:wikidata": "Q209078",
+        "operator:zh": "国家电网有限公司"
       }
     },
     {

--- a/data/brands/amenity/clinic.json
+++ b/data/brands/amenity/clinic.json
@@ -156,8 +156,8 @@
     },
     {
       "displayName": "Medicare Urgent Care Clinic",
-      "locationSet": { "include": ["au"] },
-      "matchNames": ["medicare ucc"],
+      "id": "medicareurgentcareclinic-f397d0",
+      "locationSet": {"include": ["au"]},
       "preserveTags": ["^name"],
       "tags": {
         "amenity": "clinic",

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -1146,8 +1146,10 @@
     },
     {
       "displayName": "Brown's Chicken",
-      "id": "brownschicken-dbdcb8",
-      "locationSet": {"include": ["us-il.geojson"]},
+      "id": "brownschicken-0e88aa",
+      "locationSet": {
+        "include": ["us-il.geojson"]
+      },
       "tags": {
         "amenity": "fast_food",
         "brand": "Brown's Chicken",
@@ -10189,7 +10191,7 @@
     },
     {
       "displayName": "Taco Bell",
-      "id": "tacobell-09585c",
+      "id": "tacobell-a1c9df",
       "locationSet": {
         "include": [
           "ae",

--- a/data/brands/amenity/toilets.json
+++ b/data/brands/amenity/toilets.json
@@ -1,0 +1,343 @@
+{
+  "properties": {
+    "path": "brands/amenity/toilets",
+    "preserveTags": [
+      "^amenity$",
+      "^name$",
+      "^operator$"
+    ],
+    "exclude": {"generic": ["^toilets$"]}
+  },
+  "items": [
+    {
+      "displayName": "Baños",
+      "id": "banos-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "Baños",
+        "name": "Baños"
+      }
+    },
+    {
+      "displayName": "Baños Públicos",
+      "id": "banospublicos-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "Baños Públicos",
+        "name": "Baños Públicos"
+      }
+    },
+    {
+      "displayName": "Berliner Toilette",
+      "id": "berlinertoilette-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "Berliner Toilette",
+        "name": "Berliner Toilette"
+      }
+    },
+    {
+      "displayName": "Latrine",
+      "id": "latrine-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "Latrine",
+        "name": "Latrine"
+      }
+    },
+    {
+      "displayName": "Men's Restroom",
+      "id": "mensrestroom-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "Men's Restroom",
+        "name": "Men's Restroom"
+      }
+    },
+    {
+      "displayName": "öklo",
+      "id": "oklo-2b0862",
+      "locationSet": {"include": ["at"]},
+      "matchNames": [
+        "oeklo",
+        "oeklo komposttoilette",
+        "öklo komposttoilette"
+      ],
+      "tags": {
+        "access": "yes",
+        "amenity": "toilets",
+        "brand": "öklo",
+        "brand:wikidata": "Q138034487",
+        "building": "yes",
+        "building:material": "wood",
+        "fee": "no",
+        "name": "öklo",
+        "operator": "öklo GmbH",
+        "operator:type": "private",
+        "toilets:disposal": "composting",
+        "toilets:wheelchair": "yes"
+      }
+    },
+    {
+      "displayName": "Pit Latrine",
+      "id": "pitlatrine-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "Pit Latrine",
+        "name": "Pit Latrine"
+      }
+    },
+    {
+      "displayName": "plot toilet",
+      "id": "plottoilet-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "plot toilet",
+        "name": "plot toilet"
+      }
+    },
+    {
+      "displayName": "Restroom",
+      "id": "restroom-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "Restroom",
+        "name": "Restroom"
+      }
+    },
+    {
+      "displayName": "Restrooms",
+      "id": "restrooms-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "Restrooms",
+        "name": "Restrooms"
+      }
+    },
+    {
+      "displayName": "RRI",
+      "id": "rri-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "RRI",
+        "name": "RRI"
+      }
+    },
+    {
+      "displayName": "Sanitaires",
+      "id": "sanitaires-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "Sanitaires",
+        "name": "Sanitaires"
+      }
+    },
+    {
+      "displayName": "SBM Toilet",
+      "id": "sbmtoilet-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "SBM Toilet",
+        "name": "SBM Toilet"
+      }
+    },
+    {
+      "displayName": "Tahoratxona",
+      "id": "tahoratxona-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "Tahoratxona",
+        "name": "Tahoratxona"
+      }
+    },
+    {
+      "displayName": "Toilette",
+      "id": "toilette-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "Toilette",
+        "name": "Toilette"
+      }
+    },
+    {
+      "displayName": "Toilettes",
+      "id": "toilettes-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "Toilettes",
+        "name": "Toilettes"
+      }
+    },
+    {
+      "displayName": "vlídné WC",
+      "id": "vlidnewc-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "vlídné WC",
+        "name": "vlídné WC"
+      }
+    },
+    {
+      "displayName": "WC Público",
+      "id": "wcpublico-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "WC Público",
+        "name": "WC Público"
+      }
+    },
+    {
+      "displayName": "Women's Restroom",
+      "id": "womensrestroom-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "Women's Restroom",
+        "name": "Women's Restroom"
+      }
+    },
+    {
+      "displayName": "Городской туалет",
+      "id": "9573bb-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "Городской туалет",
+        "name": "Городской туалет"
+      }
+    },
+    {
+      "displayName": "توالت",
+      "id": "e16395-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "توالت",
+        "name": "توالت"
+      }
+    },
+    {
+      "displayName": "توالت عمومی",
+      "id": "75870e-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "توالت عمومی",
+        "name": "توالت عمومی"
+      }
+    },
+    {
+      "displayName": "دستشویی",
+      "id": "bc96ee-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "دستشویی",
+        "name": "دستشویی"
+      }
+    },
+    {
+      "displayName": "سرویس بهداشتی عمومی",
+      "id": "e53c28-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "سرویس بهداشتی عمومی",
+        "name": "سرویس بهداشتی عمومی"
+      }
+    },
+    {
+      "displayName": "화장실",
+      "id": "745fe5-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "화장실",
+        "brand:ko": "화장실",
+        "name": "화장실",
+        "name:ko": "화장실"
+      }
+    },
+    {
+      "displayName": "トイレ",
+      "id": "e12c23-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "トイレ",
+        "brand:ja": "トイレ",
+        "name": "トイレ",
+        "name:ja": "トイレ"
+      }
+    },
+    {
+      "displayName": "公共卫生间",
+      "id": "fde7a8-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "公共卫生间",
+        "name": "公共卫生间"
+      }
+    },
+    {
+      "displayName": "公共厕所",
+      "id": "91c6bd-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "公共厕所",
+        "name": "公共厕所"
+      }
+    },
+    {
+      "displayName": "公衆トイレ",
+      "id": "fd08b4-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "公衆トイレ",
+        "brand:ja": "公衆トイレ",
+        "name": "公衆トイレ",
+        "name:ja": "公衆トイレ"
+      }
+    },
+    {
+      "displayName": "卫生间",
+      "id": "23aa53-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "卫生间",
+        "name": "卫生间"
+      }
+    },
+    {
+      "displayName": "廁所",
+      "id": "27628c-f3e6b6",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "amenity": "toilets",
+        "brand": "廁所",
+        "name": "廁所"
+      }
+    }
+  ]
+}

--- a/data/brands/shop/bicycle.json
+++ b/data/brands/shop/bicycle.json
@@ -208,16 +208,6 @@
       }
     },
     {
-      "displayName": "Mantel",
-      "locationSet": {"include": ["nl"]},
-      "tags": {
-        "brand": "Mantel",
-        "brand:wikidata": "Q138028950",
-        "name": "Mantel",
-        "shop": "bicycle"
-      }
-    },
-    {
       "displayName": "m-way",
       "id": "mway-dfdabf",
       "locationSet": {"include": ["ch"]},
@@ -225,6 +215,17 @@
         "brand": "m-way",
         "brand:wikidata": "Q136486907",
         "name": "m-way",
+        "shop": "bicycle"
+      }
+    },
+    {
+      "displayName": "Mantel",
+      "id": "mantel-a0a74d",
+      "locationSet": {"include": ["nl"]},
+      "tags": {
+        "brand": "Mantel",
+        "brand:wikidata": "Q138028950",
+        "name": "Mantel",
         "shop": "bicycle"
       }
     },

--- a/data/brands/shop/charity.json
+++ b/data/brands/shop/charity.json
@@ -304,6 +304,7 @@
     },
     {
       "displayName": "Magasin du Monde",
+      "id": "magasindumonde-ea61d3",
       "locationSet": {"include": ["ch"]},
       "tags": {
         "brand": "Magasin du Monde",
@@ -311,7 +312,7 @@
         "name": "Magasin du Monde",
         "shop": "charity"
       }
-    },    
+    },
     {
       "displayName": "Marie Curie",
       "id": "mariecurie-b7b967",

--- a/data/brands/shop/doityourself.json
+++ b/data/brands/shop/doityourself.json
@@ -446,6 +446,7 @@
     },
     {
       "displayName": "CEDEO",
+      "id": "cedeo-f33b88",
       "locationSet": {"include": ["fx"]},
       "tags": {
         "brand": "CEDEO",
@@ -571,6 +572,7 @@
     },
     {
       "displayName": "Frans Bonhomme",
+      "id": "fransbonhomme-f33b88",
       "locationSet": {"include": ["fx"]},
       "tags": {
         "brand": "Frans Bonhomme",
@@ -909,6 +911,17 @@
       }
     },
     {
+      "displayName": "La Plateforme du Bâtiment",
+      "id": "laplateformedubatiment-f33b88",
+      "locationSet": {"include": ["fx"]},
+      "tags": {
+        "brand": "La Plateforme du Bâtiment",
+        "brand:wikidata": "Q137972122",
+        "name": "La Plateforme du Bâtiment",
+        "shop": "doityourself"
+      }
+    },
+    {
       "displayName": "Lagerhaus (Österreich)",
       "id": "lagerhaus-5a91e1",
       "locationSet": {"include": ["at"]},
@@ -917,16 +930,6 @@
         "brand": "Lagerhaus",
         "brand:wikidata": "Q1232873",
         "name": "Lagerhaus",
-        "shop": "doityourself"
-      }
-    },
-    {
-      "displayName": "La Plateforme du Bâtiment",
-      "locationSet": {"include": ["fx"]},
-      "tags": {
-        "brand": "La Plateforme du Bâtiment",
-        "brand:wikidata": "Q137972122",
-        "name": "La Plateforme du Bâtiment",
         "shop": "doityourself"
       }
     },
@@ -1318,6 +1321,7 @@
     },
     {
       "displayName": "Samse",
+      "id": "samse-f33b88",
       "locationSet": {"include": ["fx"]},
       "tags": {
         "brand": "Samse",
@@ -1328,8 +1332,10 @@
     },
     {
       "displayName": "Screwfix",
-      "id": "screwfix-6b37cb",
-      "locationSet": {"include": ["de", "fx", "gb"]},
+      "id": "screwfix-553b50",
+      "locationSet": {
+        "include": ["de", "fx", "gb"]
+      },
       "tags": {
         "brand": "Screwfix",
         "brand:wikidata": "Q7439115",

--- a/data/brands/shop/fishing.json
+++ b/data/brands/shop/fishing.json
@@ -20,6 +20,7 @@
     },
     {
       "displayName": "Europeche",
+      "id": "europeche-bc8e02",
       "locationSet": {"include": ["fr"]},
       "matchTags": ["shop/sports"],
       "tags": {

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -4281,6 +4281,17 @@
       }
     },
     {
+      "displayName": "Kam Market (Macedonia)",
+      "id": "kammarket-2e3a41",
+      "locationSet": {"include": ["mk"]},
+      "tags": {
+        "brand": "Kam Market",
+        "brand:wikidata": "Q65296228",
+        "name": "Kam Market",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Kaufland",
       "id": "kaufland-464a37",
       "locationSet": {
@@ -10152,6 +10163,17 @@
       }
     },
     {
+      "displayName": "Кам Маркет (България)",
+      "id": "146354-56b425",
+      "locationSet": {"include": ["bg"]},
+      "tags": {
+        "brand": "Кам Маркет",
+        "brand:wikidata": "Q65296228",
+        "name": "Кам Маркет",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Квартал",
       "id": "212655-94881c",
       "locationSet": {"include": ["ua"]},
@@ -13455,26 +13477,6 @@
         "name": "阪急オアシス",
         "name:en": "Hankyu OASIS",
         "name:ja": "阪急オアシス",
-        "shop": "supermarket"
-      }
-    },
-    {
-      "displayName": "Кам Маркет (България)",
-      "locationSet": {"include": ["bg"]},
-      "tags": {
-        "brand": "Кам Маркет",
-        "brand:wikidata": "Q65296228",
-        "name": "Кам Маркет",
-        "shop": "supermarket"
-      }
-    },
-    {
-      "displayName": "Kam Market (Macedonia)",
-      "locationSet": {"include": ["mk"]},
-      "tags": {
-        "brand": "Kam Market",
-        "brand:wikidata": "Q65296228",
-        "name": "Kam Market",
         "shop": "supermarket"
       }
     }

--- a/data/brands/shop/tobacco.json
+++ b/data/brands/shop/tobacco.json
@@ -15,21 +15,6 @@
   },
   "items": [
     {
-      "displayName": "Tobacco DC",
-      "locationSet": {"include": ["cz"]},
-      "matchNames": ["trafika tobacco dc"],
-      "matchTags": [
-        "shop/newsagent"
-      ],
-      "preserveTags": ["^name"],
-      "tags": {
-        "brand": "Tobacco DC",
-        "brand:wikidata": "Q137939456",
-        "name": "Tobacco DC",
-        "shop": "tobacco"
-      }
-    },
-    {
       "displayName": "20 грамм",
       "id": "0b3858-0cd077",
       "locationSet": {"include": ["ru"]},
@@ -170,6 +155,20 @@
       "tags": {
         "brand": "Tabaktrafik",
         "name": "Tabaktrafik",
+        "shop": "tobacco"
+      }
+    },
+    {
+      "displayName": "Tobacco DC",
+      "id": "tobaccodc-56156e",
+      "locationSet": {"include": ["cz"]},
+      "matchNames": ["trafika tobacco dc"],
+      "matchTags": ["shop/newsagent"],
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Tobacco DC",
+        "brand:wikidata": "Q137939456",
+        "name": "Tobacco DC",
         "shop": "tobacco"
       }
     },

--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -2634,16 +2634,6 @@
         "tourism": "hotel"
       }
     },
-     {
-      "displayName": "Village Hotels",
-      "locationSet": {"include": ["gb"]},
-      "tags": {
-        "brand": "Village Hotels",
-        "brand:wikidata": "Q16963550",
-        "name": "Village Hotel",
-        "tourism": "hotel"
-      }
-    },
     {
       "displayName": "Microtel Inn & Suites",
       "id": "microtelinnandsuites-29a1d7",
@@ -4421,6 +4411,17 @@
         "brand:wikidata": "Q2523363",
         "name": "Vienna House",
         "official_name": "Vienna House by Wyndham",
+        "tourism": "hotel"
+      }
+    },
+    {
+      "displayName": "Village Hotels",
+      "id": "villagehotel-3fca16",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "brand": "Village Hotels",
+        "brand:wikidata": "Q16963550",
+        "name": "Village Hotel",
         "tourism": "hotel"
       }
     },

--- a/data/operators/amenity/clinic.json
+++ b/data/operators/amenity/clinic.json
@@ -3034,21 +3034,8 @@
       }
     },
     {
-      "displayName": "מאוחדת",
-      "id": "2c2c8b-1b314b",
-      "locationSet": {"include": ["il"]},
-      "tags": {
-        "amenity": "clinic",
-        "healthcare": "clinic",
-        "operator": "מאוחדת",
-        "operator:en": "Meuhedet Healthcare Services",
-        "operator:he": "מאוחדת",
-        "operator:type": "private",
-        "operator:wikidata": "Q2906716"
-      }
-    },
-    {
       "displayName": "לאומית",
+      "id": "leumithealthcareservices-1b314b",
       "locationSet": {"include": ["il"]},
       "tags": {
         "amenity": "clinic",
@@ -3058,6 +3045,20 @@
         "operator:he": "לאומית",
         "operator:type": "private",
         "operator:wikidata": "Q2909707"
+      }
+    },
+    {
+      "displayName": "מאוחדת",
+      "id": "meuhedethealthcareservices-1b314b",
+      "locationSet": {"include": ["il"]},
+      "tags": {
+        "amenity": "clinic",
+        "healthcare": "clinic",
+        "operator": "מאוחדת",
+        "operator:en": "Meuhedet Healthcare Services",
+        "operator:he": "מאוחדת",
+        "operator:type": "private",
+        "operator:wikidata": "Q2906716"
       }
     },
     {

--- a/data/operators/amenity/social_facility.json
+++ b/data/operators/amenity/social_facility.json
@@ -456,6 +456,7 @@
     },
     {
       "displayName": "Careyn",
+      "id": "careyn-627b49",
       "locationSet": {"include": ["nl"]},
       "tags": {
         "amenity": "social_facility",

--- a/data/operators/amenity/toilets.json
+++ b/data/operators/amenity/toilets.json
@@ -1144,20 +1144,6 @@
       }
     },
     {
-      "displayName": "Öklo",
-      "id": "oklo-235e3c",
-      "locationSet": {
-        "include": [
-          "at-3.geojson",
-          "at-9.geojson"
-        ]
-      },
-      "tags": {
-        "amenity": "toilets",
-        "operator": "Öklo"
-      }
-    },
-    {
       "displayName": "Orlen",
       "id": "orlen-dbab0a",
       "locationSet": {"include": ["pl"]},

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -3206,6 +3206,22 @@
       }
     },
     {
+      "displayName": "Warszawska Kolej Dojazdowa",
+      "id": "warszawskakolejdojazdowa-8d7802",
+      "locationSet": {
+        "include": ["pl-14.geojson"]
+      },
+      "tags": {
+        "network": "Warszawska Kolej Dojazdowa",
+        "network:short": "WKD",
+        "network:wikidata": "Q773832",
+        "operator": "Warszawska Kolej Dojazdowa",
+        "operator:short": "WKD",
+        "operator:wikidata": "Q137943194",
+        "route": "train"
+      }
+    },
+    {
       "displayName": "WES",
       "id": "westsideexpressservice-58257a",
       "locationSet": {
@@ -3246,23 +3262,6 @@
         "network:wikidata": "Q12072724",
         "operator": "West Somerset Railway Plc",
         "operator:wikidata": "Q20970722",
-        "route": "train"
-      }
-    },
-    {
-      "displayName": "Warszawska Kolej Dojazdowa",
-      "id": "wkd-8d7802",
-      "locationSet": {
-        "include": ["pl-14.geojson"]
-      },
-      "matchNames": ["WKD"],
-      "tags": {
-        "network": "Warszawska Kolej Dojazdowa",
-        "network:short": "WKD",
-        "network:wikidata": "Q773832",
-        "operator": "Warszawska Kolej Dojazdowa",
-        "operator:short": "WKD",
-        "operator:wikidata": "Q137943194",
         "route": "train"
       }
     },


### PR DESCRIPTION
## What

Adds öklo as a brand for public composting toilets in Austria.

## Why

öklo is a well-established brand of ecological composting toilets in Austria with over 400 installations across the country. They are commonly found in:
- Public parks in Vienna, Graz, and other cities
- Municipalities throughout Austria
- Events and festivals

## Details

- **Company**: öklo GmbH
- **Founded**: 2017
- **Headquarters**: Wolkersdorf, Lower Austria
- **Website**: https://oeklo.at
- **Type**: Composting toilets (Trockentrenntoiletten)
- **Awards**: Austrian Ecolabel (2017), Energy Globe Award (2019)

## Special features

- Water-free operation using wood shavings
- Solar-powered lighting
- Made from local Austrian wood
- Wheelchair accessible models available
- Saves approximately 5 liters of water per use

## Changes

- Added öklo brand entry in `data/brands/amenity/toilets.json`
- Removed duplicate/outdated operator entry from `data/operators/amenity/toilets.json`

## Tags

The preset includes the following tags:
- `amenity=toilets`
- `brand=öklo`
- `brand:wikidata=Q138034487`
- `operator=öklo GmbH`
- `operator:type=private`
- `toilets:disposal=composting`
- `toilets:wheelchair=yes`
- `fee=no`
- `access=yes`
- `building=yes`
- `building:material=wood`

## References

- Official website: https://oeklo.at
- Wikidata: https://www.wikidata.org/wiki/Q138034487
- News: https://neuezeit.at/oeklo-wasserverbrauch/

## Location

Active in Austria (AT), with installations primarily in:
- Lower Austria (Niederösterreich)
- Vienna
- Styria (Steiermark)
- Upper Austria (Oberösterreich)
- Burgenland