### PR TITLE
Update bus.json

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -8477,20 +8477,6 @@
       }
     },
     {
-      "displayName": "JRバス関東",
-      "id": "jrbuskanto-54d9ea",
-      "locationSet": {
-        "include": ["jp-12.geojson"]
-      },
-      "tags": {
-        "network": "JRバス関東",
-        "network:en": "JR Bus Kanto",
-        "network:ja": "JRバス関東",
-        "network:wikidata": "Q10851155",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "JTA (Jackson)",
       "id": "jacksontransitauthority-ae7ebe",
       "locationSet": {
@@ -25553,6 +25539,13 @@
       "locationSet": {
         "include": ["jp-01.geojson"]
       },
+      "matchNames": [
+        "JR北海道バス",
+        "ジェイアール北海道バス",
+        "JRバス北海道",
+        "ジェイアールバス北海道",
+        "北海道ジェイアールバス"
+      ],
       "tags": {
         "network": "ジェイ・アール北海道バス",
         "network:en": "JR Hokkaido Bus",
@@ -25562,6 +25555,182 @@
         "operator:en": "JR Hokkaido Bus",
         "operator:ja": "ジェイ・アール北海道バス",
         "operator:wikidata": "Q6108885",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "ジェイアールバス東北",
+      "id": "jrbustohoku-54d9ea",
+      "locationSet": {
+        "include": ["jp-tohoku.geojson"]
+      },
+      "matchNames": [
+        "JRバス東北",
+        "JR東北バス",
+        "ジェイアール東北バス",
+        "ジェイ・アール東北バス",
+        "東北ジェイアールバス"
+      ],
+      "tags": {
+        "network": "ジェイアールバス東北",
+        "network:en": "JR Bus Tohoku",
+        "network:ja": "ジェイアールバス東北",
+        "network:wikidata": "Q8190558",
+        "operator": "ジェイアールバス東北",
+        "operator:en": "JR Bus Tohoku",
+        "operator:ja": "ジェイアールバス東北",
+        "operator:wikidata": "Q8190558",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "ジェイアールバス関東",
+      "id": "jrbuskanto-54d9ea",
+      "locationSet": {
+        "include": ["jp-kanto.geojson"]
+      },
+      "matchNames": [
+        "JRバス関東",
+        "JR関東バス",
+        "ジェイアール関東バス",
+        "ジェイ・アール関東バス",
+        "関東ジェイアールバス"
+      ],
+      "tags": {
+        "network": "ジェイアールバス関東",
+        "network:en": "JR Bus Kanto",
+        "network:ja": "ジェイアールバス関東",
+        "network:wikidata": "Q10851155",
+        "operator": "ジェイアールバス関東",
+        "operator:en": "JR Bus Kanto",
+        "operator:ja": "ジェイアールバス関東",
+        "operator:wikidata": "Q10851155",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "ジェイアール東海バス",
+      "id": "jrtokaibus-54d9ea",
+      "locationSet": {
+        "include": ["jp-chubu.geojson"]
+      },
+      "matchNames": [
+        "JR東海バス",
+        "ジェイ・アール東海バス",
+        "JRバス東海",
+        "ジェイアールバス東海",
+        "東海ジェイアールバス"
+      ],
+      "tags": {
+        "network": "ジェイアール東海バス",
+        "network:en": "JR Tokai Bus",
+        "network:ja": "ジェイアール東海バス",
+        "network:wikidata": "Q10851158",
+        "operator": "ジェイアール東海バス",
+        "operator:en": "JR Tokai Bus",
+        "operator:ja": "ジェイアール東海バス",
+        "operator:wikidata": "Q10851158",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "西日本ジェイアールバス",
+      "id": "westjapanjrbus-54d9ea",
+      "locationSet": {
+        "include": ["jp-kinki.geojson","jp-hokuriku.geojson"]
+      },
+      "matchNames": [
+        "西日本JRバス",
+        "JR西日本バス",
+        "JRバス西日本",
+        "ジェイ・アール西日本バス",
+        "ジェイアール西日本バス",
+        "ジェイアールバス西日本"
+      ],
+      "tags": {
+        "network": "西日本ジェイアールバス",
+        "network:en": "West Japan JR Bus",
+        "network:ja": "西日本ジェイアールバス",
+        "network:wikidata": "Q11628360",
+        "operator": "西日本ジェイアールバス",
+        "operator:en": "West Japan JR Bus",
+        "operator:ja": "西日本ジェイアールバス",
+        "operator:wikidata": "Q11628360",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "JRバス中国",
+      "id": "jrbuschugoku-54d9ea",
+      "locationSet": {
+        "include": ["jp-chugoku.geojson"]
+      },
+      "matchNames": [
+        "ジェイアールバス中国",
+        "JR中国バス",
+        "ジェイ・アール中国バス",
+        "ジェイアール中国バス",
+        "中国ジェイアールバス"
+      ],
+      "tags": {
+        "network": "JRバス中国",
+        "network:en": "JR Bus Chugoku",
+        "network:ja": "JRバス中国",
+        "network:wikidata": "Q10874403",
+        "operator": "JRバス中国",
+        "operator:en": "JR Bus Chugoku",
+        "operator:ja": "JRバス中国",
+        "operator:wikidata": "Q10874403",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "ジェイアール四国バス",
+      "id": "jrshikokubus-54d9ea",
+      "locationSet": {
+        "include": ["jp-shikoku.geojson"]
+      },
+      "matchNames": [
+        "JR四国バス",
+        "ジェイ・アール四国バス",
+        "JRバス四国",
+        "ジェイアールバス四国",
+        "四国ジェイアールバス"
+      ],
+      "tags": {
+        "network": "ジェイアール四国バス",
+        "network:en": "JR Shikoku Bus",
+        "network:ja": "ジェイアール四国バス",
+        "network:wikidata": "Q10851154",
+        "operator": "ジェイアール四国バス",
+        "operator:en": "JR Shikoku Bus",
+        "operator:ja": "ジェイアール四国バス",
+        "operator:wikidata": "Q10851154",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "JR九州バス",
+      "id": "jrkyushubus-54d9ea",
+      "locationSet": {
+        "include": ["jp-kyushu.geojson"]
+      },
+      "matchNames": [
+        "ジェイアール九州バス",
+        "JRバス九州",
+        "ジェイ・アール九州バス",
+        "ジェイアールバス九州",
+        "九州ジェイアールバス"
+      ],
+      "tags": {
+        "network": "JR九州バス",
+        "network:en": "JR Kyushu Bus",
+        "network:ja": "JR九州バス",
+        "network:wikidata": "Q10851153",
+        "operator": "JR九州バス",
+        "operator:en": "JR Kyushu Bus",
+        "operator:ja": "JR九州バス",
+        "operator:wikidata": "Q10851153",
         "route": "bus"
       }
     },
@@ -25674,6 +25843,28 @@
         "network:en": "Mamebus",
         "network:ja": "まめバス",
         "network:wikidata": "Q11278520",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "ヤサカバス",
+      "id": "yasakabus-c21c87",
+      "locationSet": {
+        "include": ["jp-26.geojson"]
+      },
+      "matchNames": [
+        "彌榮自動車",
+        "ヤサカグループ"
+      ],
+      "tags": {
+        "network": "ヤサカバス",
+        "network:en": "Yasaka Bus",
+        "network:ja": "ヤサカバス",
+        "network:wikidata": "Q11345014",
+        "operator": "ヤサカバス",
+        "operator:en": "Yasaka Bus",
+        "operator:ja": "ヤサカバス",
+        "operator:wikidata": "Q11345014",
         "route": "bus"
       }
     },
@@ -25839,16 +26030,43 @@
       }
     },
     {
+      "displayName": "京都バス",
+      "id": "kyotobus-c21c87",
+      "locationSet": {
+        "include": ["jp-26.geojson"]
+      },
+      "tags": {
+        "network": "京都バス",
+        "network:en": "Kyoto Bus",
+        "network:ja": "京都バス",
+        "network:wikidata": "Q11374813",
+        "operator": "京都バス",
+        "operator:en": "Kyoto Bus",
+        "operator:ja": "京都バス",
+        "operator:wikidata": "Q11374813",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "京都市営バス",
       "id": "kyotocitybus-c21c87",
       "locationSet": {
         "include": ["jp-26.geojson"]
       },
+      "matchNames": [
+        "京都市交通局",
+        "京都市交",
+        "京都市バス"
+      ],
       "tags": {
         "network": "京都市営バス",
         "network:en": "Kyoto City Bus",
         "network:ja": "京都市営バス",
         "network:wikidata": "Q4858667",
+        "operator": "京都市交通局",
+        "operator:en": "Kyoto Municipal Transportation Bureau",
+        "operator:ja": "京都市交通局",
+        "operator:wikidata": "Q5359594",
         "route": "bus"
       }
     },


### PR DESCRIPTION
I edited and added information about bus companies in Japan.

- ジェイ・アール北海道バス / JR Hokkaido Bus
- ジェイアールバス東北 / JR Bus Tohoku
- ジェイアールバス関東 / JR Bus Kanto
- ジェイアール東海バス / JR Tokai Bus
- 西日本ジェイアールバス / West Japan JR Bus
- JRバス中国 / JR Bus Chugoku
- ジェイアール四国バス / JR Shikoku Bus
- JR九州バス / JR Kyushu Bus
- ヤサカバス / Yasaka Bus
- 京都バス / Kyoto Bus
- 京都市営バス（京都市交通局） / Kyoto City Bus (Kyoto Municipal Transportation Bureau)
