### PR TITLE
Add Smarty.cz

### DIFF
--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -5,6 +5,16 @@
   },
   "items": [
     {
+      "displayName": "Smarty.cz",
+      "locationSet": {"include": ["cz"]},
+      "tags": {
+        "brand": "Smarty.cz",
+        "brand:wikidata": "Q67806661",
+        "name": "Smarty.cz",
+        "shop": "electronics"
+      }
+    },
+    {
       "displayName": "100満ボルト",
       "id": "100manvolt-f86f5e",
       "locationSet": {"include": ["jp"]},


### PR DESCRIPTION
Add electronics chain with 30 locations in the Czech Republic.