### PR TITLE
update german regional infrastructure network operator (Badenova)

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -590,6 +590,19 @@
       }
     },
     {
+      "displayName": "Badenova",
+      "id": "badenova-6bc1fb",
+      "locationSet": {
+        "include": ["de-bw.geojson"]
+      },
+      "matchNames": ["badenova ag & co. kg"],
+      "tags": {
+        "amenity": "charging_station",
+        "operator": "Badenova",
+        "operator:wikidata": "Q798941"
+      }
+    },
+    {
       "displayName": "Baltimore Gas and Electric",
       "id": "baltimoregasandelectric-4c7d3b",
       "locationSet": {

--- a/data/operators/man_made/pipeline.json
+++ b/data/operators/man_made/pipeline.json
@@ -484,26 +484,39 @@
       }
     },
     {
-      "displayName": "badenova",
-      "id": "badenova-da7c89",
-      "locationSet": {"include": ["de"]},
-      "tags": {
-        "man_made": "pipeline",
-        "operator": "badenova",
-        "operator:wikidata": "Q798941"
-      }
-    },
-    {
-      "displayName": "badenovaWÄRMEPLUS",
-      "id": "badenovawarmeplus-da7c89",
-      "locationSet": {"include": ["de"]},
+      "displayName": "Badenova Netze",
+      "id": "badenovanetze-0b5f1c",
+      "locationSet": {
+        "include": ["de-bw.geojson"]
+      },
       "matchNames": [
-        "badenovawärmeplus gmbh & co. kg"
+        "badenova",
+        "badenova ag & co. kg",
+        "badenova netze gmbh",
+        "bnnetze",
+        "bnnetze gmbh"
       ],
       "tags": {
         "man_made": "pipeline",
-        "operator": "badenovaWÄRMEPLUS",
-        "operator:wikidata": "Q63110091"
+        "operator": "Badenova Netze",
+        "operator:wikidata": "Q57712950"
+      }
+    },
+    {
+      "displayName": "Badenova Wärmeplus",
+      "id": "badenovawarmeplus-0b5f1c",
+      "locationSet": {
+        "include": ["de-bw.geojson"]
+      },
+      "matchNames": [
+        "badenova wärmeplus gmbh",
+        "badenova wärmeplus gmbh & co. kg"
+      ],
+      "tags": {
+        "man_made": "pipeline",
+        "operator": "Badenova Wärmeplus",
+        "operator:wikidata": "Q63110091",
+        "substance": "hot_water"
       }
     },
     {

--- a/data/operators/man_made/street_cabinet.json
+++ b/data/operators/man_made/street_cabinet.json
@@ -253,12 +253,22 @@
       }
     },
     {
-      "displayName": "badenova",
-      "id": "badenova-f91ac8",
-      "locationSet": {"include": ["001"]},
+      "displayName": "Badenova Netze",
+      "id": "badenovanetze-c31658",
+      "locationSet": {
+        "include": ["de-bw.geojson"]
+      },
+      "matchNames": [
+        "badenova",
+        "badenova ag & co. kg",
+        "badenova netze gmbh",
+        "bnnetze",
+        "bnnetze gmbh"
+      ],
       "tags": {
         "man_made": "street_cabinet",
-        "operator": "badenova"
+        "operator": "Badenova Netze",
+        "operator:wikidata": "Q57712950"
       }
     },
     {

--- a/data/operators/man_made/water_works.json
+++ b/data/operators/man_made/water_works.json
@@ -14,6 +14,25 @@
       }
     },
     {
+      "displayName": "Badenova Netze",
+      "id": "badenovanetze-e7daae",
+      "locationSet": {
+        "include": ["de-bw.geojson"]
+      },
+      "matchNames": [
+        "badenova",
+        "badenova ag & co. kg",
+        "badenova netze gmbh",
+        "bnnetze",
+        "bnnetze gmbh"
+      ],
+      "tags": {
+        "man_made": "water_works",
+        "operator": "Badenova Netze",
+        "operator:wikidata": "Q57712950"
+      }
+    },
+    {
       "displayName": "Barwon Water",
       "id": "barwonwater-086b9d",
       "locationSet": {

--- a/data/operators/power/minor_line.json
+++ b/data/operators/power/minor_line.json
@@ -10,6 +10,25 @@
       "templateTags": {"power": "minor_line"}
     },
     {
+      "displayName": "Badenova Netze",
+      "id": "badenovanetze-c11af1",
+      "locationSet": {
+        "include": ["de-bw.geojson"]
+      },
+      "matchNames": [
+        "badenova",
+        "badenova ag & co. kg",
+        "badenova netze gmbh",
+        "bnnetze",
+        "bnnetze gmbh"
+      ],
+      "tags": {
+        "operator": "Badenova Netze",
+        "operator:wikidata": "Q57712950",
+        "power": "minor_line"
+      }
+    },
+    {
       "displayName": "Hydro Ottawa",
       "id": "hydroottawa-e22604",
       "locationSet": {

--- a/data/operators/power/substation.json
+++ b/data/operators/power/substation.json
@@ -696,18 +696,20 @@
       }
     },
     {
-      "displayName": "badenovaNETZE",
+      "displayName": "Badenova Netze",
       "id": "badenovanetze-dda049",
       "locationSet": {
         "include": ["de-bw.geojson"]
       },
       "matchNames": [
-        "badenovanetze gmbh",
+        "badenova",
+        "badenova ag & co. kg",
+        "badenova netze gmbh",
         "bnnetze",
         "bnnetze gmbh"
       ],
       "tags": {
-        "operator": "badenovaNETZE",
+        "operator": "Badenova Netze",
         "operator:wikidata": "Q57712950",
         "power": "substation"
       }


### PR DESCRIPTION
The german utility company re-branded itself and all subsidiary companies beginning of this year. This commit reflects these changes. Additionally, it replaces the parent company with its subsidiaries and adds them to new features where applicable. Also the location scope has been narrowed down.