### PR TITLE
Add organic tag for Biomonde and Biocoop brand

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -985,7 +985,8 @@
         "brand": "Biocoop",
         "brand:wikidata": "Q2904039",
         "name": "Biocoop",
-        "shop": "supermarket"
+        "shop": "supermarket",
+        "organic": "only"
       }
     },
     {
@@ -996,7 +997,8 @@
         "brand": "Biomonde",
         "brand:wikidata": "Q120801927",
         "name": "Biomonde",
-        "shop": "supermarket"
+        "shop": "supermarket",
+        "organic": "only"
       }
     },
     {


### PR DESCRIPTION
This PR add `organic=only` tag for [Biomonde](https://www.biomonde.fr/nos-engagements) and [Biocoop](https://www.biocoop.fr/le-projet-biocoop/nos-engagements) brand