### PR TITLE
Add Nordic ATM-networks and fix danish second-hand chains.

### DIFF
--- a/data/brands/amenity/atm.json
+++ b/data/brands/amenity/atm.json
@@ -374,13 +374,27 @@
       }
     },
     {
-      "displayName": "Kontanten",
+      "displayName": "Kontanten (Sweden)",
       "id": "kontanten-70ef7e",
-      "locationSet": {"include": ["dk", "se"]},
+      "locationSet": {"include": ["se"]},
       "tags": {
         "amenity": "atm",
         "brand": "Kontanten",
-        "brand:wikidata": "Q126902178"
+        "brand:wikidata": "Q126902178",
+        "operator": "Kontanten",
+        "operator:wikidata": "Q126902178"
+      }
+    },
+    {
+      "displayName": "Kontanten (Denmark)",
+      "id": "kontanten-70ef7e",
+      "locationSet": {"include": ["dk"]},
+      "tags": {
+        "amenity": "atm",
+        "brand": "Kontanten",
+        "brand:wikidata": "Q126902178",
+        "operator": "Nokas",
+        "operator:wikidata": "Q12307591"
       }
     },
     {
@@ -433,7 +447,7 @@
       }
     },
     {
-      "displayName": "Nokas",
+      "displayName": "Nokas (Norway)",
       "id": "nokas-924d4d",
       "locationSet": {"include": ["no"]},
       "tags": {
@@ -441,10 +455,40 @@
         "brand": "Nokas",
         "brand:en": "Nokas",
         "brand:wikidata": "Q7047836",
-        "name": "Nokas",
-        "name:en": "Nokas"
+        "network": "Nokas",
+        "network:wikidata": "Q7047836",
+        "operator": "Nokas",
+        "operator:wikidata": "Q7047836"
       }
     },
+    {
+      "displayName": "Nokas (Denmark)",
+      "locationSet": {"include": ["dk"]},
+      "tags": {
+        "amenity": "atm",
+        "brand": "Nokas",
+        "brand:en": "Nokas",
+        "brand:wikidata": "Q7047836",
+        "network": "Nokas",
+        "network:wikidata": "Q7047836",
+        "operator": "Nokas",
+        "operator:wikidata": "Q12307591"
+     }
+    },
+    {
+      "displayName": "Nosto",
+      "locationSet": {"include": ["fi"]},
+      "tags": {
+        "amenity": "atm",
+        "brand": "Nosto",
+        "brand:wikidata": "Q18693836",
+        "network": "Nosto",
+        "network:wikidata": "Q18693836",
+        "operator": "Nokas",
+        "operator:wikidata": "Q139719299"
+     }
+    },
+
     {
       "displayName": "NoteMachine",
       "id": "notemachine-396707",

--- a/data/brands/shop/charity.json
+++ b/data/brands/shop/charity.json
@@ -72,7 +72,7 @@
         "name": "Blå Kors Genbrug",
         "operator": "Blå Kors Danmark",
         "operator:wikidata": "Q123178402",
-        "second_hand": "yes",
+        "second_hand": "only",
         "shop": "charity"
       }
     },
@@ -170,7 +170,7 @@
         "name": "Danmission Genbrug",
         "operator": "Danmission",
         "operator:wikidata": "Q11964723",
-        "second_hand": "yes",
+        "second_hand": "only",
         "shop": "charity"
       }
     },
@@ -182,7 +182,7 @@
       "tags": {
         "brand": "Dansk Røde Kors Genbrug",
         "brand:wikidata": "Q12307527",
-        "name": "Dansk Røde Kors Genbrug",
+        "name": "Røde Kors Butik",
         "second_hand": "only",
         "shop": "charity"
       }
@@ -313,12 +313,12 @@
       "id": "kirkenskorshaergenbrug-40689c",
       "locationSet": {"include": ["dk"]},
       "tags": {
-        "brand": "Kirkens Korshær Genbrug",
+        "brand": "Kirkens Korshær",
         "brand:wikidata": "Q12321915",
         "name": "Kirkens Korshær Genbrug",
-        "operator": "Kirkens Korshær Genbrug",
+        "operator": "Kirkens Korshær",
         "operator:wikidata": "Q12321915",
-        "second_hand": "yes",
+        "second_hand": "only",
         "shop": "charity"
       }
     },
@@ -388,7 +388,7 @@
         "name": "Mission Afrika Genbrug",
         "operator": "Mission Afrika",
         "operator:wikidata": "Q12327349",
-        "second_hand": "yes",
+        "second_hand": "only",
         "shop": "charity"
       }
     },


### PR DESCRIPTION
I realised that the proper value for the second-hand chains is `recycling=only` rather than `recycling=yes`. There was also some wrong `name=` and `brand` of the second-hand chains, so I fixed that.

The main thing in this PR is adding the country specific operators of Nokas' atm-network across the Nordics. I also added the finnish nosto network which is also operated by Nokas through a finnish subsidiary.