### PR TITLE
Update atm.json adding new brand Nosto in FI

### DIFF
--- a/data/brands/amenity/atm.json
+++ b/data/brands/amenity/atm.json
@@ -708,6 +708,15 @@
         "brand:wikidata": "Q709259",
         "brand:zh": "中華郵政"
       }
+    },
+    {
+      "displayName": "Nosto",
+      "locationSet": {"include": ["fi"]},
+      "tags": {
+        "amenity": "atm",
+        "brand": "Nosto",
+        "brand:wikidata": "Q139719299"
+      }
     }
   ]
 }


### PR DESCRIPTION
Added new ATM network for Finland.
https://nostoautomaatti.fi/ , it is the consumer-facing website for the Nosto ATM network operated by Nokas. Nokas CMS Oy (Q139719299)