### PR TITLE
Add Meli Melo brand to fashion accessories

### DIFF
--- a/data/brands/shop/fashion_accessories.json
+++ b/data/brands/shop/fashion_accessories.json
@@ -134,6 +134,16 @@
       }
     },
     {
+      "displayName": "Meli Melo",
+      "locationSet": {"include": ["ro"]},
+      "tags": {
+        "brand": "Meli Melo",
+        "brand:wikidata": "Q134389410",
+        "name": "Meli Melo",
+        "shop": "fashion_accessories"
+      }
+    },
+    {
       "displayName": "MCM",
       "id": "mcm-afbfc9",
       "locationSet": {"include": ["001"]},

--- a/data/brands/shop/fashion_accessories.json
+++ b/data/brands/shop/fashion_accessories.json
@@ -135,7 +135,7 @@
     },
     {
       "displayName": "Meli Melo",
-      "locationSet": {"include": ["ro"]},
+      "locationSet": {"include": ["md", "ro"]},
       "tags": {
         "brand": "Meli Melo",
         "brand:wikidata": "Q134389410",


### PR DESCRIPTION
Meli Melo is a Romanian chain of fashion accessories stores with shops in every city.

Wikidata item: https://www.wikidata.org/wiki/Q134389410
Stores: https://www.melimeloparis.ro/magazine