### PR TITLE
Add Voy con Energía (AR), add Wikidata ID to DAPSA, exclude AR from Esso

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -2430,7 +2430,7 @@
       "id": "esso-053960",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["br", "jp", "pl", "th"]
+        "exclude": ["br", "jp", "pl", "th", "ar"]
       },
       "matchNames": [
         "esso canada",
@@ -9353,6 +9353,27 @@
         "operator": "福懋興業股份有限公司",
         "operator:en": "Formosa Taffeta Co.,Ltd.",
         "operator:zh": "福懋興業股份有限公司"
+      }
+    },
+    {
+      "displayName": "Voy con Energía",
+      "locationSet": {"include": ["ar"]},
+      "matchNames": ["Voy"],
+      "tags": {
+        "amenity": "fuel",
+        "brand": "Voy con Energía",
+        "brand:wikidata": "Q140480520",
+        "name": "Voy con Energía"
+      }
+    },
+    {
+      "displayName": "DAPSA",
+      "locationSet": {"include": ["ar"]},
+      "tags": {
+        "amenity": "fuel",
+        "brand": "DAPSA",
+        "brand:wikidata": "Q140480567",
+        "name": "DAPSA"
       }
     }
   ]

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -1841,7 +1841,7 @@
         "amenity": "fuel",
         "brand": "DAPSA",
         "brand:wikidata": "Q140480567",
-        "name": "DAPSA
+        "name": "DAPSA"
       }
     },
     {

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -1834,13 +1834,14 @@
       }
     },
     {
-      "displayName": "Dapsa",
+      "displayName": "DAPSA",
       "id": "dapsa-dca697",
       "locationSet": {"include": ["ar"]},
       "tags": {
         "amenity": "fuel",
-        "brand": "Dapsa",
-        "name": "Dapsa"
+        "brand": "DAPSA",
+        "brand:wikidata": "Q140480567",
+        "name": "DAPSA
       }
     },
     {
@@ -9364,16 +9365,6 @@
         "brand": "Voy con Energía",
         "brand:wikidata": "Q140480520",
         "name": "Voy con Energía"
-      }
-    },
-    {
-      "displayName": "DAPSA",
-      "locationSet": {"include": ["ar"]},
-      "tags": {
-        "amenity": "fuel",
-        "brand": "DAPSA",
-        "brand:wikidata": "Q140480567",
-        "name": "DAPSA"
       }
     }
   ]


### PR DESCRIPTION
Fuel brand updates for Argentina:

* Voy con Energía (Q140480520) : new brand, AR , https://www.voyconenergia.com.ar/nuestra-red/
* DAPSA (Q140480567) : added brand:wikidata ID to the existing entry
* Esso : excluded AR (Esso Argentina rebranded to Axion Energy in 2012)