### PR TITLE
Point San Antonio and San Diego libraries at their library systems

### DIFF
--- a/data/operators/amenity/library.json
+++ b/data/operators/amenity/library.json
@@ -8,6 +8,10 @@
         "^gemeinde$",
         "^mairie$",
         "^public$"
+      ],
+      "named": [
+        "^city of san antonio$",
+        "^city of san diego$"
       ]
     }
   },
@@ -94,7 +98,7 @@
       "tags": {
         "amenity": "library",
         "operator": "Austin Public Library",
-        "operator:type": "government",
+        "operator:type": "public",
         "operator:wikidata": "Q69491633"
       }
     },
@@ -804,32 +808,6 @@
       }
     },
     {
-      "displayName": "City of San Antonio",
-      "id": "cityofsanantonio-24a277",
-      "locationSet": {
-        "include": ["us-tx.geojson"]
-      },
-      "tags": {
-        "amenity": "library",
-        "operator": "City of San Antonio",
-        "operator:type": "government",
-        "operator:wikidata": "Q975"
-      }
-    },
-    {
-      "displayName": "City of San Diego",
-      "id": "cityofsandiego-b5320b",
-      "locationSet": {
-        "include": ["us-ca.geojson"]
-      },
-      "tags": {
-        "amenity": "library",
-        "operator": "City of San Diego",
-        "operator:type": "government",
-        "operator:wikidata": "Q138816781"
-      }
-    },
-    {
       "displayName": "Clare County Library",
       "id": "clarecountylibrary-418067",
       "locationSet": {
@@ -1372,7 +1350,7 @@
         "amenity": "library",
         "operator": "Houston Public Library",
         "operator:short": "HPL",
-        "operator:type": "government",
+        "operator:type": "public",
         "operator:wikidata": "Q1647690"
       }
     },
@@ -2387,6 +2365,19 @@
       }
     },
     {
+      "displayName": "San Antonio Public Library",
+      "id": "sanantoniopubliclibrary-24a277",
+      "locationSet": {
+        "include": ["us-tx.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "San Antonio Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q5642025"
+      }
+    },
+    {
       "displayName": "San Bernardino County Library",
       "id": "sanbernardinocountylibrary-b5320b",
       "locationSet": {
@@ -2397,6 +2388,32 @@
         "operator": "San Bernardino County Library",
         "operator:type": "public",
         "operator:wikidata": "Q30268360"
+      }
+    },
+    {
+      "displayName": "San Diego County Library",
+      "id": "sandiegocountylibrary-b5320b",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "San Diego County Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q7413630"
+      }
+    },
+    {
+      "displayName": "San Diego Public Library",
+      "id": "sandiegopubliclibrary-b5320b",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "San Diego Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q5486355"
       }
     },
     {

--- a/data/operators/amenity/library.json
+++ b/data/operators/amenity/library.json
@@ -8,10 +8,6 @@
         "^gemeinde$",
         "^mairie$",
         "^public$"
-      ],
-      "named": [
-        "^city of san antonio$",
-        "^city of san diego$"
       ]
     }
   },


### PR DESCRIPTION
Two entries named a city rather than the library system that runs the libraries, and carried the city's Wikidata QID:

  City of San Antonio -> Q975, the city itself (P31: big city)
  City of San Diego   -> Q138816781, municipal government of California

Replace them with the actual systems, and add San Diego County Library, which is a separate system from San Diego Public Library:

  San Antonio Public Library  Q5642025
  San Diego Public Library    Q5486355
  San Diego County Library    Q7413630

I  have already moved San Diego branches off the city QIDs.

Also change Austin and Houston Public Library from operator:type=government to operator:type=public, which makes operator:type uniform across US entries.