### PR TITLE
add two telecom/data_center operators

### DIFF
--- a/data/operators/telecom/data_center.json
+++ b/data/operators/telecom/data_center.json
@@ -105,6 +105,24 @@
       }
     },
     {
+      "displayName": "Cogent Communications",
+      "id": "cogentcommunications-0d80a3",
+      "locationSet": {
+        "include": ["003", "de", "es", "fr", "nl"]
+      },
+      "matchNames": [
+        "cogent",
+        "cogent communications, inc.",
+        "cogentco"
+      ],
+      "tags": {
+        "name": "Cogent Communications",
+        "operator": "Cogent Communications",
+        "operator:wikidata": "Q1106938",
+        "telecom": "data_center"
+      }
+    },
+    {
       "displayName": "Cologix",
       "id": "cologix-0f9444",
       "locationSet": {"include": ["ca", "us"]},
@@ -154,6 +172,27 @@
         "name": "Cyxtera",
         "operator": "Cyxtera",
         "operator:wikidata": "Q111143924",
+        "telecom": "data_center"
+      }
+    },
+    {
+      "displayName": "Data4",
+      "id": "data4-c5a557",
+      "locationSet": {
+        "include": [
+          "de",
+          "es",
+          "fr",
+          "gr",
+          "it",
+          "pl"
+        ]
+      },
+      "matchNames": ["data4 group"],
+      "tags": {
+        "name": "Data4",
+        "operator": "Data4",
+        "operator:wikidata": "Q61933191",
         "telecom": "data_center"
       }
     },


### PR DESCRIPTION
I added two operators for telecom/data_center:
* Cogent Communications
    * locations listed at: https://www.cogentco.com/en/network/cogent-data-centers
    * wikidata: https://www.wikidata.org/wiki/Q1106938
* Data4
    * locations listed at: https://www.data4group.com/en/
    * wikidata: https://www.wikidata.org/wiki/Q61933191