### PR TITLE
Removed forced name of AVIS from blood_donation.json

### DIFF
--- a/data/brands/healthcare/blood_donation.json
+++ b/data/brands/healthcare/blood_donation.json
@@ -41,8 +41,8 @@
         "brand": "AVIS",
         "brand:wikidata": "Q3627251",
         "donation:compensation": "no",
-        "preserveTags": ["^name"],
-        "healthcare": "blood_donation"
+        "healthcare": "blood_donation",
+        "preserveTags": ["^name"]
       }
     },
     {


### PR DESCRIPTION
Removing name since it could have a different name, e.g. it could be dedicated to someone