### PR TITLE
"Split" Aldi Süd into Aldi Süd and Aldi Suisse

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -288,7 +288,6 @@
       "locationSet": {
         "include": [
           "au",
-          "ch",
           "cn",
           "gb",
           "hu",
@@ -308,6 +307,20 @@
       "tags": {
         "brand": "Aldi",
         "brand:wikidata": "Q41171672",
+        "name": "Aldi",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "Aldi Suisse",
+      "locationSet": {
+        "include": [
+          "ch"
+        ]
+      },
+      "tags": {
+        "brand": "Aldi Suisse",
+        "brand:wikidata": "Q111030009",
         "name": "Aldi",
         "shop": "supermarket"
       }


### PR DESCRIPTION
Remove location `ch` from Aldi Süd, add https://www.wikidata.org/wiki/Q111030009 as Aldi Suisse