### PR TITLE
Add Macao Imperial Tea cafe brand

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -3024,6 +3024,20 @@
       }
     },
     {
+      "displayName": "Macao Imperial Tea",
+      "locationSet": {"include": ["bn", "id", "my", "ph"]},
+      "tags": {
+        "amenity": "cafe",
+        "brand": "Macao Imperial Tea",
+        "brand:en": "Macao Imperial Tea",
+        "brand:wikidata": "Q137921377",
+        "brand:zh": "澳門皇茶",
+        "cuisine": "bubble_tea",
+        "name": "Macao Imperial Tea",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Machi machi",
       "id": "machimachi-e1ef51",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
Adds Macao Imperial Tea to amenity/cafe brand list. Includes locationSet for bn,id,my,ph and bubble_tea cuisine.