### PR TITLE
add UniCredit in Poland and unclutter brand name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-lock.yaml
 yarn.lock
 
 .vscode/
+.idea/
 coverage/
 dist/
 node_modules/

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -13698,14 +13698,15 @@
       }
     },
     {
-      "displayName": "UniCredit Bank",
-      "id": "unicreditbank-ff6e1c",
+      "displayName": "UniCredit",
+      "id": "unicredit-d887c4",
       "locationSet": {
         "include": [
           "ba",
           "cz",
           "hu",
           "it",
+          "pl",
           "ro",
           "rs",
           "ru",
@@ -13715,15 +13716,15 @@
       },
       "matchNames": [
         "banco di sicilia",
-        "unicredit",
         "unicredit banca",
+        "unicredit bank",
         "unicredit s.p.a."
       ],
       "tags": {
         "amenity": "bank",
-        "brand": "UniCredit Bank",
+        "brand": "UniCredit",
         "brand:wikidata": "Q45568",
-        "name": "UniCredit Bank"
+        "name": "UniCredit"
       }
     },
     {


### PR DESCRIPTION
This pull request covers two things:

* adds the Unicredit brand to the location `pl` (Poland) where the bank started offering services under its own brand late last year [[1](https://unicredit.pl/media/UniCredit-w-Polsce)]
* unclutters the brand name by removing the word _bank_ which is not part of the name

To justify removal of the word _bank_ let me point you at [Wikipedia](https://en.wikipedia.org/wiki/UniCredit), [Wikidata](https://www.wikidata.org/wiki/Q45568) (which was linked here all along) and finally the [international website](https://www.unicreditgroup.eu/en.html) of the bank. Neither in the logotype nor in narratives is the word _bank_ used as part of the brand name or even the legal entity operating it.

<img width="178" height="62" alt="image" src="https://github.com/user-attachments/assets/9e41a95b-165e-40a9-bdb6-f6797d6fb917" />

<img width="943" height="93" alt="image" src="https://github.com/user-attachments/assets/3ce96eb6-5974-408a-ad3d-e6682e6aa806" />

<img width="557" height="62" alt="image" src="https://github.com/user-attachments/assets/59623979-3006-4e9b-8a93-6f0e02221b41" />

<img width="454" height="79" alt="image" src="https://github.com/user-attachments/assets/21036f85-a3aa-4afd-beaf-68df92c8aeed" />

We all know UniCredit is a bank, that's why we tag is as `amenity=bank`, but there is absolutely no reason to repeat this category in the `name` or `brand` tags.