### PR TITLE
add typescript definitions for lib/*

### DIFF
--- a/lib/file_tree.ts
+++ b/lib/file_tree.ts
@@ -9,7 +9,7 @@ import { idgen } from './idgen.ts';
 import { sortObject } from './sort_object.ts';
 import { validate } from './validate.ts';
 
-import type { NsiCache } from './types.ts';
+import type { NsiCache, NsiCategoryProperties, OsmTags } from './types.ts';
 import type LocationConflation from '@rapideditor/location-conflation';
 
 const withLocale = localeCompare('en-US');  // specify 'en-US' for stable results
@@ -234,7 +234,7 @@ write: async (cache: NsiCache) => {
           item.templateSource = _clean(item.templateSource);
 
           // clean templateTags
-          const cleaned: Record<string, unknown> = {};
+          const cleaned: OsmTags = {};
           for (const k of Object.keys(item.templateTags)) {
             const osmkey = _clean(k) as string;
             const osmval = _clean(item.templateTags[k]);
@@ -255,17 +255,19 @@ write: async (cache: NsiCache) => {
           // clean locationSet
           let cleaned: Record<string, any> = {};
           if (Array.isArray(item.locationSet.include)) {
+            // @ts-expect-error -- legacy issue
             cleaned.include = item.locationSet.include.map(_cleanLower).sort(withLocale);
           } else {
             cleaned.include = ['001'];  // default to world
           }
           if (Array.isArray(item.locationSet.exclude)) {
+            // @ts-expect-error -- legacy issue
             cleaned.exclude = item.locationSet.exclude.map(_cleanLower).sort(withLocale);
           }
           item.locationSet = cleaned;
 
           // clean matchNames/matchTags
-          for (const prop of ['matchNames', 'matchTags']) {
+          for (const prop of ['matchNames', 'matchTags'] as const) {
             if (item[prop]) {
               item[prop] = item[prop].map(_cleanLower).sort(withLocale);
             }
@@ -287,7 +289,7 @@ write: async (cache: NsiCache) => {
       const properties = category.properties || {};
       properties.exclude = properties.exclude || {};
 
-      const cleanedProps: Record<string, any> = {};
+      const cleanedProps = {} as NsiCategoryProperties;
       cleanedProps.path = tkv;
 
       if (properties.skipCollection) {
@@ -311,7 +313,7 @@ write: async (cache: NsiCache) => {
       // generate file
       const output = {
         properties: cleanedProps,
-        items: templateItems.concat(normalItems)
+        items: [...templateItems, ...normalItems],
       };
 
       itemCount += output.items.length;
@@ -336,6 +338,7 @@ write: async (cache: NsiCache) => {
    * @param   s - The value to clean
    * @returns The trimmed string, or the original value if not a string
    */
+  function _clean(s: string): string;
   function _clean(s: string | unknown): string | unknown {
     if (typeof s !== 'string') return s;
     return s.trim();
@@ -349,6 +352,7 @@ write: async (cache: NsiCache) => {
    * @returns The trimmed (and possibly lowercased) string, or the original value
    *          if not a string
    */
+  function _cleanLower(s: string): string;
   function _cleanLower(s: string | unknown): string | unknown {
     if (typeof s !== 'string') return s;
     if (/İ/.test(s)) {  // Avoid toLowerCasing this one, it changes - #8261
@@ -422,7 +426,7 @@ expandTemplates: (cache: NsiCache, loco: LocationConflation) => {
               const props = token.split('.');
               props.shift();   // Ignore first 'source'. It's just for show.
 
-              let source = sourceItem;
+              let source: any = sourceItem;
               while (props.length) {
                 const prop = props.shift()!;
                 const found = source[prop];
@@ -458,13 +462,14 @@ expandTemplates: (cache: NsiCache, loco: LocationConflation) => {
 
         // generate id
         const locationID = loco.validateLocationSet(item.locationSet).id;
-        item.id = idgen(item, tkv, locationID);
-        if (!item.id) {
+        const id = idgen(item, tkv, locationID);
+        if (!id) {
           console.error(styleText('red', `Error - Couldn't generate an id for:`));
           console.error('  ' + styleText('yellow', item.displayName));
           console.error('  ' + styleText('yellow', file));
           process.exit(1);
         }
+        item.id = id;
 
         // merge into caches
         if (cache.id.has(item.id)) {

--- a/lib/matcher.ts
+++ b/lib/matcher.ts
@@ -2,8 +2,9 @@ import whichPolygon from 'which-polygon';
 import { simplify } from './simplify.ts';
 
 import type LocationConflation from '@rapideditor/location-conflation';
-import type { Vec2 } from '@rapideditor/location-conflation';
-import type { MatchHit, MatchIndexBranch, NsiData } from './types.ts';
+import type { FeatureProperties, Vec2 } from '@rapideditor/location-conflation';
+import type { MatchHit, MatchIndexBranch, NsiData, NsiTree } from './types.ts';
+import type { Feature, Geometry } from 'geojson';
 
 // Imported JSON (will be inlined when generating a bundle)
 import matchGroupsJSON from '../config/matchGroups.json' with {type: 'json'};
@@ -35,11 +36,11 @@ export class Matcher {
   /** Map of generic-word pattern strings to compiled RegExp objects. */
   private genericWords = new Map<string, RegExp>();
   /** Map of item IDs to their resolved locationSet IDs. */
-  private itemLocation: Map<string, string> | undefined;
+  public itemLocation: Map<string, string> | undefined;
   /** Map of locationSet IDs to resolved GeoJSON features. */
-  private locationSets: Map<string, { id?: string; properties: Record<string, any>; geometry: any }> | undefined;
+  public locationSets: Map<string, Feature<Geometry, FeatureProperties>> | undefined;
   /** A `which-polygon` spatial index over resolved locationSet features. */
-  private locationIndex: ReturnType<typeof whichPolygon> | undefined;
+  public locationIndex: whichPolygon.Query<FeatureProperties> | undefined;
   /** Warnings collected during index building (e.g. duplicate cache keys). */
   private warnings: Array<string> = [];
 
@@ -213,7 +214,7 @@ export class Matcher {
     for (const tkv of Object.keys(data)) {
       const category = data[tkv];
       const parts = tkv.split('/', 3);     // tkv = "tree/key/value"
-      const t = parts[0];
+      const t = parts[0] as NsiTree;
       const k = parts[1];
       const v = parts[2];
       const thiskv = `${k}/${v}`;
@@ -440,10 +441,10 @@ export class Matcher {
 
     // If we were supplied a location, and this.locationIndex has been set up,
     // get the locationSets that are valid there so we can filter results.
-    let matchLocations;
+    let matchLocations: FeatureProperties[] | null;
     if (Array.isArray(loc) && this.locationIndex) {
       // which-polygon query returns an array of GeoJSON properties, pass true to return all results
-      matchLocations = this.locationIndex([loc[0], loc[1], loc[0], loc[1]], true);
+      matchLocations = this.locationIndex([loc[0], loc[1]], true);
     }
 
     const nsimple = simplify(n);
@@ -460,9 +461,9 @@ export class Matcher {
       return (hitB.area || 0) - (hitA.area || 0);
     };
 
-    const isValidLocation = (hit: MatchHit): boolean => {
+    const isValidLocation = (hit: MatchHit) => {
       if (!this.itemLocation) return true;
-      return matchLocations.find(props => props.id === this.itemLocation!.get(hit.itemID!));
+      return matchLocations?.some(props => props.id === this.itemLocation!.get(hit.itemID!));
     };
 
     const tryMatch = (which: 'primary' | 'alternate' | 'exclude', kv: string): boolean => {
@@ -526,8 +527,7 @@ export class Matcher {
       if (didMatch) return;
 
       // If that didn't work, look in match groups for other pairs considered equivalent to k/v..
-      for (const mg in matchGroups) {
-        const matchGroup = matchGroups[mg];
+      for (const matchGroup of Object.values(matchGroups)) {
         const inGroup = matchGroup.some(otherkv => otherkv === kv);
         if (!inGroup) continue;
 

--- a/lib/sort_object.ts
+++ b/lib/sort_object.ts
@@ -11,7 +11,8 @@ const withLocale = localeCompare('en-US');  // specify 'en-US' for stable result
  * @param   obj - The input object to sort
  * @returns A new object with sorted keys and sorted array values, or `null` if the input is falsy.
  */
-export function sortObject(obj: Record<string, unknown>): Record<string, unknown> | null {
+export function sortObject<T extends object>(obj: T): T;
+export function sortObject<T extends Record<string, unknown>>(obj: T): T | null {
   if (!obj) return null;
 
   const sorted: Record<string, unknown> = {};
@@ -20,7 +21,7 @@ export function sortObject(obj: Record<string, unknown>): Record<string, unknown
     const v = obj[k];
     sorted[k] = Array.isArray(v) ? v.sort(withLocale) : v;
   }
-  return sorted;
+  return sorted as T;
 
 
   /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -76,6 +76,13 @@ export interface NsiCategory {
 /** The full NSI dataset: an object keyed by `tree/key/value` path. */
 export type NsiData = Record<string, NsiCategory>;
 
+export interface NsiDissolved {
+  dissolved: Record<string, Dissolution[]>
+};
+
+export interface NsiPresets {
+  presets: Record<string, RapidPreset>
+}
 
 // Match index types
 
@@ -105,7 +112,7 @@ export interface MatchIndexBranch {
 
 /** Top-level shape of `config/trees.json`. */
 export interface TreesConfig {
-  trees: Record<string, NsiTreeConfig>;
+  trees: Record<NsiTree, NsiTreeConfig>;
 }
 
 /** Top-level shape of `config/matchGroups.json`. */
@@ -177,4 +184,14 @@ export interface RapidPreset {
   reference?: { key?: string; value?: string };
   /** The ID of a preset that is preferable to this one (for deprecated presets) */
   replacement?: string;
+}
+
+
+/** @internal */
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace globalThis {
+        // eslint-disable-next-line no-var
+        var nsi: typeof import('../src/nsi');
+    }
 }

--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -1,5 +1,6 @@
 import { styleText } from 'node:util';
 import type { Validator, Schema } from 'jsonschema';
+import type { NsiItem } from './types';
 
 
 /**
@@ -24,7 +25,7 @@ export function validate(validator: Validator, filepath: string, object: unknown
       if (e.property) {
         console.error('  ' + styleText('yellow', e.property + ' ' + e.message));
         if (e.name === 'uniqueItems') {
-          const arr: any[]  = e.instance;
+          const arr: NsiItem[]  = e.instance;
           const duplicates = arr
             .map(n => n.displayName || n)
             .filter((e, i, a) => a.indexOf(e) !== i);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     // Language and Environment
     "target": "ES2022",
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ESNext"],
+    "types": ["bun"],
 
     // Modules
     "module": "ESNext",
@@ -18,6 +19,7 @@
     "declarationDir": "./dist/ts",
     "outDir": "./dist/ts",
     "sourceMap": true,
+    "stripInternal": true,
     "noEmitOnError": true,
 
     // Interop
@@ -26,7 +28,7 @@
 
     // Type Checking
     "strict": true,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "skipLibCheck": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": false,
@@ -37,7 +39,7 @@
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
   },
-  "include": ["./src/nsi.ts"],
+  "include": ["src", "lib", "scripts"],
   "exclude": [
     "node_modules",
     "dist",


### PR DESCRIPTION
It would be helpful for downstream consumers to have complete TypeScript definitions for the public API.

This PR adds all the missing annotations to `lib/*`. I could send a separate PR for the internal `scripts/*` files 