### PR TITLE
Add HobbyTown

### DIFF
--- a/data/brands/shop/craft.json
+++ b/data/brands/shop/craft.json
@@ -185,6 +185,21 @@
         "name": "Леонардо",
         "shop": "craft"
       }
+    },
+    {
+      "displayName": "HobbyTown",
+      "id": "HobbyTown",
+      "locationSet": {
+        "include": [
+          "us"
+        ]
+      },
+      "tags": {
+        "shop": "craft",
+        "name": "HobbyTown",
+        "brand": "HobbyTown",
+        "brand:wikidata": "Q5874921"
+      }
     }
   ]
 }


### PR DESCRIPTION
This pull request adds HobbyTown to craft.json

Wikidata item: [wikidata.org/wiki/Q5874921](https://www.wikidata.org/wiki/Q5874921)
Location URL: [hobbytown.com/store-locations](https://www.hobbytown.com/store-locations)