### PR TITLE
Add Li Auto Supercharger to charging station data 添加理想超级充电站

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -1686,6 +1686,21 @@
       }
     },
     {
+      "displayName": "理想超级充电站",
+      "id": "liautosupercharger-07dd34",
+      "locationSet": {"include": ["cn"]},
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "理想",
+        "brand:en": "Li Auto",
+        "brand:wikidata": "Q98139925",
+        "brand:zh": "理想",
+        "name": "理想超级充电站",
+        "name:en": "Li Auto Supercharger",
+        "name:zh": "理想超级充电站"
+      }
+    },
+    {
       "displayName": "東光高岳",
       "id": "takaokatoko-610a46",
       "locationSet": {

--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -1688,7 +1688,7 @@
     {
       "displayName": "理想超级充电站",
       "id": "liautosupercharger-07dd34",
-      "locationSet": {"include": ["cn"]},
+      "locationSet": {"include": ["cn"], "exclude":["hk","mo"]},
       "tags": {
         "amenity": "charging_station",
         "brand": "理想",


### PR DESCRIPTION
This pull request adds a new charging station brand entry for Li Auto to the `charging_station.json` data file.

Brand data update:

* Added a new entry for "Li Auto Supercharger" (`理想超级充电站`) with relevant tags, including English and Chinese names, brand information, and Wikidata reference, for locations in China.

@LaoshuBaby 