### PR TITLE
Add ESB matchName for Energie Südbayern charging station

### DIFF
--- a/data/operators/amenity/charging_station.json
+++ b/data/operators/amenity/charging_station.json
@@ -2296,6 +2296,7 @@
     },
     {
       "displayName": "Energie Südbayern",
+      "matchNames": ["ESB"],
       "id": "energiesudbayern-259ab2",
       "locationSet": {
         "include": ["de-by.geojson"]


### PR DESCRIPTION
The abbreviation "ESB" is publicly used, see domain name, title and logo of their website:
https://www.esb.de/privatkunden