### PR TITLE
Update Armenian pharmacies

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -14,6 +14,7 @@
         "^аптечный (пункт|склад)$",
         "^дорухона$",
         "^эмийн сан$",
+        "^դեղատուն$",
         "^داروخانه( شبانه روزی)?$",
         "^صيدلية$",
         "^药店$"
@@ -1946,7 +1947,7 @@
         "brand:en": "Gedeon Richter",
         "brand:hy": "Գեդեոն Ռիխտեր",
         "brand:ru": "Гедеон Рихтер",
-        "brand:wikidata": "Q630125",
+        "brand:wikidata": "Q138454503",
         "healthcare": "pharmacy",
         "name": "Գեդեոն Ռիխտեր",
         "name:en": "Gedeon Richter",
@@ -3748,6 +3749,20 @@
       }
     },
     {
+      "displayName": "Theopharma",
+      "id": "theopharma-447e41",
+      "locationSet": {"include": ["am"]},
+      "tags": {
+        "amenity": "pharmacy",
+        "brand": "Theopharma",
+        "brand:en": "Theopharma",
+        "brand:wikidata": "Q138436683",
+        "healthcare": "pharmacy",
+        "name": "Theopharma",
+        "name:en": "Theopharma"
+      }
+    },
+    {
       "displayName": "ThreeSixty Pharmacy",
       "id": "threesixty-2ddb76",
       "locationSet": {"include": ["ph"]},
@@ -3776,21 +3791,18 @@
       }
     },
     {
-      "displayName": "Tonus-Les",
-      "id": "tonusles-447e41",
+      "displayName": "Tonus Pharm",
+      "id": "tonuspharm-447e41",
       "locationSet": {"include": ["am"]},
+      "matchNames": ["tonus-les", "տոնուս-լես"],
       "tags": {
         "amenity": "pharmacy",
-        "brand": "Տոնուս-Լես",
-        "brand:en": "Tonus-Les",
-        "brand:hy": "Տոնուս-Լես",
-        "brand:ru": "Тонус-Лес",
+        "brand": "Tonus Pharm",
+        "brand:en": "Tonus Pharm",
         "brand:wikidata": "Q118727363",
         "healthcare": "pharmacy",
-        "name": "Տոնուս-Լես",
-        "name:en": "Tonus-Les",
-        "name:hy": "Տոնուս-Լես",
-        "name:ru": "Тонус-Лес"
+        "name": "Tonus Pharm",
+        "name:en": "Tonus Pharm"
       }
     },
     {
@@ -3906,14 +3918,14 @@
       "locationSet": {"include": ["am"]},
       "tags": {
         "amenity": "pharmacy",
-        "brand": "ՎԱԳԱ ՖԱՐՄ",
+        "brand": "Վագա Ֆարմ",
         "brand:en": "Vaga Pharm",
-        "brand:hy": "ՎԱԳԱ ՖԱՐՄ",
+        "brand:hy": "Վագա Ֆարմ",
         "brand:wikidata": "Q123378075",
         "healthcare": "pharmacy",
-        "name": "ՎԱԳԱ ՖԱՐՄ",
+        "name": "Վագա Ֆարմ",
         "name:en": "Vaga Pharm",
-        "name:hy": "ՎԱԳԱ ՖԱՐՄ"
+        "name:hy": "Վագա Ֆարմ"
       }
     },
     {


### PR DESCRIPTION
- add a generic word for 'pharmacy' in Armenian
- wikidata for Gedeon Richter
- add Theopharma
- Tonus-Les -> Tonus Pharma rebranding
- fix the letter casing of Vaga Pharm