### PR TITLE
Remove operator ladenetz.de for charging_station

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -15,6 +15,7 @@
         "^genedis - valt$",
         "^hypercharger$",
         "^jernbaneverket$",
+        "^ladenetz.de$",
         "^private?$",
         "polar",
         "rolec"
@@ -3913,15 +3914,6 @@
       "tags": {
         "amenity": "charging_station",
         "operator": "Lade i Norge"
-      }
-    },
-    {
-      "displayName": "ladenetz.de",
-      "id": "ladenetzde-1299a8",
-      "locationSet": {"include": ["de"]},
-      "tags": {
-        "amenity": "charging_station",
-        "operator": "ladenetz.de"
       }
     },
     {


### PR DESCRIPTION
ladenetz.de is not an actual operator for charging_stations. It is only a conglomeration of some smaller companies which still operate their charging_stations independently. A lot more occurrences are currently tagged as `network=ladenetz.de` + `operator =*`which is also more appropriate. Thus this PR removes the corresponding entry.