### PR TITLE
add Flip Out for AU as leisure=trampoline_park

### DIFF
--- a/data/brands/leisure/trampoline_park.json
+++ b/data/brands/leisure/trampoline_park.json
@@ -29,7 +29,7 @@
       }
     },
     {
-      "displayName": "Flip Out",
+      "displayName": "Flip Out (UK)",
       "id": "flipout-002cc1",
       "locationSet": {"include": ["gb"]},
       "tags": {
@@ -40,7 +40,7 @@
       }
     },
     {
-      "displayName": "Flip Out",
+      "displayName": "Flip Out (AU)",
       "locationSet": {"include": ["au"]},
       "preserveTags": ["^name"],
       "tags": {

--- a/data/brands/leisure/trampoline_park.json
+++ b/data/brands/leisure/trampoline_park.json
@@ -40,6 +40,17 @@
       }
     },
     {
+      "displayName": "Flip Out",
+      "locationSet": {"include": ["au"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Flip Out",
+        "brand:wikidata": "Q141100414",
+        "leisure": "trampoline_park",
+        "name": "Flip Out"
+      }
+    },
+    {
       "displayName": "Sky Zone",
       "id": "skyzone-746047",
       "locationSet": {


### PR DESCRIPTION
I opted to use a new wikidata ID for the AU business as a separate business entity, sharing the same branding.

cc @UKChris-osm (who added the UK one)

I got a check error

> build | build:json | Error - duplicate displayName 'Flip Out' in:

therefore I've specified the countries within the `displayName`, but ideally we could just use the name "Flip Out" for both given the `locationSet` is disjoint.