### PR TITLE
Add BKF

### DIFF
--- a/data/brands/amenity/car_wash.json
+++ b/data/brands/amenity/car_wash.json
@@ -20,6 +20,18 @@
   },
   "items": [
     {
+      "displayName": "BKF",
+      "locationSet": {"include": ["150", "ru"]},
+      "matchNames": ["bkf carwash"],
+      "preserveTags": ["^name"],
+      "tags": {
+        "amenity": "car_wash",
+        "brand": "BKF",
+        "brand:wikidata": "Q132174871",
+        "name": "BKF"
+      }
+    },
+    {
       "displayName": "Alltown",
       "id": "alltown-cac12f",
       "locationSet": {


### PR DESCRIPTION
Add BKF car wash brand with more than 50 locations in OSM.