### PR TITLE
Update Miele

### DIFF
--- a/data/brands/shop/appliance.json
+++ b/data/brands/shop/appliance.json
@@ -5,6 +5,17 @@
   },
   "items": [
     {
+      "displayName": "Miele",
+      "locationSet": {"include": ["001"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Miele",
+        "brand:wikidata": "Q695230",
+        "name": "Miele",
+        "shop": "appliance"
+      }
+    },
+    {
       "displayName": "Appliance Repair by Asurion",
       "id": "appliancerepairbyasurion-70060f",
       "locationSet": {"include": ["us"]},

--- a/data/brands/shop/electronics.json
+++ b/data/brands/shop/electronics.json
@@ -1161,17 +1161,6 @@
       }
     },
     {
-      "displayName": "Miele",
-      "id": "miele-9377b7",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "brand": "Miele",
-        "brand:wikidata": "Q695230",
-        "name": "Miele",
-        "shop": "electronics"
-      }
-    },
-    {
       "displayName": "Milar",
       "id": "milar-c76981",
       "locationSet": {"include": ["es"]},


### PR DESCRIPTION
Move Miele to shop=appliance as it sells white goods like fridges, ovens, hoods, washing machines, and dryers. Some stores are named 'Miele Center' or 'Miele Experience Center', therefore, preserveTags has been included.