### PR TITLE
Unclutter BNP Paribas bank name in Poland

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -4296,12 +4296,14 @@
       "displayName": "BNP Paribas Bank Polska",
       "id": "bnpparibaspolska-68054b",
       "locationSet": {"include": ["pl"]},
-      "matchNames": ["bgż", "bgż bnp paribas"],
+      "matchNames": ["bgż", "bgż bnp paribas", "bnp paribas bank polska"],
       "tags": {
         "amenity": "bank",
-        "brand": "BNP Paribas Bank Polska",
-        "brand:wikidata": "Q20744004",
-        "name": "BNP Paribas Polska"
+        "brand": "BNP Paribas",
+        "brand:wikidata": "Q499707",
+        "operator": "BNP Paribas Bank Polska",
+        "operator:wikidata": "Q20744004",
+        "name": "BNP Paribas"
       }
     },
     {


### PR DESCRIPTION
This PR removes the suffix _Bank Polska_ from the name of BNP Paribas branches in Poland. _BNP Paribas Bank Polska_ is the name of the legal entity that operates these branches. This is why I recommend to keep it as the value of `operator`. However, for general purposes the suffix is not used as evidenced by the [website branding](https://www.bnpparibas.pl/), [TV commercials](https://www.youtube.com/watch?v=OVmfGzYSFpI) or [press releases](https://media.bnpparibas.pl/pr/867180/bank-bnp-paribas-nagrodzony-w-pieciu-kategoriach-w-konkursie-instytucja-roku-23-oddzialy-uznane-za-najlepsze-placowki-bankowe-w-polsce).

I decided to keep the `displayName` in the current form, but something like `BNP Paribas (Poland)` would also be fine.