### PR TITLE
Deprecated tag gtfs:feed

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -4957,7 +4957,6 @@
       "id": "compagniedestransportsstrasbourgeois-e5fe57",
       "locationSet": {"include": [[7.75, 48.58]]},
       "tags": {
-        "gtfs:feed": "FR-GES-CTS",
         "network": "Compagnie des Transports Strasbourgeois",
         "network:short": "CTS",
         "network:wikidata": "Q2990068",

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -126,7 +126,6 @@
       "id": "compagniedestransportsstrasbourgeois-19418d",
       "locationSet": {"include": [[7.75, 48.58]]},
       "tags": {
-        "gtfs:feed": "FR-GES-CTS",
         "network": "Compagnie des Transports Strasbourgeois",
         "network:short": "CTS",
         "network:wikidata": "Q2990068",


### PR DESCRIPTION
I removed the `gtfs:feed` tag that I had added for the Strasbourg public transit network, because this tag is now deprecated and has been replaced by the suffix code (for example, `gtfs:feed=FR-GES-CTS` + `gtfs:stop_id=230E` => `gtfs:stop_id:FR-GES-CTS=230E`).

https://wiki.openstreetmap.org/wiki/Key:gtfs:feed