### PR TITLE
Update PKP PLK to match the recently unified tagging – an update

### DIFF
--- a/data/operators/man_made/mast.json
+++ b/data/operators/man_made/mast.json
@@ -1224,19 +1224,13 @@
       "displayName": "PKP Polskie Linie Kolejowe",
       "id": "pkppolskieliniekolejowe-41b0bd",
       "locationSet": {"include": ["pl"]},
+      "matchNames": [
+        "pkp polskie linie kolejowe s.a."
+      ],
       "tags": {
         "man_made": "mast",
         "operator": "PKP Polskie Linie Kolejowe",
         "operator:wikidata": "Q1344677"
-      }
-    },
-    {
-      "displayName": "PKP Polskie Linie Kolejowe S.A.",
-      "id": "pkppolskieliniekolejowesa-6ada36",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "man_made": "mast",
-        "operator": "PKP Polskie Linie Kolejowe S.A."
       }
     },
     {

--- a/data/operators/route/railway.json
+++ b/data/operators/route/railway.json
@@ -572,7 +572,10 @@
       "displayName": "PKP Polskie Linie Kolejowe",
       "id": "pkppolskieliniekolejowe-b8385d",
       "locationSet": {"include": ["pl"]},
-      "matchNames": ["pkp plk"],
+      "matchNames": [
+        "pkp plk",
+        "pkp polskie linie kolejowe s.a."
+      ],
       "tags": {
         "operator": "PKP Polskie Linie Kolejowe",
         "operator:wikidata": "Q1344677",

--- a/data/operators/route/tracks.json
+++ b/data/operators/route/tracks.json
@@ -87,19 +87,13 @@
       "displayName": "PKP Polskie Linie Kolejowe",
       "id": "pkppolskieliniekolejowe-3a0b03",
       "locationSet": {"include": ["pl"]},
-      "matchNames": ["pkp plk"],
+      "matchNames": [
+        "pkp plk",
+        "pkp polskie linie kolejowe s.a."
+      ],
       "tags": {
         "operator": "PKP Polskie Linie Kolejowe",
         "operator:wikidata": "Q1344677",
-        "route": "tracks"
-      }
-    },
-    {
-      "displayName": "PKP Polskie Linie Kolejowe S.A.",
-      "id": "pkppolskieliniekolejowesa-5e3d05",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "operator": "PKP Polskie Linie Kolejowe S.A.",
         "route": "tracks"
       }
     },


### PR DESCRIPTION
In https://github.com/osmlab/name-suggestion-index/pull/11469, I edited most of the railway-related files to update PKP Polskie Linie Kolejowe S.A. in order to remove the S.A. company type marker. However, I erroneously forgot to do so in the routes/railway.json file. This PR fixes this ommission.