### PR TITLE
Remove First Republic Bank

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -7294,17 +7294,6 @@
       }
     },
     {
-      "displayName": "First Republic Bank",
-      "id": "firstrepublicbank-ea2e2d",
-      "locationSet": {"include": ["us"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "First Republic Bank",
-        "brand:wikidata": "Q5453752",
-        "name": "First Republic Bank"
-      }
-    },
-    {
       "displayName": "First Security Bank (Arkansas)",
       "id": "firstsecuritybank-76df1a",
       "locationSet": {


### PR DESCRIPTION
https://www.firstrepublic.com/404

I'm unsure if all the locations went to JPMorgan Chase so no match name, just gone.