### PR TITLE
Rebranding of Santander into Erste in Poland

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -6808,11 +6808,9 @@
         "amenity": "bank",
         "brand": "Erste",
         "brand:wikidata": "Q696867",
-        "brand:wikipedia": "pl:Erste Bank",
         "name": "Erste",
         "operator": "Erste Bank Polska",
-        "operator:wikidata": "Q806653",
-        "operator:wikipedia": "pl:Erste Bank Polska"
+        "operator:wikidata": "Q806653"
       }
     },
     {

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -12498,19 +12498,6 @@
       }
     },
     {
-      "displayName": "Santander (Polska)",
-      "id": "santander-68054b",
-      "locationSet": {"include": ["pl"]},
-      "matchNames": ["santander bank"],
-      "note": "Is being rebranded into Erste",
-      "tags": {
-        "amenity": "bank",
-        "brand": "Santander",
-        "brand:wikidata": "Q806653",
-        "name": "Santander"
-      }
-    },
-    {
       "displayName": "Santander (Portugal)",
       "id": "santander-4028ed",
       "locationSet": {"include": ["pt"]},

--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -6803,12 +6803,16 @@
       "displayName": "Erste (Polska)",
       "id": "erste-68054b",
       "locationSet": {"include": ["pl"]},
-      "matchNames": ["erste bank polska"],
+      "matchNames": ["erste bank polska santander"],
       "tags": {
         "amenity": "bank",
         "brand": "Erste",
-        "brand:wikidata": "Q806653",
-        "name": "Erste"
+        "brand:wikidata": "Q696867",
+        "brand:wikipedia": "pl:Erste Bank",
+        "name": "Erste",
+        "operator": "Erste Bank Polska",
+        "operator:wikidata": "Q806653",
+        "operator:wikipedia": "pl:Erste Bank Polska"
       }
     },
     {


### PR DESCRIPTION
1. Updated the tags for Erste Bank in Poland. The brand is the same as in other countries where Erste operates, but the Polish branches are operated by Erste Bank Polska, so the operator tag has been set to the Poland-specific value. This approach was discussed on the [Polish OSM Community forum](https://community.openstreetmap.org/t/santander-do-erste/144075/15).
2. Removed Santander Bank entries for Poland, as the rebranding to Erste has now been completed.