### PR TITLE
Rename Pathé Gaumont to Pathé Cinémas

### DIFF
--- a/data/brands/amenity/cinema.json
+++ b/data/brands/amenity/cinema.json
@@ -902,22 +902,11 @@
     },
     {
       "displayName": "Pathé",
-      "id": "pathe-484389",
-      "locationSet": {"include": ["nl"]},
-      "tags": {
-        "amenity": "cinema",
-        "brand": "Pathé",
-        "brand:wikidata": "Q61959392",
-        "name": "Pathé"
-      }
-    },
-    {
-      "displayName": "Pathé",
       "id": "pathegaumont-22090e",
       "locationSet": {
-        "include": ["be", "ch", "ci", "fr", "ma", "sn", "tn"]
+        "include": ["be", "ch", "ci", "fr", "ma", "nl", "sn", "tn"]
       },
-      "matchNames": ["pathé gaumont"],
+      "matchNames": ["pathé gaumont", "pathé cinémas"],
       "tags": {
         "amenity": "cinema",
         "brand": "Pathé",


### PR DESCRIPTION
Updated displayName, tags.name, and tags.brand to reflect the new name "Pathé Cinémas". The id remains unchanged (pathegaumont-22090e) to preserve entity continuity and all existing references. No changes to locationSet or brand:wikidata.