### PR TITLE
feat: add Tilbords

### DIFF
--- a/data/brands/shop/kitchen.json
+++ b/data/brands/shop/kitchen.json
@@ -415,6 +415,18 @@
       }
     },
     {
+      "displayName": "Tilbords",
+      "id": "tilbords-17151f",
+      "locationSet": {"include": ["no"]},
+      "matchTags": ["shop/houseware"],
+      "tags": {
+        "brand": "Tilbords",
+        "brand:wikidata": "Q19392507",
+        "name": "Tilbords",
+        "shop": "kitchen"
+      }
+    },
+    {
       "displayName": "Tulp Keukens",
       "id": "tulpkeukens-169f26",
       "locationSet": {"include": ["nl"]},


### PR DESCRIPTION
Adds Tilbords to the Norway `shop=kitchen` brand index with Wikidata tag `Q19392507`.

The entry uses the `Tilbords` name, matches in osm observed with `shop=houseware` tagging, and some `Tilbords AS` name variant.

**Verification:**
- Checked Wikidata Q19392507 https://www.wikidata.org/wiki/Q19392507
- Checked Norway retail tagging https://wiki.openstreetmap.org/wiki/Norway/Retail_stores
- Checked existing OSM Tilbords objects in Norway
- Ran `bun run all`
