### PR TITLE
feat(theitaliancoffeecompany): resolve missing Wikidata tag

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -4845,6 +4845,7 @@
       "tags": {
         "amenity": "cafe",
         "brand": "The Italian Coffee Company",
+        "brand:wikidata": "Q126896645",
         "cuisine": "coffee_shop",
         "name": "The Italian Coffee Company",
         "takeaway": "yes"


### PR DESCRIPTION
Add missing wikidata https://www.wikidata.org/wiki/Q126896645 to `theitaliancoffeecompany-2f3766`

[Turbo](https://overpass-turbo.eu/?Q=%5Bout%3Ajson%5D%5Btimeout%3A100%5D%3B%0A(nwr%5B%22name%22%3D%22The%20Italian%20Coffee%20Company%22%5D%3B)%3B%0Aout%20center%3B%0A%0A%7B%7Bstyle%3A%0Anode%2C%0Away%2C%0Arelation%0A%7B%20color%3Ared%3B%20fill-color%3Ared%3B%20%7D%0Anode%5Bamenity%3Dcafe%5D%2C%0Away%5Bamenity%3Dcafe%5D%2C%0Arelation%5Bamenity%3Dcafe%5D%0A%7B%20color%3Ayellow%3B%20fill-color%3Ayellow%3B%20%7D%0Anode%5Bamenity%3Dcafe%5D%5Bbrand%3DThe%20Italian%20Coffee%20Company%5D%5Bbrand%3Awikidata%3Dundefined%5D%2C%0Away%5Bamenity%3Dcafe%5D%5Bbrand%3DThe%20Italian%20Coffee%20Company%5D%5Bbrand%3Awikidata%3Dundefined%5D%2C%0Arelation%5Bamenity%3Dcafe%5D%5Bbrand%3DThe%20Italian%20Coffee%20Company%5D%5Bbrand%3Awikidata%3Dundefined%5D%0A%7B%20color%3Agreen%3B%20fill-color%3Agreen%3B%20%7D%0A%7D%7D&R)