### PR TITLE
feat: add Espira kindergarten entry

### DIFF
--- a/data/brands/amenity/kindergarten.json
+++ b/data/brands/amenity/kindergarten.json
@@ -223,7 +223,7 @@
     },
     {
       "displayName": "Espira",
-      "id": "espira-167e3f",
+      "id": "espira-87cca0",
       "locationSet": {"include": ["no"]},
       "tags": {
         "amenity": "kindergarten",

--- a/data/brands/amenity/kindergarten.json
+++ b/data/brands/amenity/kindergarten.json
@@ -222,6 +222,16 @@
       }
     },
     {
+      "displayName": "Espira",
+      "id": "espira-167e3f",
+      "locationSet": {"include": ["no"]},
+      "tags": {
+        "amenity": "kindergarten",
+        "brand": "Espira",
+        "brand:wikidata": "Q21592512"
+      }
+    },
+    {
       "displayName": "Guidepost Montessori",
       "id": "guidepostmontessori-b03e52",
       "locationSet": {


### PR DESCRIPTION
Adds [Espira](https://www.wikidata.org/wiki/Q21592512), a Norwegian chain of private kindergartens.

| Field    | Value                                                |
| -------- | ---------------------------------------------------- |
| Brand    | Espira                                               |
| Wikidata | [Q21592512](https://www.wikidata.org/wiki/Q21592512) |
| Category | `amenity=kindergarten`                               |
| Location | Norway (`no`)                                        |
