### PR TITLE
Add Shell Mobility

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -6103,6 +6103,20 @@
       }
     },
     {
+      "displayName": "Shell Mobility",
+      "id": "shell-ph1898",
+      "locationSet": {
+        "include": ["ph"]
+      },
+      "note": "Philippine variant of Shell with additional amenities",
+      "tags": {
+        "amenity": "fuel",
+        "brand": "Shell",
+        "brand:wikidata": "Q110716465",
+        "name": "Shell Mobility"
+      }
+    },
+    {
       "displayName": "Shell Express",
       "id": "shellexpress-b81a67",
       "locationSet": {


### PR DESCRIPTION
"Shell Mobility" is a name for some new branches of Shell in the Philippines that have additional amenities.

Adding this also to reduce edit wars at OSM over removing the "Mobility" name even though on-the-ground signages have that.