### PR TITLE
Update preset for Transport GZM

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -24023,13 +24023,13 @@
       }
     },
     {
-      "displayName": "Zarząd Transportu Metropolitalnego",
+      "displayName": "Transport GZM",
       "id": "zarzadtransportumetropolitalnego-9340cc",
       "locationSet": {"include": ["pl"]},
       "note": "ISO 3166-2 PL-12, PL-24",
       "tags": {
-        "network": "Zarząd Transportu Metropolitalnego",
-        "network:wikidata": "Q48862619",
+        "network": "Transport GZM",
+        "network:wikidata": "Q124678630",
         "route": "bus"
       }
     },

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -1347,13 +1347,13 @@
       }
     },
     {
-      "displayName": "Zarząd Transportu Metropolitalnego",
+      "displayName": "Transport GZM",
       "id": "zarzadtransportumetropolitalnego-ba1938",
       "locationSet": {"include": ["pl"]},
       "note": "ISO 3166-2 PL-12, PL-24",
       "tags": {
-        "network": "Zarząd Transportu Metropolitalnego",
-        "network:wikidata": "Q48862619",
+        "network": "Transport GZM",
+        "network:wikidata": "Q124678630",
         "operator": "Tramwaje Śląskie",
         "operator:wikidata": "Q9361097",
         "route": "tram"

--- a/data/transit/route/trolleybus.json
+++ b/data/transit/route/trolleybus.json
@@ -738,13 +738,13 @@
       }
     },
     {
-      "displayName": "Zarząd Transportu Metropolitalnego",
+      "displayName": "Transport GZM",
       "id": "zarzadtransportumetropolitalnego-ac5bc5",
       "locationSet": {"include": ["pl"]},
       "note": "ISO 3166-2 PL-12, PL-24",
       "tags": {
-        "network": "Zarząd Transportu Metropolitalnego",
-        "network:wikidata": "Q48862619",
+        "network": "Transport GZM",
+        "network:wikidata": "Q124678630",
         "operator": "Tyskie Linie Trolejbusowe",
         "operator:wikidata": "Q130340846",
         "route": "trolleybus"


### PR DESCRIPTION
A new _"Transport GZM"_ brand identity has been created in 2024 for the network managed by _Zarząd Transport Metropolitalnego_, and it replaced the transit authority's own branding for use on buses, stops etc.

The old tag values were replaced with the new ones in OSM due to a local community consensus on the matter.