### PR TITLE
Add tinyfish, a Swiss sushi fast food chain

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -11226,6 +11226,20 @@
       }
     },
     {
+      "displayName": "tinyfish",
+      "locationSet": {"include": ["ch"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "tinyfish",
+        "brand:wikidata": "Q141190900",
+        "cuisine": "sushi",
+        "name": "tinyfish",
+        "operator": "Tiny Fish AG",
+        "payment:cards": "only",
+        "takeaway": "yes"
+      }
+    },    
+    {
       "displayName": "TKK Fried Chicken",
       "id": "tkkfriedchicken-4d2ff4",
       "locationSet": {"include": ["us"]},


### PR DESCRIPTION
15 branches according to their website, all cards-only