### PR TITLE
Added Wikidata for Camicissima brand (plus added Romania)

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -1997,9 +1997,11 @@
     {
       "displayName": "Camicissima",
       "id": "camicissima-d72191",
-      "locationSet": {"include": ["it"]},
+      "locationSet": {"include": ["it","ro"]},
       "tags": {
         "brand": "Camicissima",
+        "brand:wikidata": "Q140471177",
+        "clothes": "men;shirts",
         "name": "Camicissima",
         "shop": "clothes"
       }


### PR DESCRIPTION
I added the Wikipedia brand item (https://www.wikidata.org/wiki/Q140471177) and I added Romania to the locationSet. Seems operates in China too, but I don't know if it's using another chinese lettering.

Store locator: https://www.camicissima.it/allShops