### PR TITLE
Cotti Coffee operates in 28 countries

### DIFF
--- a/data/brands/amenity/cafe.json
+++ b/data/brands/amenity/cafe.json
@@ -7444,26 +7444,7 @@
     {
       "displayName": "库迪咖啡",
       "id": "cotticoffee-c68570",
-      "locationSet": {
-        "include": [
-          "ae",
-          "au",
-          "ca",
-          "cn",
-          "hk",
-          "id",
-          "jp",
-          "kr",
-          "mo",
-          "my",
-          "ph",
-          "qa",
-          "sg",
-          "th",
-          "us",
-          "vn"
-        ]
-      },
+      "locationSet": {"include": ["001"]},
       "tags": {
         "amenity": "cafe",
         "brand": "Cotti Coffee 库迪咖啡",


### PR DESCRIPTION
As of April 2026, Cotti Coffee has stores in 28 countries. Resolves #12565.