### PR TITLE
Update Czech and Slovak parcel locker brands

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -12,7 +12,7 @@
         "amenity": "parcel_locker",
         "brand": "BalíkoBOX",
         "brand:wikidata": "Q131136953",
-        "name": "BalíkoBOX"
+        "name": "BalíkoBOX",
         "operator": "Slovenská pošta",
         "operator:wikidata": "Q1191849"
       }
@@ -24,7 +24,7 @@
         "amenity": "parcel_locker",
         "brand": "balíkovo box",
         "brand:wikidata": "Q132188077",
-        "name": "balíkovo box"
+        "name": "balíkovo box",
         "operator": "Slovak Parcel Service",
         "operator:wikidata": "Q132187919"
       }
@@ -36,7 +36,7 @@
         "amenity": "parcel_locker",
         "brand": "DPD Pickup Box",
         "brand:wikidata": "Q114273730",
-        "name": "DPD Pickup Box"
+        "name": "DPD Pickup Box",
         "operator": "Direct Parcel Distribution CZ",
         "operator:wikidata": "Q58550406"
       }
@@ -48,8 +48,8 @@
       "tags": {
         "amenity": "parcel_locker",
         "brand": "One Box",
-        "brand:wikidata": "Q110738715"
-        "name": "One Box"
+        "brand:wikidata": "Q110738715",
+        "name": "One Box",
         "operator": "Allegro Retail",
         "operator:wikidata": "Q96265995"
       }


### PR DESCRIPTION
Update names and operators os parcel locker brands. Remove operators from AlzaBox and Z-Box due to users map these parcel lockers with national operators.