### PR TITLE
Modify Philippine fastfood chains

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -5341,7 +5341,7 @@
         "amenity": "fast_food",
         "brand": "Jollibee",
         "brand:wikidata": "Q37614",
-        "cuisine": "burger",
+        "cuisine": "burger;chicken",
         "name": "Jollibee",
         "takeaway": "yes"
       }

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -2165,7 +2165,7 @@
         "amenity": "fast_food",
         "brand": "Chowking",
         "brand:wikidata": "Q1076816",
-        "cuisine": "asian",
+        "cuisine": "chinese;filipino",
         "name": "Chowking",
         "takeaway": "yes"
       }

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -6776,7 +6776,7 @@
       "tags": {
         "amenity": "fast_food",
         "brand": "McDonald's",
-        "brand:wikidata": "Q60775813",
+        "brand:wikidata": "Q38076",
         "cuisine": "burger;chicken",
         "name": "McDonald's",
         "short_name": "McDo",

--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -6704,6 +6704,7 @@
           "ma",
           "no",
           "om",
+          "ph",
           "qa",
           "ru",
           "sa",
@@ -6765,6 +6766,20 @@
         "name": "McDonald's",
         "name:en": "McDonald's",
         "name:uk": "МакДональдз",
+        "takeaway": "yes"
+      }
+    },
+    {
+      "displayName": "McDonald's (Philippines)",
+      "id": "mcdonalds-ph1898",
+      "locationSet": {"include": ["ph"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "McDonald's",
+        "brand:wikidata": "Q60775813",
+        "cuisine": "burger;chicken",
+        "name": "McDonald's",
+        "short_name": "McDo",
         "takeaway": "yes"
       }
     },


### PR DESCRIPTION
Modified Philippine fastfood chains:
* Chowking is `"cuisine": "chinese;filipino"`
* Jollibee is `"cuisine": "burger;chicken"`
* McDonald's Philippines has a separate Wikidata, is `"cuisine": "burger;chicken"`, and has `"short_name": "McDo"`.