### PR TITLE
Add King Kullen

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -13822,6 +13822,21 @@
         "name:ja": "阪急オアシス",
         "shop": "supermarket"
       }
+    },
+    {
+      "displayName": "King Kullen",
+      "id": "King Kullen",
+      "locationSet": {
+        "include": [
+          "us-ny.geojson"
+        ]
+      },
+      "tags": {
+        "shop": "supermarket",
+        "name": "King Kullen",
+        "brand": "King Kullen",
+        "brand:wikidata": "Q6411832"
+      }
     }
   ]
 }


### PR DESCRIPTION
This pull request adds King Kullen to supermarket.json

Wikidata item: [wikidata.org/wiki/Q6411832](https://www.wikidata.org/wiki/Q6411832)
Location URL: [kingkullen.com/store-locator/](https://kingkullen.com/store-locator/)