### PR TITLE
feat: add Princess

### DIFF
--- a/data/brands/shop/household_linen.json
+++ b/data/brands/shop/household_linen.json
@@ -93,6 +93,18 @@
       }
     },
     {
+      "displayName": "Princess",
+      "id": "princess-84d058",
+      "locationSet": {"include": ["no"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Princess",
+        "brand:wikidata": "Q127790786",
+        "name": "Princess",
+        "shop": "household_linen"
+      }
+    },
+    {
       "displayName": "QE Home",
       "id": "qehome-f35021",
       "locationSet": {"include": ["ca"]},


### PR DESCRIPTION
Adds Princess to the Norway `shop=household_linen` brand index with Wikidata tag `Q127790786`.

The entry uses the canonical `Princess` name and preserves existing `name=*` values for branch-qualified stores.

**Verification:**

- Checked Wikidata Q127790786 https://www.wikidata.org/wiki/Q127790786
- Checked wiki https://wiki.openstreetmap.org/wiki/Norway/Retail_stores
- Checked existing OSM Princess objects in Norway
- Ran `bun run all`
