### PR TITLE
Update Pure Energie

### DIFF
--- a/data/operators/power/generator.json
+++ b/data/operators/power/generator.json
@@ -7143,18 +7143,10 @@
       "displayName": "Pure Energie",
       "id": "pureenergie-7c4044",
       "locationSet": {"include": ["nl"]},
+      "matchNames": ["pure energy"],
       "tags": {
         "operator": "Pure Energie",
         "operator:wikidata": "Q138356702",
-        "power": "generator"
-      }
-    },
-    {
-      "displayName": "Pure Energy",
-      "id": "pureenergy-74685d",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "operator": "Pure Energy",
         "power": "generator"
       }
     },


### PR DESCRIPTION
Added wikidata to Pure Energie - Dutch energy company.
Removed Pure Energy item - Pure Energy in the Netherlands is a typo and Pure Energy companies in Bosnia and Herzegovina and Slovakia have only a few locations."
