### PR TITLE
Rename Viva MTS to Viva

### DIFF
--- a/data/brands/office/telecommunication.json
+++ b/data/brands/office/telecommunication.json
@@ -321,19 +321,20 @@
       }
     },
     {
-      "displayName": "Viva MTS",
-      "id": "vivamts-2921eb",
+      "displayName": "Viva",
+      "id": "viva-2921eb",
       "locationSet": {"include": ["am"]},
+      "matchNames": ["վիվա մտս"],
       "tags": {
-        "brand": "Վիվա ՄՏՍ",
-        "brand:en": "Viva MTS",
-        "brand:hy": "Վիվա ՄՏՍ",
-        "brand:ru": "Вива МТС",
+        "brand": "Viva",
+        "brand:en": "Viva",
+        "brand:hy": "Վիվա",
+        "brand:ru": "Вива",
         "brand:wikidata": "Q16486896",
-        "name": "Վիվա ՄՏՍ",
-        "name:en": "Viva MTS",
-        "name:hy": "Վիվա ՄՏՍ",
-        "name:ru": "Вива МТС",
+        "name": "Viva",
+        "name:en": "Viva",
+        "name:hy": "Վիվա",
+        "name:ru": "Вива",
         "office": "telecommunication"
       }
     },


### PR DESCRIPTION
There was a rebranding in 2024:
https://www.viva.am/en/about-us/news/detail/2024/07/01/viva-armenias-leading-technology

Also changing the main 'name'/'brand' tags to the Latin script in accordance with official branding