### PR TITLE
Add VodafoneZiggo, keep name of KPN XL/Experience store

### DIFF
--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -465,6 +465,7 @@
       "displayName": "KPN",
       "id": "kpn-c62d58",
       "locationSet": {"include": ["nl"]},
+      "preserveTags": ["^name"]
       "tags": {
         "brand": "KPN",
         "brand:wikidata": "Q338633",
@@ -904,12 +905,25 @@
       "displayName": "Vodafone",
       "id": "vodafone-bfcfa8",
       "locationSet": {
-        "include": ["de", "es", "gr", "it", "nl"]
+        "include": ["de", "es", "gr", "it"]
       },
       "tags": {
         "brand": "Vodafone",
         "brand:wikidata": "Q122141",
         "name": "Vodafone",
+        "shop": "telecommunication"
+      }
+    },
+    {
+      "displayName": "VodafoneZiggo",
+      "locationSet": {
+        "include": ["nl"]
+      },
+      "matchNames": ["Vodafone"],
+      "tags": {
+        "brand": "VodafoneZiggo",
+        "brand:wikidata": "Q55640416",
+        "name": "VodafoneZiggo",
         "shop": "telecommunication"
       }
     },

--- a/data/brands/shop/telecommunication.json
+++ b/data/brands/shop/telecommunication.json
@@ -465,7 +465,7 @@
       "displayName": "KPN",
       "id": "kpn-c62d58",
       "locationSet": {"include": ["nl"]},
-      "preserveTags": ["^name"]
+      "preserveTags": ["^name"],
       "tags": {
         "brand": "KPN",
         "brand:wikidata": "Q338633",


### PR DESCRIPTION
This change removes Vodafone from NL and adds VodafoneZiggo, since all stores are rebranded for both brands.

Also, the preserveTag name is added to KPN, since they also have KPN XL and KPN Experience Store as options for the name.