### PR TITLE
Remove Wendy's exclusion for AU

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -11714,7 +11714,7 @@
       "id": "wendys-01b047",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["au", "ge", "jp"]
+        "exclude": ["ge", "jp"]
       },
       "tags": {
         "amenity": "fast_food",


### PR DESCRIPTION
Wendy's now has multiple outlets in Australia.