### PR TITLE
remove au from Ray-Ban shop=optician as Ray-Ban have no dedicated stores in AU, but their products are stocked by a range of other brands

### DIFF
--- a/data/brands/shop/optician.json
+++ b/data/brands/shop/optician.json
@@ -1241,7 +1241,6 @@
         "include": [
           "ae",
           "at",
-          "au",
           "br",
           "ca",
           "de",


### PR DESCRIPTION
There are no dedicated Ray-Ban stores in AU. Ray-Ban products are sold through a range of different shops https://www.ray-ban.com/australia/c/store-locator?location=Sydney%20NSW&latitude=-33.8622503&longitude=151.207684 

Even outlets like DFO etc where you typically find dedicated stores for a single product brand don't have "Ray-Ban" shops.

Nothing is mapped in OSM in AU at the moment using this preset.

cc @willemarcel this was  added originally in https://github.com/osmlab/name-suggestion-index/commit/8b7da8d2b4a6a1bdd3f74f0718b15d2ecd1110d6