### PR TITLE
Remove Consejería de Educación de la Junta de Castilla y León

### DIFF
--- a/data/operators/amenity/school.json
+++ b/data/operators/amenity/school.json
@@ -12627,29 +12627,6 @@
       }
     },
     {
-      "displayName": "Consejería de Educación de la Junta de Castilla y León",
-      "id": "consejeriadeeducaciondelajuntadecastillayleon-5f247a",
-      "locationSet": {
-        "include": [
-          "es-av.geojson",
-          "es-bu.geojson",
-          "es-le.geojson",
-          "es-p.geojson",
-          "es-sa.geojson",
-          "es-sg.geojson",
-          "es-so.geojson",
-          "es-va.geojson",
-          "es-za.geojson"
-        ]
-      },
-      "tags": {
-        "amenity": "school",
-        "operator": "Consejería de Educación de la Junta de Castilla y León",
-        "operator:type": "public",
-        "operator:wikidata": "Q30297363"
-      }
-    },
-    {
       "displayName": "Consejo Escolar Alto Valle Centro I - Cipolletti",
       "id": "consejoescolaraltovallecentroicipolletti-e6aec9",
       "locationSet": {


### PR DESCRIPTION
According to the local community, no need to use different operators. _Junta de Castilla y León_, plain and simple, is enough

https://github.com/osmlab/name-suggestion-index/blob/main/data/operators/amenity/school.json#L23794-L23816