### PR TITLE
Delete Azerbaijan and Georgia from Ozon locationSet

### DIFF
--- a/data/brands/shop/outpost.json
+++ b/data/brands/shop/outpost.json
@@ -75,9 +75,7 @@
       "locationSet": {
         "include": [
           "am",
-          "az",
           "by",
-          "ge",
           "kg",
           "kz",
           "ru",


### PR DESCRIPTION
Ozon doesn't have its own shops in these countries, it delivers goods via partner networks

Fix #11886