### PR TITLE
Add Estonia (EE) and Lithuania (LT) to Citadele in bank.json

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -5331,7 +5331,7 @@
     {
       "displayName": "Citadele",
       "id": "citadele-2d4942",
-      "locationSet": {"include": ["lv"]},
+      "locationSet": {"include": ["lv","lt","ee"]},
       "tags": {
         "amenity": "bank",
         "brand": "Citadele bank",


### PR DESCRIPTION
Add Estonia (EE) and Lithuania (LT) to Citadele (Q14239556), where the brand also operates.

https://www.citadele.ee/et/contacts/#locations
https://www.citadele.lt/lt/contacts/#locations