### PR TITLE
Add Aavin brand entry to dairy shop category

### DIFF
--- a/data/brands/shop/dairy.json
+++ b/data/brands/shop/dairy.json
@@ -15,7 +15,7 @@
       "id": "aavin-6e9671",
       "locationSet": {"include": ["in"]},
       "tags": {
-        "brand": "Aavin - Tamilnadu Co-operative Milk Producers’ Federation Limited",
+        "brand": "Aavin",
         "brand:wikidata": "Q4662814",
         "name": "Aavin",
         "shop": "dairy"


### PR DESCRIPTION
Added tag "brand:wikipedia": "en:Aavin - Tamilnadu Co-operative Milk Producers’ Federation Limited"
- Wikidata ID: Q4662814
- Location: India (Tamil Nadu)
- Brand tag uses full official name while display name and name tag use 
  the common brand name "Aavin"

> **Tested changes with** `bun run all`