### PR TITLE
when generating iD presets, copy the relation property

### DIFF
--- a/lib/presets_id.ts
+++ b/lib/presets_id.ts
@@ -370,6 +370,7 @@ export function buildIDPresets(data: NsiData, opts: BuildIDPresetsOptions): Buil
       if (logoURL)             targetPreset.imageURL = logoURL;
       if (terms.size)          targetPreset.terms = Array.from(terms).sort(withLocale);
       if (preset.reference)    targetPreset.reference = preset.reference;
+      if (preset.relation)     targetPreset.relation = preset.relation;
       if (dissolved[item.id])  targetPreset.searchable = false;  // dissolved/closed businesses
       if (preserveTags.length) targetPreset.preserveTags = preserveTags; // see NSI#10083
 


### PR DESCRIPTION
iD-tagging-schema has [a new feature](https://github.com/openstreetmap/schema-builder/issues/134) which defines [metadata about relations](https://github.com/openstreetmap/id-tagging-schema/pull/1538). For example, which relation-roles are valid for a bus route.

When NSI generates iD presets, it needs to copy this property into the NSI presets. Just like the line above