### PR TITLE
Move Fresh Corner restaurant to fast_food.json and extend to PL and RS

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -4006,6 +4006,27 @@
       }
     },
     {
+      "displayName": "Fresh Corner Restaurant",
+      "locationSet": {
+        "include": [
+          "cz",
+          "hr",
+          "hu",
+          "pl",
+          "ro",
+          "rs",
+          "sk"
+        ]
+      },
+      "tags": {
+        "amenity": "fast_food",
+        "brand": "Fresh Corner Restaurant",
+        "brand:wikidata": "Q129256375",
+        "fast_food": "cafeteria",
+        "name": "Fresh Corner Restaurant"
+      }
+    },
+    {
       "displayName": "Freshëns",
       "id": "freshens-4d2ff4",
       "locationSet": {"include": ["us"]},

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -2829,28 +2829,6 @@
       }
     },
     {
-      "displayName": "Fresh Corner Restaurant",
-      "id": "freshcornerrestaurant-3a73d6",
-      "locationSet": {
-        "include": [
-          "cz",
-          "hr",
-          "hu",
-          "pl",
-          "ro",
-          "rs",
-          "sk"
-        ]
-      },
-      "tags": {
-        "amenity": "restaurant",
-        "brand": "Fresh Corner Restaurant",
-        "brand:wikidata": "Q129256375",
-        "cuisine": "hot_dog;sandwich",
-        "name": "Fresh Corner Restaurant"
-      }
-    },
-    {
       "displayName": "Freshii",
       "id": "freshii-2d261b",
       "locationSet": {

--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -2830,9 +2830,17 @@
     },
     {
       "displayName": "Fresh Corner Restaurant",
-      "id": "freshcornerrestaurant-c8a273",
+      "id": "freshcornerrestaurant-3a73d6",
       "locationSet": {
-        "include": ["cz", "hr", "hu", "ro", "sk"]
+        "include": [
+          "cz",
+          "hr",
+          "hu",
+          "pl",
+          "ro",
+          "rs",
+          "sk"
+        ]
       },
       "tags": {
         "amenity": "restaurant",


### PR DESCRIPTION
MOL Group's public station finder (tankstellenfinder.molaustria.at) lists Fresh Corner Restaurant locations in Poland (43) and Serbia (2) alongside the existing CZ, HR, HU, RO and SK coverage. The entry is also moved from `amenity/restaurant.json` to `amenity/fast_food.json`, retagged as  `amenity=fast_food` + `fast_food=cafeteria`, and the `cuisine=hot_dog;sandwich` tag is dropped since menus differ by country (see discussin below).