### PR TITLE
Add Olife Energy

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -10,6 +10,15 @@
   },
   "items": [
     {
+      "displayName": "Olife Energy",
+      "locationSet": {"include": ["cz"]},
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Olife Energy",
+        "brand:wikidata": "Q116895290",
+      }
+    },
+    {
       "displayName": "7-Eleven",
       "id": "7eleven-5598dd",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Added charging station brand with around 40 locations in the Czech Republic.