### PR TITLE
Update ferry.json

### DIFF
--- a/data/transit/route/ferry.json
+++ b/data/transit/route/ferry.json
@@ -520,20 +520,6 @@
       }
     },
     {
-      "displayName": "RiverCity Ferries",
-      "id": "translink-98c650",
-      "locationSet": {
-        "include": ["au-qld.geojson"]
-      },
-      "tags": {
-        "network": "Translink",
-        "network:wikidata": "Q7833625",
-        "operator": "RiverCity Ferries",
-        "operator:wikidata": "Q97194713",
-        "route": "ferry"
-      }
-    },
-    {
       "displayName": "RTL",
       "id": "rtl-982c29",
       "locationSet": {"include": ["mv"]},
@@ -676,6 +662,18 @@
         "network:wikidata": "Q867333",
         "operator": "Translink",
         "operator:wikidata": "Q1142140",
+        "route": "ferry"
+      }
+    },
+    {
+      "displayName": "Translink (Queensland)",
+      "id": "translink-98c650",
+      "locationSet": {
+        "include": ["au-qld.geojson"]
+      },
+      "tags": {
+        "network": "Translink",
+        "network:wikidata": "Q7833625",
         "route": "ferry"
       }
     },


### PR DESCRIPTION
Remove RiverCity ferries Operator from Translink (Queensland) due to there being multiple ferry operators that operate under the same Translink network.