### PR TITLE
Change ÖAMTC tagging to office association and create new ÖAMTC entry as vehicle inspection

### DIFF
--- a/data/brands/amenity/vehicle_inspection.json
+++ b/data/brands/amenity/vehicle_inspection.json
@@ -122,6 +122,17 @@
       }
     },
     {
+      "displayName": "ÖAMTC Fahrzeuginspektion",
+      "id": "oamtc-584778",
+      "locationSet": {"include": ["at"]},
+      "tags": {
+        "amenity": "vehicle_inspection",
+        "brand": "ÖAMTC",
+        "brand:wikidata": "Q306057",
+        "name": "ÖAMTC"
+      }
+    },
+    {
       "displayName": "Puspakom",
       "id": "puspakom-0c47dd",
       "locationSet": {"include": ["my"]},
@@ -263,17 +274,6 @@
         "name": "ホリデー車検",
         "name:en": "Holiday",
         "name:ja": "ホリデー車検"
-      }
-    },
-    {
-      "displayName": "ÖAMTC Fahrzeuginspektion",
-      "id": "oamtc-d1143e",
-      "locationSet": {"include": ["at"]},
-      "tags": {
-        "amenity": "vehicle_inspection",
-        "brand": "ÖAMTC",
-        "brand:wikidata": "Q306057",
-        "name": "ÖAMTC"
       }
     }
   ]

--- a/data/brands/highway/services.json
+++ b/data/brands/highway/services.json
@@ -104,7 +104,7 @@
     },
     {
       "displayName": "Sapp Brothers Travel Center",
-      "id": "sappbrostravelcenter-35c0ca",
+      "id": "sappbrotherstravelcenter-35c0ca",
       "locationSet": {"include": ["us"]},
       "tags": {
         "brand": "Sapp Bros.",

--- a/data/brands/office/association.json
+++ b/data/brands/office/association.json
@@ -199,6 +199,17 @@
       }
     },
     {
+      "displayName": "ÖAMTC Stützpunkt",
+      "id": "oamtc-71b284",
+      "locationSet": {"include": ["at"]},
+      "tags": {
+        "brand": "ÖAMTC",
+        "brand:wikidata": "Q306057",
+        "name": "ÖAMTC",
+        "office": "association"
+      }
+    },
+    {
       "displayName": "VCD",
       "id": "vcd-496920",
       "locationSet": {"include": ["de"]},
@@ -209,17 +220,6 @@
         "name": "VCD",
         "office": "association",
         "official_name": "Verkehrsclub Deutschland"
-      }
-    },
-    {
-      "displayName": "ÖAMTC Stützpunkt",
-      "id": "oamtc-d1144d",
-      "locationSet": {"include": ["at"]},
-      "tags": {
-        "brand": "ÖAMTC",
-        "brand:wikidata": "Q306057",
-        "name": "ÖAMTC",
-        "office": "association"
       }
     }
   ]

--- a/data/brands/shop/car_repair.json
+++ b/data/brands/shop/car_repair.json
@@ -12,6 +12,7 @@
         "^garage\\s?(moto|auto|automobile)?$",
         "^gomer[ií]a$",
         "^lubri(centro|ficantes)$",
+        "^öamtc$",
         "^taller( mec[aá]nico)?$",
         "^авто(рынок|ремонт|сервис|запчасти|электрик|запчастини)?$",
         "^автома(г|газин|стерская)?$",


### PR DESCRIPTION
ÖAMTC is not a car repair but an association office or a vehicle inspection place