### PR TITLE
Removing wrong network tags

### DIFF
--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -2081,16 +2081,6 @@
       }
     },
     {
-      "displayName": "RFI",
-      "id": "rfi-66b763",
-      "locationSet": {"include": ["it"]},
-      "tags": {
-        "network": "RFI",
-        "network:wikidata": "Q1060049",
-        "route": "train"
-      }
-    },
-    {
       "displayName": "RhB",
       "id": "rhb-0c66c7",
       "locationSet": {
@@ -2833,9 +2823,6 @@
       "locationSet": {"include": ["it"]},
       "matchNames": ["trenitalia s.p.a"],
       "tags": {
-        "network": "Trenitalia",
-        "network:short": "TI",
-        "network:wikidata": "Q286650",
         "operator": "Trenitalia",
         "operator:short": "TI",
         "operator:wikidata": "Q286650",


### PR DESCRIPTION
After a discussion on the relevant telegram groups of the Italian community the following networks resulted to be inserted wrongfully and are outside the scope of the network tag.
A discussion on the forum was also opened and advertised but no discussion happened there.
https://community.openstreetmap.org/t/discussione-riguardante-luso-di-network-rfi-su-stazioni-e-relazioni/142687