### PR TITLE
Add Givova

### DIFF
--- a/data/brands/shop/sports.json
+++ b/data/brands/shop/sports.json
@@ -353,6 +353,16 @@
       }
     },
     {
+      "displayName": "Givova",,
+      "locationSet": {"include": ["it"]},
+      "tags": {
+        "brand": "Givova",
+        "brand:wikidata": "Q3108205",
+        "name": "Givova",
+        "shop": "sports"
+      }
+    },
+    {
       "displayName": "GO Sport",
       "id": "gosport-63990e",
       "locationSet": {"include": ["fr"]},

--- a/data/brands/shop/sports.json
+++ b/data/brands/shop/sports.json
@@ -353,7 +353,7 @@
       }
     },
     {
-      "displayName": "Givova",,
+      "displayName": "Givova",
       "locationSet": {"include": ["it"]},
       "tags": {
         "brand": "Givova",


### PR DESCRIPTION
Add Italian sports brand Givova (https://www.wikidata.org/wiki/Q3108205)