### PR TITLE
feat: add Deli de Luca

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1838,6 +1838,23 @@
       }
     },
     {
+      "displayName": "Deli de Luca",
+      "id": "delideluca-2da37b",
+      "locationSet": {"include": ["no"]},
+      "matchTags": [
+        "amenity/fast_food",
+        "amenity/restaurant",
+        "shop/deli"
+      ],
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Deli de Luca",
+        "brand:wikidata": "Q11965047",
+        "name": "Deli de Luca",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "Delikatesy Centrum",
       "id": "delikatesycentrum-95f41b",
       "locationSet": {"include": ["pl"]},


### PR DESCRIPTION
Adds Deli de Luca to the Norway `shop=convenience` brand index with Wikidata tag `Q11965047`.

The entry uses the canonical spelling `Deli de Luca`, preserves existing `name=*` values for branch-qualified stores, and includes observed alternate tagging from current OSM data via `matchTags`.

**Verification:**
- Checked Wikidata Q11965047: https://www.wikidata.org/wiki/Q11965047
- Checked Norway retail tagging https://wiki.openstreetmap.org/wiki/Norway/Retail_stores
- Checked existing OSM Deli de Luca objects in Norway
- Ran `bun run all`