### PR TITLE
Add brand Whitehouse & Continental Linen ZA .json

### DIFF
--- a/data/brands/shop/household_linen.json
+++ b/data/brands/shop/household_linen.json
@@ -196,6 +196,16 @@
         "name:ka": "მანამო ჰოუმი",
         "shop": "household_linen"
       }
+    },
+    {
+      "displayName": "Whitehouse & Continental Linen",
+      "locationSet": {"include": ["za"]},
+      "tags": {
+        "brand": "Whitehouse & Continental Linen",
+        "brand:wikidata": "Q141238478",
+        "name": "Whitehouse & Continental Linen",
+        "shop": "household_linen"
+      }
     }
   ]
 }


### PR DESCRIPTION
Brand Whitehouse & Continental Linen: Approximately 100 stores nationwide across South Africa. The group states it has grown from a single linen store in 2006 to a nationwide retail network.
website: https://bedbathhome.co.za/
QCode: Q141238478