### PR TITLE
Remove Fastighetsbyrån from list of generic estate agent names

### DIFF
--- a/data/brands/office/estate_agent.json
+++ b/data/brands/office/estate_agent.json
@@ -4,7 +4,7 @@
     "preserveTags": ["^name"],
     "exclude": {
       "generic": [
-        "^(real estate agency|fastighetsbyrån)$",
+        "^real estate agency$",
         "^estate agent$"
       ]
     }


### PR DESCRIPTION
Fastighetsbyrån is the name of a specific estate agent chain that was added in 40e198dbda31e7a4834e20401193576cd04d4082.