### PR TITLE
Add brand Postlink ZA

### DIFF
--- a/data/brands/amenity/post_office.json
+++ b/data/brands/amenity/post_office.json
@@ -771,6 +771,16 @@
         "name:en": "SF Express",
         "name:zh": "顺丰速运"
       }
+    },
+    {
+      "displayName": "PostLink",
+      "locationSet": {"include": ["za"]},
+      "tags": {
+        "amenity": "post_office",
+        "brand": "PostLink",
+        "brand:wikidata": "Q141246404",
+        "name": "PostLink"
+      }
     }
   ]
 }


### PR DESCRIPTION
PostLink is a South African franchise chain that provides postal, courier, printing, and business support services through a nationwide network of retail outlets. The company was founded in 2012 when a group of entrepreneurs developed a one-stop-shop concept aimed at offering SMEs and individuals a range of business services under one roof. Its services include domestic and international courier delivery, postal services, printing and copying, packaging, mailbox rentals, and other business-related services. As of 2026, the PostLink store locator lists 49 locations across South Africa, making it one of the country's larger private postal and courier franchise networks. 

website: https://www.postlink.co.za/

QCode: Q141246404