### PR TITLE
Add network:wikidata for Związek Powiatowo-Gminny "SOWIOGÓRSKIE AUTOBUSY"

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -24470,6 +24470,7 @@
       },
       "tags": {
         "network": "Związek Powiatowo-Gminny \"SOWIOGÓRSKIE AUTOBUSY\"",
+        "network:wikidata": "Q140249677",
         "route": "bus"
       }
     },


### PR DESCRIPTION
I have created Wikidata entry for for Związek Powiatowo-Gminny "SOWIOGÓRSKIE AUTOBUSY": https://www.wikidata.org/wiki/Q140249677 and would like it to modify existing NSI transit route definition.