### PR TITLE
Add Mongolia to location sets for CU and GS25

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -1712,7 +1712,7 @@
     {
       "displayName": "CU",
       "id": "cu-3b6392",
-      "locationSet": {"include": ["kr", "my"]},
+      "locationSet": {"include": ["kr", "mn", "my"]},
       "matchNames": ["씨유"],
       "tags": {
         "brand": "CU",
@@ -2650,7 +2650,7 @@
     {
       "displayName": "GS25",
       "id": "gs25-f248a7",
-      "locationSet": {"include": ["kr", "vn"]},
+      "locationSet": {"include": ["kr", "mn", "vn"]},
       "matchNames": ["gs편의점", "지에스25", "지에스편의점"],
       "matchTags": ["shop/supermarket"],
       "tags": {


### PR DESCRIPTION
Both convenience stores operate in Mongolia as well.

Websites are https://cumongol.mn and https://gs25.mn respectively.
The stores' respective Wikipedia pages and OSM POI data also further back this up.

The stores are signed as "CU" and "GS25" in Mongolia, the same as in Korea, therefore the name tags remain unchanged. I did add the Mongolian websites to Wikidata though under the "applies to jurisdiction = Mongolia" qualifier.