### PR TITLE
Add hotel brand Spark by Hilton

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -5078,6 +5078,16 @@
         "operator:zh": "長榮集團",
         "tourism": "hotel"
       }
+    },
+    {
+      "displayName": "Spark by Hilton",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "Spark by Hilton",
+        "brand:wikidata": "Q136412253",
+        "name": "Spark by Hilton",
+        "tourism": "hotel"
+      }
     }
   ]
 }


### PR DESCRIPTION
Please add hotel brand Spark by Hilton.
website: https://www.hilton.com/en/brands/spark-by-hilton/?WT.mc_id=zINDA0EMEA1MB2PSH3Paid_ggl4ACBI_Corebrand5dkt6MULTIBR7ML8i81487387_121127646_22194627494&&&&&gclsrc=aw.ds&gad_source=1&gad_campaignid=22194627494&gclid=EAIaIQobChMI5aaw_4GakwMVBqiDBx0XNANaEAAYASAAEgKeX_D_BwE Spark by Hilton is a rapidly growing premium economy brand that has expanded significantly since its launch in 2023. According to current figures, there are over 220 locations open worldwide. The brand focuses on converting existing hotels and is primarily represented in the US, but is increasingly expanding internationally, including its first properties in Germany (e.g., Stuttgart/Sindelfingen).