### PR TITLE
Aramco: add Philippine entry

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -8609,15 +8609,28 @@
     {
       "displayName": "أرامكو",
       "id": "aramco-13ec76",
-      "locationSet": {"include": ["sa", "pk", "cl", "ph"]},
+      "locationSet": {"include": ["sa"]},
       "tags": {
         "amenity": "fuel",
         "brand": "أرامكو",
         "brand:ar": "أرامكو",
-        "brand:en": "Aramco",
+        "brand:en": "aramco",
         "brand:wikidata": "Q679322",
         "name": "أرامكو",
         "name:ar": "أرامكو",
+        "name:en": "aramco"
+      }
+    },
+    {
+      "displayName": "Aramco",
+      "id": "aramco-ph1898",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "amenity": "fuel",
+        "brand": "Aramco",
+        "brand:en": "Aramco",
+        "brand:wikidata": "Q679322",
+        "name": "Aramco",
         "name:en": "Aramco"
       }
     },

--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -8609,16 +8609,16 @@
     {
       "displayName": "أرامكو",
       "id": "aramco-13ec76",
-      "locationSet": {"include": ["sa"]},
+      "locationSet": {"include": ["sa", "pk", "cl", "ph"]},
       "tags": {
         "amenity": "fuel",
         "brand": "أرامكو",
         "brand:ar": "أرامكو",
-        "brand:en": "aramco",
+        "brand:en": "Aramco",
         "brand:wikidata": "Q679322",
         "name": "أرامكو",
         "name:ar": "أرامكو",
-        "name:en": "aramco"
+        "name:en": "Aramco"
       }
     },
     {


### PR DESCRIPTION
The first Aramco station in the Philippines has just opened, with more stations upcoming.

Creating a separate entry from the Saudi Arabian one since the name is in English.