### PR TITLE
Add Keylog

### DIFF
--- a/data/brands/amenity/bicycle_parking.json
+++ b/data/brands/amenity/bicycle_parking.json
@@ -10,6 +10,17 @@
   },
   "items": [
     {
+      "displayName": "Keylog",
+      "locationSet": {"include": ["cz"]},
+      "tags": {
+        "amenity": "bicycle_parking",
+        "bicycle_parking": "bollard",
+        "brand": "Keylog",
+        "brand:wikidata": "Q140031150",
+        "name": "Keylog"
+      }
+    },
+    {
       "displayName": "Altinnova",
       "id": "altinnova-057a8b",
       "locationSet": {


### PR DESCRIPTION
Czech bicycle parking brand with more than 30 locations.