### PR TITLE
Add Ptáček

### DIFF
--- a/data/brands/shop/bathroom_furnishing.json
+++ b/data/brands/shop/bathroom_furnishing.json
@@ -10,6 +10,17 @@
   },
   "items": [
     {
+      "displayName": "Ptáček",
+      "locationSet": {"include": ["cz", "sk"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Ptáček",
+        "brand:wikidata": "Q58195153",
+        "name": "Ptáček",
+        "shop": "bathroom_furnishing"
+      }
+    },
+    {
       "displayName": "Easy Bathrooms",
       "id": "easybathrooms-72592f",
       "locationSet": {"include": ["gb"]},

--- a/data/brands/shop/wholesale.json
+++ b/data/brands/shop/wholesale.json
@@ -5,6 +5,17 @@
   },
   "items": [
     {
+      "displayName": "Ptáček",
+      "locationSet": {"include": ["cz", "sk"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Ptáček",
+        "brand:wikidata": "Q58195153",
+        "name": "Ptáček",
+        "shop": "wholesale"
+      }
+    },
+    {
       "displayName": "Bestway",
       "id": "bestway-650ac6",
       "locationSet": {"include": ["gb"]},


### PR DESCRIPTION
In addition to trade counters (already in NSI), Ptáček also operates a network of over 70 bathroom showrooms and more than 130 wholesale centres.