### PR TITLE
Update brand names with JHC (HK)

### DIFF
--- a/data/brands/shop/houseware.json
+++ b/data/brands/shop/houseware.json
@@ -1095,13 +1095,13 @@
         "japan home centre"
       ],
       "tags": {
-        "brand": "日本城 JHC",
+        "brand": "真好城 JHC",
         "brand:en": "JHC",
         "brand:wikidata": "Q11507765",
-        "brand:zh": "日本城",
-        "name": "日本城 JHC",
+        "brand:zh": "真好城",
+        "name": "真好城 JHC",
         "name:en": "JHC",
-        "name:zh": "日本城",
+        "name:zh": "真好城",
         "shop": "houseware"
       }
     }

--- a/data/brands/shop/houseware.json
+++ b/data/brands/shop/houseware.json
@@ -1087,7 +1087,7 @@
       }
     },
     {
-      "displayName": "日本城 JHC",
+      "displayName": "真好城 JHC",
       "id": "jhc-067b48",
       "locationSet": {"include": ["hk", "mo"]},
       "matchNames": [
@@ -1102,6 +1102,10 @@
         "name": "真好城 JHC",
         "name:en": "JHC",
         "name:zh": "真好城",
+        "operator": "國際家居零售 International Housewares Retail",
+        "operator:en": "International Housewares Retail",
+        "operator:wikidata": "Q140545123",
+        "operator:zh": "國際家居零售",
         "shop": "houseware"
       }
     }


### PR DESCRIPTION
“日本城 JHC” Chinese name changed name to “真好城”.

Official website: https://www.jhceshop.com

Related news:
- https://www.thestandard.com.hk/finance/article/337194/JHC-rebrand-sparks-9pc-surge-in-International-Housewares-Retail-shares
- https://www.lifestyleasia.com/hk/whats-on/jhc-japan-home-centre-to-rebrand-to-really-good-city-after-35-years/
- https://www.hk01.com/社會新聞/60369750/日本城改名jhc真好城-北角起家僅9年擴展百間店-回顧35年發迹史