### PR TITLE
Update brand name Spar Express convenience.json

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5651,8 +5651,8 @@
       },
       "matchTags": ["shop/supermarket"],
       "tags": {
-        "brand": "Spar",
-        "brand:wikidata": "Q610492",
+        "brand": "Spar Express",
+        "brand:wikidata": "Q12321004",
         "name": "Spar Express",
         "shop": "convenience"
       }
@@ -5665,8 +5665,8 @@
       "matchTags": ["shop/supermarket"],
       "preserveTags": ["^name"],
       "tags": {
-        "brand": "Spar",
-        "brand:wikidata": "Q610492",
+        "brand": "Spar Express",
+        "brand:wikidata": "Q12321004",
         "name": "Spar Express",
         "shop": "convenience"
       }


### PR DESCRIPTION
update brand name to 'Spar Express':
SPAR Express is an own brand within the SPAR group, only the display name is 'Spar Express' but not the brand name 'Spar'. references: https://spar-international.com/aboutus/store-formats/ Wikidata Q-Code for Spar Express (supermarket brand of SPAR) is also available Q12321004 and should be changed. The same change should  also be applied to "Spar Express (Norge)"