### PR TITLE
Add some Catalan bakery and café chains

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -766,8 +766,7 @@
         "amenity": "cafe",
         "brand": "Boheme",
         "brand:wikidata": "Q140089658",
-        "name": "Boheme",
-        "shop": "bakery"
+        "name": "Boheme"
       }
     },
     {

--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -759,6 +759,18 @@
       }
     },
     {
+      "displayName": "Boheme",
+      "id": "boheme",
+      "locationSet": {"include": ["es"]},
+      "tags": {
+        "amenity": "cafe",
+        "brand": "Boheme",
+        "brand:wikidata": "Q140089658",
+        "name": "Boheme",
+        "shop": "bakery"
+      }
+    },
+    {
       "displayName": "Bombay Cutting Chai",
       "id": "bombaycuttingchai-12649c",
       "locationSet": {"include": ["in", "qa"]},

--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -1008,6 +1008,17 @@
       }
     },
     {
+      "displayName": "Forn de Cabrianes",
+      "id": "forndecabrianes",
+      "locationSet": {"include": ["es"]},
+      "tags": {
+        "brand": "Forn de Cabrianes",
+        "brand:wikidata": "Q140089594",
+        "name": "Forn de Cabrianes",
+        "shop": "bakery"
+      }
+    },    
+    {
       "displayName": "Fornetti",
       "id": "fornetti-0c6f37",
       "locationSet": {

--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -410,6 +410,17 @@
       }
     },
     {
+      "displayName": "Baluard Barceloneta",
+      "id": "baluard",
+      "locationSet": {"include": ["es"]},
+      "tags": {
+        "brand": "Baluard Barceloneta",
+        "brand:wikidata": "Q140090087",
+        "name": "Baluard Barceloneta",
+        "shop": "bakery"
+      }
+    },
+    {
       "displayName": "Banette",
       "id": "banette-731a34",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -2628,6 +2628,22 @@
       }
     },
     {
+      "displayName": "Valero",
+      "id": "valero",
+      "locationSet": {"include": ["es"]},
+      "matchNames": [
+        "forn valero",
+        "valero forn tradicional",
+        "valero forn de pa"
+      ],
+      "tags": {
+        "brand": "Forn de pa Valero",
+        "brand:wikidata": "Q140089514",
+        "name": "Forn de pa Valero",
+        "shop": "bakery"
+      }
+    },    
+    {
       "displayName": "Valerio's Tropical Bakeshop",
       "id": "valeriostropicalbakeshop-515502",
       "locationSet": {"include": ["ca", "us"]},

--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -1698,6 +1698,17 @@
       }
     },
     {
+      "displayName": "Macxipa",
+      "id": "macxipa",
+      "locationSet": {"include": ["es"]},
+      "tags": {
+        "brand": "Macxipa",
+        "brand:wikidata": "Q140089625",
+        "name": "Macxipa",
+        "shop": "bakery"
+      }
+    },
+    {
       "displayName": "Maison Bécam",
       "id": "maisonbecam-09ad2c",
       "locationSet": {"include": ["fx"]},

--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -2645,12 +2645,13 @@
       "matchNames": [
         "forn valero",
         "valero forn tradicional",
-        "valero forn de pa"
+        "valero forn de pa",
+        "forn de pa valero"
       ],
       "tags": {
-        "brand": "Forn de pa Valero",
+        "brand": "Valero",
         "brand:wikidata": "Q140089514",
-        "name": "Forn de pa Valero",
+        "name": "Valero",
         "shop": "bakery"
       }
     },    

--- a/data/brands/shop/pastry.json
+++ b/data/brands/shop/pastry.json
@@ -174,6 +174,22 @@
       }
     },
     {
+      "displayName": "Demasié",
+      "id": "demasie",
+      "locationSet": {"include": ["es"]},
+      "matchNames": [
+        "demasie",
+        "cookies demasie"
+      ],
+      "tags": {
+        "brand": "Demasié",
+        "brand:wikidata": "Q140089894",
+        "name": "Demasié",
+        "shop": "pastry",
+        "alt_name": "Demasie"
+      }
+    },
+    {
       "displayName": "Gigi's Cupcakes",
       "id": "gigiscupcakes-64e364",
       "locationSet": {"include": ["us"]},

--- a/data/brands/shop/pastry.json
+++ b/data/brands/shop/pastry.json
@@ -176,7 +176,7 @@
     {
       "displayName": "Demasié",
       "id": "demasie",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es", "ad"]},
       "matchNames": [
         "demasie",
         "cookies demasie"


### PR DESCRIPTION
Valero is a bakery chain in the Vallès region of Catalonia, with [29 locations](https://www.pavalero.com/ca/botigues) as of June 2026. `locationSet` is `es` rather than `es-b.geojson` to be more future-proof.