### PR TITLE
feat: link to wikiwarnings and fix mobile styling

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -74,11 +74,14 @@ input[type=text] {
   text-overflow: ellipsis;
 }
 .dark textarea,
-.dark input[type=text],
-.dark input[type=checkbox] {
+.dark input[type=text] {
   background-color: #666;
   color: #ddd;
   border: 1px solid #777;
+}
+.dark input[type=checkbox] {
+  accent-color: #666;
+  color-scheme: dark;
 }
 
 button {
@@ -112,26 +115,51 @@ input:focus {
 /* Sections */
 #header {
   display: flex;
-  align-items: start;
-  padding: 5px 20px;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 16px;
+  row-gap: 8px;
+  padding: 10px 16px;
   background: #111;
   color: #ddd;
   font-weight: bold;
-  flex-direction: column;
 }
 #header a:visited, #header a       { color: #aaf; }
 #header a:hover, #header a:active  { color: #ccf; }
+
+#title {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+#title h1 {
+  display: flex;
+  align-items: center;
+  font-size: clamp(16px, 4vw, 28px);
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+#header-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
 
 #title img.icon {
   filter: invert(1);
   opacity: 1;
   padding-right: 10px;
+  flex-shrink: 0;
 }
+
 #treeswitcher {
   appearance: base-select;
   background-color: #393939;
   color: #aaa;
   border: 1px solid #666;
+  padding: 4px 8px;
 }
 #treeswitcher::picker-icon {
   color: #999;
@@ -141,38 +169,39 @@ input:focus {
 }
 
 #darkmode {
-  flex: 0 0 120px;
-  padding: 1em 0;
-  flex: 0 0 90px;
-  padding: 5px 10px;
+  display: flex;
   align-items: center;
-  justify-content: flex-start;
   font-size: 16px;
 }
 #darkmode > svg {
   margin: 0 5px;
 }
-
-@media screen and (min-width: 614px) {
-  div#header {
-    flex-direction: row;
-    align-items: center;
-  }
-  div#darkmode {
-    display: flex;
-    padding: 0 28px;
-    align-items: center;
-  }
-}
-
 #darkmode > svg.fa-sun { color: gold; }
 .dark #darkmode > svg.fa-sun { color: unset; }
 #darkmode > svg.fa-moon { color: unset; }
 .dark #darkmode > svg.fa-moon { color: #88c; }
 
-#octocat { flex: 0 0 40px; }
+#octocat, #wikiwarnings {
+  display: flex;
+  align-items: center;
+}
 #octocat a:visited, #octocat a       { color: #fff; }
 #octocat a:hover, #octocat a:active  { color: #ddd; }
+
+#wikiwarnings a:visited, #wikiwarnings a       { color: #f5b400; }
+#wikiwarnings a:hover, #wikiwarnings a:active  { color: #ffd24d; }
+
+@media screen and (max-width: 420px) {
+  #header {
+    column-gap: 10px;
+  }
+  #header-controls {
+    gap: 10px;
+  }
+  #darkmode > svg {
+    margin: 0 2px;
+  }
+}
 
 #content { padding: 0 20px 60px 20px; }
 #footer  {
@@ -180,14 +209,6 @@ input:focus {
   padding: 20px;
   color: #aaa;
   font-size: 12px;
-}
-@media (min-width: 640px) {
-  div#treeswitcher {
-    padding: 0em 1em;
-  }
-  div#darkmode {
-    padding: 0em 1em;
-  }
 }
 
 
@@ -219,12 +240,26 @@ input:focus {
 .filters .filterby {
   margin: 0;
   font-weight: bold;
+  width: max-content;
 }
-.filters .field label { margin-right: 0.5em; }
-.filters .field { margin: 0; }
+.filters .filterhead {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}
+.filters .field label {
+  width: max-content;
+  margin-right: 0.5em;
+}
+.filters .field {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
 .filters .field button.clearFilters { margin: 0 !important; }
 
-@media (min-width: 640px) {
+@media (min-width: 660px) {
   .filters {
     flex-direction: row;
     align-items: center;

--- a/nsiguide/Filters.jsx
+++ b/nsiguide/Filters.jsx
@@ -14,8 +14,10 @@ export function Filters() {
 
   return (
     <div className={klass}>
-      <span className='icon'><FontAwesomeIcon icon={faFilter} /></span>
-      <span className='filterby'>Filter by</span>
+      <span className='filterhead'>
+        <span className='icon'><FontAwesomeIcon icon={faFilter} /></span>
+        <span className='filterby'>Filter by</span>
+      </span>
 
       <span className='field'>
         <label htmlFor='tt'>Text:</label>

--- a/nsiguide/Header.jsx
+++ b/nsiguide/Header.jsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSun, faMoon } from '@fortawesome/free-solid-svg-icons';
+import { faSun, faMoon, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 
 import { AppContext, getFilterParams } from './AppContext';
@@ -9,11 +9,14 @@ import { TREES } from './constants';
 
 export function Header() {
   return (
-    <div id='header' className='hasCols'>
+    <div id='header'>
       <Title/>
-      <TreeSwitcher/>
-      <DarkMode/>
-      <GitHub/>
+      <div id='header-controls'>
+        <TreeSwitcher/>
+        <DarkMode/>
+        <WikidataWarnings/>
+        <GitHub/>
+      </div>
     </div>
   );
 };
@@ -137,6 +140,17 @@ function GitHub() {
     <div id='octocat'>
       <a href='https://github.com/osmlab/name-suggestion-index' target='_blank'>
         <FontAwesomeIcon icon={faGithub} size='2x' />
+      </a>
+    </div>
+  );
+}
+
+
+function WikidataWarnings() {
+  return (
+    <div id='wikiwarnings'>
+      <a href='wikidata-warnings.htm' target='_blank' title='View Wikidata warnings'>
+        <FontAwesomeIcon icon={faTriangleExclamation} size='2x' />
       </a>
     </div>
   );


### PR DESCRIPTION
This is an attempt to fix https://github.com/osmlab/name-suggestion-index/issues/12250 by adding a more prominent link that encourages people to use https://nsi.guide/wikidata-warnings.htm to fix Wikidata issues.

It also resolves issues with mobile header responsiveness.

<details><summary>Before</summary>
<img width="1290" height="2796" alt="before-index-mobile" src="https://github.com/user-attachments/assets/cc9012dc-2d14-4d41-8021-eb9bac429549" />
<img width="2180" height="1769" alt="before-index" src="https://github.com/user-attachments/assets/dea86e84-a8ea-4a8b-bda0-37ca72dc890b" />
<img width="1290" height="2796" alt="before-page-mobile" src="https://github.com/user-attachments/assets/97b1e3f3-65c0-497e-8ac7-4c73d4bdbd9d" />

</details> 

<details><summary>After</summary>
<img width="1290" height="2796" alt="after-index-mobile" src="https://github.com/user-attachments/assets/61988fa1-a813-4db9-bc0a-6d110b6a5c61" />
<img width="2180" height="1767" alt="after-index" src="https://github.com/user-attachments/assets/9cabdf53-4f59-47b9-b0b3-e5f802756408" />
<img width="1290" height="2796" alt="after-page-mobile" src="https://github.com/user-attachments/assets/5593705b-baa6-4b84-b7f5-3574b94b1074" />

</details> 