### PR TITLE
Add 'Just in Case' brand to mobile phone accessories

### DIFF
--- a/data/brands/shop/mobile_phone_accessories.json
+++ b/data/brands/shop/mobile_phone_accessories.json
@@ -28,6 +28,18 @@
       }
     },
     {
+      "displayName": "Just in Case",
+      "locationSet": {
+        "include": ["it"]
+      },
+      "tags": {
+        "brand": "Just in Case",
+        "brand:wikidata": "Q139700407",
+        "name": "Just in Case",
+        "shop": "mobile_phone_accessories"
+      }
+    },
+    {
       "displayName": "La Casa de las Carcasas",
       "id": "lacasadelascarcasas-09f8fb",
       "locationSet": {


### PR DESCRIPTION
It's an Italian franchise of mobile phone accessories (mostly covers) with over 100 stores.

Store locator: https://justincaseitalia.it/pages/store-locator
Wikidata item: https://www.wikidata.org/wiki/Q139700407