### PR TITLE
ÖAMTC as one entity

### DIFF
--- a/data/brands/office/association.json
+++ b/data/brands/office/association.json
@@ -205,10 +205,8 @@
       "tags": {
         "brand": "ÖAMTC",
         "brand:wikidata": "Q306057",
-        "brand:wikipedia": "de:Österreichischer Automobil-, Motorrad- und Touring Club",
         "name": "ÖAMTC",
-        "office": "association",
-        "amenity": "vehicle_inspection"
+        "office": "association"
       }
     },
     {


### PR DESCRIPTION
ÖAMTC offices are by default also vehicle_inspections. Splitting them into two entries was not the way, since it is one and the same amenity. I'd like to correct my previous change, please.