### PR TITLE
Add Art Lunch cafeterias

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -474,7 +474,7 @@
     {
       "displayName": "Art Lunch",
       "id": "artlunch-c2a495",
-      "locationSet": {"include": ["am"]},
+      "locationSet": {"include": ["am", "ru"]},
       "tags": {
         "amenity": "fast_food",
         "brand": "Art Lunch",


### PR DESCRIPTION
The largest cafeteria chain in Armenia (26 venues)
https://artlunch.am/en/about-us