### PR TITLE
Add ShockPrice store

### DIFF
--- a/data/brands/shop/department_store.json
+++ b/data/brands/shop/department_store.json
@@ -1395,6 +1395,16 @@
       }
     },
     {
+      "displayName": "ShockPrice",
+      "id": "shockprice-44c79d",
+      "locationSet": {"include": ["pl"]},
+      "tags": {
+        "brand": "ShockPrice",
+        "name": "ShockPrice",
+        "shop": "department_store"
+      }
+    },
+    {
       "displayName": "Shopko",
       "id": "shopko-592fe0",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
ShockPrice, new HalfPrice-like store chain, [is being opened](https://www.dlahandlu.pl/nonfood/nowy-dyskont-w-polsce-21-sierpnia-otworzyli-pierwszy-sklep,174313.html).

There was small discussion on Polish OSM Discord ([here](https://discord.com/channels/783754873861963786/783766269707026483/1538573452053708861)) on how to tag ShockPrice and HalfPrice. Two people strongly suggested `shop=department_store`, as both shops provide great range of products. One of them compared HalfPrice (and so ShockPrice, which is just "a cheaper HalfPrice") to TK Maxx, which is tagged `shop=department_store`. The other one argued the shops should be tagged `shop=clothes`, like Pepco is, as clothing is primary group of products being sold. The opinion was also expressed that both HalfPrice and TK Maxx should be tagged the same way, either `shop=department_store` or `shop=clothes`. Personally, I'm doubtful on tagging them `shop=department_store` and favour `shop=variety_store`.

In this pull request ShockPrice is tagged `shop=department_store`, as the original requester, [morissa14](https://www.openstreetmap.org/user/morissa14), is a supporter of this way of tagging and did put it on two shops ([1](https://www.openstreetmap.org/way/1550168183), [2](https://www.openstreetmap.org/way/1536795627)).

The requester also proposed changing the suggestion for HalfPrice to `shop=department_store`, but I'm currently abstaining from doing so and waiting for the result of this pull because not only are virtually all shops tagged `shop=clothes`, but also they are located in several countries.