### PR TITLE
Added hk & mo to global starbucks exclude entry

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -4402,7 +4402,7 @@
     },
     {
       "displayName": "Starbucks",
-      "id": "starbucks-795f60",
+      "id": "starbucks-93e47b",
       "locationSet": {
         "include": ["001"],
         "exclude": [
@@ -4411,6 +4411,7 @@
           "cn",
           "dz",
           "eg",
+          "hk",
           "iq",
           "jo",
           "jp",
@@ -4419,6 +4420,7 @@
           "lb",
           "ly",
           "ma",
+          "mo",
           "om",
           "qa",
           "rs",


### PR DESCRIPTION
Added hk & mo to the global starbucks location.exludes list as hk & mo have their own entry in NSI.