### PR TITLE
Add McPen

### DIFF
--- a/data/brands/shop/stationery.json
+++ b/data/brands/shop/stationery.json
@@ -11,6 +11,16 @@
   },
   "items": [
     {
+      "displayName": "McPen",
+      "locationSet": {"include": ["cz"]},
+      "tags": {
+        "brand": "McPen",
+        "brand:wikidata": "Q116892513",
+        "name": "McPen",
+        "shop": "stationery"
+      }
+    },
+    {
       "displayName": "101文具天堂",
       "id": "101stationeryparadise-1884c5",
       "locationSet": {"include": ["tw"]},


### PR DESCRIPTION
Add stationery chain with 42 locations in the Czech Republic.