### PR TITLE
Move Hecht

### DIFF
--- a/data/brands/shop/groundskeeping.json
+++ b/data/brands/shop/groundskeeping.json
@@ -5,6 +5,16 @@
   },
   "items": [
     {
+      "displayName": "Hecht",
+      "locationSet": {"include": ["cz", "sk"]},
+      "tags": {
+        "brand": "Hecht",
+        "brand:wikidata": "Q130677979",
+        "name": "Hecht",
+        "shop": "groundskeeping"
+      }
+    },
+    {
       "displayName": "Mountfield",
       "id": "mountfield-9aa91c",
       "locationSet": {"include": ["cz", "sk"]},

--- a/data/brands/shop/hardware.json
+++ b/data/brands/shop/hardware.json
@@ -164,17 +164,6 @@
       }
     },
     {
-      "displayName": "HECHT",
-      "id": "hecht-82539a",
-      "locationSet": {"include": ["cz", "sk"]},
-      "tags": {
-        "brand": "HECHT",
-        "brand:wikidata": "Q130677979",
-        "name": "HECHT",
-        "shop": "hardware"
-      }
-    },
-    {
       "displayName": "Home Hardware",
       "id": "homehardware-98155f",
       "locationSet": {"include": ["ca"]},


### PR DESCRIPTION
Moved Hecht from shop=hardware to shop=groundskeeping. Hecht sells primarily garden machinery, not fasteners.