### PR TITLE
Add some amenity or shop chains in Japan

### DIFF
--- a/data/brands/amenity/car_rental.json
+++ b/data/brands/amenity/car_rental.json
@@ -288,6 +288,19 @@
       }
     },
     {
+      "displayName": "Jネットレンタカー",
+      "id": "1887c1-f05847",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "car_rental",
+        "brand": "Jネットレンタカー",
+        "brand:ja": "Jネットレンタカー",
+        "brand:wikidata": "Q11227092",
+        "name": "Jネットレンタカー",
+        "name:ja": "Jネットレンタカー"
+      }
+    },
+    {
       "displayName": "Localiza",
       "id": "localiza-d9531a",
       "locationSet": {"include": ["001"]},
@@ -502,6 +515,36 @@
         "name": "オリックスレンタカー",
         "name:en": "ORIX Rent a Car",
         "name:ja": "オリックスレンタカー"
+      }
+    },
+    {
+      "displayName": "ガッツレンタカー",
+      "id": "gutsrentacar-f05847",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "car_rental",
+        "brand": "ガッツレンタカー",
+        "brand:en": "Guts Rent-a-car",
+        "brand:ja": "ガッツレンタカー",
+        "brand:wikidata": "Q30928585",
+        "name": "ガッツレンタカー",
+        "name:en": "Guts Rent-a-car",
+        "name:ja": "ガッツレンタカー"
+      }
+    },
+    {
+      "displayName": "ジャパンレンタカー",
+      "id": "japanrentacar-f05847",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "car_rental",
+        "brand": "ジャパンレンタカー",
+        "brand:en": "Japan Rent a Car",
+        "brand:ja": "ジャパンレンタカー",
+        "brand:wikidata": "Q33123382",
+        "name": "ジャパンレンタカー",
+        "name:en": "Japan Rent a Car",
+        "name:ja": "ジャパンレンタカー"
       }
     },
     {

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -9080,6 +9080,26 @@
       }
     },
     {
+      "displayName": "かごの屋",
+      "id": "20021d-879364",
+      "locationSet": {
+        "include": [
+          "jp-23.geojson",
+          "jp-kanto.geojson",
+          "jp-kinki.geojson"
+        ]
+      },
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "かごの屋",
+        "brand:ja": "かごの屋",
+        "brand:wikidata": "Q122661918",
+        "cuisine": "japanese",
+        "name": "かごの屋",
+        "name:ja": "かごの屋"
+      }
+    },
+    {
       "displayName": "ガスト",
       "id": "gusto-36ca8e",
       "locationSet": {"include": ["jp"]},
@@ -9445,6 +9465,24 @@
       }
     },
     {
+      "displayName": "ばんどう太郎",
+      "id": "bandotaro-65e15a",
+      "locationSet": {
+        "include": ["jp-kanto.geojson"]
+      },
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "ばんどう太郎",
+        "brand:en": "Bando Taro",
+        "brand:ja": "ばんどう太郎",
+        "brand:wikidata": "Q11276024",
+        "cuisine": "japanese",
+        "name": "ばんどう太郎",
+        "name:en": "Bando Taro",
+        "name:ja": "ばんどう太郎"
+      }
+    },
+    {
       "displayName": "ビッグボーイ",
       "id": "bigboy-36ca8e",
       "locationSet": {"include": ["jp"]},
@@ -9490,6 +9528,22 @@
         "name": "ブロンコビリー",
         "name:en": "Bronco Billy",
         "name:ja": "ブロンコビリー"
+      }
+    },
+    {
+      "displayName": "やっぱりステーキ",
+      "id": "yapparisteak-36ca8e",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "やっぱりステーキ",
+        "brand:en": "Yappari Steak",
+        "brand:ja": "やっぱりステーキ",
+        "brand:wikidata": "Q109598132",
+        "cuisine": "steak_house",
+        "name": "やっぱりステーキ",
+        "name:en": "Yappari Steak",
+        "name:ja": "やっぱりステーキ"
       }
     },
     {
@@ -9616,6 +9670,26 @@
         "name": "ロイヤルホスト",
         "name:en": "Royal Host",
         "name:ja": "ロイヤルホスト"
+      }
+    },
+    {
+      "displayName": "ワンカルビ",
+      "id": "f1cd26-9d5c47",
+      "locationSet": {
+        "include": [
+          "jp-kanto.geojson",
+          "jp-kinki.geojson",
+          "jp-kyushu.geojson"
+        ]
+      },
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "ワンカルビ",
+        "brand:ja": "ワンカルビ",
+        "brand:wikidata": "Q108762176",
+        "cuisine": "barbecue",
+        "name": "ワンカルビ",
+        "name:ja": "ワンカルビ"
       }
     },
     {
@@ -9994,6 +10068,22 @@
         "name": "南城香",
         "name:en": "BJNCX",
         "name:zh": "南城香"
+      }
+    },
+    {
+      "displayName": "叙々苑",
+      "id": "jojoen-36ca8e",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "叙々苑",
+        "brand:en": "Jojoen",
+        "brand:ja": "叙々苑",
+        "brand:wikidata": "Q11271464",
+        "cuisine": "barbecue",
+        "name": "叙々苑",
+        "name:en": "Jojoen",
+        "name:ja": "叙々苑"
       }
     },
     {
@@ -11087,6 +11177,22 @@
         "name": "焼肉きんぐ",
         "name:en": "Yakiniku King",
         "name:ja": "焼肉きんぐ"
+      }
+    },
+    {
+      "displayName": "焼肉トラジ",
+      "id": "yakinikutoraji-36ca8e",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "amenity": "restaurant",
+        "brand": "焼肉トラジ",
+        "brand:en": "Yakiniku Toraji",
+        "brand:ja": "焼肉トラジ",
+        "brand:wikidata": "Q108803097",
+        "cuisine": "barbecue",
+        "name": "焼肉トラジ",
+        "name:en": "Yakiniku Toraji",
+        "name:ja": "焼肉トラジ"
       }
     },
     {

--- a/data/brands/shop/bicycle.json
+++ b/data/brands/shop/bicycle.json
@@ -458,6 +458,21 @@
       }
     },
     {
+      "displayName": "ダイワサイクル",
+      "id": "daiwacycle-1d9d0f",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "ダイワサイクル",
+        "brand:en": "Daiwa Cycle",
+        "brand:ja": "ダイワサイクル",
+        "brand:wikidata": "Q109598687",
+        "name": "ダイワサイクル",
+        "name:en": "Daiwa Cycle",
+        "name:ja": "ダイワサイクル",
+        "shop": "bicycle"
+      }
+    },
+    {
       "displayName": "上海永久",
       "id": "forever-88c22b",
       "locationSet": {

--- a/data/brands/shop/butcher.json
+++ b/data/brands/shop/butcher.json
@@ -609,6 +609,21 @@
       }
     },
     {
+      "displayName": "ニュー・クイック",
+      "id": "newquick-2bf181",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "ニュー・クイック",
+        "brand:en": "New-Quick",
+        "brand:ja": "ニュー・クイック",
+        "brand:wikidata": "Q11325009",
+        "name": "ニュー・クイック",
+        "name:en": "New-Quick",
+        "name:ja": "ニュー・クイック",
+        "shop": "butcher"
+      }
+    },
+    {
       "displayName": "肉のハナマサ",
       "id": "hanamasameat-2bf181",
       "locationSet": {"include": ["jp"]},

--- a/data/brands/shop/jewelry.json
+++ b/data/brands/shop/jewelry.json
@@ -10,6 +10,19 @@
   },
   "items": [
     {
+      "displayName": "4℃",
+      "id": "092279-36e4b3",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "4℃",
+        "brand:ja": "ヨンドシー",
+        "brand:wikidata": "Q61055700",
+        "name": "4℃",
+        "name:ja": "ヨンドシー",
+        "shop": "jewelry"
+      }
+    },
+    {
       "displayName": "585 Gold",
       "id": "585gold-a038d2",
       "locationSet": {"include": ["001"]},

--- a/data/brands/shop/sports.json
+++ b/data/brands/shop/sports.json
@@ -1267,6 +1267,21 @@
       }
     },
     {
+      "displayName": "ムラサキスポーツ",
+      "id": "murasakisports-04ead7",
+      "locationSet": {"include": ["jp"]},
+      "tags": {
+        "brand": "ムラサキスポーツ",
+        "brand:en": "Murasaki Sports",
+        "brand:ja": "ムラサキスポーツ",
+        "brand:wikidata": "Q11343172",
+        "name": "ムラサキスポーツ",
+        "name:en": "Murasaki Sports",
+        "name:ja": "ムラサキスポーツ",
+        "shop": "sports"
+      }
+    },
+    {
       "displayName": "迪卡儂",
       "id": "decathlon-ba0397",
       "locationSet": {"include": ["tw"]},


### PR DESCRIPTION
Added following chains for amenity or shop.

## amenity

### car_rental

- Jネットレンタカー
- ガッツレンタカー / Guts Rent-a-car
- ジャパンレンタカー / Japan Rent a Car

### restaurant

- かごの屋
- ばんどう太郎 / Bando Taro
- やっぱりステーキ / Yappari Steak
- ワンカルビ
- 叙々苑 / Jojoen
- 焼肉トラジ / Yakiniku Toraji

## shop

### bicycle

- ダイワサイクル / Daiwa Cycle

### butcher

- ニュー・クイック / New-Quick

### jewelry

- 4℃(ヨンドシー)

### sports

- ムラサキスポーツ / Murasaki Sports