### PR TITLE
Update Interstate Batteries

### DIFF
--- a/data/brands/shop/car_parts.json
+++ b/data/brands/shop/car_parts.json
@@ -349,7 +349,8 @@
         "brand": "Interstate Batteries",
         "brand:wikidata": "Q12060773",
         "name": "Interstate Batteries",
-        "shop": "car_parts"
+        "shop": "car_parts",
+        "car_parts": "battery"
       }
     },
     {


### PR DESCRIPTION
Add `car_parts=battery` to show specialization in batteries.

Using precedent set by #7877 (specifically 6393d39) with similar usage quantity `cuisine=milkshake` tag. 61 vs 63 uses.