### PR TITLE
chore: regenerate sitemap

### DIFF
--- a/.github/workflows/sitemap.yml
+++ b/.github/workflows/sitemap.yml
@@ -1,0 +1,35 @@
+name: regenerate sitemap
+
+on:
+  push:
+    tags:
+      - '**'
+  workflow_dispatch:
+
+env:
+  FORCE_COLOR: 2
+
+jobs:
+  sitemap:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: main
+        fetch-depth: 0    # full history so `git log` can compute per-file lastmod
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: latest
+    - run: bun install
+    - run: bun run dist:sitemap
+    - name: Open PR
+      uses: peter-evans/create-pull-request@v8
+      with:
+        commit-message: 'chore: regenerate sitemap'
+        title: 'chore: regenerate sitemap'
+        body: |
+          Regenerates `docs/sitemap.xml` after tag `${{ github.ref_name }}`.
+        branch: chore/regenSitemap
+        add-paths: docs/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -3,2011 +3,2046 @@
   <url>
     <loc>https://nsi.guide/index.html</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=advertising&amp;v=totem</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=animal_boarding</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=animal_shelter</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=atm</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=bank</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=bar</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=bicycle_parking</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=bicycle_rental</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=bicycle_repair_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=bureau_de_change</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=cafe</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=car_rental</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=car_sharing</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=car_wash</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=casino</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=charging_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=childcare</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=cinema</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=clinic</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=college</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=community_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=conference_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=dentist</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=doctors</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=driving_school</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=fast_food</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=food_sharing</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=fuel</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=gambling</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=hospital</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=ice_cream</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=internet_cafe</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=karaoke_box</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=kindergarten</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=language_school</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=library</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=money_transfer</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=mortuary</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=motorcycle_rental</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=music_school</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=parcel_locker</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=parking</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=payment_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=payment_terminal</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=pharmacy</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=photo_booth</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=post_depot</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=post_office</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=prep_school</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=pub</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=public_bookcase</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=recycling</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=restaurant</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=school</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=social_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=social_facility</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=telephone</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=training</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=trolley_bay</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=university</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=vehicle_inspection</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=vending_machine</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=veterinary</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=waste_basket</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=weighbridge</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=club&amp;v=freemasonry</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=club&amp;v=scout</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=carpenter</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=cleaning</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=electrician</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=electronics_repair</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=glaziery</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=handicraft</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+  </url>
+  <url>
+    <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=painter</loc>
+    <changefreq>weekly</changefreq>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=plumber</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=signmaker</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=window_construction</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=emergency&amp;v=ambulance_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+  </url>
+  <url>
+    <loc>https://nsi.guide/index.html?t=brands&amp;k=emergency&amp;v=lifeguard</loc>
+    <changefreq>weekly</changefreq>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=alternative</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=audiologist</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=blood_donation</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=counselling</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=laboratory</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=physiotherapist</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=rehabilitation</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=sample_collection</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=highway&amp;v=services</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=landuse&amp;v=industrial</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=landuse&amp;v=residential</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=adult_gaming_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=amusement_arcade</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=bowling_alley</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=dance</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=dog_park</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=escape_game</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=fitness_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=fitness_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=high_ropes_course</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=indoor_play</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=miniature_golf</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=playground</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=sports_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=trampoline_park</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=man_made&amp;v=charge_point</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=association</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=bail_bond_agent</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=company</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=consulting</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=coworking</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=employment_agency</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=engineer</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=estate_agent</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=financial</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=financial_advisor</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=government</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=insurance</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=insurance_adjuster</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=it</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=lawyer</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=logistics</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=mortgage</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=moving_company</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=political_party</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=security</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=tax_advisor</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=telecommunication</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=union</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=agrarian</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=alcohol</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=anime</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=appliance</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=art</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=baby_goods</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=bag</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=bakery</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=bathroom_furnishing</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=bbq</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=beauty</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=bed</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=beverages</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=bicycle</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=boat</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=bookmaker</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=books</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=butcher</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=camera</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=candles</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=cannabis</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=car</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=car_parts</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=car_repair</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=caravan</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=carpet</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=catalogue</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=charity</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=cheese</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=chemist</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=chocolate</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=clothes</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=coffee</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=computer</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=confectionery</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=convenience</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=copyshop</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=cosmetics</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=country_store</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=craft</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=curtain</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=dairy</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=deli</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=department_store</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=doityourself</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=doors</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=dry_cleaning</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=e-cigarette</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=electrical</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=electronics</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=erotic</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=fabric</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=fashion_accessories</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=fishing</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=flooring</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=florist</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=frame</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=frozen_food</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=funeral_directors</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=furniture</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=games</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=garden_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=gas</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=general</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=gift</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+  </url>
+  <url>
+    <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=glaziery</loc>
+    <changefreq>weekly</changefreq>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=gold_buyer</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=greengrocer</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+  </url>
+  <url>
+    <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=groundskeeping</loc>
+    <changefreq>weekly</changefreq>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=hairdresser</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=hairdresser_supply</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=hardware</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=health_food</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=hearing_aids</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=herbalist</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=hifi</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=household_linen</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=houseware</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=interior_decoration</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=jewelry</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=kiosk</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=kitchen</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=laundry</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=leather</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=lighting</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=locksmith</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=lottery</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=mall</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=massage</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=medical_supply</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=mobile_phone</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=mobile_phone_accessories</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=model</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=money_lender</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=motorcycle</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=motorcycle_repair</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=music</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=musical_instrument</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=newsagent</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=nutrition_supplements</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=nuts</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=optician</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=outdoor</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=outpost</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=paint</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=party</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=pastry</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=pawnbroker</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=perfumery</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=pest_control</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=pet</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=photo</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=plant_hire</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=pottery</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=power_tools</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=printer_ink</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=pyrotechnics</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=rental</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=repair</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=seafood</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=second_hand</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=shoes</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=spices</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=sports</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=stationery</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=storage_rental</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=supermarket</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=swimming_pool</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tailor</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tattoo</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tea</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=telecommunication</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=ticket</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tiles</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tobacco</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tool_hire</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=toys</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+  </url>
+  <url>
+    <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tractor</loc>
+    <changefreq>weekly</changefreq>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+  </url>
+  <url>
+    <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tractor_repair</loc>
+    <changefreq>weekly</changefreq>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=trade</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=travel_agency</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=truck</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=truck_repair</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tyres</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=vacuum_cleaner</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=variety_store</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=video</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=video_games</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=watches</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=wholesale</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=window_blind</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=wine</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=tourism&amp;v=caravan_site</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=tourism&amp;v=hostel</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=tourism&amp;v=hotel</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=tourism&amp;v=information</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=tourism&amp;v=motel</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=tourism&amp;v=theme_park</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=waterway&amp;v=fuel</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=flags&amp;k=man_made&amp;v=flagpole</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=advertising&amp;v=billboard</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=advertising&amp;v=column</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=advertising&amp;v=poster_box</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=advertising&amp;v=screen</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=bicycle_parking</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=car_sharing</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=charging_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=childcare</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=clinic</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=college</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=community_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=courthouse</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=doctors</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=drinking_water</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=fire_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=hospital</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=kindergarten</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=library</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=marketplace</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=parking</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=police</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=post_box</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=post_depot</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=post_office</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=prison</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=pub</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=recycling</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=school</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=social_facility</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=telephone</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=ticket_validator</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=toilets</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=townhall</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=university</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=vending_machine</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=veterinary</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=waste_disposal</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=waste_transfer_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=barrier&amp;v=toll_booth</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=boundary&amp;v=aboriginal_lands</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=boundary&amp;v=national_park</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=boundary&amp;v=protected_area</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=emergency&amp;v=ambulance_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=emergency&amp;v=disaster_response</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=emergency&amp;v=lifeguard</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=emergency&amp;v=phone</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=emergency&amp;v=siren</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=emergency&amp;v=water_rescue</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=highway&amp;v=services</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=highway&amp;v=street_lamp</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=highway&amp;v=toll_gantry</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=internet_access&amp;v=wlan</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=landuse&amp;v=industrial</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=landuse&amp;v=landfill</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=landuse&amp;v=military</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=landuse&amp;v=quarry</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=landuse&amp;v=residential</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=landuse&amp;v=retail</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=leisure&amp;v=nature_reserve</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=leisure&amp;v=park</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=leisure&amp;v=pitch</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=charge_point</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=mast</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=monitoring_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=pipeline</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=pumping_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=reservoir_covered</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=street_cabinet</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=surveillance</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=survey_point</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=tower</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=wastewater_plant</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=water_tower</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=water_works</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=works</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=natural&amp;v=water</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=office&amp;v=association</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=office&amp;v=energy_supplier</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=office&amp;v=government</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=office&amp;v=visa</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=office&amp;v=water_utility</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=pipeline&amp;v=substation</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=catenary_mast</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=generator</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=line</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=minor_line</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=plant</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=pole</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=substation</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=tower</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=transformer</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=route&amp;v=power</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=route&amp;v=railway</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=route&amp;v=tracks</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=shop&amp;v=bookmaker</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=shop&amp;v=convenience</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=shop&amp;v=mall</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=shop&amp;v=mobile_phone</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=shop&amp;v=ticket</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=telecom&amp;v=data_center</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=telecom&amp;v=exchange</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=tourism&amp;v=camp_site</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=tourism&amp;v=information</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=tourism&amp;v=wilderness_hut</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=amenity&amp;v=ferry_terminal</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=highway&amp;v=bus_stop</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=public_transport&amp;v=station_light_rail</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=public_transport&amp;v=station_subway</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+  </url>
+  <url>
+    <loc>https://nsi.guide/index.html?t=transit&amp;k=railway&amp;v=halt</loc>
+    <changefreq>weekly</changefreq>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=railway&amp;v=station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=railway&amp;v=tram_stop</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=aerialway</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=bus</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=ferry</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=light_rail</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=subway</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=train</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=tram</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=trolleybus</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=walking_bus</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2025-10-30T15:04:07.458Z</lastmod>
+    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
   </url>
 </urlset>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -3,2046 +3,2046 @@
   <url>
     <loc>https://nsi.guide/index.html</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-01T15:22:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=advertising&amp;v=totem</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-31T13:00:46.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=animal_boarding</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-08-23T16:19:44.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=animal_shelter</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-08-23T16:19:44.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=atm</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T20:27:39.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=bank</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-25T14:00:50.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=bar</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-27T17:57:05.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=bicycle_parking</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-04-20T16:25:04.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=bicycle_rental</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-17T09:43:26.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=bicycle_repair_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-12-29T15:53:56.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=bureau_de_change</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T20:15:54.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=cafe</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-18T10:16:51.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=car_rental</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-24T05:07:26.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=car_sharing</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-15T21:02:37.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=car_wash</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-16T15:05:39.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=casino</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-11-11T09:42:04.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=charging_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-14T07:47:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=childcare</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-30T04:50:08.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=cinema</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T19:43:04.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=clinic</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T19:43:51.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=college</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-07-03T14:36:06.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=community_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T18:46:37.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=conference_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-27T15:58:25.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=dentist</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-05-10T17:51:37.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=doctors</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-31T19:32:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=driving_school</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-11-16T09:16:02.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=fast_food</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-24T19:02:28.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=food_sharing</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-23T14:56:06.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=fuel</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-27T11:53:26.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=gambling</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-06-22T14:57:30.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=hospital</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-02-26T03:37:04.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=ice_cream</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-04T13:55:57.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=internet_cafe</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-27T13:45:50.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=karaoke_box</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-02-20T13:29:06.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=kindergarten</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-18T20:44:20.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=language_school</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-03T09:54:48.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=library</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-06-11T12:36:37.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=money_transfer</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-12-14T19:26:02.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=mortuary</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-08-29T16:52:35.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=motorcycle_rental</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2022-04-21T17:01:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=music_school</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-02T22:06:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=parcel_locker</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-18T19:15:39.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=parking</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-11-24T16:20:46.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=payment_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-11-22T08:05:53.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=payment_terminal</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-04T13:55:00.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=pharmacy</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-14T07:47:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=photo_booth</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T20:27:39.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=post_depot</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-04-03T02:17:23.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=post_office</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-18T12:35:59.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=prep_school</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-24T22:06:03.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=pub</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T06:46:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=public_bookcase</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-24T05:57:56.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=recycling</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-14T07:47:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=restaurant</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-27T07:23:39.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=school</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-02-09T22:04:41.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=social_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-05-01T04:36:16.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=social_facility</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-12-29T14:34:48.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=telephone</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2022-04-21T17:01:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=training</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-05-26T16:22:18.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=trolley_bay</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-12-04T11:02:28.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=university</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-03T09:54:48.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=vehicle_inspection</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-18T14:22:18.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=vending_machine</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=veterinary</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-02-05T13:59:38.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=waste_basket</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-08-23T16:19:44.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=amenity&amp;v=weighbridge</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2022-07-23T11:05:48.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=club&amp;v=freemasonry</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-09-25T01:56:53.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=club&amp;v=scout</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-07-11T00:02:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=carpenter</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-10-10T11:12:08.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=cleaning</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-11-16T09:16:02.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=electrician</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-11-10T19:37:36.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=electronics_repair</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-12-29T14:34:48.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=glaziery</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-12-03T17:00:55.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=handicraft</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-27T14:25:40.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=painter</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-23T02:44:21.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=plumber</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-28T13:38:21.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=signmaker</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-12-29T16:10:48.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=craft&amp;v=window_construction</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-11-16T09:16:02.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=emergency&amp;v=ambulance_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-07-04T16:09:11.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=emergency&amp;v=lifeguard</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-11-04T20:34:57.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=alternative</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-09-25T01:56:53.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=audiologist</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2021-02-18T17:30:42.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=blood_donation</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-04T21:02:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=counselling</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-11-11T19:08:49.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=laboratory</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-01-27T21:09:09.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=physiotherapist</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-11T15:42:13.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=rehabilitation</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-09-08T13:16:19.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=healthcare&amp;v=sample_collection</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-01-27T21:09:09.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=highway&amp;v=services</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-04T13:54:19.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=landuse&amp;v=industrial</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-11-24T16:20:46.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=landuse&amp;v=residential</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-23T14:02:58.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=adult_gaming_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-08-29T14:51:15.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=amusement_arcade</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-04-20T09:22:15.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=bowling_alley</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-09-01T02:38:25.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=dance</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2022-04-21T17:01:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=dog_park</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-07-21T05:28:29.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=escape_game</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-12-24T09:55:50.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=fitness_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-11T03:06:09.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=fitness_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-01-15T20:44:36.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=high_ropes_course</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-24T05:34:51.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=indoor_play</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-23T10:59:03.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=miniature_golf</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-02-18T05:10:12.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=playground</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-04-29T16:13:10.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=sports_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T12:26:41.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=leisure&amp;v=trampoline_park</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-07-06T15:52:02.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=man_made&amp;v=charge_point</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-05-16T14:10:26.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=association</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T19:33:45.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=bail_bond_agent</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-11-30T05:19:16.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=company</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-23T14:02:58.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=consulting</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-02-20T13:29:06.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=coworking</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-23T10:59:03.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=employment_agency</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-05-11T19:27:13.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=engineer</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-27T14:25:40.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=estate_agent</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-15T20:55:30.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=financial</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-09-08T12:43:19.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=financial_advisor</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T18:42:34.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=government</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-15T21:18:50.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=insurance</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-14T07:47:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=insurance_adjuster</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-11-14T22:28:48.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=it</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-11-16T09:16:02.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=lawyer</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-30T04:50:08.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=logistics</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-11-24T16:20:46.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=mortgage</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-01-25T21:20:41.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=moving_company</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-07-04T07:20:08.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=political_party</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=security</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-27T15:58:25.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=tax_advisor</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-11-24T11:37:51.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=telecommunication</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=office&amp;v=union</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-04-27T01:13:47.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=agrarian</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-05-18T13:57:20.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=alcohol</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-27T13:47:25.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=anime</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2022-04-21T17:01:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=appliance</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-20T10:42:28.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=art</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-09-04T12:59:43.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=baby_goods</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T06:46:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=bag</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-23T14:02:58.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=bakery</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T06:46:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=bathroom_furnishing</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-20T10:42:28.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=bbq</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-30T04:50:08.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=beauty</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-19T16:52:09.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=bed</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-04T21:02:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=beverages</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-12-20T09:45:51.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=bicycle</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-04T21:02:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=boat</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-10-08T21:42:16.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=bookmaker</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-16T09:01:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=books</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=butcher</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-17T00:57:41.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=camera</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-10-03T20:51:30.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=candles</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-09-08T15:24:39.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=cannabis</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-08-17T16:31:16.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=car</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=car_parts</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-27T13:52:49.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=car_repair</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T06:46:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=caravan</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-04-24T00:24:07.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=carpet</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-23T10:59:03.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=catalogue</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-10-18T14:37:49.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=charity</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-06T11:37:02.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=cheese</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-14T07:40:16.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=chemist</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-16T18:34:26.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=chocolate</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-06T11:37:02.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=clothes</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-27T11:52:57.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=coffee</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-02-26T18:20:40.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=computer</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-07-04T05:45:12.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=confectionery</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-05-20T14:14:15.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=convenience</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-24T19:02:28.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=copyshop</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-06-19T20:19:54.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=cosmetics</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-27T13:53:19.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=country_store</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-07-04T05:45:12.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=craft</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-09-07T16:28:45.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=curtain</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2022-07-27T01:45:30.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=dairy</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-16T14:52:06.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=deli</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T06:46:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=department_store</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T12:35:37.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=doityourself</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T06:46:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=doors</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-27T23:23:08.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=dry_cleaning</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-13T07:32:06.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=e-cigarette</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-01-11T14:42:23.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=electrical</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-01-17T07:46:16.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=electronics</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-18T08:39:50.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=erotic</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-11T15:42:13.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=fabric</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-02-09T15:07:08.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=fashion_accessories</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T06:46:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=fishing</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-09T09:10:38.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=flooring</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-04-12T19:39:40.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=florist</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-13T07:32:06.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=frame</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2021-02-18T17:30:42.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=frozen_food</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-23T14:02:58.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=funeral_directors</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-16T14:02:49.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=furniture</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-02T14:20:02.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=games</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-24T21:52:23.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=garden_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-17T21:54:57.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=gas</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-18T13:55:29.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=general</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-16T14:51:03.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=gift</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-30T12:56:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=glaziery</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-11-24T16:20:46.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=gold_buyer</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-07-01T14:57:16.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=greengrocer</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-08T14:29:29.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=groundskeeping</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-26T21:43:35.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=hairdresser</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-11-24T16:20:46.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=hairdresser_supply</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-11T15:42:13.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=hardware</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T06:46:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=health_food</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-11T15:42:13.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=hearing_aids</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=herbalist</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-08-15T00:36:37.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=hifi</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-12-24T09:55:50.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=household_linen</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-17T21:45:21.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=houseware</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-26T21:43:35.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=interior_decoration</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-06-25T18:06:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=jewelry</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T06:46:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=kiosk</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-20T10:42:28.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=kitchen</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-18T08:06:31.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=laundry</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-20T08:12:28.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=leather</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-05-03T13:03:05.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=lighting</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-03-16T14:07:39.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=locksmith</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-11-04T20:47:09.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=lottery</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-05-31T16:39:56.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=mall</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-01-09T17:08:57.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=massage</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-12-05T08:03:25.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=medical_supply</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-08-17T16:31:16.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=mobile_phone</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=mobile_phone_accessories</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T08:05:31.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=model</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2022-10-25T03:56:02.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=money_lender</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-08-31T11:05:47.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=motorcycle</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-12-17T12:30:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=motorcycle_repair</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-08-17T16:31:16.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=music</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-07-04T05:45:12.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=musical_instrument</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-08-24T16:39:33.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=newsagent</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=nutrition_supplements</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-09-08T15:06:53.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=nuts</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-01-14T08:38:11.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=optician</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-18T08:03:09.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=outdoor</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T06:46:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=outpost</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-27T13:53:29.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=paint</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-27T15:58:25.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=party</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-02-14T18:54:54.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=pastry</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-27T13:53:42.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=pawnbroker</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-04-29T16:13:10.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=perfumery</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-11-24T16:20:46.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=pest_control</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-28T13:38:21.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=pet</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-29T08:46:39.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=photo</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-10T02:32:44.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=plant_hire</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2022-10-08T05:41:20.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=pottery</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2022-12-18T09:45:02.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=power_tools</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-12-29T15:13:42.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=printer_ink</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-09-17T11:43:55.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=pyrotechnics</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-04-24T12:55:50.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=rental</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-09-25T05:36:37.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=repair</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-09-26T12:15:22.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=seafood</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-30T04:50:08.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=second_hand</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-04T21:02:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=shoes</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T06:46:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=spices</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2022-04-21T17:01:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=sports</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-17T21:47:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=stationery</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-15T20:55:30.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=storage_rental</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-07-03T14:36:06.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=supermarket</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-24T19:02:28.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=swimming_pool</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-01-22T11:18:33.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tailor</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-27T03:18:54.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tattoo</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-27T17:45:43.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tea</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-01-20T09:14:20.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=telecommunication</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=ticket</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-11-24T16:20:46.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tiles</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-27T03:18:54.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tobacco</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-20T10:46:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tool_hire</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-05-10T17:51:37.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=toys</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T06:46:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tractor</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-12-29T15:53:56.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tractor_repair</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-12-29T15:53:56.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=trade</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-26T21:43:35.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=travel_agency</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-12-29T15:53:56.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=truck</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-01-05T20:31:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=truck_repair</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-01-06T07:41:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=tyres</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-23T15:37:51.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=vacuum_cleaner</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-27T17:45:43.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=variety_store</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-12-29T14:41:08.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=video</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-11-23T02:22:39.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=video_games</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-10T13:42:57.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=watches</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-06-12T05:44:09.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=wholesale</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-20T10:42:28.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=window_blind</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-16T20:34:45.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=shop&amp;v=wine</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-14T07:47:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=tourism&amp;v=caravan_site</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-10T13:42:29.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=tourism&amp;v=hostel</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-04-14T03:16:45.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=tourism&amp;v=hotel</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T06:46:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=tourism&amp;v=information</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-03T09:54:48.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=tourism&amp;v=motel</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-23T14:02:58.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=tourism&amp;v=theme_park</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-09-22T00:59:08.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=brands&amp;k=waterway&amp;v=fuel</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-10-09T17:31:54.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=flags&amp;k=man_made&amp;v=flagpole</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-18T14:27:36.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=advertising&amp;v=billboard</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=advertising&amp;v=column</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-23T02:39:38.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=advertising&amp;v=poster_box</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-02T14:20:02.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=advertising&amp;v=screen</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-04-15T03:46:44.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=bicycle_parking</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T19:30:38.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=car_sharing</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=charging_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-18T14:22:18.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=childcare</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-04T21:02:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=clinic</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-09T09:10:38.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=college</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-25T16:46:42.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=community_centre</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-25T08:37:59.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=courthouse</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-23T14:02:58.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=doctors</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-23T14:02:58.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=drinking_water</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-04T12:54:59.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=fire_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-18T08:52:22.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=hospital</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=kindergarten</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-24T19:02:28.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=library</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-28T08:43:31.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=marketplace</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-23T14:02:58.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=parking</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-28T08:43:31.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=police</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T18:58:09.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=post_box</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-09T09:08:18.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=post_depot</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-05-18T15:18:25.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=post_office</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-15T20:58:37.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=prison</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-04-23T02:39:48.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=pub</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-04-29T20:35:10.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=recycling</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-10T06:46:24.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=school</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-28T08:43:31.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=social_facility</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-09T09:10:38.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=telephone</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=ticket_validator</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-06T11:23:06.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=toilets</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-25T08:37:59.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=townhall</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-05-21T13:47:03.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=university</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-05-22T19:39:58.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=vending_machine</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-15T18:52:19.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=veterinary</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-08-17T16:31:16.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=waste_disposal</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-11-24T16:20:46.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=amenity&amp;v=waste_transfer_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-29T16:42:50.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=barrier&amp;v=toll_booth</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-01-06T11:42:10.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=boundary&amp;v=aboriginal_lands</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-04-21T00:23:33.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=boundary&amp;v=national_park</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-06-16T01:21:50.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=boundary&amp;v=protected_area</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=emergency&amp;v=ambulance_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-08-17T16:31:16.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=emergency&amp;v=disaster_response</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-19T04:07:47.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=emergency&amp;v=lifeguard</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-11-04T20:34:57.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=emergency&amp;v=phone</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-01-20T09:28:46.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=emergency&amp;v=siren</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T20:31:12.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=emergency&amp;v=water_rescue</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-24T03:38:11.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=highway&amp;v=services</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-01-20T09:28:46.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=highway&amp;v=street_lamp</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T20:17:14.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=highway&amp;v=toll_gantry</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-01-06T11:42:10.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=internet_access&amp;v=wlan</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-30T04:50:08.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=landuse&amp;v=industrial</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-05-14T18:35:32.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=landuse&amp;v=landfill</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-08-30T18:18:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=landuse&amp;v=military</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-10-23T15:39:53.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=landuse&amp;v=quarry</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-11-16T09:16:02.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=landuse&amp;v=residential</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-06-17T17:43:47.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=landuse&amp;v=retail</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2022-11-20T22:10:09.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=leisure&amp;v=nature_reserve</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-25T19:24:13.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=leisure&amp;v=park</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-25T19:24:13.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=leisure&amp;v=pitch</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-04T09:35:29.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=charge_point</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-05-16T14:10:26.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=mast</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=monitoring_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=pipeline</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=pumping_station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T18:58:09.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=reservoir_covered</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-30T23:13:53.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=street_cabinet</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-14T07:47:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=surveillance</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-25T08:37:59.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=survey_point</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T20:34:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=tower</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-01-23T15:24:16.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=wastewater_plant</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T18:58:09.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=water_tower</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-03-03T16:04:47.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=water_works</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T18:58:09.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=man_made&amp;v=works</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-08-17T16:31:16.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=natural&amp;v=water</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-04-02T10:35:30.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=office&amp;v=association</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-02-27T20:45:19.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=office&amp;v=energy_supplier</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-13T09:15:26.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=office&amp;v=government</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-24T19:02:28.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=office&amp;v=visa</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2023-10-06T17:42:48.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=office&amp;v=water_utility</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-23T10:59:03.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=pipeline&amp;v=substation</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2022-12-29T23:27:22.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=catenary_mast</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-05-30T11:41:46.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=generator</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=line</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-14T07:47:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=minor_line</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-02-20T07:42:04.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=plant</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=pole</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2022-04-21T17:01:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=substation</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-14T07:47:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=tower</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2021-09-13T14:43:02.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=power&amp;v=transformer</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2021-08-11T19:14:25.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=route&amp;v=power</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-23T02:39:38.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=route&amp;v=railway</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T18:58:09.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=route&amp;v=tracks</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-07T14:29:30.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=shop&amp;v=bookmaker</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2022-04-21T17:01:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=shop&amp;v=convenience</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-12T20:04:19.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=shop&amp;v=mall</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-05-24T20:13:34.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=shop&amp;v=mobile_phone</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-04-23T16:21:47.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=shop&amp;v=ticket</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-05-24T19:39:26.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=telecom&amp;v=data_center</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=telecom&amp;v=exchange</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2025-08-30T09:22:38.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=tourism&amp;v=camp_site</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-11-10T09:42:23.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=tourism&amp;v=information</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-17T14:27:03.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=operators&amp;k=tourism&amp;v=wilderness_hut</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-11-10T09:42:23.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=amenity&amp;v=ferry_terminal</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2021-03-13T20:19:47.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=highway&amp;v=bus_stop</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-16T15:39:42.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=public_transport&amp;v=station_light_rail</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-05-25T15:19:20.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=public_transport&amp;v=station_subway</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-05-25T15:19:20.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=railway&amp;v=halt</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-23T10:08:58.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=railway&amp;v=station</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-06-10T15:14:36.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=railway&amp;v=tram_stop</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-03-16T15:39:42.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=aerialway</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2022-04-21T17:01:01.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=bus</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-28T08:43:31.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=ferry</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-03T18:05:21.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=light_rail</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=subway</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-18T08:48:09.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=train</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=tram</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-04-18T08:46:39.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=trolleybus</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2026-05-07T00:23:17.000Z</lastmod>
   </url>
   <url>
     <loc>https://nsi.guide/index.html?t=transit&amp;k=route&amp;v=walking_bus</loc>
     <changefreq>weekly</changefreq>
-    <lastmod>2026-05-28T15:16:05.770Z</lastmod>
+    <lastmod>2024-11-18T05:31:46.000Z</lastmod>
   </url>
 </urlset>

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "check:types": "tsc --noEmit",
     "clean": "bun ./scripts/clean.ts",
     "dist": "bun ./scripts/dist.ts",
+    "dist:sitemap": "bun ./scripts/build_sitemap.ts",
     "prepublishOnly": "bun ./scripts/prepublish.ts",
     "postpublish": "bun ./scripts/postpublish.ts",
     "start": "bun ./scripts/server.ts",

--- a/scripts/build_sitemap.ts
+++ b/scripts/build_sitemap.ts
@@ -1,0 +1,93 @@
+import { $, Glob } from 'bun';
+import XMLBuilder from 'fast-xml-builder';
+import { styleText } from 'node:util';
+
+import type { XmlBuilderOptions } from 'fast-xml-builder';
+
+const withLocale = new Intl.Collator('en-US').compare;  // specify 'en-US' for stable sorting
+
+await buildSitemap();
+
+
+/**
+ * Generate a sitemap for https://nsi.guide and write it to `./docs/sitemap.xml`.
+ * Per-URL `lastmod` is derived from the most recent git commit that touched
+ * the corresponding category file (or `docs/index.html` for the root URL).
+ * Falls back to "now" if a file isn't tracked in git (e.g. shallow clone).
+ * @see https://en.wikipedia.org/wiki/Sitemaps
+ */
+export async function buildSitemap() {
+  const START = '🏗   ' + styleText('yellow', 'Building sitemap…');
+  const END = '👍  ' + styleText('green', 'sitemap built');
+  console.log('');
+  console.log(START);
+  console.time(END);
+
+  const changefreq = 'weekly';
+  const nowISO = (new Date()).toISOString();
+
+  // Collect all category files under data/ as `tree/key/value` tkv paths.
+  const glob = new Glob('data/*/*/*.json');
+  const tkvs: string[] = [];
+  for await (const file of glob.scan({ cwd: '.' })) {
+    // file = 'data/<tree>/<key>/<value>.json'
+    const tkv = file.slice('data/'.length, -'.json'.length);
+    tkvs.push(tkv);
+  }
+  tkvs.sort(withLocale);
+
+  // Build a map of `<path> -> <ISO commit date>` for all data/ category files
+  // and docs/index.html in a single git invocation.
+  // Output format (one commit per block):
+  //   COMMIT 2024-11-18T00:31:46-05:00
+  //   data/transit/route/walking_bus.json
+  //   data/...
+  const lastmodByFile = new Map<string, string>();
+  try {
+    const out = await $`git log --name-only --format=COMMIT\ %cI -- data docs/index.html`.text();
+    let currentDate = '';
+    for (const line of out.split('\n')) {
+      if (line.startsWith('COMMIT ')) {
+        currentDate = line.slice('COMMIT '.length).trim();
+      } else if (line && currentDate && !lastmodByFile.has(line)) {
+        // First time we see a file == most recent commit that touched it
+        lastmodByFile.set(line, new Date(currentDate).toISOString());
+      }
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(styleText('yellow', `Warning: could not read git history for sitemap lastmod (${message}). Falling back to current date.`));
+  }
+
+  const indexLastmod = lastmodByFile.get('docs/index.html') ?? nowISO;
+  const url = [
+    { loc: 'https://nsi.guide/index.html', changefreq, lastmod: indexLastmod },
+    ...tkvs.map(tkv => {
+      const [t, k, v] = tkv.split('/', 3);     // tkv = "tree/key/value"
+      const file = `data/${tkv}.json`;
+      const lastmod = lastmodByFile.get(file) ?? nowISO;
+      return {
+        loc: `https://nsi.guide/index.html?t=${t}&k=${k}&v=${v}`,
+        changefreq,
+        lastmod
+      };
+    })
+  ];
+
+  const xmlBuilderOptions = {
+    ignoreAttributes: false,
+    suppressEmptyNode: true
+  } satisfies XmlBuilderOptions;
+
+  const builder = new XMLBuilder({ ...xmlBuilderOptions, format: true });
+  const xml = builder.build({
+    '?xml': { '@_version': '1.0', '@_encoding': 'UTF-8' },
+    urlset: {
+      '@_xmlns': 'http://www.sitemaps.org/schemas/sitemap/0.9',
+      url
+    }
+  });
+  await Bun.write('./docs/sitemap.xml', xml);
+
+  console.timeEnd(END);
+}

--- a/scripts/dist.ts
+++ b/scripts/dist.ts
@@ -1,6 +1,5 @@
 import { $ } from 'bun';
 import LocationConflation from '@rapideditor/location-conflation';
-import XMLBuilder from 'fast-xml-builder';
 import stringify from 'json-stringify-pretty-compact';
 import { styleText } from 'node:util';
 
@@ -8,8 +7,7 @@ import { fileTree } from '../lib/file_tree.ts';
 import { buildIDPresets } from '../lib/presets_id.ts';
 import { buildJOSMPresets } from '../lib/presets_josm.ts';
 
-import type { XmlBuilderOptions } from 'fast-xml-builder';
-import type { NsiCache, NsiData, NsiDissolved, NsiJSON, NsiPath, NsiWikidataJSON, TaginfoItem, TaginfoJSON } from '../lib/types.ts';
+import type { NsiCache, NsiData, NsiDissolved, NsiJSON, NsiWikidataJSON, TaginfoItem, TaginfoJSON } from '../lib/types.ts';
 
 const withLocale = new Intl.Collator('en-US').compare;  // specify 'en-US' for stable sorting
 
@@ -97,7 +95,6 @@ async function distAll() {
   await writeIDPresets();     // nsi-id-presets.json
   await writeJOSMPresets();   // nsi-josm-presets.json
   await buildTaginfo();       // taginfo.json
-  // await buildSitemap();  // lets not do this for now (maybe nsiguide can generate it?)
 }
 
 
@@ -216,42 +213,4 @@ async function buildTaginfo() {
 
   taginfo.tags = Object.keys(tagPairs).sort(withLocale).map(kv => tagPairs[kv]);
   await Bun.write('./dist/json/taginfo.json', stringify(taginfo, { maxLength: 9999 }) + '\n');
-}
-
-
-/**
- * Generate a sitemap for https://nsi.guide and write it to `./docs/sitemap.xml`.
- * @see https://en.wikipedia.org/wiki/Sitemaps
- */
-export async function buildSitemap() {
-  const changefreq = 'weekly';
-  const lastmod = (new Date()).toISOString();
-
-  const paths = Object.keys(_nsi.path).sort(withLocale) as NsiPath[];
-  const url = [
-    { loc: 'https://nsi.guide/index.html', changefreq, lastmod },
-    ...paths.map(tkv => {
-      const [t, k, v] = tkv.split('/', 3);     // tkv = "tree/key/value"
-      return {
-        loc: `https://nsi.guide/index.html?t=${t}&k=${k}&v=${v}`,
-        changefreq,
-        lastmod
-      };
-    })
-  ];
-
-  const xmlBuilderOptions = {
-    ignoreAttributes: false,
-    suppressEmptyNode: true
-  } satisfies XmlBuilderOptions;
-
-  const builder = new XMLBuilder({ ...xmlBuilderOptions, format: true });
-  const xml = builder.build({
-    '?xml': { '@_version': '1.0', '@_encoding': 'UTF-8' },
-    urlset: {
-      '@_xmlns': 'http://www.sitemaps.org/schemas/sitemap/0.9',
-      url
-    }
-  });
-  await Bun.write('./docs/sitemap.xml', xml);
 }


### PR DESCRIPTION
Sitemap was quite far behind main, so it was missing a few things, so why not regenerate it :)

Since it seems to have been disabled in a previous commit to avoid having to push the changed file on every dist generation, I moved it out to its own script, so Github actions can create a PR whenever a new tag is released.

Also added some code to get the last modification date from commit history to better utilise crawl budgets on changes URLs