### PR TITLE
Add missing bank brands (IL, EE, ME, SI) and extend location sets (Itaú UY, Erste ME)

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -6599,7 +6599,7 @@
       "displayName": "Erste Bank",
       "id": "erstebank-d01b30",
       "locationSet": {
-        "include": ["at", "hr", "hu", "rs"]
+        "include": ["at", "hr", "hu", "rs","me"]
       },
       "matchNames": ["erste banka"],
       "tags": {
@@ -8785,7 +8785,7 @@
       "displayName": "Itaú",
       "id": "itau-1923f1",
       "locationSet": {
-        "include": ["ar", "br", "py"]
+        "include": ["ar", "br", "py","uy"]
       },
       "matchNames": [
         "banco itau",
@@ -20655,6 +20655,80 @@
         "name": "鹿児島銀行",
         "name:en": "Kagoshima Bank",
         "name:ja": "鹿児島銀行"
+      }
+    },
+    {
+      "displayName": "בנק מרכנתיל דיסקונט",
+      "locationSet": {"include": ["il"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "בנק מרכנתיל דיסקונט",
+        "brand:en": "Mercantile Discount Bank",
+        "brand:he": "בנק מרכנתיל דיסקונט",
+        "brand:wikidata": "Q6818018",
+        "name": "בנק מרכנתיל דיסקונט",
+        "name:en": "Mercantile Discount Bank",
+        "name:he": "בנק מרכנתיל דיסקונט"
+      }
+    },
+    {
+      "displayName": "LHV Pank",
+      "locationSet": {"include": ["ee"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "LHV Pank",
+        "brand:wikidata": "Q12664045",
+        "name": "LHV Pank"
+      }
+    },
+    {
+      "displayName": "Prva banka Crne Gore",
+      "locationSet": {"include": ["me"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "Prva banka Crne Gore",
+        "brand:wikidata": "Q3511098",
+        "name": "Prva banka Crne Gore"
+      }
+    },
+    {
+      "displayName": "Hipotekarna banka",
+      "locationSet": {"include": ["me"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "Hipotekarna banka",
+        "brand:wikidata": "Q140419526",
+        "name": "Hipotekarna banka"
+      }
+    },
+    {
+      "displayName": "Banka Intesa Sanpaolo",
+      "locationSet": {"include": ["si"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "Banka Intesa Sanpaolo",
+        "brand:wikidata": "Q12785447",
+        "name": "Banka Intesa Sanpaolo"
+      }
+    },
+    {
+      "displayName": "Gorenjska Banka",
+      "locationSet": {"include": ["si"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "Gorenjska Banka",
+        "brand:wikidata": "Q124632214",
+        "name": "Gorenjska Banka"
+      }
+    },
+    {
+      "displayName": "Delavska hranilnica",
+      "locationSet": {"include": ["si"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "Delavska hranilnica",
+        "brand:wikidata": "Q111481938",
+        "name": "Delavska hranilnica"
       }
     }
   ]


### PR DESCRIPTION
Add missing bank brands for IL, EE, ME, SI

- Mercantile Discount Bank / בנק מרכנתיל דיסקונט (Q6818018) — il : https://www.mercantile.co.il/branches/ 
- LHV Pank (Q12664045) — ee : https://www.lhv.ee/et/kus-asub (95 ATMs and a few offices)
- Prva banka Crne Gore (Q3511098) — me : https://www.prvabankacg.com/poslovna_mreza.php (31 branches and 109 ATMs)
- Hipotekarna banka (Q140419526) — me : https://hipotekarnabanka.com/filijale-i-bankomati/ (24 branches and 47 ATMs)
- Banka Intesa Sanpaolo (Q12785447) — si : https://www.intesasanpaolobank.si/ (41 branches and 80 ATMs)
- Gorenjska Banka (Q124632214) — si : https://www.gbkr.si/poslovalnice-in-bankomati/ (18 branches and 66 ATMs)
- Delavska hranilnica (Q111481938) — si : https://www.dh.si/poti-do-banke/poslovalnice-in-bankomati/ (33 branches and 55 ATMs)

Location set additions:
- Itaú — added uy — https://www.itau.com.uy/inst/sucursales.html
- Erste Bank — added me — https://www.erstebank.me/sr_ME/stanovnistvo/Alati/filijale-i-bankomati