### PR TITLE
Add new car brands Discovery and Defender

### DIFF
--- a/data/brands/shop/car.json
+++ b/data/brands/shop/car.json
@@ -13,6 +13,27 @@
   },
   "items": [
     {
+      "displayName": "Discovery",
+      "locationSet": {"include": ["001"]},
+      },
+      "tags": {
+        "brand": "Discovery",
+        "brand:wikidata": "Q140645228",
+        "name": "Discovery",
+        "shop": "car"
+      }
+    },
+    {
+      "displayName": "Defender",
+      "locationSet": {"include": ["001"]},
+      "tags": {
+        "brand": "Defender",
+        "brand:wikidata": "Q140645257",
+        "name": "Defender",
+        "shop": "car"
+      }
+    },
+    {
       "displayName": "AAA Auto",
       "id": "aaaauto-e524cd",
       "locationSet": {

--- a/data/brands/shop/car.json
+++ b/data/brands/shop/car.json
@@ -15,7 +15,6 @@
     {
       "displayName": "Discovery",
       "locationSet": {"include": ["001"]},
-      },
       "tags": {
         "brand": "Discovery",
         "brand:wikidata": "Q140645228",


### PR DESCRIPTION
Under JLR's House of Brands structure, Discovery and Defender are positioned as standalone brands, each with its own identity and marketing, rather than simply being models within the Land Rover brand.

https://media.jaguarlandrover.com/news/2023/06/jaguar-land-rover-unveils-new-jlr-corporate-identity-it-accelerates-modern-luxury