### PR TITLE
Fix Bank of Georgia name: Solo → Bank of Georgia (Q2469733)

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -16885,10 +16885,10 @@
         "brand:ru": "Банк Грузии",
         "brand:tr": "Gürcistan Bankası",
         "brand:wikidata": "Q2469733",
-        "name": "სოლო",
-        "name:en": "Solo",
-        "name:ka": "სოლო",
-        "name:ru": "Соло"
+        "name": "საქართველოს ბანკი",
+        "name:en": "Bank of Georgia",
+        "name:ka": "საქართველოს ბანკი",
+        "name:ru": "Банк Грузии"
       }
     },
     {


### PR DESCRIPTION
Correct `name` on the Bank of Georgia bank entry (Q2469733): Solo → Bank of Georgia

### Problem

The single `amenity=bank` entry for **Bank of Georgia** (`solo-293074`, `brand:wikidata=Q2469733`) is internally inconsistent:

| tag | value |
|---|---|
| `displayName` | საქართველოს ბანკი (Bank of Georgia) | | `brand` / `brand:en` | საქართველოს ბანკი / Bank of Georgia | | `brand:wikidata` | Q2469733 → **Bank of Georgia** | | `name` / `name:en` | სოლო / **Solo** |

`displayName`, `brand`, and `brand:wikidata` all identify **Bank of Georgia**, but the `name*` tags say **Solo**. Since the entry's Wikidata item (Q2469733) is *Bank of Georgia*, the `name` should match it.

"Solo" is Bank of Georgia's premium banking fascia. It shares the same legal entity and has no Wikidata item of its own, so it cannot be represented as a distinct brand here, a second `amenity=bank` entry under the same Q2469733 would also be ambiguous for downstream consumers that match by `brand:wikidata`.

### Fix

Set the `name*` tags to match the brand / Wikidata entity:

```
name    : სოლო  → საქართველოს ბანკი
name:en : Solo  → Bank of Georgia
name:ka : სოლო  → საქართველოს ბანკი
name:ru : Соло  → Банк Грузии
```

All other tags (`amenity`, `bic`, `brand*`, `brand:wikidata`, `locationSet`) are unchanged.

### Effect

Regular Bank of Georgia branches now carry the correct `name=Bank of Georgia` instead of `Solo`. `brand` stays `საქართველოს ბანკი` throughout, so the brand identity is unaffected.