### PR TITLE
Update bus to add Italian branch

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -1047,7 +1047,6 @@
           "es",
           "gb",
           "hr",
-          "it",
           "nl",
           "pl",
           "si",
@@ -1057,6 +1056,17 @@
       "tags": {
         "network": "Arriva",
         "network:wikidata": "Q680991",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Arriva Italia",
+      "locationSet": {
+        "include": ["it"]
+      },
+      "tags": {
+        "operator": "Arriva Italia",
+        "operator:wikidata": "Q48803910",
         "route": "bus"
       }
     },


### PR DESCRIPTION
Separated Arriva from Arriva Italia; moreover in most of Italy Arriva it's just an operator, so I changed to that tag