### PR TITLE
feat(amenity): add EVChaja charging station brand

### DIFF
--- a/data/brands/amenity/charging_station.json
+++ b/data/brands/amenity/charging_station.json
@@ -625,6 +625,17 @@
       }
     },
     {
+      "displayName": "EVChaja",
+      "id": "EVChaja",
+      "locationSet": {"include": ["ke"]},
+      "tags": {
+        "amenity": "charging_station",
+        "brand": "EVChaja",
+        "brand:wikidata": "Q140930713",
+        "name": "EVChaja"
+  }
+},
+    {
       "displayName": "EV Georgia",
       "id": "evgeorgia-dfa5ee",
       "locationSet": {"include": ["ge"]},


### PR DESCRIPTION
Adds EVChaja as a charging station brand in Kenya.

- Adds Wikidata ID Q140930713
- Limits the brand to Kenya (ke)

Closes #12547