### PR TITLE
Add Servizio Urbano Trento operator name and wikidata

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -17071,6 +17071,8 @@
       },
       "tags": {
         "network": "Servizio Urbano Trento",
+        "operator": "Trentino Trasporti",
+        "operator:wikidata": "Q3998389",
         "route": "bus"
       }
     },


### PR DESCRIPTION
As title says, this MR adds `operator` and `operator:wikidata` to an existing bus route network