### PR TITLE
Update Czech transit networks

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -29,6 +29,45 @@
   },
   "items": [
     {
+      "displayName": "Ideska",
+      "locationSet": {
+        "include": ["cz-31.geojson"]
+      },
+      "tags": {
+        "network": "Integrovaný dopravní systém Jihočeského kraje",
+        "network:short": "Ideska",
+        "network:wikidata": "Q138862649",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "ODIS",
+      "locationSet": {
+        "include": [
+          "cz-71.geojson",
+          "cz-72.geojson",
+          "cz-80.geojson"
+        ]
+      },
+      "tags": {
+        "network": "Integrovaný dopravní systém Moravskoslezského kraje",
+        "network": "ODIS",
+        "network:wikidata": "Q12043044",
+        "route": "bus"
+      }
+    },
+    {
+      "displayName": "Poulička",
+      "locationSet": {
+        "include": ["cz-72.geojson"]
+      },
+      "tags": {
+        "network": "Poulička",
+        "network:wikidata": "Q132080682",
+        "route": "bus"
+      }
+    },
+    {
       "displayName": "A-Welle",
       "id": "awelle-ba16da",
       "locationSet": {"include": ["ch"]},
@@ -7922,18 +7961,6 @@
       }
     },
     {
-      "displayName": "IDS TA",
-      "id": "idsta-f0f35e",
-      "locationSet": {
-        "include": ["cz-31.geojson"]
-      },
-      "tags": {
-        "network": "IDS TA",
-        "network:wikidata": "Q12021690",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "IDS Východ",
       "id": "integrovanydopravnysystemidsvychod-51c51c",
       "locationSet": {"include": ["sk"]},
@@ -10328,18 +10355,6 @@
       "tags": {"network": "Macau", "route": "bus"}
     },
     {
-      "displayName": "MAD Třebíč",
-      "id": "madtrebic-7409c5",
-      "locationSet": {
-        "include": ["cz-63.geojson"]
-      },
-      "tags": {
-        "network": "MAD Třebíč",
-        "network:wikidata": "Q12039369",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "Madison Metro Transit",
       "id": "madisonmetrotransit-589abe",
       "locationSet": {
@@ -11351,26 +11366,6 @@
       }
     },
     {
-      "displayName": "MHD Česká Lípa",
-      "id": "mhdceskalipa-d65ed1",
-      "locationSet": {
-        "include": ["cz-51.geojson"]
-      },
-      "tags": {
-        "network": "MHD Česká Lípa",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "MHD DPmML",
-      "id": "mhddpmml-a45453",
-      "locationSet": {"include": ["001"]},
-      "tags": {
-        "network": "MHD DPmML",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "MHD Galanta",
       "id": "mhdgalanta-51c51c",
       "locationSet": {"include": ["sk"]},
@@ -11408,28 +11403,6 @@
       }
     },
     {
-      "displayName": "MHD Jablonec Nad Nisou",
-      "id": "mhdjablonecnadnisou-d65ed1",
-      "locationSet": {
-        "include": ["cz-51.geojson"]
-      },
-      "tags": {
-        "network": "MHD Jablonec Nad Nisou",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "MHD Jihlava",
-      "id": "mhdjihlava-7409c5",
-      "locationSet": {
-        "include": ["cz-63.geojson"]
-      },
-      "tags": {
-        "network": "MHD Jihlava",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "MHD Kladno",
       "id": "mhdkladno-8f3333",
       "locationSet": {
@@ -11451,6 +11424,10 @@
       },
       "tags": {
         "network": "MHD Kolín",
+        "network:wikidata": "Q140092099",
+        "operator": "Okresní autobusová doprava Kolín",
+        "operator:short": "OAD Kolín",
+        "operator:wikidata": "Q14324218",
         "route": "bus"
       }
     },
@@ -11489,17 +11466,6 @@
         "network:wikidata": "Q110521792",
         "operator": "Arriva Nové Zámky",
         "operator:wikidata": "Q102542886",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "MHD Liberec",
-      "id": "mhdliberec-d65ed1",
-      "locationSet": {
-        "include": ["cz-51.geojson"]
-      },
-      "tags": {
-        "network": "MHD Liberec",
         "route": "bus"
       }
     },
@@ -11552,18 +11518,6 @@
         "network:wikidata": "Q12771415",
         "operator": "Transdev",
         "operator:wikidata": "Q135073012",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "MHD Opava",
-      "id": "mhdopava-f6645c",
-      "locationSet": {
-        "include": ["cz-80.geojson"]
-      },
-      "tags": {
-        "network": "MHD Opava",
-        "network:wikidata": "Q12043044",
         "route": "bus"
       }
     },
@@ -11660,17 +11614,6 @@
       }
     },
     {
-      "displayName": "MHD Prostějov",
-      "id": "mhdprostejov-655c18",
-      "locationSet": {
-        "include": ["cz-71.geojson"]
-      },
-      "tags": {
-        "network": "MHD Prostějov",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "MHD Říčany",
       "id": "mhdricany-6a7ed1",
       "locationSet": {
@@ -11681,6 +11624,9 @@
       },
       "tags": {
         "network": "MHD Říčany",
+        "network:wikidata": "Q140078738",
+        "operator": "ČSAD Benešov",
+        "operator:wikidata": "Q58875637",
         "route": "bus"
       }
     },
@@ -11741,17 +11687,6 @@
         "network:wikidata": "Q136803571",
         "operator": "Městská doprava Teplice",
         "operator:wikidata": "Q136803599",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "MHD Uherské Hradiště",
-      "id": "mhduherskehradiste-acaf49",
-      "locationSet": {
-        "include": ["cz-72.geojson"]
-      },
-      "tags": {
-        "network": "MHD Uherské Hradiště",
         "route": "bus"
       }
     },
@@ -13419,22 +13354,6 @@
       "tags": {
         "network": "OC Transpo",
         "network:wikidata": "Q3347525",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "ODIS",
-      "id": "odis-028705",
-      "locationSet": {
-        "include": [
-          "cz-71.geojson",
-          "cz-72.geojson",
-          "cz-80.geojson"
-        ]
-      },
-      "tags": {
-        "network": "ODIS",
-        "network:wikidata": "Q12043044",
         "route": "bus"
       }
     },

--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -14,6 +14,69 @@
   },
   "items": [
     {
+      "displayName": "Ideska",
+      "locationSet": {
+        "include": ["cz-31.geojson"]
+      },
+      "tags": {
+        "network": "Integrovaný dopravní systém Jihočeského kraje",
+        "network:short": "Ideska",
+        "network:wikidata": "Q138862649",
+        "route": "train"
+      }
+    },
+    {
+      "displayName": "IDOK",
+      "locationSet": {
+        "include": ["cz-41.geojson"]
+      },
+      "tags": {
+        "network": "Integrovaná doprava Karlovarského kraje",
+        "network:short": "IDOK",
+        "network:wikidata": "Q12021681",
+        "route": "train"
+      }
+    },
+    {
+      "displayName": "Leo Express",
+      "locationSet": {
+        "include": ["cz", "de", "pl", "sk"]
+      },
+      "tags": {
+        "network": "Leo Express",
+        "network:wikidata": "Q851963",
+        "route": "train"
+      }
+    },
+    {
+      "displayName": "ODIS",
+      "locationSet": {
+        "include": [
+          "cz-71.geojson",
+          "cz-72.geojson",
+          "cz-80.geojson"
+        ]
+      },
+      "tags": {
+        "network": "Integrovaný dopravní systém Moravskoslezského kraje",
+        "network": "ODIS",
+        "network:wikidata": "Q12043044",
+        "route": "train"
+      }
+    },
+    {
+      "displayName": "VDV",
+      "locationSet": {
+        "include": ["cz-63.geojson"]
+      },
+      "tags": {
+        "network": "Veřejná doprava Vysočiny",
+        "network:short": "VDV",
+        "network:wikidata": "Q85938572",
+        "route": "train"
+      }
+    },
+    {
       "displayName": "A-Welle",
       "id": "awelle-d5549f",
       "locationSet": {"include": ["ch"]},
@@ -1841,22 +1904,6 @@
         "network": "Oberösterreichischer Verkehrsverbund",
         "network:short": "OÖVV",
         "network:wikidata": "Q2011605",
-        "route": "train"
-      }
-    },
-    {
-      "displayName": "ODIS",
-      "id": "odis-e2fb0f",
-      "locationSet": {
-        "include": [
-          "cz-71.geojson",
-          "cz-72.geojson",
-          "cz-80.geojson"
-        ]
-      },
-      "tags": {
-        "network": "ODIS",
-        "network:wikidata": "Q12043044",
         "route": "train"
       }
     },

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -11,6 +11,22 @@
   },
   "items": [
     {
+      "displayName": "ODIS",
+      "locationSet": {
+        "include": [
+          "cz-71.geojson",
+          "cz-72.geojson",
+          "cz-80.geojson"
+        ]
+      },
+      "tags": {
+        "network": "Integrovaný dopravní systém Moravskoslezského kraje",
+        "network:short": "ODIS",
+        "network:wikidata": "Q12043044",
+        "route": "tram"
+      }
+    },
+    {
       "displayName": "Asociația de Dezvoltare Intercomunitară pentru Transport Public București – Ilfov",
       "id": "asociatiadedezvoltareintercomunitarapentrutransportpublicbucurestiilfov-200f98",
       "locationSet": {"include": ["ro"]},
@@ -556,25 +572,6 @@
         "network": "Nordhessischer VerkehrsVerbund",
         "network:short": "NVV",
         "network:wikidata": "Q1998056",
-        "route": "tram"
-      }
-    },
-    {
-      "displayName": "ODIS",
-      "id": "odis-ad1f04",
-      "locationSet": {
-        "include": [
-          "cz-71.geojson",
-          "cz-72.geojson",
-          "cz-80.geojson"
-        ]
-      },
-      "tags": {
-        "network": "ODIS",
-        "network:wikidata": "Q1741955",
-        "operator": "Dopravní podnik Ostrava",
-        "operator:short": "DPO",
-        "operator:wikidata": "Q11323689",
         "route": "tram"
       }
     },

--- a/data/transit/route/trolleybus.json
+++ b/data/transit/route/trolleybus.json
@@ -11,6 +11,64 @@
   },
   "items": [
     {
+      "displayName": "DÚK",
+      "locationSet": {
+        "include": ["cz-42.geojson"]
+      },
+      "tags": {
+        "network": "Doprava Ústeckého kraje",
+        "network:short": "DÚK",
+        "network:wikidata": "Q12021691",
+        "route": "trolleybus"
+      }
+    },
+    {
+      "displayName": "Ideska",
+      "locationSet": {
+        "include": ["cz-31.geojson"]
+      },
+      "tags": {
+        "network": "Integrovaný dopravní systém Jihočeského kraje",
+        "network:short": "Ideska",
+        "network:wikidata": "Q138862649",
+        "operator": "Dopravní podnik města České Budějovice",
+        "operator:short": "DPMCB",
+        "operator:wikidata": "Q15123983",
+        "route": "trolleybus"
+      }
+    },
+    {
+      "displayName": "IDOK",
+      "locationSet": {
+        "include": ["cz-41.geojson"]
+      },
+      "tags": {
+        "network": "Integrovaná doprava Karlovarského kraje",
+        "network:short": "IDOK",
+        "network:wikidata": "Q12021681",
+        "operator": "Městská doprava Mariánské Lázně",
+        "operator:short": "MDML",
+        "operator:wikidata": "Q61950567",
+        "route": "train"
+      }
+    },
+    {
+      "displayName": "ODIS",
+      "locationSet": {
+        "include": [
+          "cz-71.geojson",
+          "cz-72.geojson",
+          "cz-80.geojson"
+        ]
+      },
+      "tags": {
+        "network": "Integrovaný dopravní systém Moravskoslezského kraje",
+        "network": "ODIS",
+        "network:wikidata": "Q12043044",
+        "route": "trolleybus"
+      }
+    },
+    {
       "displayName": "Arnhem-Nijmegen",
       "id": "arnhemnijmegen-90583d",
       "locationSet": {"include": ["nl"]},
@@ -257,31 +315,6 @@
       }
     },
     {
-      "displayName": "MHD Jihlava",
-      "id": "mhdjihlava-287375",
-      "locationSet": {
-        "include": ["cz-63.geojson"]
-      },
-      "tags": {
-        "network": "MHD Jihlava",
-        "route": "trolleybus"
-      }
-    },
-    {
-      "displayName": "MHD Opava",
-      "id": "mhdopava-19e5db",
-      "locationSet": {
-        "include": ["cz-80.geojson"]
-      },
-      "tags": {
-        "network": "MHD Opava",
-        "network:wikidata": "Q12043044",
-        "operator": "MDPO",
-        "operator:wikidata": "Q12039422",
-        "route": "trolleybus"
-      }
-    },
-    {
       "displayName": "MHD Pardubice",
       "id": "mhdpardubice-6aa65f",
       "locationSet": {
@@ -385,25 +418,6 @@
         "operator": "San Francisco Municipal Transportation Agency",
         "operator:short": "SFMTA",
         "operator:wikidata": "Q7414072",
-        "route": "trolleybus"
-      }
-    },
-    {
-      "displayName": "ODIS",
-      "id": "odis-6959ea",
-      "locationSet": {
-        "include": [
-          "cz-71.geojson",
-          "cz-72.geojson",
-          "cz-80.geojson"
-        ]
-      },
-      "tags": {
-        "network": "ODIS",
-        "network:wikidata": "Q12043044",
-        "operator": "Dopravní podnik Ostrava",
-        "operator:short": "DPO",
-        "operator:wikidata": "Q11323689",
         "route": "trolleybus"
       }
     },

--- a/data/transit/route/trolleybus.json
+++ b/data/transit/route/trolleybus.json
@@ -49,7 +49,7 @@
         "operator": "Městská doprava Mariánské Lázně",
         "operator:short": "MDML",
         "operator:wikidata": "Q61950567",
-        "route": "train"
+        "route": "trolleybus"
       }
     },
     {


### PR DESCRIPTION
Updated bus, train, tram and trolleybus networks in the Czech Republic. Some were removed due to integration into new integrated transport systems.