### PR TITLE
Add ČSOB Leasing

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -24,6 +24,16 @@
   },
   "items": [
     {
+      "displayName": "ČSOB Leasing",
+      "locationSet": {"include": ["sk"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "ČSOB Leasing",
+        "brand:wikidata": "Q102543416",
+        "name": "ČSOB Leasing"
+      }
+    },
+    {
       "displayName": "1st Security Bank",
       "id": "1stsecuritybank-181391",
       "locationSet": {


### PR DESCRIPTION
Add ČSOB Leasing to distinguish from standard ČSOB commercial bank and to prevent incorrect suggestions in the iD editor.