### PR TITLE
Remove fake names from Dutch parcel lockers

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -317,8 +317,7 @@
       "tags": {
         "amenity": "parcel_locker",
         "brand": "DHL",
-        "brand:wikidata": "Q132858576",
-        "name": "DHL Pakketautomaat"
+        "brand:wikidata": "Q132858576"
       }
     },
     {
@@ -1047,7 +1046,6 @@
         "amenity": "parcel_locker",
         "brand": "PostNL",
         "brand:wikidata": "Q5921598",
-        "name": "PostNL Pakketautomaat",
         "operator": "PostNL",
         "operator:wikidata": "Q5921598"
       }


### PR DESCRIPTION
These objects don't really have a name according to the OSM standards. So, the name tag shouldn't be added.