### PR TITLE
add Service NSW for au-nsw

### DIFF
--- a/data/operators/office/government.json
+++ b/data/operators/office/government.json
@@ -1954,6 +1954,19 @@
       }
     },
     {
+      "displayName": "Service NSW",
+      "locationSet": {"include": ["au-nsw.geojson"]},
+      "tags": {
+        "office": "government",
+        "government": "public_service",
+        "operator": "Service NSW",
+        "operator:wikidata": "Q29324815",
+        "operator:type": "government",
+        "brand": "Service NSW",
+        "brand:wikidata": "Q29324815"
+      }
+    },
+    {
       "displayName": "Servicio Nacional de Sanidad Agraria del Perú",
       "id": "servicionacionaldesanidadagrariadelperu-b5f2e9",
       "locationSet": {"include": ["pe"]},


### PR DESCRIPTION
We have a few different `government=*` values in use, `services`, `register_office`, `social_services`, `public_service`, `administrative`.

* They do provide `register_office` services as one function, but given that's only a small subset of what they provide likely another tag is best.
* I would say they are less likely to be `social_services` as most of that goes through the federal Medicare/Centerlink service centres.
* `administrative` seems more like backend government administration offices than service centers
* `public_service` on the wiki is described as "An office with public services for government affairs" seems best, given `services` isn't even on the list at https://wiki.openstreetmap.org/wiki/Key:government

Personally I also tag these with `admin_level=4` but I haven't included that in this PR.

Discord ref https://discord.com/channels/413070382636072960/471231032645910529/1524680365086740563