### PR TITLE
Add Mistrz Piekarz bakery brand

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -1868,6 +1868,18 @@
       }
     },
     {
+      "displayName": "Mistrz Piekarz",
+      "id": "mistrzpiekarz-839c38",
+      "locationSet": {"include": ["pl"]},
+      "matchNames": ["piekarnia mistrz piekarz"],
+      "tags": {
+        "brand": "Mistrz Piekarz",
+        "brand:wikidata": "Q138412294",
+        "name": "Mistrz Piekarz",
+        "shop": "bakery"
+      }
+    },
+    {
       "displayName": "Mlinar",
       "id": "mlinar-f94504",
       "locationSet": {


### PR DESCRIPTION
## Summary

- Adds **Mistrz Piekarz** (`Q138412294`) — a Polish franchise bakery chain — to `data/brands/shop/bakery.json`
- Location set restricted to Poland (`pl`)
- Includes `matchNames` for the common OSM variant `piekarnia mistrz piekarz`

## Test plan

- [x] Entry placed alphabetically between "Minit" and "Mlinar"
- [x] `bun run build:json` completes without errors
- [x] `brand:wikidata` links to correct Wikidata item ([Q138412294](https://www.wikidata.org/wiki/Q138412294))