### PR TITLE
Add Bankomat ATM network in Sweden (971 locations) in atm.json

### DIFF
--- a/data/brands/amenity/atm.json
+++ b/data/brands/amenity/atm.json
@@ -708,6 +708,15 @@
         "brand:wikidata": "Q709259",
         "brand:zh": "中華郵政"
       }
+    },
+    {
+      "displayName": "Bankomat",
+      "locationSet": {"include": ["se"]},
+      "tags": {
+        "amenity": "atm",
+        "brand": "Bankomat",
+        "brand:wikidata": "Q10426078"
+      }
     }
   ]
 }


### PR DESCRIPTION
Added new atm entry for Sweden ("Bankomat") 
https://www.bankomat.se/karta/
Bankomat (Q10426078)