### PR TITLE
Add hotel brand Small Luxury Hotels of the World

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -5078,6 +5078,16 @@
         "operator:zh": "長榮集團",
         "tourism": "hotel"
       }
+    },
+    {
+      "displayName": "Small Luxury Hotels of the World",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": " Small Luxury Hotels of the World ",
+        "brand:wikidata": "Q9338601",
+        "name": " Small Luxury Hotels of the World ",
+        "tourism": "hotel"
+      }
     }
   ]
 }


### PR DESCRIPTION
Please add hotel brand Small Luxury Hotels of the World  website: https://slh.com/
Small Luxury Hotels of the World comprises over 650 independent boutique hotels in more than 90 countries worldwide. Small Luxury Hotels of the World is not part of the Hilton Group, but rather an association of independent boutique hotels. Partnership with Hilton group.