### PR TITLE
fix: fixed PTT name in Thai

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -8946,18 +8946,19 @@
       }
     },
     {
-      "displayName": "ป.ต.ท.",
+      "displayName": "ปตท.",
       "id": "ptt-56d9b3",
       "locationSet": {"include": ["th"]},
+      "matchNames": ["ป.ต.ท."],
       "tags": {
         "amenity": "fuel",
-        "brand": "ป.ต.ท.",
+        "brand": "ปตท.",
         "brand:en": "PTT",
-        "brand:th": "ป.ต.ท.",
+        "brand:th": "ปตท.",
         "brand:wikidata": "Q1810389",
-        "name": "ป.ต.ท.",
+        "name": "ปตท.",
         "name:en": "PTT",
-        "name:th": "ป.ต.ท."
+        "name:th": "ปตท."
       }
     },
     {


### PR DESCRIPTION
Fixed PTT name in Thai from ป.ต.ท. to ปตท. as used on WikiData  https://www.wikidata.org/wiki/Q1810389