### PR TITLE
Updated tobacco brands

### DIFF
--- a/data/brands/shop/kiosk.json
+++ b/data/brands/shop/kiosk.json
@@ -19,6 +19,18 @@
   },
   "items": [
     {
+      "displayName": "GGT Tabak Press",
+      "locationSet": {"include": ["sk"]},
+      "matchNames": ["ggt", "gg tabak", "tabak press"],
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "GGT",
+        "brand:wikidata": "Q110264693",
+        "name": "GGT Tabak Press",
+        "shop": "kiosk"
+      }
+    },
+    {
       "displayName": "City Kiosk",
       "id": "citykiosk-586994",
       "locationSet": {"include": ["ch", "de"]},

--- a/data/brands/shop/newsagent.json
+++ b/data/brands/shop/newsagent.json
@@ -73,20 +73,6 @@
       }
     },
     {
-      "displayName": "GECO",
-      "id": "geco-6f95ad",
-      "locationSet": {
-        "include": ["cz", "de", "sk"]
-      },
-      "matchNames": ["geco tabak"],
-      "tags": {
-        "brand": "GECO",
-        "brand:wikidata": "Q58206631",
-        "name": "GECO",
-        "shop": "newsagent"
-      }
-    },
-    {
       "displayName": "Hudson News",
       "id": "hudsonnews-a0252c",
       "locationSet": {"include": ["ca", "us"]},
@@ -132,18 +118,6 @@
         "brand": "Kolporter",
         "brand:wikidata": "Q6427874",
         "name": "Kolporter",
-        "shop": "newsagent"
-      }
-    },
-    {
-      "displayName": "M+M Tabak",
-      "id": "mmtabak-ab066a",
-      "locationSet": {"include": ["sk"]},
-      "matchNames": ["m plus m"],
-      "tags": {
-        "brand": "M+M Tabak",
-        "brand:wikidata": "Q136689176",
-        "name": "M+M Tabak",
         "shop": "newsagent"
       }
     },
@@ -248,18 +222,6 @@
         "brand": "Świat Prasy",
         "brand:wikidata": "Q127769965",
         "name": "Świat Prasy",
-        "shop": "newsagent"
-      }
-    },
-    {
-      "displayName": "Tabak Press",
-      "id": "tabakpress-5d4c3a",
-      "locationSet": {"include": ["cz", "sk"]},
-      "matchNames": ["gg tabak"],
-      "tags": {
-        "brand": "Tabak Press",
-        "brand:wikidata": "Q110264693",
-        "name": "Tabak Press",
         "shop": "newsagent"
       }
     },

--- a/data/brands/shop/tobacco.json
+++ b/data/brands/shop/tobacco.json
@@ -15,6 +15,42 @@
   },
   "items": [
     {
+      "displayName": "Geco",
+      "locationSet": {"include": ["cz", "de", "sk"]},
+      "matchNames": ["geco tabak tisk", "geco tabak tlac"],
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Geco",
+        "brand:wikidata": "Q58206631",
+        "name": "Geco",
+        "shop": "tobacco"
+      }
+    },
+    {
+      "displayName": "GGT Tabak Press",
+      "locationSet": {"include": ["sk"]},
+      "matchNames": ["ggt", "gg tabak", "tabak press"],
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "GGT",
+        "brand:wikidata": "Q110264693",
+        "name": "GGT Tabak Press",
+        "shop": "tobacco"
+      }
+    },
+    {
+      "displayName": "GGT Tabák Tisk",
+      "locationSet": {"include": ["cz"]},
+      "matchNames": ["ggt", "gg tabak", "tabak tisk"],
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "GGT",
+        "brand:wikidata": "Q110264693",
+        "name": "GGT Tabák Tisk",
+        "shop": "tobacco"
+      }
+    },
+    {
       "displayName": "20 грамм",
       "id": "0b3858-0cd077",
       "locationSet": {"include": ["ru"]},
@@ -64,6 +100,7 @@
       "displayName": "M+M Tabak",
       "id": "mmtabak-219048",
       "locationSet": {"include": ["sk"]},
+      "matchNames": ["m plus m"],
       "matchTags": [
         "shop/kiosk",
         "shop/newsagent"
@@ -173,18 +210,19 @@
       }
     },
     {
-      "displayName": "TRAFICON",
+      "displayName": "Traficon",
       "id": "traficon-56156e",
       "locationSet": {"include": ["cz"]},
-      "matchNames": ["tabák traficon"],
+      "matchNames": ["tabak traficon"],
+      "preserveTags": ["^name"],
       "matchTags": [
         "shop/kiosk",
         "shop/newsagent"
       ],
       "tags": {
-        "brand": "TRAFICON",
+        "brand": "Traficon",
         "brand:wikidata": "Q67807570",
-        "name": "TRAFICON",
+        "name": "Traficon",
         "shop": "tobacco"
       }
     },


### PR DESCRIPTION
Moved some Czech and Slovak tobacco brands to shop=tobacco (sell primarily tobacco products). Also updated names and preserveTags. Added 1 brand as shop=kiosk.