### PR TITLE
Add Richter+Frenzel

### DIFF
--- a/data/brands/shop/bathroom_furnishing.json
+++ b/data/brands/shop/bathroom_furnishing.json
@@ -10,6 +10,17 @@
   },
   "items": [
     {
+      "displayName": "Richter+Frenzel",
+      "locationSet": {"include": ["cz", "de"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Richter+Frenzel",
+        "brand:wikidata": "Q2151266",
+        "name": "Richter+Frenzel",
+        "shop": "bathroom_furnishing"
+      }
+    },
+    {
       "displayName": "Easy Bathrooms",
       "id": "easybathrooms-72592f",
       "locationSet": {"include": ["gb"]},

--- a/data/brands/shop/trade.json
+++ b/data/brands/shop/trade.json
@@ -7,6 +7,17 @@
   },
   "items": [
     {
+      "displayName": "Richter+Frenzel",
+      "locationSet": {"include": ["cz", "de"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Richter+Frenzel",
+        "brand:wikidata": "Q2151266",
+        "name": "Richter+Frenzel",
+        "shop": "trade"
+      }
+    },
+    {
       "displayName": "84 Lumber",
       "id": "84lumber-4e950c",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Added Richter+Frenzel as trade counter (more than 160 locations) and bathroom studio (more than 70 locations).