### PR TITLE
Replace Wikidata places with governments

### DIFF
--- a/data/operators/amenity/community_centre.json
+++ b/data/operators/amenity/community_centre.json
@@ -246,7 +246,7 @@
         "amenity": "community_centre",
         "operator": "City of Cleveland",
         "operator:type": "government",
-        "operator:wikidata": "Q37320"
+        "operator:wikidata": "Q139385923"
       }
     },
     {
@@ -344,7 +344,7 @@
         "amenity": "community_centre",
         "operator": "City of Portland",
         "operator:type": "government",
-        "operator:wikidata": "Q6106"
+        "operator:wikidata": "Q5589293"
       }
     },
     {

--- a/data/operators/amenity/library.json
+++ b/data/operators/amenity/library.json
@@ -813,7 +813,7 @@
         "amenity": "library",
         "operator": "City of San Diego",
         "operator:type": "government",
-        "operator:wikidata": "Q16552"
+        "operator:wikidata": "Q138816781"
       }
     },
     {

--- a/data/operators/boundary/protected_area.json
+++ b/data/operators/boundary/protected_area.json
@@ -407,7 +407,7 @@
         "boundary": "protected_area",
         "operator": "City of Los Angeles",
         "operator:type": "government",
-        "operator:wikidata": "Q65"
+        "operator:wikidata": "Q5589234"
       }
     },
     {
@@ -511,6 +511,34 @@
       "tags": {
         "boundary": "protected_area",
         "operator": "CORTOLIMA"
+      }
+    },
+    {
+      "displayName": "County of Los Angeles",
+      "id": "countyoflosangeles-396679",
+      "locationSet": {
+        "include": [
+          "us-ca-los_angeles_county.geojson"
+        ]
+      },
+      "tags": {
+        "boundary": "protected_area",
+        "operator": "County of Los Angeles",
+        "operator:type": "government",
+        "operator:wikidata": "Q5589236"
+      }
+    },
+    {
+      "displayName": "County of Orange (California)",
+      "id": "countyoforange-637e4d",
+      "locationSet": {
+        "include": ["us-ca-orange_county.geojson"]
+      },
+      "tags": {
+        "boundary": "protected_area",
+        "operator": "County of Orange",
+        "operator:type": "government",
+        "operator:wikidata": "Q135990426"
       }
     },
     {
@@ -1532,22 +1560,6 @@
       }
     },
     {
-      "displayName": "Los Angeles County",
-      "id": "losangelescounty-396679",
-      "locationSet": {
-        "include": [
-          "us-ca-los_angeles_county.geojson"
-        ]
-      },
-      "matchNames": ["county of los angeles"],
-      "tags": {
-        "boundary": "protected_area",
-        "operator": "Los Angeles County",
-        "operator:type": "government",
-        "operator:wikidata": "Q104994"
-      }
-    },
-    {
       "displayName": "Louisiana Department of Wildlife and Fisheries",
       "id": "louisianadepartmentofwildlifeandfisheries-da8dad",
       "locationSet": {
@@ -2365,20 +2377,6 @@
         "operator": "Ontario Parks",
         "operator:type": "public",
         "operator:wikidata": "Q3364902"
-      }
-    },
-    {
-      "displayName": "Orange County (California)",
-      "id": "orangecounty-637e4d",
-      "locationSet": {
-        "include": ["us-ca-orange_county.geojson"]
-      },
-      "matchNames": ["county of orange"],
-      "tags": {
-        "boundary": "protected_area",
-        "operator": "Orange County",
-        "operator:type": "government",
-        "operator:wikidata": "Q5925"
       }
     },
     {

--- a/data/operators/emergency/siren.json
+++ b/data/operators/emergency/siren.json
@@ -288,7 +288,7 @@
       "tags": {
         "emergency": "siren",
         "operator": "City of Tulsa",
-        "operator:wikidata": "Q44989",
+        "operator:wikidata": "Q5589324",
         "siren:purpose": "tornado;nuclear_attack;flood",
         "siren:type": "electronic"
       }

--- a/data/operators/leisure/park.json
+++ b/data/operators/leisure/park.json
@@ -959,7 +959,7 @@
         "leisure": "park",
         "operator": "City of Anaheim",
         "operator:type": "government",
-        "operator:wikidata": "Q49247"
+        "operator:wikidata": "Q139044657"
       }
     },
     {
@@ -1709,7 +1709,7 @@
         "leisure": "park",
         "operator": "City of Detroit",
         "operator:type": "government",
-        "operator:wikidata": "Q12439"
+        "operator:wikidata": "Q2824588"
       }
     },
     {
@@ -2281,7 +2281,7 @@
         "leisure": "park",
         "operator": "City of Irvine",
         "operator:type": "government",
-        "operator:wikidata": "Q49219"
+        "operator:wikidata": "Q139033177"
       }
     },
     {
@@ -2750,7 +2750,7 @@
         "leisure": "park",
         "operator": "City of Miami",
         "operator:type": "government",
-        "operator:wikidata": "Q8652"
+        "operator:wikidata": "Q5589249"
       }
     },
     {
@@ -3165,7 +3165,7 @@
         "leisure": "park",
         "operator": "City of Richmond",
         "operator:type": "government",
-        "operator:wikidata": "Q43421"
+        "operator:wikidata": "Q29093055"
       }
     },
     {
@@ -3178,7 +3178,7 @@
         "leisure": "park",
         "operator": "City of Riverside",
         "operator:type": "government",
-        "operator:wikidata": "Q49243"
+        "operator:wikidata": "Q139000354"
       }
     },
     {
@@ -3387,7 +3387,7 @@
         "leisure": "park",
         "operator": "City of Santa Fe",
         "operator:type": "government",
-        "operator:wikidata": "Q38555"
+        "operator:wikidata": "Q96338858"
       }
     },
     {
@@ -4144,6 +4144,19 @@
         "operator": "Corvallis Parks & Recreation",
         "operator:type": "public",
         "operator:wikidata": "Q123583799"
+      }
+    },
+    {
+      "displayName": "County of San Bernardino",
+      "id": "countyofsanbernardino-dc1787",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "leisure": "park",
+        "operator": "County of San Bernardino",
+        "operator:type": "government",
+        "operator:wikidata": "Q138891274"
       }
     },
     {
@@ -7404,19 +7417,6 @@
         "operator": "Saint Paul Department of Parks and Recreation",
         "operator:type": "government",
         "operator:wikidata": "Q123583563"
-      }
-    },
-    {
-      "displayName": "San Bernardino County",
-      "id": "sanbernardinocounty-dc1787",
-      "locationSet": {
-        "include": ["us-ca.geojson"]
-      },
-      "tags": {
-        "leisure": "park",
-        "operator": "San Bernardino County",
-        "operator:type": "government",
-        "operator:wikidata": "Q108053"
       }
     },
     {

--- a/data/operators/man_made/survey_point.json
+++ b/data/operators/man_made/survey_point.json
@@ -116,6 +116,18 @@
       }
     },
     {
+      "displayName": "County of Santa Clara",
+      "id": "countyofsantaclara-9c6b17",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "man_made": "survey_point",
+        "operator": "County of Santa Clara",
+        "operator:wikidata": "Q106513502"
+      }
+    },
+    {
       "displayName": "Enedis",
       "id": "enedis-9dddf6",
       "locationSet": {"include": ["fr"]},
@@ -390,18 +402,6 @@
         "man_made": "survey_point",
         "operator": "RTE",
         "operator:wikidata": "Q2178795"
-      }
-    },
-    {
-      "displayName": "Santa Clara County",
-      "id": "santaclaracounty-9c6b17",
-      "locationSet": {
-        "include": ["us-ca.geojson"]
-      },
-      "tags": {
-        "man_made": "survey_point",
-        "operator": "Santa Clara County",
-        "operator:wikidata": "Q106513502"
       }
     },
     {

--- a/data/operators/power/generator.json
+++ b/data/operators/power/generator.json
@@ -5330,7 +5330,7 @@
       },
       "tags": {
         "operator": "Kendall County",
-        "operator:wikidata": "Q112512",
+        "operator:wikidata": "Q121489944",
         "power": "generator"
       }
     },


### PR DESCRIPTION
I [queried Wikidata](https://qlever.dev/wikidata/F5k53v) for any item about a place in the United States that has an NSI identifier and also has a corresponding item about the government of that place. The latter item is more appropriate for `operator=*` tags. I’ve updated the relevant QIDs in this repository.

This process will need to be repeated in the future as more government items get split out from place items.