### PR TITLE
Add brand: Enterprise Bank & Trust bank.json

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -6458,26 +6458,6 @@
       }
     },
     {
-      "displayName": "Enterprise Bank & Trust",
-      "locationSet": {
-        "include": [
-          "us-az.geojson",
-          "us-ca.geojson",
-          "us-fl.geojson",
-          "us-ks.geojson",
-          "us-mo.geojson",
-          "us-nv.geojson",
-          "us-nm.geojson"
-        ]
-      },
-      "tags": {
-        "amenity": "bank",
-        "brand": "Enterprise Bank & Trust",
-        "brand:wikidata": "Q128645525",
-        "name": "Enterprise Bank & Trust"
-      }
-    },
-    {
       "displayName": "Equitas Small Finance Bank",
       "id": "equitassmallfinancebank-34f411",
       "locationSet": {"include": ["in"]},

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -20583,6 +20583,26 @@
         "name:en": "Kagoshima Bank",
         "name:ja": "鹿児島銀行"
       }
-    }
+    },
+    {
+  "displayName": "Enterprise Bank & Trust",
+  "locationSet": {
+    "include": [
+      "us-az.geojson",
+      "us-ca.geojson",
+      "us-fl.geojson",
+      "us-ks.geojson",
+      "us-mo.geojson",
+      "us-nv.geojson",
+      "us-nm.geojson"
+    ]
+  },
+  "tags": {
+    "amenity": "bank",
+    "brand": "Enterprise Bank & Trust",
+    "brand:wikidata": "Q128645525",
+    "name": "Enterprise Bank & Trust"
+  }
+}
   ]
 }

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -6458,6 +6458,26 @@
       }
     },
     {
+      "displayName": "Enterprise Bank & Trust",
+      "locationSet": {
+        "include": [
+          "us-az.geojson",
+          "us-ca.geojson",
+          "us-fl.geojson",
+          "us-ks.geojson",
+          "us-mo.geojson",
+          "us-nv.geojson",
+          "us-nm.geojson"
+        ]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": "Enterprise Bank & Trust",
+        "brand:wikidata": "Q128645525",
+        "name": "Enterprise Bank & Trust"
+      }
+    },
+    {
       "displayName": "Equitas Small Finance Bank",
       "id": "equitassmallfinancebank-34f411",
       "locationSet": {"include": ["in"]},

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -20604,25 +20604,25 @@
         "name:ja": "鹿児島銀行"
       }
     },
-    {
-  "displayName": "Enterprise Bank & Trust",
-  "locationSet": {
-    "include": [
-      "us-az.geojson",
-      "us-ca.geojson",
-      "us-fl.geojson",
-      "us-ks.geojson",
-      "us-mo.geojson",
-      "us-nv.geojson",
-      "us-nm.geojson"
-    ]
-  },
-  "tags": {
-    "amenity": "bank",
-    "brand": "Enterprise Bank & Trust",
-    "brand:wikidata": "Q128645525",
-    "name": "Enterprise Bank & Trust"
-  }
-}
+  {
+      "displayName": " Enterprise Bank & Trust ",
+      "locationSet": {
+        "include": [
+          "us-az.geojson",
+          "us-ca.geojson",
+          "us-fl.geojson",
+          "us-ks.geojson",
+          "us-mo.geojson",
+          "us-nv.geojson",
+          "us-nm.geojson"
+        ]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": " Enterprise Bank & Trust ",
+        "brand:wikidata": " Q128645525",
+        "name": " Enterprise Bank & Trust "
+      }
+    }
   ]
 }


### PR DESCRIPTION
add Enterprise Bank & Trust: a commercial bank 
official website: https://www.enterprisebank.com/
Enterprise Bank & Trust is chartered as a trust company with banking powers. It acts, operates, and is regulated in exactly the same way as traditional commercial banks. As of 2026, Enterprise Bank & Trust operates 58 full-service domestic branches. This reflects their absolute physical footprint following the completion of their latest major expansion, in which they successfully finalized the acquisition of 12 branch locations from First Interstate Bank. Enterprise Bank & Trust operates physical, full-service branches in 7 U.S. states: Arizona, California, Florida, Kansas, Missouri, Nevada, New Mexico

Wikidata: Q5379218