### PR TITLE
Use structural resolver type for Matcher.buildLocationIndex

### DIFF
--- a/lib/matcher.ts
+++ b/lib/matcher.ts
@@ -1,7 +1,7 @@
 import { LocationConflation } from '@rapideditor/location-conflation';
 import { simplify } from './simplify.ts';
 
-import type { LocationSetID, Vec2 } from '@rapideditor/location-conflation';
+import type { HasLocationSet, HasLocationSetID, LocationSetID, Vec2 } from '@rapideditor/location-conflation';
 import type { MatchHit, MatchIndexBranch, NsiData, NsiMatchGroupsJSON, NsiPath, NsiTree, NsiTreeProperties } from './types.ts';
 
 // Imported JSON (will be inlined by bun)
@@ -14,6 +14,13 @@ const matchGroups: NsiMatchGroupsJSON['matchGroups'] = matchGroupsJSON.matchGrou
 
 /** Tree configuration keyed by tree name (e.g. `brands`, `operators`). */
 const trees: Record<NsiTree, NsiTreeProperties> = treesJSON.trees;
+
+
+export interface LocationResolver {
+  registerLocationSets<T extends HasLocationSet>(objects: T[]): (T & HasLocationSetID)[];
+  locationSetsAt(loc: Vec2): Map<LocationSetID, number>;
+  getLocationSetArea(locationSetID: LocationSetID): number | undefined;
+}
 
 
 /**
@@ -33,8 +40,8 @@ export class Matcher {
   private matchIndex: Map<string, MatchIndexBranch> | undefined;
   /** Map of generic-word pattern strings to compiled RegExp objects. */
   private genericWords = new Map<string, RegExp>();
-  /** The `LocationConflation` instance used to resolve locationSets (set by {@link buildLocationIndex}). */
-  private loco: LocationConflation | undefined;
+  /** The location resolver used to resolve locationSets (set by {@link buildLocationIndex}). */
+  private loco: LocationResolver | undefined;
   /** Map of item id → locationSetID, populated by {@link buildLocationIndex}. */
   private itemLocationSetID: Map<string, LocationSetID> | undefined;
   /** Warnings collected during index building (e.g. duplicate cache keys). */
@@ -347,7 +354,7 @@ export class Matcher {
    *   Whichever instance is used, the matcher keeps a reference and delegates
    *   `locationSetsAt` / `getLocationSetArea` calls to it at match time.
    */
-  buildLocationIndex(data: NsiData, loco?: LocationConflation): void {
+  buildLocationIndex(data: NsiData, loco?: LocationResolver): void {
     loco = loco ?? new LocationConflation();
     this.loco = loco;
 


### PR DESCRIPTION
## Problem

`Matcher.buildLocationIndex` currently accepts a concrete `LocationConflation` class type.

In consumers that end up with multiple installed copies/versions of `@rapideditor/location-conflation` in their dependency tree, TypeScript reports incompatibility even when declaration files are effectively identical, because class types with private/protected members are nominally checked across declaration origins.

That causes errors like:

- `Types have separate declarations of a private property '_resolved'`

## Solution

Switch the boundary from a concrete class type to a structural interface that describes the methods `Matcher` actually uses:

- `registerLocationSets`
- `locationSetsAt`
- `getLocationSetArea`

`buildLocationIndex` now accepts this resolver interface, while still defaulting to `new LocationConflation()` when no resolver is provided.

## Notes

- Runtime behavior is unchanged.
- Existing callers that pass a real `LocationConflation` instance continue to work.
- This removes nominal class-identity coupling at the API boundary and avoids cross-install TS conflicts for consumers.

## Validation

- `bun run check:types`