### PR TITLE
Rename Total by Verizon to Total Wireless

### DIFF
--- a/data/brands/shop/mobile_phone.json
+++ b/data/brands/shop/mobile_phone.json
@@ -1091,14 +1091,14 @@
       }
     },
     {
-      "displayName": "Total by Verizon",
+      "displayName": "Total Wireless",
       "id": "totalbyverizon-ce3e5c",
       "locationSet": {"include": ["us"]},
-      "matchNames": ["total", "total wireless"],
+      "matchNames": ["total", "total by verizon"],
       "tags": {
-        "brand": "Total by Verizon",
+        "brand": "Total Wireless",
         "brand:wikidata": "Q64590606",
-        "name": "Total by Verizon",
+        "name": "Total Wireless",
         "shop": "mobile_phone"
       }
     },


### PR DESCRIPTION
I saw a store today that said Total Wireless on the sign.

This article on the Verizon website says "Total Wireless, formerly Total by Verizon"
https://www.verizon.com/about/news/total-wireless-launches-bold-new-offers-new-look-outshine-rivals-prepaid-wireless