### PR TITLE
feat: add bakerhansen

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -440,6 +440,20 @@
       }
     },
     {
+      "displayName": "Baker Hansen",
+      "id": "bakerhansen-d290fd",
+      "locationSet": {"include": ["no"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "amenity": "cafe",
+        "brand": "Baker Hansen",
+        "brand:wikidata": "Q11960022",
+        "cuisine": "bakery;coffee_shop",
+        "name": "Baker Hansen",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Bakers + Baristas",
       "id": "bakersbaristas-ff9b1e",
       "locationSet": {"include": ["gb", "ie"]},


### PR DESCRIPTION
Adds Baker Hansen to the Norway `amenity=cafe` brand index with Wikidata tag `Q11960022`.

**Verification:**
- Checked Wikidata Q11960022 https://www.wikidata.org/wiki/Q11960022
- Checked Norway retail tagging https://wiki.openstreetmap.org/wiki/Norway/Retail_stores
- Checked existing OSM Tilbords objects in Norway
- Ran `bun run all`
