### PR TITLE
Normalize Caja Rural Group brands

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -4776,7 +4776,7 @@
     {
       "displayName": "Caixa Popular",
       "id": "caixapopular-ce59ab",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["ES-A.geojson", "ES-V.geojson"]},
       "matchNames": ["caja popular"],
       "tags": {
         "amenity": "bank",
@@ -4827,9 +4827,21 @@
       }
     },
     {
+      "displayName": "Caja Rural Central",
+      "locationSet": {
+        "include": ["ES-A.geojson", "ES-MU.geojson"]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": "Caja Rural Central",
+        "brand:wikidata": "Q118720020",
+        "name": "Caja Rural Central"
+      }
+    },
+    {
       "displayName": "Caja Rural de Aragón",
       "id": "cajaruraldearagon-ce59ab",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["ES-HU.geojson", "ES-TE.geojson", "ES-Z.geojson", "ES-LO.geojson"]},
       "matchNames": ["bantierra"],
       "tags": {
         "amenity": "bank",
@@ -4859,14 +4871,112 @@
       }
     },
     {
-      "displayName": "Caja Rural de Jaén",
-      "id": "cajaruraldejaen-ce59ab",
-      "locationSet": {"include": ["es"]},
+      "displayName": "Caja Rural del Sur",
+      "locationSet": {
+        "include": ["ES-HU.geojson", "ES-SE.geojson", "ES-CA.geojson"]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": "Caja Rural del Sur",
+        "brand:wikidata": "Q118719995",
+        "name": "Caja Rural del Sur"
+      }
+    },
+    {
+      "displayName": "Caja Rural de Extremadura",
+      "locationSet": {
+        "include": ["ES-BA.geojson", "ES-CC.geojson"]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": "Caja Rural de Extremadura",
+        "brand:wikidata": "Q118720015",
+        "name": "Caja Rural de Extremadura"
+      }
+    },
+    {
+      "displayName": "Caja Rural de Gijón",
+      "locationSet": {
+        "include": ["ES-O.geojson"]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": "Caja Rural de Gijón",
+        "brand:wikidata": "Q118720010",
+        "name": "Caja Rural de Gijón"
+      }
+    },
+    {
+      "displayName": "Caja Rural de Jaén, Barcelona y Madrid",
+      "locationSet": {
+        "include": ["ES-J.geojson", "ES-CO.geojson"]
+      },
       "tags": {
         "amenity": "bank",
         "brand": "Caja Rural de Jaén",
         "brand:wikidata": "Q18720350",
+        "official_name": "Caja Rural de Jaén, Barcelona y Madrid",
         "name": "Caja Rural de Jaén"
+      }
+    },
+    {
+      "displayName": "Caja Rural de Navarra",
+      "locationSet": {
+        "include": ["ES-NA.geojson", "ES-VI.geojson", "ES-BI.geojson", "ES-SS.geojson", "ES-LO.geojson"]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": "Caja Rural de Navarra",
+        "brand:wikidata": "Q73399877",
+        "name": "Caja Rural de Navarra"
+      }
+    },
+    {
+      "displayName": "Caja Rural de Salamanca",
+      "locationSet": {
+        "include": ["ES-AV.geojson", "ES-SA.geojson", "ES-VA.geojson"]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": "Caja Rural de Salamanca",
+        "brand:wikidata": "Q106928223",
+        "name": "Caja Rural de Salamanca"
+      }
+    },
+    {
+      "displayName": "Caja Rural de Soria",
+      "locationSet": {
+        "include": ["ES-SO.geojson", "ES-LO.geojson"]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": "Caja Rural de Soria",
+        "brand:wikidata": "Q118719955",
+        "name": "Caja Rural de Soria"
+      }
+    },
+    {
+      "displayName": "Caja Rural de Teruel",
+      "locationSet": {
+        "include": ["ES-TE.geojson", "ES-CS.geojson"]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": "Caja Rural de Teruel",
+        "brand:wikidata": "Q5739403",
+        "name": "Caja Rural de Teruel"
+      }
+    },
+    {
+      "displayName": "Caja Rural de Zamora",
+      "locationSet": {
+        "include": ["ES-LE.geojson", "ES-VA.geojson", "ES-ZA.geojson"]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": "Caja Rural de Zamora",
+        "brand:wikidata": "Q118719984",
+        "name": "Caja Rural de Zamora"
       }
     },
     {
@@ -4882,6 +4992,18 @@
       }
     },
     {
+      "displayName": "Cajasiete",
+      "locationSet": {
+        "include": ["ic"]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": "Cajasiete",
+        "brand:wikidata": "Q5739505",
+        "name": "Cajasiete"
+      }
+    },
+    {
       "displayName": "CajaSur",
       "id": "cajasur-ce59ab",
       "locationSet": {"include": ["es"]},
@@ -4890,6 +5012,19 @@
         "brand": "CajaSur",
         "brand:wikidata": "Q20013689",
         "name": "CajaSur"
+      }
+    },
+    {
+      "displayName": "Cajaviva. Caja Rural de Burgos, Fuentepelayo, Segovia y Castelldans",
+      "locationSet": {
+        "include": ["ES-BU.geojson", "ES-P.geojson", "ES-SO.geojson"]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": "Cajaviva",
+        "brand:wikidata": "Q139055477",
+        "official_name": "Cajaviva. Caja Rural de Burgos, Fuentepelayo, Segovia y Castelldans",
+        "name": "Cajaviva"
       }
     },
     {
@@ -6679,6 +6814,18 @@
       }
     },
     {
+      "displayName": "Eurocaja Rural",
+      "locationSet": {
+        "include": ["es"]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": "Eurocaja Rural",
+        "brand:wikidata": "Q57496866",
+        "name": "Eurocaja Rural"
+      }
+    },
+    {
       "displayName": "Eurobank (Србија)",
       "id": "eurobank-e9ea45",
       "locationSet": {"include": ["rs"]},
@@ -7785,6 +7932,18 @@
         "brand:wikidata": "Q1529290",
         "name": "Glarner Kantonalbank",
         "short_name": "GLKB"
+      }
+    },
+    {
+      "displayName": "Globalcaja",
+      "locationSet": {
+        "include": ["ES-AB.geojson", "ES-CR.geojson", "ES-CU.geojson", "ES-GU.geojson", "ES-TO.geojson", "ES-M.geojson", "ES-MU.geojson", "ES-A.geojson", "ES-CS.geojson", "ES-V.geojson", "ES-AL.geojson"]
+      },
+      "tags": {
+        "amenity": "bank",
+        "brand": "Globalcaja",
+        "brand:wikidata": "Q18223400",
+        "name": "Globalcaja"
       }
     },
     {


### PR DESCRIPTION
Standardize all different brands belonging to Caja Rural group (https://www.wikidata.org/wiki/Q3649971). Note: only added those over than 10 branch offices.

Related to https://github.com/osmlab/name-suggestion-index/pull/12242