### PR TITLE
Tag more specific cuisine on Yunnan rice noodle shops

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -7068,7 +7068,7 @@
         "brand:en": "Shi Miao Dao Yunnan Rice Noodle",
         "brand:wikidata": "Q119118794",
         "brand:zh": "十秒到云南过桥米线",
-        "cuisine": "chinese",
+        "cuisine": "chinese;noodle",
         "name": "Shi Miao Dao Yunnan Rice Noodle",
         "name:en": "Shi Miao Dao Yunnan Rice Noodle",
         "name:zh": "十秒到云南过桥米线"
@@ -7771,7 +7771,7 @@
         "brand:en": "Ten Seconds Yunnan Rice Noodle",
         "brand:wikidata": "Q119118794",
         "brand:zh": "十秒到云南过桥米线",
-        "cuisine": "chinese",
+        "cuisine": "chinese;noodle",
         "name": "Ten Seconds Yunnan Rice Noodle",
         "name:en": "Ten Seconds Yunnan Rice Noodle",
         "name:zh": "十秒到云南过桥米线"
@@ -8518,7 +8518,7 @@
         "amenity": "restaurant",
         "brand": "Yunshang Rice Noodle",
         "brand:wikidata": "Q109381268",
-        "cuisine": "noodle",
+        "cuisine": "chinese;noodle",
         "name": "Yunshang Rice Noodle",
         "name:en": "Yunshang Rice Noodle",
         "name:zh": "云尚过桥米线",
@@ -9692,7 +9692,7 @@
         "brand:en": "Yuan Shi Miao Dao Yunnan Rice Noodle",
         "brand:wikidata": "Q119118794",
         "brand:zh": "十秒到云南过桥米线",
-        "cuisine": "chinese",
+        "cuisine": "chinese;noodle",
         "name": "十秒到云南过桥米线",
         "name:en": "Yuan Shi Miao Dao Yunnan Rice Noodle",
         "name:zh": "十秒到云南过桥米线"


### PR DESCRIPTION
Shops specializing in [crossing-the-bridge noodles](https://en.wikipedia.org/wiki/Crossing-the-bridge_noodles) (过桥米线/過橋米線) are Chinese noodle shops, so `cuisine=chinese;noodle`.