### PR TITLE
Split AlzaBox

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -27,16 +27,49 @@
       }
     },
     {
-      "displayName": "AlzaBox",
-      "id": "alzabox-bee63b",
-      "locationSet": {
-        "include": ["at", "cz", "hu", "sk"]
-      },
+      "displayName": "AlzaBox (Česko)",
+      "locationSet": {"include": ["cz"]},
       "tags": {
         "amenity": "parcel_locker",
         "brand": "AlzaBox",
         "brand:wikidata": "Q115254158",
         "name": "AlzaBox"
+      }
+    },
+    {
+      "displayName": "AlzaBox (Magyarország)",
+      "locationSet": {"include": ["hu"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "AlzaBox",
+        "brand:wikidata": "Q115254158",
+        "name": "AlzaBox",
+        "operator": "Alza.hu",
+        "operator:wikidata": "Q138637883"
+      }
+    },
+    {
+      "displayName": "AlzaBox (Österreich)",
+      "locationSet": {"include": ["at"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "AlzaBox",
+        "brand:wikidata": "Q115254158",
+        "name": "AlzaBox",
+        "operator": "Alza.at",
+        "operator:wikidata": "Q138637901"
+      }
+    },
+    {
+      "displayName": "AlzaBox (Slovensko)",
+      "locationSet": {"include": ["sk"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "AlzaBox",
+        "brand:wikidata": "Q115254158",
+        "name": "AlzaBox",
+        "operator": "Alza.sk",
+        "operator:wikidata": "Q138637855"
       }
     },
     {


### PR DESCRIPTION
Split AlzaBox parcel locker brand by country-specific operator.

AlzaBox lockers are operated by separate Alza group companies in each country:
CZ (Alza.cz) - operator will be feeded directly from Wikidata item (Q115254158)
SK (Alza.sk) - "operator" and "operator:wikidata" specified
HU (Alza.hu) - "operator" and "operator:wikidata" specified
AT (Alza.at) - "operator" and "operator:wikidata" specified

This change splits initial NSI entry, "operator" and "operator:wikidata" will now be based on location.