### PR TITLE
Add places leisure to UK Sports Centre Brands

### DIFF
--- a/data/brands/leisure/sports_centre.json
+++ b/data/brands/leisure/sports_centre.json
@@ -307,11 +307,7 @@
       "tags": {
         "brand": "Places Leisure",
         "brand:wikidata": "Q130223830",
-        "fee": "yes",
-        "leisure": "sports_centre",
-        "operator": "Places For People Leisure Limited",
-        "operator:type": "private_non_profit",
-        "operator:wikidata": "Q130223830"
+        "leisure": "sports_centre"
       }
     },
     {

--- a/data/brands/leisure/sports_centre.json
+++ b/data/brands/leisure/sports_centre.json
@@ -301,6 +301,20 @@
       }
     },
     {
+      "displayName": "Places Leisure",
+      "locationSet": {"include": ["gb"]},
+      "matchNames": ["places leisure"],
+      "tags": {
+        "brand": "Places Leisure",
+        "brand:wikidata": "Q130223830",
+        "fee": "yes",
+        "leisure": "sports_centre",
+        "operator": "Places For People Leisure Limited",
+        "operator:type": "private_non_profit",
+        "operator:wikidata": "Q130223830"
+      }
+    },
+    {
       "displayName": "Poliesportiu Municipal",
       "id": "poliesportiumunicipal-b5508a",
       "locationSet": {"include": ["es"]},


### PR DESCRIPTION
Adding Places Leisure who operate about 90 leisure centres in England and Scotland.