### PR TITLE
Move Husqvarna and Stihl

### DIFF
--- a/data/brands/shop/groundskeeping.json
+++ b/data/brands/shop/groundskeeping.json
@@ -16,6 +16,17 @@
       }
     },
     {
+      "displayName": "Husqvarna",
+      "locationSet": {"include": ["001"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Husqvarna",
+        "brand:wikidata": "Q899356",
+        "name": "Husqvarna",
+        "shop": "groundskeeping"
+      }
+    },
+    {
       "displayName": "Mountfield",
       "id": "mountfield-9aa91c",
       "locationSet": {"include": ["cz", "sk"]},
@@ -24,6 +35,17 @@
         "brand": "Mountfield",
         "brand:wikidata": "Q21180783",
         "name": "Mountfield",
+        "shop": "groundskeeping"
+      }
+    },
+    {
+      "displayName": "Stihl",
+      "locationSet": {"include": ["001"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Stihl",
+        "brand:wikidata": "Q239372",
+        "name": "Stihl",
         "shop": "groundskeeping"
       }
     }

--- a/data/brands/shop/hardware.json
+++ b/data/brands/shop/hardware.json
@@ -175,17 +175,6 @@
       }
     },
     {
-      "displayName": "Husqvarna",
-      "id": "husqvarna-7cd80a",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "brand": "Husqvarna",
-        "brand:wikidata": "Q899356",
-        "name": "Husqvarna",
-        "shop": "hardware"
-      }
-    },
-    {
       "displayName": "Jernia",
       "id": "jernia-8a3989",
       "issues": [5500],
@@ -345,17 +334,6 @@
         "brand": "Santandreu",
         "brand:wikidata": "Q113217174",
         "name": "Santandreu",
-        "shop": "hardware"
-      }
-    },
-    {
-      "displayName": "Stihl",
-      "id": "stihl-7cd80a",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "brand": "Stihl",
-        "brand:wikidata": "Q239372",
-        "name": "Stihl",
         "shop": "hardware"
       }
     },


### PR DESCRIPTION
Husqvarna and Stihl are categorised under `shop=hardware`, which is a shop that mainly sells metal fasteners (screws, bolts, nails, hooks). However, Stihl and Husqvarna sell lawn mowers, chainsaws or string trimmers, and therefore the `shop=groundskeeping` category is more appropriate. They often also have a local shop name, so they should have preserveTags.