### PR TITLE
add alsuper supermarket chain with its 3 types of stores

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -8062,6 +8062,36 @@
       }
     },
     {
+      "displayName": "Alsuper",
+      "locationSet": {"include": ["mx"]},
+      "tags": {
+        "brand": "Alsuper",
+        "brand:wikidata": "Q6051516",
+        "name": "Alsuper",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "Alsuper Plus",
+      "locationSet": {"include": ["mx"]},
+      "tags": {
+        "brand": "Alsuper",
+        "brand:wikidata": "Q6051516",
+        "name": "Alsuper Plus",
+        "shop": "supermarket"
+      }
+    },
+    {
+      "displayName": "Alsuper Fresh Market",
+      "locationSet": {"include": ["mx"]},
+      "tags": {
+        "brand": "Alsuper",
+        "brand:wikidata": "Q6051516",
+        "name": "Alsuper Fresh Market",
+        "shop": "supermarket"
+      }
+    },
+    {
       "displayName": "Spar",
       "id": "spar-eedea5",
       "locationSet": {


### PR DESCRIPTION
Adds Alsuper, Mexican supermarket chain with 89 locations. It has 3 types of stores. Closes #12564 (my issue)