### PR TITLE
Move Utrecht Binnen from tram to light rail

### DIFF
--- a/data/transit/route/light_rail.json
+++ b/data/transit/route/light_rail.json
@@ -82,6 +82,21 @@
       }
     },
     {
+      "displayName": "Utrecht Binnen",
+      "id": "utrechtbinnen-50b0a0",
+      "locationSet": {"include": ["nl"]},
+      "matchNames": ["regio utrecht"],
+      "tags": {
+        "network": "Utrecht Binnen",
+        "network:wikidata": "Q116159424",
+        "operator": "U-OV",
+        "operator:wikidata": "Q15910412",
+        "brand": "U-tram",
+        "brand:wikidata": "Q124567597",
+        "route": "light_rail"
+      }
+    },
+    {
       "displayName": "Docklands Light Railway",
       "id": "docklandslightrailway-0d7c17",
       "locationSet": {"include": ["gb"]},

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -1008,17 +1008,6 @@
       }
     },
     {
-      "displayName": "Utrecht Binnen",
-      "id": "utrechtbinnen-50b0a0",
-      "locationSet": {"include": ["nl"]},
-      "matchNames": ["regio utrecht"],
-      "tags": {
-        "network": "Utrecht Binnen",
-        "network:wikidata": "Q116159424",
-        "route": "tram"
-      }
-    },
-    {
       "displayName": "Västtrafik",
       "id": "vasttrafik-2462bf",
       "locationSet": {"include": ["se"]},


### PR DESCRIPTION
The tram in Utrecht is tagged as light_rail, since it's more light_rail than a tram. This should make sure the NSI entry is for the right route type.