### PR TITLE
Add brand WeBuyCars .json

### DIFF
--- a/data/brands/shop/car.json
+++ b/data/brands/shop/car.json
@@ -1857,6 +1857,17 @@
         "name:zh-Hans": "雷克萨斯",
         "shop": "car"
       }
+    },
+    {
+      "displayName": "WeBuyCars",
+      "locationSet": {"include": ["za"]},
+      "tags": {
+        "brand": "WeBuyCars",
+        "brand:wikidata": "Q135910440",
+        "name": "WeBuyCars",
+        "second_hand": "only",
+        "shop": "car"
+      }
     }
   ]
 }


### PR DESCRIPTION
WeBuyCars is a South African automotive retail company specializing in the buying and selling of pre-owned vehicles. Through a nationwide network of vehicle supermarkets, branches, and customer-focused vehicle buying locations, the company offers vehicle purchasing, vehicle sales, financing, insurance, trade-ins, auctions, and vehicle valuation services. Customers can sell vehicles through physical locations or by using the company's vehicle assessment services, including selected locations where vehicles are evaluated and purchased directly from customers. WeBuyCars operates exclusively in South Africa and maintains approximately 129 locations nationwide as of 2026. 

website: https://www.webuycars.co.za

QCode: Q135910440