### PR TITLE
Add Maury's Italian houseware brand

### DIFF
--- a/data/brands/shop/houseware.json
+++ b/data/brands/shop/houseware.json
@@ -556,6 +556,16 @@
       }
     },
     {
+      "displayName": "Maury's",
+      "locationSet": {"include": ["it"]},
+      "tags": {
+        "brand": "Maury's",
+        "brand:wikidata": "Q138307558",
+        "name": "Maury's",
+        "shop": "houseware"
+      }
+    },
+    {
       "displayName": "Metalac",
       "id": "metalac-21e4ab",
       "locationSet": {


### PR DESCRIPTION
Wikidata item here: https://www.wikidata.org/wiki/Q138307558

108 stores across Italy: https://www.maurys.it/punti-vendita/store-locator.html