### PR TITLE
Add brand Agrimark ZA .json

### DIFF
--- a/data/brands/shop/agrarian.json
+++ b/data/brands/shop/agrarian.json
@@ -139,9 +139,11 @@
         "brand:wikidata": "Q136135",
         "name": "ZG Raiffeisen Technik",
         "shop": "agrarian"
-      },
-      {
+      }
+    },
+    {
       "displayName": "Agrimark",
+      "id": "agrimark-XXXXXX",
       "locationSet": {"include": ["za"]},
       "tags": {
         "brand": "Agrimark",

--- a/data/brands/shop/agrarian.json
+++ b/data/brands/shop/agrarian.json
@@ -139,6 +139,15 @@
         "brand:wikidata": "Q136135",
         "name": "ZG Raiffeisen Technik",
         "shop": "agrarian"
+      },
+      {
+      "displayName": "Agrimark",
+      "locationSet": {"include": ["za"]},
+      "tags": {
+        "brand": "Agrimark",
+        "brand:wikidata": "Q141238019",
+        "name": "Agrimark",
+        "shop": "agrarian"
       }
     }
   ]


### PR DESCRIPTION
Agrimark is a South African agri-retail and lifestyle store chain owned by KAL Group (formerly Kaap Agri). The brand operates a nationwide network of agricultural and lifestyle retail stores offering farming supplies, irrigation equipment, hardware, gardening products, pet supplies, outdoor equipment, and related products. 

70+ stores in South Africa according to the official Agrimark website. Website: https://www.agrimark.co.za/

QCode: Q141238019