### PR TITLE
[brands/amenity/cafe] Expand Cotti Coffee operating locations

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -7379,18 +7379,15 @@
     {
       "displayName": "库迪咖啡",
       "id": "cotticoffee-823e31",
-      "locationSet": {
-        "include": ["cn"],
-        "exclude": ["hk", "mo"]
-      },
+      "locationSet": {"include": ["ae", "au", "ca", "cn", "id", "jp", "hk", "kr", "mo", "my", "ph", "qa", "sg", "th", "us", "vn"]},
       "tags": {
         "amenity": "cafe",
-        "brand": "库迪咖啡",
+        "brand": "Cotti Coffee 库迪咖啡",
         "brand:en": "Cotti Coffee",
         "brand:wikidata": "Q123370986",
         "brand:zh": "库迪咖啡",
         "cuisine": "coffee_shop",
-        "name": "库迪咖啡",
+        "name": "Cotti Coffee 库迪咖啡",
         "name:en": "Cotti Coffee",
         "name:zh": "库迪咖啡",
         "takeaway": "yes"


### PR DESCRIPTION
Added a lot more countries to the locationSet for Cotti Coffee. Also changed the suggested default (ie non-language-specific) values for the rand and ame tags, since even in their jurisdiction of origin, mainland China, they [place their coffeehouse chain's English name prominently](https://www.cotticoffee.global/#/stores/index) and would be read first before their Chinese name with smaller font size.

Source for the list of operating jurisdictions is the Chinese-language Wikipedia. Current version (with edit #91545798) as of this commit/PR is at: https://zh.wikipedia.org/w/index.php?title=%E5%BA%93%E8%BF%AA%E5%92%96%E5%95%A1&oldid=91545798