### PR TITLE
Remove Great Western Bank

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -7181,7 +7181,8 @@
         "1st interstate",
         "1st interstate bancsystem",
         "1st interstate bank",
-        "first interstate"
+        "first interstate",
+        "great western bank"
       ],
       "tags": {
         "amenity": "bank",
@@ -7766,17 +7767,6 @@
         "short_name": "GKB",
         "short_name:de": "GKB",
         "short_name:it": "BCG"
-      }
-    },
-    {
-      "displayName": "Great Western Bank",
-      "id": "greatwesternbank-ea2e2d",
-      "locationSet": {"include": ["us"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "Great Western Bank",
-        "brand:wikidata": "Q5600185",
-        "name": "Great Western Bank"
       }
     },
     {


### PR DESCRIPTION
> expected to occur in May 2022. After this conversion, Great Western Bank branches will be branded as First Interstate Bank branches.

https://www.businesswire.com/news/home/20220201005250/en/First-Interstate-BancSystem-Inc.-Completes-Merger-with-Great-Western-Bancorp-Inc.