### PR TITLE
Add brand: Enterprise Bank & Trust bank.json

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -20593,6 +20593,26 @@
         "brand:wikidata": "Q13537695",
         "name": "OTP Banka"
       }
+    },
+    {
+      "displayName": "Enterprise Bank & Trust",
+      "locationSet": {
+        "include": [
+          "us-az.geojson",
+          "us-ca.geojson",
+          "us-fl.geojson",
+          "us-ks.geojson",
+          "us-mo.geojson",
+          "us-nv.geojson",
+          "us-nm.geojson"
+        ]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": "Enterprise Bank & Trust",
+        "brand:wikidata": "Q128645525",
+        "name": "Enterprise Bank & Trust"
+      }
     }
   ]
 }


### PR DESCRIPTION
add Enterprise Bank & Trust: a commercial bank
official website: https://www.enterprisebank.com/
Enterprise Bank & Trust is chartered as a trust company with banking powers. It acts, operates, and is regulated in exactly the same way as traditional commercial banks. As of 2026, Enterprise Bank & Trust operates 58 full-service domestic branches. This reflects their absolute physical footprint following the completion of their latest major expansion, in which they successfully finalized the acquisition of 12 branch locations from First Interstate Bank. Enterprise Bank & Trust operates physical, full-service