### PR TITLE
Rename Kieser Training to Kieser

### DIFF
--- a/data/brands/leisure/fitness_centre.json
+++ b/data/brands/leisure/fitness_centre.json
@@ -1032,16 +1032,16 @@
       }
     },
     {
-      "displayName": "Kieser Training",
+      "displayName": "Kieser",
       "id": "kiesertraining-a70e35",
       "locationSet": {
         "include": ["at", "au", "ch", "de", "lu"]
       },
       "tags": {
-        "brand": "Kieser Training",
+        "brand": "Kieser",
         "brand:wikidata": "Q1112367",
         "leisure": "fitness_centre",
-        "name": "Kieser Training"
+        "name": "Kieser"
       }
     },
     {


### PR DESCRIPTION
Since 2023, _Kieser Training_ is called just _Kieser_. Sources (all in German):

- https://web.archive.org/web/20230208072157/https://www.kieser-training.com/medienmitteilungen/id/3238/
- https://de.linkedin.com/posts/kieser_kieser-rebranding-brand-activity-7022182303544045568-dC0q
- https://www.horizont.net/schweiz/nachrichten/neue-kraft-kieser-training-verstaerkt-geschaeftsleitung-und-verkuerzt-namen-205596

This PR updates the entry.

Important to note:

- the main company is still called _Kieser Training AG_
  - but because it's a franchise, the `operator:*` is usually a different company
- the press release writes the brand in all caps, but on their website, it's always in title case
- Wikidata entry still has the old name, and I'm unsure whether to rename it as it's also tied to the German Wikipedia page "Kieser Training" as well as the Commons category