### PR TITLE
Charging station file cleanup

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -614,9 +614,7 @@
       "tags": {
         "amenity": "charging_station",
         "brand": "evmapa",
-        "brand:wikidata": "Q136929506",
-        "network": "evmapa",
-        "network:wikidata": "Q136929506"
+        "brand:wikidata": "Q136929506"
       }
     },
     {
@@ -1027,9 +1025,7 @@
       "tags": {
         "amenity": "charging_station",
         "brand": "NabiBajk",
-        "brand:wikidata": "Q131407297",
-        "network": "Powerbox.one",
-        "network:wikidata": "Q131535492"
+        "brand:wikidata": "Q131407297"
       }
     },
     {
@@ -1129,9 +1125,7 @@
       "tags": {
         "amenity": "charging_station",
         "brand": "OpenLoop",
-        "brand:wikidata": "Q113289213",
-        "network": "OpenLoop",
-        "network:wikidata": "Q113289213"
+        "brand:wikidata": "Q113289213"
       }
     },
     {
@@ -1201,9 +1195,7 @@
       "tags": {
         "amenity": "charging_station",
         "brand": "Powerbox.one",
-        "brand:wikidata": "Q131535492",
-        "network": "Powerbox.one",
-        "network:wikidata": "Q131535492"
+        "brand:wikidata": "Q131535492"
       }
     },
     {
@@ -1605,11 +1597,7 @@
         "brand": "Энергия Москвы",
         "brand:en": "Energy of Moscow",
         "brand:ru": "Энергия Москвы",
-        "brand:wikidata": "Q125346046",
-        "network": "Энергия Москвы",
-        "network:en": "Energy of Moscow",
-        "network:ru": "Энергия Москвы",
-        "network:wikidata": "Q125346046"
+        "brand:wikidata": "Q125346046"
       }
     },
     {


### PR DESCRIPTION
Following discussion in openstreetmap-carto/openstreetmap-carto#5238 and openstreetmap-carto/openstreetmap-carto#4450 regarding rendering of names and following the [disputed tags](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dcharging_station#Disputed_Tags) section of the charging station wiki, I have gone through and removed inaccurate `network` tags from charging stations. These were duplicate information from `brand` in this index, so no information is lost.