### PR TITLE
Add `operator:kw` and `network:kw` to Cornwall Council and Transport for Cornwall

### DIFF
--- a/data/operators/amenity/school.json
+++ b/data/operators/amenity/school.json
@@ -12902,6 +12902,7 @@
       "tags": {
         "amenity": "school",
         "operator": "Cornwall Council",
+        "operator:kw": "Konsel Kernow",
         "operator:type": "government",
         "operator:wikidata": "Q3774189"
       }

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -20354,6 +20354,7 @@
       },
       "tags": {
         "network": "Transport for Cornwall",
+        "network:kw": "Karyans rag Kernow",
         "network:wikidata": "Q117290050",
         "route": "bus"
       }


### PR DESCRIPTION
Follow-up to https://github.com/osmlab/name-suggestion-index/pull/11949, adds a missed `operator:kw=Konsel Kernow` and adds `network:kw=Karyans rag Kernow`