### PR TITLE
Refine geography of Pizza Inn

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -8265,7 +8265,7 @@
       }
     },
     {
-      "displayName": "Pizza Inn",
+      "displayName": "Pizza Inn (America)",
       "id": "pizzainn-658eea",
       "locationSet": {"include": ["us"]},
       "tags": {


### PR DESCRIPTION
The wikidata is for:
https://www.pizzainn.com/

The pages for even the most obvious overlap have very different history and branding, I think it's just a very popular name/lacking in strong trademarking
https://www.pizzainn.com/about-us/
https://www.pizzainn.com.au/about-us/

Presumably the original matcher would have just found lots of similar named stores across the world?