### PR TITLE
Add mister garden (french salad bar chain in Paris)

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -15571,6 +15571,19 @@
         "name:zh": "齊柏林熱狗",
         "takeaway": "yes"
       }
+    },
+    {
+      "displayName": "Mister Garden",
+      "locationSet": {"include": ["fr"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Mister Garden",
+        "brand:wikidata": "Q138312953",
+        "cuisine": "salad",
+        "diet:vegan": "yes",
+        "diet:vegetarian": "yes",
+        "takeaway": "yes"
+      }
     }
   ]
 }


### PR DESCRIPTION
There is 22 shops in Paris for now, according to the website ( https://restaurants.mister-garden.com/ ).