### PR TITLE
update german regional power network operator

### DIFF
--- a/data/operators/man_made/street_cabinet.json
+++ b/data/operators/man_made/street_cabinet.json
@@ -882,6 +882,26 @@
       }
     },
     {
+      "displayName": "E-Werk Netze",
+      "id": "ewerknetze-c31658",
+      "locationSet": {
+        "include": ["de-bw.geojson"]
+      },
+      "matchNames": [
+        "e-werk mittelbaden",
+        "e-werk netze gmbh & co. kg",
+        "elektrizitätswerk mittelbaden",
+        "elektrizitätswerk mittelbaden ag & co. kg",
+        "überlandwerk mittelbaden",
+        "überlandwerk mittelbaden gmbh & co. kg"
+      ],
+      "tags": {
+        "man_made": "street_cabinet",
+        "operator": "E-Werk Netze",
+        "operator:wikidata": "Q124480690"
+      }
+    },
+    {
       "displayName": "E.DIS Netz",
       "id": "edisnetz-4b5a53",
       "locationSet": {
@@ -4496,21 +4516,6 @@
         "man_made": "street_cabinet",
         "operator": "Überlandwerk Fulda",
         "operator:wikidata": "Q332669"
-      }
-    },
-    {
-      "displayName": "Überlandwerk Mittelbaden",
-      "id": "uberlandwerkmittelbaden-c31658",
-      "locationSet": {
-        "include": ["de-bw.geojson"]
-      },
-      "matchNames": [
-        "überlandwerk mittelbaden gmbh & co. kg"
-      ],
-      "tags": {
-        "man_made": "street_cabinet",
-        "operator": "Überlandwerk Mittelbaden",
-        "operator:wikidata": "Q124480690"
       }
     },
     {

--- a/data/operators/power/line.json
+++ b/data/operators/power/line.json
@@ -2516,6 +2516,26 @@
       }
     },
     {
+      "displayName": "E-Werk Netze",
+      "id": "ewerknetze-2bcac7",
+      "locationSet": {
+        "include": ["de-bw.geojson"]
+      },
+      "matchNames": [
+        "e-werk mittelbaden",
+        "e-werk netze gmbh & co. kg",
+        "elektrizitätswerk mittelbaden",
+        "elektrizitätswerk mittelbaden ag & co. kg",
+        "überlandwerk mittelbaden",
+        "überlandwerk mittelbaden gmbh & co. kg"
+      ],
+      "tags": {
+        "operator": "E-Werk Netze",
+        "operator:wikidata": "Q124480690",
+        "power": "line"
+      }
+    },
+    {
       "displayName": "E.DIS Netz",
       "id": "edisnetz-3723c9",
       "locationSet": {

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -2636,14 +2636,22 @@
       }
     },
     {
-      "displayName": "E-Werk Mittelbaden",
-      "id": "ewerkmittelbaden-dda049",
+      "displayName": "E-Werk Netze",
+      "id": "ewerknetze-dda049",
       "locationSet": {
         "include": ["de-bw.geojson"]
       },
+      "matchNames": [
+        "e-werk mittelbaden",
+        "e-werk netze gmbh & co. kg",
+        "elektrizitätswerk mittelbaden",
+        "elektrizitätswerk mittelbaden ag & co. kg",
+        "überlandwerk mittelbaden",
+        "überlandwerk mittelbaden gmbh & co. kg"
+      ],
       "tags": {
-        "operator": "E-Werk Mittelbaden",
-        "operator:wikidata": "Q15110012",
+        "operator": "E-Werk Netze",
+        "operator:wikidata": "Q124480690",
         "power": "substation"
       }
     },
@@ -12264,21 +12272,6 @@
         "operator": "Überlandwerk Leinetal",
         "operator:short": "ÜWL",
         "operator:wikidata": "Q130557603",
-        "power": "substation"
-      }
-    },
-    {
-      "displayName": "Überlandwerk Mittelbaden",
-      "id": "uberlandwerkmittelbaden-dda049",
-      "locationSet": {
-        "include": ["de-bw.geojson"]
-      },
-      "matchNames": [
-        "überlandwerk mittelbaden gmbh & co. kg"
-      ],
-      "tags": {
-        "operator": "Überlandwerk Mittelbaden",
-        "operator:wikidata": "Q124480690",
         "power": "substation"
       }
     },


### PR DESCRIPTION
Überlandwerk Mittelbaden was renamed to E-Werk Netze this month. This commit reflects these changes. Also it removes the parent company E-Werk Mittelbaden from features that are only valid for the network operator subsidiary company after a mandatory company split several years ago.