### PR TITLE
Remove SNS bank and RegioBank

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -1144,7 +1144,7 @@
       "displayName": "ASN Bank",
       "id": "asnbank-fb21a8",
       "locationSet": {"include": ["nl"]},
-      "matchNames": ["SNS Bank"],
+      "matchNames": ["SNS Bank", "RegioBank"],
       "tags": {
         "amenity": "bank",
         "brand": "ASN Bank",
@@ -11823,17 +11823,6 @@
         "brand:wikidata": "Q7339070",
         "name": "RCBC",
         "official_name": "Rizal Commercial Banking Corporation"
-      }
-    },
-    {
-      "displayName": "RegioBank",
-      "id": "regiobank-fb21a8",
-      "locationSet": {"include": ["nl"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "RegioBank",
-        "brand:wikidata": "Q2115864",
-        "name": "RegioBank"
       }
     },
     {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -1144,6 +1144,7 @@
       "displayName": "ASN Bank",
       "id": "asnbank-fb21a8",
       "locationSet": {"include": ["nl"]},
+      "matchNames": ["SNS Bank"],
       "tags": {
         "amenity": "bank",
         "brand": "ASN Bank",
@@ -12720,17 +12721,6 @@
         "brand:wikidata": "Q17218805",
         "name": "SMBC信託銀行",
         "name:en": "SMBC Trust Bank"
-      }
-    },
-    {
-      "displayName": "SNS Bank",
-      "id": "snsbank-fb21a8",
-      "locationSet": {"include": ["nl"]},
-      "tags": {
-        "amenity": "bank",
-        "brand": "SNS Bank",
-        "brand:wikidata": "Q135338857",
-        "name": "SNS Bank"
       }
     },
     {


### PR DESCRIPTION
Both SNS bank and RegioBank are rebranded to ASN Bank. Hence, they should be removed from the NSI.