### PR TITLE
Add 'ch' to locationSet for Rossmann

### DIFF
--- a/data/brands/shop/chemist.json
+++ b/data/brands/shop/chemist.json
@@ -541,6 +541,7 @@
       "id": "rossmann-06ae64",
       "locationSet": {
         "include": [
+          "ch",
           "cz",
           "de",
           "es",


### PR DESCRIPTION
They are opening branches in Switzerland now, too. See https://www.rossmannonline.ch/ where it states "Jetzt ist ROSSMANN auch in der Schweiz! Wir freuen uns sehr darauf, dass unsere Schweizer Kunden [...] uns[...] kennenlernen", which translates to "we're now in Switzerland".