### PR TITLE
Add Locky parcel locker

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -683,6 +683,18 @@
       }
     },
     {
+      "displayName": "Locky",
+      "id": "locky-12sac2",
+      "locationSet": {"include": ["pt"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "Locky",
+        "brand:wikidata": "Q127548459",
+        "operator": "CTT",
+        "operator:wikidata": "Q1024518"
+      }
+    },
+    {
       "displayName": "Lodówkomat InPost",
       "id": "lodowkomatinpost-ce4e28",
       "locationSet": {"include": ["pl"]},


### PR DESCRIPTION
A parcel locker company in Portugal owned by CTT.