### PR TITLE
feat: add Anton Sport

### DIFF
--- a/data/brands/shop/sports.json
+++ b/data/brands/shop/sports.json
@@ -74,6 +74,19 @@
       }
     },
     {
+      "displayName": "Anton Sport",
+      "id": "antonsport-6faf2d",
+      "locationSet": {"include": ["no"]},
+      "matchTags": ["shop/bicycle"],
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Anton Sport",
+        "brand:wikidata": "Q11958427",
+        "name": "Anton Sport",
+        "shop": "sports"
+      }
+    },
+    {
       "displayName": "Arei Outdoor Gear",
       "id": "areioutdoorgear-f9c896",
       "locationSet": {"include": ["id"]},


### PR DESCRIPTION
Adds Anton Sport to the Norway `shop=sports` brand index with Wikidata tag `Q11958427`.

The entry uses the canonical `Anton Sport` name, preserves existing `name=*` values for branch-qualified stores, and matches observed `shop=bicycle` tagging in OSM.

**Verification:**

- Checked Wikidata Q11958427 https://www.wikidata.org/wiki/Q11958427
- Checked Norway retail tagging https://wiki.openstreetmap.org/wiki/Norway/Retail_stores
- Checked existing OSM Anton Sport objects in Norway
- Ran `bun run all`
