### PR TITLE
Update Team Telecom Armenia wikidata id

### DIFF
--- a/data/brands/office/telecommunication.json
+++ b/data/brands/office/telecommunication.json
@@ -240,7 +240,7 @@
         "brand:en": "Team Telecom Armenia",
         "brand:hy": "Թիմ Տելեկոմ Արմենիա",
         "brand:ru": "Тим Телеком Армения",
-        "brand:wikidata": "Q97125249",
+        "brand:wikidata": "Q487164",
         "name": "Թիմ Տելեկոմ Արմենիա",
         "name:en": "Team Telecom Armenia",
         "name:hy": "Թիմ Տելեկոմ Արմենիա",


### PR DESCRIPTION
Current id points to an outdated duplicate (https://www.wikidata.org/wiki/Q97125249)

Correct item: https://www.wikidata.org/wiki/Q487164

