### PR TITLE
Update railway.json

### DIFF
--- a/data/operators/route/railway.json
+++ b/data/operators/route/railway.json
@@ -593,11 +593,13 @@
       }
     },
     {
-      "displayName": "RFI",
+      "displayName": "Rete Ferroviaria Italiana",
       "id": "rfi-4ed8db",
+      "matchNames": ["RFI"],
       "locationSet": {"include": ["it"]},
       "tags": {
-        "operator": "RFI",
+        "operator": "Rete Ferroviaria Italiana",
+        "operator:short" "RFI",
         "operator:wikidata": "Q1060049",
         "route": "railway"
       }


### PR DESCRIPTION
Extended name for RFI in Italy. See also https://community.openstreetmap.org/t/rete-ferroviaria-italiana-differenze-di-nome-osm-wikidata-e-nome-ufficiale/140123