### PR TITLE
Update tram and trolleybus networks (CZ)

### DIFF
--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -11,6 +11,21 @@
   },
   "items": [
     {
+      "displayName": "IDOL",
+      "locationSet": {
+        "include": ["cz-51.geojson"]
+      },
+      "tags": {
+        "network": "Integrovaná doprava Libereckého kraje",
+        "network:short": "IDOL",
+        "network:wikidata": "Q12021686",
+        "operator": "Dopravní podnik měst Liberce a Jablonce nad Nisou",
+        "operator:short": "DPMLJ",
+        "operator:wikidata": "Q1243534",
+        "route": "tram"
+      }
+    },
+    {
       "displayName": "Asociația de Dezvoltare Intercomunitară pentru Transport Public București – Ilfov",
       "id": "asociatiadedezvoltareintercomunitarapentrutransportpublicbucurestiilfov-200f98",
       "locationSet": {"include": ["ro"]},
@@ -572,6 +587,9 @@
         "network": "Integrovaný dopravní systém Moravskoslezského kraje",
         "network:short": "ODIS",
         "network:wikidata": "Q12043044",
+        "operator": "Dopravní podnik Ostrava",
+        "operator:short": "DPO",
+        "operator:wikidata": "Q11323689",
         "route": "tram"
       }
     },
@@ -613,6 +631,9 @@
         "network": "Pražská integrovaná doprava",
         "network:short": "PID",
         "network:wikidata": "Q2108171",
+        "operator": "Dopravní podnik hl. m. Prahy",
+        "operator:short": "DPP",
+        "operator:wikidata": "Q381100",
         "route": "tram"
       }
     },

--- a/data/transit/route/trolleybus.json
+++ b/data/transit/route/trolleybus.json
@@ -11,6 +11,41 @@
   },
   "items": [
     {
+      "displayName": "IDESKA",
+      "locationSet": {"include": ["cz-31.geojson"]},
+      "tags": {
+        "network": "IDESKA",
+        "network:wikidata": "Q138862649",
+        "operator": "Dopravní podnik města České Budějovice",
+        "operator:short": "DPMCB",
+        "operator:wikidata": "Q15123983",
+        "route": "trolleybus"
+      }
+    },
+    {
+      "displayName": "ODIS",
+      "locationSet": {"include": ["cz-80.geojson"]},
+      "tags": {
+        "network": "Integrovaný dopravní systém Moravskoslezského kraje",
+        "network:short": "ODIS",
+        "network:wikidata": "Q12043044",
+        "route": "trolleybus"
+      }
+    },
+    {
+      "displayName": "VDV",
+      "locationSet": {"include": ["cz-63.geojson"]},
+      "tags": {
+        "network": "Veřejná doprava Vysočiny",
+        "network:short": "VDV",
+        "network:wikidata": "Q85938572",
+        "operator": "Dopravní podnik města Jihlavy",
+        "operator:short": "DPMJ",
+        "operator:wikidata": "Q18523923",
+        "route": "trolleybus"
+      }
+    },
+    {
       "displayName": "Arnhem-Nijmegen",
       "id": "arnhemnijmegen-90583d",
       "locationSet": {"include": ["nl"]},
@@ -105,22 +140,6 @@
         "network": "БГ Превоз",
         "operator": "ГСП Београд",
         "operator:wikidata": "Q8227578",
-        "route": "trolleybus"
-      }
-    },
-    {
-      "displayName": "Ideska",
-      "id": "integrovanydopravnisystemjihoceskehokraje-e4d628",
-      "locationSet": {
-        "include": ["cz-31.geojson"]
-      },
-      "tags": {
-        "network": "Integrovaný dopravní systém Jihočeského kraje",
-        "network:short": "Ideska",
-        "network:wikidata": "Q138862649",
-        "operator": "Dopravní podnik města České Budějovice",
-        "operator:short": "DPMCB",
-        "operator:wikidata": "Q15123983",
         "route": "trolleybus"
       }
     },
@@ -418,22 +437,6 @@
       }
     },
     {
-      "displayName": "ODIS",
-      "id": "odis-6959ea",
-      "locationSet": {
-        "include": [
-          "cz-71.geojson",
-          "cz-72.geojson",
-          "cz-80.geojson"
-        ]
-      },
-      "tags": {
-        "network": "ODIS",
-        "network:wikidata": "Q12043044",
-        "route": "trolleybus"
-      }
-    },
-    {
       "displayName": "Ostwind",
       "id": "ostwind-fad92c",
       "locationSet": {
@@ -472,6 +475,9 @@
         "network": "Pražská integrovaná doprava",
         "network:short": "PID",
         "network:wikidata": "Q2108171",
+        "operator": "Dopravní podnik hl. m. Prahy",
+        "operator:short": "DPP",
+        "operator:wikidata": "Q381100",
         "route": "trolleybus"
       }
     },


### PR DESCRIPTION
Tram: Add IDOL network, operators of ODIS and PID.
Trolleybus: Add VDV network, update ODIS, IDESKA and PID.