### PR TITLE
Add operator and operator:wikidata to Proxym pharmacies

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -3259,6 +3259,8 @@
         "amenity": "pharmacy",
         "brand": "Proxim",
         "brand:wikidata": "Q3408523",
+        "operator": "Corporation Groupe Pharmessor",
+        "operator:wikidata": "Q139621965",
         "healthcare": "pharmacy",
         "name": "Proxim"
       }


### PR DESCRIPTION
Operator [Corporation Groupe Pharmessor](https://www.wikidata.org/wiki/Q139621965) has been added for this pharmacy chain.