### PR TITLE
Add new brand "Deutsche Vermögensverwaltung"

### DIFF
--- a/data/brands/office/financial_advisor.json
+++ b/data/brands/office/financial_advisor.json
@@ -63,6 +63,24 @@
       }
     },
     {
+      "displayName": "Deutsche Vermögensberatung",
+      "id": "deutschevermogensberatung-04d559",
+      "locationSet": {"include": ["de"]},
+      "matchTags": [
+        "office/association",
+        "office/company",
+        "office/insurance",
+        "office/investment"
+      ],
+      "tags": {
+        "brand": "Deutsche Vermögensberatung",
+        "brand:wikidata": "Q320111",
+        "name": "Deutsche Vermögensberatung",
+        "office": "financial_advisor",
+        "short_name": "DVAG"
+      }
+    },
+    {
       "displayName": "Edward Jones",
       "id": "edwardjones-ea0e83",
       "locationSet": {"include": ["ca", "us"]},


### PR DESCRIPTION
Has 5200 locations according to its own website.

Wikidata: https://www.wikidata.org/wiki/Q320111
Location finder: https://www.dvag.de/dvag/unsere-vermoegensberater/vermoegensberater-finden.html