### PR TITLE
fix: update wikidata to non-redirected entries

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -940,7 +940,7 @@
         "brand": "Arab African International Bank",
         "brand:ar": "البنك العربي الإفريقي الدولي",
         "brand:en": "Arab African International Bank",
-        "brand:wikidata": "Q126391861",
+        "brand:wikidata": "Q12184644",
         "name": "Arab African International Bank",
         "name:ar": "البنك العربي الإفريقي الدولي",
         "name:en": "Arab African International Bank"

--- a/data/brands/amenity/vehicle_inspection.json
+++ b/data/brands/amenity/vehicle_inspection.json
@@ -259,7 +259,7 @@
         "brand:en": "Greenway",
         "brand:ka": "გრინვეი",
         "brand:ru": "Гринвей",
-        "brand:wikidata": "Q134735986",
+        "brand:wikidata": "Q59843664",
         "name": "გრინვეი",
         "name:en": "Greenway",
         "name:ka": "გრინვეი",

--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -8404,7 +8404,7 @@
       "locationSet": {"include": ["001"]},
       "tags": {
         "brand": "ONLY",
-        "brand:wikidata": "Q61799370",
+        "brand:wikidata": "Q12329792",
         "name": "ONLY",
         "shop": "clothes"
       }

--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -112,7 +112,7 @@
       "tags": {
         "amenity": "charging_station",
         "operator": "Acea Energia",
-        "operator:wikidata": "Q113465154"
+        "operator:wikidata": "Q3604235"
       }
     },
     {


### PR DESCRIPTION
Fixes redirected wikidata entries for the following NSI objects:
- Arab African International Bank - [Q126391861](https://www.wikidata.org/wiki/Q126391861) -> [Q12184644](https://www.wikidata.org/wiki/Q12184644)
- Greenway - [Q134735986](https://www.wikidata.org/wiki/Q134735986) -> [Q12329792](https://www.wikidata.org/wiki/Q12329792)
- ONLY - [Q61799370](https://www.wikidata.org/wiki/Q61799370) -> [Q12329792](https://www.wikidata.org/wiki/Q12329792)
- Acea Energia - [Q113465154](https://www.wikidata.org/wiki/Q113465154) -> [Q3604235](https://www.wikidata.org/wiki/Q3604235)

Seems like all where correctly edited by Wikidata contributors by merging duplicates