### PR TITLE
Add Boston Public Library

### DIFF
--- a/data/operators/amenity/library.json
+++ b/data/operators/amenity/library.json
@@ -3259,6 +3259,18 @@
         "operator:wikidata": "Q15900287",
         "operator:zh": "高雄市立圖書館"
       }
+    },
+    {
+      "displayName": "Boston Public Library",
+      "locationSet": {
+        "include": ["us-ma.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Boston Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q894583"
+      }
     }
   ]
 }


### PR DESCRIPTION
This pull request adds Boston Public Library to library.json

Wikidata item: [wikidata.org/wiki/Q894583](https://www.wikidata.org/wiki/Q894583)
Location URL: [bpl.bibliocommons.com/v2/locations](https://bpl.bibliocommons.com/v2/locations)