### PR TITLE
Add "Volta" from Portugal

### DIFF
--- a/data/operators/amenity/recycling.json
+++ b/data/operators/amenity/recycling.json
@@ -9412,7 +9412,7 @@
       "tags": {
         "amenity": "recycling",
         "recycling_type": "reverse_vending_machine",
-        "website": "https://volta.com.pt"
+        "website": "https://volta.com.pt",
         "operator:wikidata": "Q138952882"
       }
     }

--- a/data/operators/amenity/recycling.json
+++ b/data/operators/amenity/recycling.json
@@ -9406,6 +9406,17 @@
       }
     },
     {
+      "displayName": "Volta",
+      "id": "volta-a37xv2",
+      "locationSet": {"include": ["pt"]},
+      "tags": {
+        "amenity": "recycling",
+        "recycling_type": "reverse_vending_machine",
+        "website": "https://volta.com.pt"
+        "operator:wikidata": "Q138952882"
+      }
+    }
+    {
       "displayName": "Waardlanden",
       "id": "waardlanden-fcd61b",
       "locationSet": {"include": ["nl"]},

--- a/data/operators/amenity/recycling.json
+++ b/data/operators/amenity/recycling.json
@@ -9415,7 +9415,7 @@
         "website": "https://volta.com.pt",
         "operator:wikidata": "Q138952882"
       }
-    }
+    },
     {
       "displayName": "Waardlanden",
       "id": "waardlanden-fcd61b",

--- a/data/operators/amenity/recycling.json
+++ b/data/operators/amenity/recycling.json
@@ -9413,8 +9413,7 @@
         "amenity": "recycling",
         "recycling_type": "reverse_vending_machine",
         "operator": "Volta",
-        "operator:wikidata": "Q138952882",
-        "website": "https://volta.com.pt"
+        "operator:wikidata": "Q138952882"
       }
     },
     {

--- a/data/operators/amenity/recycling.json
+++ b/data/operators/amenity/recycling.json
@@ -9408,12 +9408,13 @@
     {
       "displayName": "Volta",
       "id": "volta-a37xv2",
-      "locationSet": {"include": ["pt"]},
+      "locationSet": { "include": ["pt"] },
       "tags": {
         "amenity": "recycling",
         "recycling_type": "reverse_vending_machine",
-        "website": "https://volta.com.pt",
-        "operator:wikidata": "Q138952882"
+        "operator": "Volta",
+        "operator:wikidata": "Q138952882",
+        "website": "https://volta.com.pt"
       }
     },
     {


### PR DESCRIPTION
The wikidata is not available yet, because it was deleted for a "notability" policy.
However, the admin who deleted it is admitting to re-add the wikidata page again if it was added to this project (NSI).