### PR TITLE
Update atm.json Adding new brand OTP Banka in SI

### DIFF
--- a/data/brands/amenity/atm.json
+++ b/data/brands/amenity/atm.json
@@ -708,6 +708,15 @@
         "brand:wikidata": "Q709259",
         "brand:zh": "中華郵政"
       }
+    },
+    {
+      "displayName": "OTP Banka",
+      "locationSet": {"include": ["si"]},
+      "tags": {
+        "amenity": "atm",
+        "brand": "OTP Banka",
+        "brand:wikidata": "Q13537695"
+      }
     }
   ]
 }


### PR DESCRIPTION
Added new ATM network in Slovenia
https://www.otpbanka.si/
OTP Banka Slovensko (Q13537695)