### PR TITLE
Tax, customs and border control offices (Poland)

### DIFF
--- a/data/operators/office/government.json
+++ b/data/operators/office/government.json
@@ -1180,24 +1180,34 @@
     },
     {
       "displayName": "Krajowa Administracja Skarbowa (urzędy i oddziały celne)",
+      "id": "krajowaadministracjaskarbowa-995fc9",
       "locationSet": {"include": ["pl"]},
-      "matchNames": ["urząd celno-skarbowy, izba celna", "urząd celny", "oddział celny"],
+      "matchNames": [
+        "oddział celny",
+        "urząd celno-skarbowy, izba celna",
+        "urząd celny"
+      ],
       "tags": {
-        "office": "government",
         "government": "customs",
+        "office": "government",
         "operator": "Krajowa Administracja Skarbowa",
+        "operator:short": "KAS",
         "operator:type": "government",
         "operator:wikidata": "Q30904637"
       }
     },
     {
       "displayName": "Krajowa Administracja Skarbowa (urzędy skarbowe)",
-      "locationSet": {"include": ["pl"]},
+      "id": "krajowaadministracjaskarbowa-dcc9ed",
+      "locationSet": {
+        "include": [[19.423561, 52.114503, 425]]
+      },
       "matchNames": ["urząd skarbowy", "us"],
       "tags": {
-        "office": "government",
         "government": "tax",
+        "office": "government",
         "operator": "Krajowa Administracja Skarbowa",
+        "operator:short": "KAS",
         "operator:type": "government",
         "operator:wikidata": "Q30904637"
       }
@@ -2096,12 +2106,15 @@
     },
     {
       "displayName": "Straż Graniczna",
-      "id": "strazgraniczna-e84fe8",
+      "id": "strazgraniczna-995fc9",
       "locationSet": {"include": ["pl"]},
-      "matchNames": ["sg", "placówka straży granicznej"],
+      "matchNames": [
+        "placówka straży granicznej",
+        "sg"
+      ],
       "tags": {
-        "office": "government",
         "government": "border_control",
+        "office": "government",
         "operator": "Straż Graniczna",
         "operator:type": "government",
         "operator:wikidata": "Q4944572"

--- a/data/operators/office/government.json
+++ b/data/operators/office/government.json
@@ -1179,9 +1179,9 @@
       }
     },
     {
-      "displayName": "Urząd Celno-Skarbowy",
+      "displayName": "Krajowa Administracja Skarbowa (urzędy i oddziały celne)",
       "locationSet": {"include": ["pl"]},
-      "matchNames": ["urząd celno-skarbowy, izba celna", "urząd celny"],
+      "matchNames": ["urząd celno-skarbowy, izba celna", "urząd celny", "oddział celny"],
       "tags": {
         "office": "government",
         "government": "customs",
@@ -1191,19 +1191,7 @@
       }
     },
     {
-      "displayName": "Oddział Celny",
-      "locationSet": {"include": ["pl"]},
-      "matchNames": ["oddział celny"],
-      "tags": {
-        "office": "government",
-        "government": "customs",
-        "operator": "Krajowa Administracja Skarbowa",
-        "operator:type": "government",
-        "operator:wikidata": "Q30904637"
-      }
-    },
-    {
-      "displayName": "Urząd Skarbowy",
+      "displayName": "Krajowa Administracja Skarbowa (urzędy skarbowe)",
       "locationSet": {"include": ["pl"]},
       "matchNames": ["urząd skarbowy", "us"],
       "tags": {

--- a/data/operators/office/government.json
+++ b/data/operators/office/government.json
@@ -1179,6 +1179,42 @@
       }
     },
     {
+      "displayName": "Urząd Celno-Skarbowy",
+      "locationSet": {"include": ["pl"]},
+      "matchNames": ["urząd celno-skarbowy, izba celna", "urząd celny"],
+      "tags": {
+        "office": "government",
+        "government": "customs",
+        "operator": "Krajowa Administracja Skarbowa",
+        "operator:type": "government",
+        "operator:wikidata": "Q30904637"
+      }
+    },
+    {
+      "displayName": "Oddział Celny",
+      "locationSet": {"include": ["pl"]},
+      "matchNames": ["oddział celny"],
+      "tags": {
+        "office": "government",
+        "government": "customs",
+        "operator": "Krajowa Administracja Skarbowa",
+        "operator:type": "government",
+        "operator:wikidata": "Q30904637"
+      }
+    },
+    {
+      "displayName": "Urząd Skarbowy",
+      "locationSet": {"include": ["pl"]},
+      "matchNames": ["urząd skarbowy", "us"],
+      "tags": {
+        "office": "government",
+        "government": "tax",
+        "operator": "Krajowa Administracja Skarbowa",
+        "operator:type": "government",
+        "operator:wikidata": "Q30904637"
+      }
+    },
+    {
       "displayName": "LADWP",
       "id": "losangelesdepartmentofwaterandpower-2a14ff",
       "locationSet": {
@@ -2068,6 +2104,19 @@
         "office": "government",
         "operator": "Stadt Neuss",
         "operator:wikidata": "Q2948"
+      }
+    },
+    {
+      "displayName": "Straż Graniczna",
+      "id": "strazgraniczna-e84fe8",
+      "locationSet": {"include": ["pl"]},
+      "matchNames": ["sg", "placówka straży granicznej"],
+      "tags": {
+        "office": "government",
+        "government": "border_control",
+        "operator": "Straż Graniczna",
+        "operator:type": "government",
+        "operator:wikidata": "Q4944572"
       }
     },
     {

--- a/data/operators/office/government.json
+++ b/data/operators/office/government.json
@@ -1179,32 +1179,21 @@
       }
     },
     {
-      "displayName": "Krajowa Administracja Skarbowa (urzędy i oddziały celne)",
+      "displayName": "Krajowa Administracja Skarbowa",
       "id": "krajowaadministracjaskarbowa-995fc9",
-      "locationSet": {"include": ["pl"]},
+      "locationSet": {
+        "include": [
+          "pl"
+        ]
+      },
       "matchNames": [
         "oddział celny",
         "urząd celno-skarbowy, izba celna",
-        "urząd celny"
+        "urząd celny",
+        "urząd skarbowy",
+        "us"
       ],
       "tags": {
-        "government": "customs",
-        "office": "government",
-        "operator": "Krajowa Administracja Skarbowa",
-        "operator:short": "KAS",
-        "operator:type": "government",
-        "operator:wikidata": "Q30904637"
-      }
-    },
-    {
-      "displayName": "Krajowa Administracja Skarbowa (urzędy skarbowe)",
-      "id": "krajowaadministracjaskarbowa-dcc9ed",
-      "locationSet": {
-        "include": [[19.423561, 52.114503, 425]]
-      },
-      "matchNames": ["urząd skarbowy", "us"],
-      "tags": {
-        "government": "tax",
         "office": "government",
         "operator": "Krajowa Administracja Skarbowa",
         "operator:short": "KAS",


### PR DESCRIPTION
This PR replaces #12312, which got prematurely closed, which in turn replaced #12006, whose author abandoned it.

For visibility, let me repeat my comment about closing #12312:

I'm fine with the verdict on _Administracja Celno-Skarbowa_, but then you could at least let me merge the _Straż Graniczna_ entry. Instead, the whole PR is closed, while for example the original one by @DevManiak17 still isn't 😕 I will resubmit it.

I also must note that by calling these _duplicate entries in the same location_ you seem not to acknowledge that they are only duplicate from the perspective of NSI's technical design. From the perspective of OpenStreetMap and mapping workflows in general, which I guess you are trying to facilitate, both are distinctive and valuable real-world types of features (POIs). So ultimately it is arguably a flaw in NSI's design that standardising both entries is not possible. I understand you will not turn the design up side down because of this case, but if I were in your place, I would acknowledge this when declining a PR.