### PR TITLE
Updated displayName of PubliBike Velospot Region Bern

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -3347,7 +3347,7 @@
       }
     },
     {
-      "displayName": "PubliBike Velospot (Velo Bern)",
+      "displayName": "PubliBike Velospot (Region Bern)",
       "id": "publibikevelospot-a8de7e",
       "locationSet": {
         "include": [[7.45, 46.95, 10]]


### PR DESCRIPTION
Updated the displayName of PubliBike Velospot Region Bern, reflecting the change of the network name (Velo Bern → Velo Region Bern). I forgot to do this the last time (#11804).