### PR TITLE
Update bus.json & tram.json: unify Kraków's bus and tram entries to be uniform

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -9056,6 +9056,7 @@
       "note": "ISO 3166-2 PL-12",
       "tags": {
         "network": "Komunikacja Miejska w Krakowie",
+        "network:wikidata": "Q141244075",
         "route": "bus"
       }
     },

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -8923,17 +8923,6 @@
       }
     },
     {
-      "displayName": "KMK",
-      "id": "kmk-9340cc",
-      "locationSet": {"include": ["pl"]},
-      "note": "ISO 3166-2 PL-12",
-      "tags": {
-        "network": "KMK",
-        "network:wikidata": "Q11687034",
-        "route": "bus"
-      }
-    },
-    {
       "displayName": "Kocaeli Otobüsleri",
       "id": "kocaeliotobusleri-8150d4",
       "locationSet": {"include": ["tr"]},
@@ -9056,6 +9045,7 @@
       "note": "ISO 3166-2 PL-12",
       "tags": {
         "network": "Komunikacja Miejska w Krakowie",
+        "network:short": "KMK",
         "network:wikidata": "Q141244075",
         "route": "bus"
       }

--- a/data/transit/route/tram.json
+++ b/data/transit/route/tram.json
@@ -349,7 +349,8 @@
       "note": "ISO 3166-2 PL-12",
       "tags": {
         "network": "Komunikacja Miejska w Krakowie",
-        "network:wikidata": "Q1784404",
+        "network:short": "KMK",
+        "network:wikidata": "Q141244075",
         "operator": "MPK Kraków",
         "operator:wikidata": "Q11780297",
         "route": "tram"


### PR DESCRIPTION
This PR aims to unify the two networks' entries. Functionally, the bus and tram networks are part of one entity (same authority, same fares, same rules, for the most part the same operator), but their entries have been different in practice. This PR introduces a new Wikidata item and unifies the tagging across the two.

There is no operator added to the bus.json entry as there are two bus operators contracted in Kraków.