### PR TITLE
Merge entries for Caffe Bene and add Mongolia to location list

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -1114,6 +1114,29 @@
       }
     },
     {
+      "displayName": "Caffe Bene",
+      "id": "caffebene-f30cc0",
+      "locationSet": {
+        "include": ["kr", "mn", "tw"]
+      },
+      "matchNames": [
+        "cafe bene",
+        "кафе бэнэ",
+        "咖啡伴"
+      ],
+      "tags": {
+        "amenity": "cafe",
+        "brand": "Caffebene",
+        "brand:wikidata": "Q5017149",
+        "cuisine": "coffee_shop",
+        "name": "Caffe Bene",
+        "name:en": "Caffe Bene",
+        "name:ko": "카페베네",
+        "name:zh": "Caffe Bene咖啡伴",
+        "takeaway": "yes"
+      }
+    },
+    {
       "displayName": "Caffè Nero",
       "id": "caffenero-0d98f2",
       "locationSet": {
@@ -1194,26 +1217,6 @@
         "brand:wikidata": "Q3649598",
         "cuisine": "coffee_shop",
         "name": "Caffè Vergnano 1882",
-        "takeaway": "yes"
-      }
-    },
-    {
-      "displayName": "Caffebene咖啡伴",
-      "id": "caffebene-7d270d",
-      "locationSet": {"include": ["tw"]},
-      "matchNames": ["咖啡伴"],
-      "tags": {
-        "amenity": "cafe",
-        "brand": "Caffebene",
-        "brand:en": "Caffé Bene",
-        "brand:ko": "카페베네",
-        "brand:wikidata": "Q5017149",
-        "brand:zh": "Caffebene",
-        "cuisine": "coffee_shop",
-        "name": "Caffebene咖啡伴",
-        "name:en": "Caffé Bene",
-        "name:ko": "카페베네",
-        "name:zh": "Caffebene咖啡伴",
         "takeaway": "yes"
       }
     },
@@ -6378,23 +6381,6 @@
         "name": "카페드롭탑",
         "name:en": "Cafe Droptop",
         "name:ko": "카페드롭탑",
-        "takeaway": "yes"
-      }
-    },
-    {
-      "displayName": "카페베네",
-      "id": "caffebene-77c68b",
-      "locationSet": {"include": ["kr"]},
-      "tags": {
-        "amenity": "cafe",
-        "brand": "카페베네",
-        "brand:en": "Caffé Bene",
-        "brand:ko": "카페베네",
-        "brand:wikidata": "Q5017149",
-        "cuisine": "coffee_shop",
-        "name": "카페베네",
-        "name:en": "Caffé Bene",
-        "name:ko": "카페베네",
         "takeaway": "yes"
       }
     },


### PR DESCRIPTION
Korean, Taiwanese and Mongolian branches are owned by the same company (Caffebene).

There are 30+ locations in Mongolia according to the official website. No name tag is added for Mongolian as stores are always signed as "Caffe Bene".