### PR TITLE
Add `operator:kw` to Cornwall Council features

### DIFF
--- a/data/operators/amenity/library.json
+++ b/data/operators/amenity/library.json
@@ -922,6 +922,7 @@
       "tags": {
         "amenity": "library",
         "operator": "Cornwall Council",
+        "operator:kw": "Konsel Kernow",
         "operator:type": "government",
         "operator:wikidata": "Q3774189"
       }

--- a/data/operators/amenity/parking.json
+++ b/data/operators/amenity/parking.json
@@ -196,6 +196,7 @@
       "tags": {
         "amenity": "parking",
         "operator": "Cornwall Council",
+        "operator:kw": "Konsel Kernow",
         "operator:type": "government",
         "operator:wikidata": "Q3774189"
       }


### PR DESCRIPTION
Cornwall Council is bilingual, this PR adds the Kernewek `operator:kw` tag.

More about [Konsel Kernow yn Kernewek](https://www.cornwall.gov.uk/media/oxqmsd3m/cornwall-councils-brand.pdf#%5B%7B%22num%22%3A101%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C40%2C546%2Cnull%5D)