### PR TITLE
move battery shop into shop=battery per community discussion

### DIFF
--- a/data/brands/shop/battery.json
+++ b/data/brands/shop/battery.json
@@ -1,0 +1,19 @@
+{
+  "properties": {
+    "path": "brands/shop/battery",
+    "exclude": {"generic": ["^battery$"]}
+  },
+  "items": [
+    {
+      "displayName": "Battery World",
+      "id": "batteryworld-31899b",
+      "locationSet": {"include": ["au"]},
+      "tags": {
+        "brand": "Battery World",
+        "brand:wikidata": "Q124003678",
+        "name": "Battery World",
+        "shop": "battery"
+      }
+    }
+  ]
+}

--- a/data/brands/shop/electrical.json
+++ b/data/brands/shop/electrical.json
@@ -5,17 +5,6 @@
   },
   "items": [
     {
-      "displayName": "Battery World",
-      "id": "batteryworld-31899b",
-      "locationSet": {"include": ["au"]},
-      "tags": {
-        "brand": "Battery World",
-        "brand:wikidata": "Q124003678",
-        "name": "Battery World",
-        "shop": "electrical"
-      }
-    },
-    {
       "displayName": "CEF",
       "id": "cef-7c8ef7",
       "locationSet": {"include": ["gb"]},


### PR DESCRIPTION
https://community.openstreetmap.org/t/shop-exclusively-for-batteries/143333 showed 7 :+1: for using `shop=battery` for a battery shop, so moving this battery shop into a more appropriate tag.

Proposed mass edit suggested at https://discord.com/channels/413070382636072960/471231032645910529/1498505094055067710