### PR TITLE
Extend charging_station options by adding Greek brands.

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -1858,6 +1858,63 @@
         "name:en": "NIO Power Charger",
         "name:zh": "蔚来超充站"
       }
+    },
+    {
+      "displayName": "nrg incharge",
+      "locationSet": { "include": ["gr"] },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "nrg incharge",
+        "brand:wikidata": "Q140817704",
+        "name": "nrg incharge",
+        "operator": "Motor Oil Hellas",
+        "operator:wikidata": "Q6918149"
+      }
+    },
+    {
+      "displayName": "DEI Blue",
+      "locationSet": { "include": ["gr"] },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "DEI Blue",
+        "brand:wikidata": "Q140818654",
+        "name": "DEI Blue",
+        "operator": "Public Power Corporation SA",
+        "operator:wikidata": "Q326345"
+      }
+    },
+    {
+      "displayName": "PlugQ",
+      "locationSet": { "include": ["gr"] },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "PlugQ",
+        "brand:wikidata": "Q140818570",
+        "name": "PlugQ"
+      }
+    },
+    {
+      "displayName": "Witty",
+      "locationSet": { "include": ["gr"] },
+      "matchNames": ["witty by hager hellas"],
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "Witty",
+        "brand:wikidata": "Q140818696",
+        "name": "Witty"
+      }
+    },
+    {
+      "displayName": "EKO Charge&Go",
+      "locationSet": { "include": ["gr"] },
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "EKO Charge&Go",
+        "brand:wikidata": "Q140818770",
+        "name": "EKO Charge&Go",
+        "operator": "HELLENiQ ENERGY",
+        "operator:wikidata": "Q903198"
+      }
     }
   ]
 }


### PR DESCRIPTION
Adding:
1. [nrg incharge](https://www.wikidata.org/wiki/Q140817704)
2. [DEI Blue](https://www.wikidata.org/wiki/Q140818654)
3. [PlugQ](https://www.wikidata.org/wiki/Q140818570)
4. [Witty](https://www.wikidata.org/wiki/Q140818696)
5. [EKO Charge&Go](https://www.wikidata.org/wiki/Q140818770)

There are many more but I do not possess the time to expand upon them by creating wikidata entries for them. For now, this shall suffice.

I have also not set the IDs and haven't sorted them alphabetically as I suppose this will be automated by the script, if not so, please bump me to fix. Thanks