### PR TITLE
feat: add Kaffebrenneriet

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -2911,6 +2911,20 @@
       }
     },
     {
+      "displayName": "Kaffebrenneriet",
+      "id": "kaffebrenneriet-d290fd",
+      "locationSet": {"include": ["no"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "amenity": "cafe",
+        "brand": "Kaffebrenneriet",
+        "brand:wikidata": "Q6346093",
+        "cuisine": "coffee_shop",
+        "name": "Kaffebrenneriet",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Kahve Dünyası",
       "id": "kahvedunyasi-9278bc",
       "locationSet": {


### PR DESCRIPTION
Adds Kaffebrenneriet to the Norway `amenity=cafe` brand index with Wikidata tag `Q6346093`.

The entry uses the canonical `Kaffebrenneriet` name, preserves existing `name=*` values for branch-qualified stores, and adds standard coffee shop tagging with `cuisine=coffee_shop` and `takeaway=yes`.

**Verification:**

- Checked Wikidata Q6346093 https://www.wikidata.org/wiki/Q6346093
- Checked existing OSM Kaffebrenneriet objects in Norway https://nominatim.openstreetmap.org/search?format=jsonv2&countrycodes=no&limit=50&extratags=1&namedetails=1&q=Kaffebrenneriet
- Ran `bun run all`
