### PR TITLE
Add Boutique Paraboot entry to shoes.json

### DIFF
--- a/data/brands/shop/shoes.json
+++ b/data/brands/shop/shoes.json
@@ -1545,6 +1545,18 @@
       }
     },
     {
+      "displayName": "Boutique Paraboot",
+      "id": "paraboot",
+      "locationSet": {"include": ["fr"]},
+      "tags": {
+        "brand": "Paraboot",
+        "brand:wikidata": "Q139098562",
+        "operator": "société Capuce",
+        "operator:wikidata": "Q139099074",
+        "shop": "shoes"
+      }
+    },
+    {
       "displayName": "Pataugas",
       "id": "pataugas-e6cf1b",
       "locationSet": {"include": ["fx"]},


### PR DESCRIPTION
Hi,
This is to add Paraboot retail chain, [35 stores](https://www.paraboot.com/en/boutiques/) operated in France by [Capuce](https://annuaire-entreprises.data.gouv.fr/entreprise/capuce-349869594#etablissements).