### PR TITLE
Update tracks.json

### DIFF
--- a/data/operators/route/tracks.json
+++ b/data/operators/route/tracks.json
@@ -98,13 +98,14 @@
       }
     },
     {
-      "displayName": "RFI",
+      "displayName": "Rete Ferroviaria Italiana",
       "id": "rfi-063200",
       "locationSet": {"include": ["it"]},
       "tags": {
-        "operator": "RFI",
+        "operator": "Rete Ferroviaria Italiana",
+        "operator:short" "RFI",
         "operator:wikidata": "Q1060049",
-        "route": "tracks"
+        "route": "railway"
       }
     },
     {


### PR DESCRIPTION
Extended name for RFI in Italy. See also https://community.openstreetmap.org/t/rete-ferroviaria-italiana-differenze-di-nome-osm-wikidata-e-nome-ufficiale/140123