### PR TITLE
Add brand Neovision ZA_Update optician.json

### DIFF
--- a/data/brands/shop/optician.json
+++ b/data/brands/shop/optician.json
@@ -2059,6 +2059,16 @@
         "name:zh-Hant": "眼鏡市場",
         "shop": "optician"
       }
+    },
+    {
+      "displayName": "Neovision",
+      "locationSet": {"include": ["za"]},
+      "tags": {
+        "brand": "Neovision",
+        "brand:wikidata": "Q141253662",
+        "name": "Neovision",
+        "shop": "optician"
+      }
     }
   ]
 }


### PR DESCRIPTION
NeoVision Optometrists is a South African optometry and eyewear retail chain that provides eye examinations, prescription glasses, sunglasses, contact lenses, and related eye-care services through a nationwide network of stores and franchise-operated optometry practices. NeoVision operates approximately 80 stores across South Africa as of 2026. The official store locator confirms a nationwide presence with locations across multiple provinces including Western Cape, Gauteng, KwaZulu-Natal and Eastern Cape. Website: https://www.neovision.co.za/
QCode: Q141253662