### PR TITLE
Add Snabbgross wholesale brand

### DIFF
--- a/data/brands/shop/wholesale.json
+++ b/data/brands/shop/wholesale.json
@@ -372,6 +372,17 @@
       }
     },
     {
+      "displayName": "Snabbgross",
+      "locationSet": {"include": ["se"]},
+      "matchNames": ["axfood snabbgross"],
+      "tags": {
+        "brand": "Snabbgross",
+        "brand:wikidata": "Q10423751",
+        "name": "Snabbgross",
+        "shop": "wholesale"
+      }
+    },
+    {
       "displayName": "Transgourmet",
       "id": "transgourmet-4d1ebd",
       "locationSet": {


### PR DESCRIPTION
Currently has 31 stores according to https://www.snabbgross.se/butik-sok.