### PR TITLE
Add operator Landesbetrieb Mobilität Rheinland-Pfalz for guideposts

### DIFF
--- a/data/operators/tourism/information.json
+++ b/data/operators/tourism/information.json
@@ -11,7 +11,10 @@
       "locationSet": {
         "include": ["de-rp.geojson"]
       },
-      "matchNames": ["lbm rheinland-pfalz"],
+      "matchNames": [
+        "lbm rheinland-pfalz",
+        "lbm rlp"
+      ],
       "tags": {
         "information": "guidepost",
         "operator": "Landesbetrieb Mobilität Rheinland-Pfalz",

--- a/data/operators/tourism/information.json
+++ b/data/operators/tourism/information.json
@@ -6,6 +6,20 @@
   },
   "items": [
     {
+      "displayName": "Landesbetrieb Mobilität Rheinland-Pfalz",
+      "id": "landesbetriebmobilitatrheinlandpfalz-095948",
+      "locationSet": {
+        "include": ["de-rp.geojson"]
+      },
+      "matchNames": ["lbm rheinland-pfalz"],
+      "tags": {
+        "information": "guidepost",
+        "operator": "Landesbetrieb Mobilität Rheinland-Pfalz",
+        "operator:wikidata": "Q1802132",
+        "tourism": "information"
+      }
+    },
+    {
       "displayName": "Millennium Milepost",
       "id": "walkwheelcycletrust-482d1d",
       "locationSet": {"include": ["gb"]},


### PR DESCRIPTION
This PR adds Landesbetrieb Mobilität Rheinland-Pfalz (also LBM Rheinland-Pfalz, sometimes  LBM RLP) as operator for guideposts; ~110 occurrences are already tagged with operator:wikidata =Q1802132

Occurences via overpass
node["operator"="Landesbetrieb Mobilität Rheinland-Pfalz"]["information"="guidepost"]
node["operator"="LBM Rheinland-Pfalz"]["information"="guidepost"]
