### PR TITLE
Bus route networks ref colour

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -2302,6 +2302,8 @@
       "tags": {
         "network": "Bizkaibus",
         "network:wikidata": "Q879270",
+        "ref:colour": "#9ACD32",
+        "ref:colour_tx": "white",
         "route": "bus"
       }
     },
@@ -2895,6 +2897,8 @@
         "network": "Autobuses de España",
         "network:short": "bus.es",
         "network:wikidata": "Q108443913",
+        "ref:colour": "#0FDDC4",
+        "ref:colour_tx": "#003A47",
         "route": "bus"
       }
     },
@@ -4574,6 +4578,8 @@
       "tags": {
         "network": "Consorcio de Transporte Metropolitano Área de Almería",
         "network:wikidata": "Q5784309",
+        "ref:colour": "#009639",
+        "ref:colour_tx": "white",
         "route": "bus"
       }
     },
@@ -4586,6 +4592,8 @@
       "tags": {
         "network": "Consorcio de Transporte Metropolitano del Área de Granada",
         "network:wikidata": "Q5784314",
+        "ref:colour": "#009639",
+        "ref:colour_tx": "white",
         "route": "bus"
       }
     },
@@ -4599,6 +4607,8 @@
         "network": "Consorcio de Transporte Metropolitano del Área de Málaga",
         "network:short": "CTMAM",
         "network:wikidata": "Q6949617",
+        "ref:colour": "#009639",
+        "ref:colour_tx": "white",
         "route": "bus"
       }
     },
@@ -4612,6 +4622,8 @@
         "network": "Consorcio de Transporte Metropolitano del Campo de Gibraltar",
         "network:short": "CTMCG",
         "network:wikidata": "Q5784307",
+        "ref:colour": "#009639",
+        "ref:colour_tx": "white",
         "route": "bus"
       }
     },
@@ -4652,6 +4664,8 @@
         "network": "Consorcio Metropolitano de Transportes de la Bahía de Cádiz",
         "network:short": "CMTBC",
         "network:wikidata": "Q5784325",
+        "ref:colour": "#009639",
+        "ref:colour_tx": "white",
         "route": "bus"
       }
     },
@@ -4665,6 +4679,8 @@
         "network": "Consorcio Regional de Transportes de Madrid",
         "network:short": "CRTM",
         "network:wikidata": "Q8350122",
+        "ref:colour": "#62A70B",
+        "ref:colour_tx": "white",
         "route": "bus"
       }
     },
@@ -10262,6 +10278,8 @@
       "tags": {
         "network": "Lurraldebus",
         "network:wikidata": "Q5984914",
+        "ref:colour": "#00A0AE",
+        "ref:colour_tx": "white",
         "route": "bus"
       }
     },
@@ -12944,6 +12962,8 @@
       "tags": {
         "network": "NBus",
         "network:wikidata": "Q74445218",
+        "ref:colour": "#DA291C",
+        "ref:colour_tx": "white",
         "route": "bus"
       }
     },


### PR DESCRIPTION
Added default network colours for some Spanish bus route systems. In these networks, all routes consistently use the same reference colour (ref_colour) as per official branding guidelines. This helps maintain consistency across all route relations in Spain.