### PR TITLE
feat: add Brilleland

### DIFF
--- a/data/brands/shop/optician.json
+++ b/data/brands/shop/optician.json
@@ -208,6 +208,17 @@
       }
     },
     {
+      "displayName": "Brilleland",
+      "id": "brilleland-4ee896",
+      "locationSet": {"include": ["no"]},
+      "tags": {
+        "brand": "Brilleland",
+        "brand:wikidata": "Q11962280",
+        "name": "Brilleland",
+        "shop": "optician"
+      }
+    },
+    {
       "displayName": "Brillen Rottler",
       "id": "brillenrottler-7fb7e9",
       "locationSet": {"include": ["de"]},


### PR DESCRIPTION
**Add Brilleland (Q11962280) to brands/shop/optician**

Adds [Brilleland](https://www.wikidata.org/wiki/Q11962280), a Norwegian optician chain, to the name-suggestion-index.

- **Wikidata:** [Q11962280](https://www.wikidata.org/wiki/Q11962280)
- **Location:** Norway (`no`)
- **Category:** `shop=optician`
- **OSM prevalence:** 22 objects (20 nodes, 2 ways) — all tagged `shop=optician` + `brand=Brilleland`
- **Actual store count:** Around ~80 retail locations cross Norway
- **Website:** https://www.brilleland.no/

Tags are based on existing OSM usage (e.g. [node/1329411499](https://www.openstreetmap.org/node/1329411499)).