### PR TITLE
Matchnames for AutobahnGmbH des Bundes

### DIFF
--- a/data/operators/emergency/phone.json
+++ b/data/operators/emergency/phone.json
@@ -361,6 +361,10 @@
       "displayName": "Die Autobahn GmbH des Bundes",
       "id": "dieautobahngmbhdesbundes-3876cc",
       "locationSet": {"include": ["de"]},
+      "matchNames": [
+        "autobahn gmbh",
+        "die autobahn gmbh"
+      ],
       "tags": {
         "emergency": "phone",
         "operator": "Die Autobahn GmbH des Bundes",


### PR DESCRIPTION
Some commonly used shorter names for AutobahnGmbH des Bundes