### PR TITLE
Rename bus network

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -13766,14 +13766,14 @@
       }
     },
     {
-      "displayName": "Otwockie Przewozy Gminno-Powiatowe",
-      "id": "otwockieprzewozygminnopowiatowe-c14885",
+      "displayName": "Nadwiślańska Komunikacja Autobusowa",
+      "id": "nadwislanskakomunikacjaautobusowa-c14885",
       "locationSet": {
         "include": ["pl-14.geojson"]
       },
+      "matchNames": ["Otwockie Przewozy Gminno-Powiatowe"],
       "tags": {
-        "network": "Otwockie Przewozy Gminno-Powiatowe",
-        "network:short": "OPGP",
+        "network": "Nadwiślańska Komunikacja Autobusowa",
         "network:wikidata": "Q136485442",
         "route": "bus"
       }

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -13771,9 +13771,13 @@
       "locationSet": {
         "include": ["pl-14.geojson"]
       },
-      "matchNames": ["Otwockie Przewozy Gminno-Powiatowe"],
+      "matchNames": [
+        "Otwockie Przewozy Gminno-Powiatowe",
+        "OPGP"
+      ],
       "tags": {
         "network": "Nadwiślańska Komunikacja Autobusowa",
+        "network:short": "NKA",
         "network:wikidata": "Q136485442",
         "route": "bus"
       }


### PR DESCRIPTION
Update bus network name: "Otwockie Przewozy Gminno-Powiatowe" to "Nadwiślańska Komunikacja Autobusowa". The change reflects the official and currently used name of the transport association.
Sources:
https://www.facebook.com/photo.php?fbid=122202350354053841&set=a.122143595864053841&type=3
https://nka.powiat-otwocki.pl/