### PR TITLE
Add Rapo

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -57,6 +57,18 @@
   },
   "items": [
     {
+      "displayName": "Rapo",
+      "locationSet": {"include": ["cz"]},
+      "matchNames": ["potraviny rapo"],
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Rapo",
+        "brand:wikidata": "Q138357241",
+        "name": "Rapo",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "10-11",
       "id": "1011-ead397",
       "locationSet": {"include": ["is"]},


### PR DESCRIPTION
Add convenience franchise chain with more than 50 locations in the Czech Republic.