### PR TITLE
Add wikidata reference for Teapresso Bar

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -4675,6 +4675,7 @@
       "tags": {
         "amenity": "cafe",
         "brand": "Teapresso Bar",
+        "brand:wikidata": "Q140383803"
         "cuisine": "tea;coffee_shop",
         "name": "Teapresso Bar",
         "takeaway": "yes"

--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -4675,7 +4675,7 @@
       "tags": {
         "amenity": "cafe",
         "brand": "Teapresso Bar",
-        "brand:wikidata": "Q140383803"
+        "brand:wikidata": "Q140383803",
         "cuisine": "tea;coffee_shop",
         "name": "Teapresso Bar",
         "takeaway": "yes"


### PR DESCRIPTION
Apparently, Teapresso Bar was already added, but didn't have a Wikidata page; Fixes #12390