### PR TITLE
Add LBRUT Toilets

### DIFF
--- a/data/operators/amenity/library.json
+++ b/data/operators/amenity/library.json
@@ -1722,7 +1722,7 @@
       }
     },
     {
-      "displayName": "London Borough of Richmond Upon Thames",
+      "displayName": "London Borough of Richmond upon Thames",
       "id": "londonboroughofrichmonduponthames-d8f64f",
       "locationSet": {
         "include": ["gb-lon.geojson"]
@@ -1732,7 +1732,7 @@
       ],
       "tags": {
         "amenity": "library",
-        "operator": "London Borough of Richmond Upon Thames",
+        "operator": "London Borough of Richmond upon Thames",
         "operator:short": "LBRUT",
         "operator:type": "government",
         "operator:wikidata": "Q32515",

--- a/data/operators/amenity/toilets.json
+++ b/data/operators/amenity/toilets.json
@@ -818,6 +818,23 @@
       }
     },
     {
+      "displayName": "London Borough of Richmond upon Thames",
+      "id": "londonboroughofrichmonduponthames-a1f30d",
+      "locationSet": {
+        "include": ["gb-lon.geojson"]
+      },
+      "matchNames": [
+        "london borough of richmond upon thames council"
+      ],
+      "tags": {
+        "amenity": "toilets",
+        "operator": "London Borough of Richmond upon Thames",
+        "operator:short": "LBRUT",
+        "operator:type": "government",
+        "operator:wikidata": "Q32515"
+      }
+    },
+    {
       "displayName": "Lutheran World Federation",
       "id": "lutheranworldfederation-48c608",
       "locationSet": {"include": ["001"]},


### PR DESCRIPTION
The London Borough of Richmond upon Thames runs a number of toilets: https://www.richmond.gov.uk/services/roads_and_transport/toilets/find_a_toilet

Also fixes a capitalisation error that I made in https://github.com/osmlab/name-suggestion-index/pull/6648

I have run `bun run build` to generate the ID.

Contributes to the [UK Quarterly Project](https://wiki.openstreetmap.org/wiki/UK_Quarterly_Project/2026/2026_Q3_Project:_Public_Toilets_and_Drinking_Water)