### PR TITLE
Migrol chargers call themselves now "Migrol Charge" or "M-Charge"

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -4394,6 +4394,7 @@
       "displayName": "Migrol Charge",
       "id": "migrol-086737",
       "locationSet": {"include": ["ch"]},
+      "matchNames" : ["Migrol"],
       "tags": {
         "amenity": "charging_station",
         "operator": "Migrol",


### PR DESCRIPTION
example: https://www.migrol.ch/de/rund-ums-fahrzeug/standorte-oeffnungszeiten/mcharge-wollerau-maert-roospark