### PR TITLE
fix au-nsw leisure=park local government operator:wikidata

### DIFF
--- a/data/operators/leisure/park.json
+++ b/data/operators/leisure/park.json
@@ -3322,7 +3322,7 @@
         "leisure": "park",
         "operator": "City of Ryde",
         "operator:type": "government",
-        "operator:wikidata": "Q1006309"
+        "operator:wikidata": "Q56477522"
       }
     },
     {
@@ -3570,7 +3570,7 @@
         "leisure": "park",
         "operator": "City of Sydney",
         "operator:type": "government",
-        "operator:wikidata": "Q1094194"
+        "operator:wikidata": "Q56477532"
       }
     },
     {
@@ -5627,7 +5627,7 @@
         "leisure": "park",
         "operator": "Lismore City Council",
         "operator:type": "government",
-        "operator:wikidata": "Q753599"
+        "operator:wikidata": "Q116847658"
       }
     },
     {
@@ -8876,7 +8876,7 @@
         "leisure": "park",
         "operator": "Willoughby City Council",
         "operator:type": "government",
-        "operator:wikidata": "Q634933"
+        "operator:wikidata": "Q56477608"
       }
     },
     {


### PR DESCRIPTION
these were pointing to the wikidata ID of the LGA area/geography rather than the mayor-council government / government entity which is the operator. The two are linked to each other within wikidata, but it's more correct to say the operator is the government entity not the geographic area.