### PR TITLE
OTP banka - Slovakia fix, add Slovenia

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -10725,9 +10725,9 @@
       }
     },
     {
-      "displayName": "OTP Banka",
+      "displayName": "OTP Banka (Slovakia)",
       "id": "otpbanka-30392e",
-      "locationSet": {"include": ["si"]},
+      "locationSet": {"include": ["sk"]},
       "tags": {
         "amenity": "bank",
         "brand": "OTP Banka",

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -10725,14 +10725,14 @@
       }
     },
     {
-      "displayName": "OTP Banka (Slovakia)",
-      "id": "otpbanka-30392e",
-      "locationSet": {"include": ["sk"]},
+      "displayName": "OTP banka (Slovenija)",
+      "locationSet": {"include": ["si"]},
+      "matchNames": ["otp", "otp bank"],
       "tags": {
         "amenity": "bank",
-        "brand": "OTP Banka",
-        "brand:wikidata": "Q13537695",
-        "name": "OTP Banka"
+        "brand": "OTP banka",
+        "brand:wikidata": "Q140373875",
+        "name": "OTP banka"
       }
     },
     {
@@ -10744,17 +10744,6 @@
         "amenity": "bank",
         "brand": "OTP banka",
         "brand:wikidata": "Q31198593",
-        "name": "OTP banka"
-      }
-    },
-    {
-      "displayName": "OTP banka (Slovenija)",
-      "locationSet": {"include": ["si"]},
-      "matchNames": ["otp", "otp bank"],
-      "tags": {
-        "amenity": "bank",
-        "brand": "OTP banka",
-        "brand:wikidata": "Q140373875",
         "name": "OTP banka"
       }
     },

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -10748,6 +10748,17 @@
       }
     },
     {
+      "displayName": "OTP banka (Slovenija)",
+      "locationSet": {"include": ["si"]},
+      "matchNames": ["otp", "otp bank"],
+      "tags": {
+        "amenity": "bank",
+        "brand": "OTP banka",
+        "brand:wikidata": "Q140373875",
+        "name": "OTP banka"
+      }
+    },
+    {
       "displayName": "OTP banka (Србија)",
       "id": "otpbanka-e9ea45",
       "locationSet": {"include": ["rs"]},


### PR DESCRIPTION
- fixes wrong entry for Slovakia (`.sk`) - Q13537695 is _"OTP Banka Slovensko"_ which is Slovakian, not Slovenian (yeah they get mixed up often)
- also adds missing Slovenian (`.si`) "OTP Banka"