### PR TITLE
Remove Matchname Great Western Bank.json

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -7211,8 +7211,7 @@
         "1st interstate bancsystem",
         "1st interstate bank",
         "first interstate",
-        "first interstate bancsystem",
-        "great western bank"
+        "first interstate bancsystem"
       ],
       "tags": {
         "amenity": "bank",


### PR DESCRIPTION
Remove Matchname Great Western Bank
Great Western Bank is part of First Interstate Bank and is no longer a valid bank brand. The Brand is retired: The Great Western Bank name, logo, and signage have been fully phased out since May 2022. All former locations, marketing materials, and websites operate solely under the First Interstate Bank name. Official website:
https://www.firstinterstatebank.com/