### PR TITLE
Add convenience chain stores (CZ)

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -57,6 +57,38 @@
   },
   "items": [
     {
+      "displayName": "Flop",
+      "locationSet": {"include": ["cz"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Flop",
+        "brand:wikidata": "Q141119217",
+        "name": "Flop",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "Flop Top",
+      "locationSet": {"include": ["cz"]},
+      "tags": {
+        "brand": "Flop Top",
+        "brand:wikidata": "Q141119217",
+        "name": "Flop Top",
+        "shop": "convenience"
+      }
+    },
+    {
+      "displayName": "Potraviny CZ",
+      "locationSet": {"include": ["cz"]},
+      "preserveTags": ["^name"],
+      "tags": {
+        "brand": "Potraviny CZ",
+        "brand:wikidata": "Q141119228",
+        "name": "Potraviny CZ",
+        "shop": "convenience"
+      }
+    },
+    {
       "displayName": "10-11",
       "id": "1011-ead397",
       "locationSet": {"include": ["is"]},


### PR DESCRIPTION
Add Flop, Flop Top and Potraviny CZ. All brands with more than 30 locations.