### PR TITLE
Rōti Modern Mediterranean

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -9194,6 +9194,20 @@
       }
     },
     {
+      "displayName": "Rōti Modern Mediterranean",
+      "locationSet": {
+        "include": ["gb-eng", "us"]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Rōti Modern Mediterranean",
+        "brand:wikidata": "Q137217049",
+        "cuisine": "mediterranean",
+        "name": "Rōti Modern Mediterranean",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Roy Rogers",
       "id": "royrogers-4d2ff4",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
Add Rōti Modern Mediterranean, an American fast casual brand, which is opening locations in England.