### PR TITLE
Update funeral_directors.json

### DIFF
--- a/data/brands/shop/funeral_directors.json
+++ b/data/brands/shop/funeral_directors.json
@@ -122,9 +122,11 @@
         "the co-operative group"
       ],
       "matchTags": ["office/company"],
+      "preserveTags": ["^name"],
       "tags": {
         "brand": "The Co-operative Funeralcare",
         "brand:wikidata": "Q7726521",
+        "name": "The Co-operative Funeralcare",
         "shop": "funeral_directors"
       }
     },


### PR DESCRIPTION
Is removing the name field correct to enable other names? Lots of the Coop Funeral Directors have a different name.