### PR TITLE
Added belgium for Benu Pharmacy.

### DIFF
--- a/data/brands/amenity/pharmacy.json
+++ b/data/brands/amenity/pharmacy.json
@@ -546,9 +546,10 @@
     },
     {
       "displayName": "Benu",
-      "id": "benu-9cc401",
+      "id": "benu-c1f9dd",
       "locationSet": {
         "include": [
+          "be",
           "bg",
           "ch",
           "cz",


### PR DESCRIPTION
Benu pharmacy also has  many locations throughout Belgium.