### PR TITLE
Adding new fuel brand WICO in Argentina fuel.json

### DIFF
--- a/data/brands/amenity/fuel.json
+++ b/data/brands/amenity/fuel.json
@@ -9383,6 +9383,17 @@
         "operator:en": "Formosa Taffeta Co.,Ltd.",
         "operator:zh": "福懋興業股份有限公司"
       }
+    },
+    {
+      "displayName": "WICO",
+      "locationSet": {"include": ["ar"]},
+      "matchNames": ["Wico"],
+      "tags": {
+        "amenity": "fuel",
+        "brand": "WICO",
+        "brand:wikidata": "Q141235933",
+        "name": "WICO"
+      }
     }
   ]
 }


### PR DESCRIPTION
Add WICO, an Argentine fuel refining and retailing company, as a fuel brand in AR.

* WICO (Q141235933) AR amenity=fuel https://www.wico.com.ar/estaciones

Wikidata: https://www.wikidata.org/wiki/Q141235933