### PR TITLE
Added Polish store brands - Minivita Market, MarketVita Express and MarketVita

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1870,6 +1870,26 @@
       }
     },
     {
+      "displayName": "Minivita Market",
+      "locationSet": {"include": ["pl"]},
+      "tags": {
+        "brand": "Minivita Market",
+        "brand:wikidata": "Q119660457",
+        "name": "Minivita Market",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "MarketVita Express",
+      "locationSet": {"include": ["pl"]},
+      "tags": {
+        "brand": "MarketVita Express",
+        "brand:wikidata": "Q118958725",
+        "name": "MarketVita Express",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "Delikatesy SLAWEX",
       "id": "delikatesyslawex-95f41b",
       "locationSet": {"include": ["pl"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -131,6 +131,16 @@
       }
     },
     {
+      "displayName": "MarketVita",
+      "locationSet": {"include": ["pl"]},
+      "tags": {
+        "brand": "MarketVita",
+        "brand:wikidata": "Q118958720",
+        "name": "MarketVita",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Acme",
       "id": "acme-dde59d",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
These are 3 brands of the same franchise.

There are not many of them in OSM right now.
MarketVita - 22 stores in OSM
MarketVita Express - 33 stores in OSM
Minivita - 20 stores in OSM

But according to the company's website, there are more stores to be mapped:
MarketVita + MarketVita Express - 94 stores overall
Minivita - 86 stores overall