### PR TITLE
nsiguide: Force display: none on .hide CSS class

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -47,7 +47,7 @@ ul {
 .nav { margin-top: 10px; }
 .instructions { max-width: 1000px; margin: 20px 0; }
 pre { font-size: 12px; margin: 0; }
-.hide { display: none; }
+.hide { display: none !important; }
 
 code       { background: #eee; }
 .dark code { background: #444; }


### PR DESCRIPTION
The empty categories are not getting hidden when a filter is applied ([example](https://nsi.guide/?t=*&tt=geely)). This PR forces `display: none` on the `.hide` CSS class.

<img width="2744" height="682" alt="image" src="https://github.com/user-attachments/assets/673378b9-08e1-4a20-baa1-1b85686076cc" />
