### PR TITLE
Add a new bank entry OTP Banka in Slovenia

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -20583,6 +20583,16 @@
         "name:en": "Kagoshima Bank",
         "name:ja": "鹿児島銀行"
       }
+    },
+    {
+      "displayName": "OTP Banka",
+      "locationSet": {"include": ["si"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "OTP Banka",
+        "brand:wikidata": "Q13537695",
+        "name": "OTP Banka"
+      }
     }
   ]
 }


### PR DESCRIPTION
Added new bank entry for Slovenia
https://www.otpbanka.si/
OTP Banka Slovensko (Q13537695)