### PR TITLE
Libraries/add us library systems

### DIFF
--- a/data/operators/amenity/library.json
+++ b/data/operators/amenity/library.json
@@ -67,6 +67,19 @@
       }
     },
     {
+      "displayName": "Athens Regional Library System",
+      "id": "athensregionallibrarysystem-3f6d55",
+      "locationSet": {
+        "include": ["us-ga.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Athens Regional Library System",
+        "operator:type": "public",
+        "operator:wikidata": "Q29094268"
+      }
+    },
+    {
       "displayName": "Auckland Libraries",
       "id": "aucklandlibraries-f1e6a6",
       "locationSet": {
@@ -570,6 +583,19 @@
       }
     },
     {
+      "displayName": "Brevard County Library System",
+      "id": "brevardcountylibrarysystem-7fd740",
+      "locationSet": {
+        "include": ["us-fl.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Brevard County Library System",
+        "operator:type": "public",
+        "operator:wikidata": "Q15615911"
+      }
+    },
+    {
       "displayName": "Brighton and Hove City Council",
       "id": "brightonandhovecitycouncil-5f562a",
       "locationSet": {
@@ -624,6 +650,19 @@
       }
     },
     {
+      "displayName": "Broward County Library",
+      "id": "browardcountylibrary-7fd740",
+      "locationSet": {
+        "include": ["us-fl.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Broward County Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q4975894"
+      }
+    },
+    {
       "displayName": "Bruce County Public Library",
       "id": "brucecountypubliclibrary-b0fd6b",
       "locationSet": {
@@ -662,6 +701,19 @@
         "operator:short": "B&ECPL",
         "operator:type": "public",
         "operator:wikidata": "Q4985640"
+      }
+    },
+    {
+      "displayName": "Calcasieu Parish Public Library",
+      "id": "calcasieuparishpubliclibrary-998f51",
+      "locationSet": {
+        "include": ["us-la.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Calcasieu Parish Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q5018702"
       }
     },
     {
@@ -727,6 +779,32 @@
         "operator:short": "CCLSD",
         "operator:type": "public",
         "operator:wikidata": "Q69488646"
+      }
+    },
+    {
+      "displayName": "Charleston County Public Library System",
+      "id": "charlestoncountypubliclibrarysystem-5407bf",
+      "locationSet": {
+        "include": ["us-sc.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Charleston County Public Library System",
+        "operator:type": "public",
+        "operator:wikidata": "Q69490344"
+      }
+    },
+    {
+      "displayName": "Charlotte Mecklenburg Library",
+      "id": "charlottemecklenburglibrary-ee2325",
+      "locationSet": {
+        "include": ["us-nc.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Charlotte Mecklenburg Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q69482058"
       }
     },
     {
@@ -927,6 +1005,19 @@
       }
     },
     {
+      "displayName": "Contra Costa County Library",
+      "id": "contracostacountylibrary-b5320b",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Contra Costa County Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q5165604"
+      }
+    },
+    {
       "displayName": "Cornwall Council",
       "id": "cornwallcouncil-1aa95b",
       "locationSet": {
@@ -954,6 +1045,19 @@
         "operator": "Cuyahoga County Public Library",
         "operator:type": "public",
         "operator:wikidata": "Q5197076"
+      }
+    },
+    {
+      "displayName": "Dakota County Library",
+      "id": "dakotacountylibrary-8eb121",
+      "locationSet": {
+        "include": ["us-mn.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Dakota County Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q69480717"
       }
     },
     {
@@ -1002,6 +1106,19 @@
         "operator": "de Bibliotheek Midden-Brabant",
         "operator:type": "public",
         "operator:wikidata": "Q59962312"
+      }
+    },
+    {
+      "displayName": "Denver Public Library",
+      "id": "denverpubliclibrary-0087cb",
+      "locationSet": {
+        "include": ["us-co.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Denver Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q5259775"
       }
     },
     {
@@ -1167,6 +1284,19 @@
       }
     },
     {
+      "displayName": "Fairfax County Public Library",
+      "id": "fairfaxcountypubliclibrary-1c5016",
+      "locationSet": {
+        "include": ["us-va.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Fairfax County Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q5430165"
+      }
+    },
+    {
       "displayName": "Finger Lakes Library System",
       "id": "fingerlakeslibrarysystem-4be4fd",
       "locationSet": {
@@ -1246,6 +1376,32 @@
       }
     },
     {
+      "displayName": "Fresno County Public Library",
+      "id": "fresnocountypubliclibrary-b5320b",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Fresno County Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q2587462"
+      }
+    },
+    {
+      "displayName": "Fulton County Library System",
+      "id": "fultoncountylibrarysystem-3f6d55",
+      "locationSet": {
+        "include": ["us-ga.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Fulton County Library System",
+        "operator:type": "public",
+        "operator:wikidata": "Q4815975"
+      }
+    },
+    {
       "displayName": "FVRLibraries",
       "id": "fortvancouverregionallibraries-48ecdd",
       "locationSet": {
@@ -1269,6 +1425,32 @@
         "amenity": "library",
         "operator": "Geelong Regional Libraries",
         "operator:type": "public"
+      }
+    },
+    {
+      "displayName": "Great River Regional Library",
+      "id": "greatriverregionallibrary-8eb121",
+      "locationSet": {
+        "include": ["us-mn.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Great River Regional Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q5599882"
+      }
+    },
+    {
+      "displayName": "Gwinnett County Public Library System",
+      "id": "gwinnettcountypubliclibrarysystem-3f6d55",
+      "locationSet": {
+        "include": ["us-ga.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Gwinnett County Public Library System",
+        "operator:type": "public",
+        "operator:wikidata": "Q5623669"
       }
     },
     {
@@ -1310,6 +1492,19 @@
         "operator": "Harford County Public Library",
         "operator:type": "public",
         "operator:wikidata": "Q69478565"
+      }
+    },
+    {
+      "displayName": "Harris County Public Library",
+      "id": "harriscountypubliclibrary-24a277",
+      "locationSet": {
+        "include": ["us-tx.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Harris County Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q5836595"
       }
     },
     {
@@ -1363,6 +1558,19 @@
       }
     },
     {
+      "displayName": "Hillsborough County Public Library Cooperative",
+      "id": "hillsboroughcountypubliclibrarycooperative-7fd740",
+      "locationSet": {
+        "include": ["us-fl.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Hillsborough County Public Library Cooperative",
+        "operator:type": "public",
+        "operator:wikidata": "Q69471074"
+      }
+    },
+    {
       "displayName": "Houston Public Library",
       "id": "houstonpubliclibrary-24a277",
       "locationSet": {
@@ -1374,6 +1582,19 @@
         "operator:short": "HPL",
         "operator:type": "government",
         "operator:wikidata": "Q1647690"
+      }
+    },
+    {
+      "displayName": "Humboldt County Library",
+      "id": "humboldtcountylibrary-b5320b",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Humboldt County Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q66369332"
       }
     },
     {
@@ -1425,6 +1646,19 @@
         "operator:short": "JCLS",
         "operator:type": "public",
         "operator:wikidata": "Q69488445"
+      }
+    },
+    {
+      "displayName": "Jacksonville Public Library",
+      "id": "jacksonvillepubliclibrary-7fd740",
+      "locationSet": {
+        "include": ["us-fl.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Jacksonville Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q69471028"
       }
     },
     {
@@ -1506,6 +1740,19 @@
       }
     },
     {
+      "displayName": "Kern County Library",
+      "id": "kerncountylibrary-b5320b",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Kern County Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q6394118"
+      }
+    },
+    {
       "displayName": "King County Library System",
       "id": "kingcountylibrarysystem-48ecdd",
       "locationSet": {
@@ -1556,6 +1803,19 @@
         "operator": "Knjižnice grada Zagreba",
         "operator:type": "public",
         "operator:wikidata": "Q17440978"
+      }
+    },
+    {
+      "displayName": "Knox County Public Library",
+      "id": "knoxcountypubliclibrary-e0c707",
+      "locationSet": {
+        "include": ["us-ky.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Knox County Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q69476889"
       }
     },
     {
@@ -1682,6 +1942,32 @@
       }
     },
     {
+      "displayName": "Lee County Library System",
+      "id": "leecountylibrarysystem-7fd740",
+      "locationSet": {
+        "include": ["us-fl.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Lee County Library System",
+        "operator:type": "public",
+        "operator:wikidata": "Q24260922"
+      }
+    },
+    {
+      "displayName": "Lexington County Public Library",
+      "id": "lexingtoncountypubliclibrary-5407bf",
+      "locationSet": {
+        "include": ["us-sc.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Lexington County Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q69490393"
+      }
+    },
+    {
       "displayName": "Libraries Tasmania",
       "id": "librariestasmania-41eb09",
       "locationSet": {"include": ["au-tas"]},
@@ -1768,6 +2054,19 @@
       }
     },
     {
+      "displayName": "Long Beach Public Library",
+      "id": "longbeachpubliclibrary-b5320b",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Long Beach Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q6672332"
+      }
+    },
+    {
       "displayName": "Los Angeles Public Library",
       "id": "losangelespubliclibrary-d6a8bf",
       "locationSet": {
@@ -1797,6 +2096,19 @@
       }
     },
     {
+      "displayName": "Memphis Public Libraries",
+      "id": "memphispubliclibraries-5adb32",
+      "locationSet": {
+        "include": ["us-tn.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Memphis Public Libraries",
+        "operator:type": "public",
+        "operator:wikidata": "Q6815865"
+      }
+    },
+    {
       "displayName": "Mestna knjižnica Ljubljana",
       "id": "mestnaknjiznicaljubljana-86076e",
       "locationSet": {"include": ["si"]},
@@ -1818,6 +2130,32 @@
         "operator": "Městská knihovna v Praze",
         "operator:type": "public",
         "operator:wikidata": "Q9170816"
+      }
+    },
+    {
+      "displayName": "Miami-Dade Public Library System",
+      "id": "miamidadepubliclibrarysystem-7fd740",
+      "locationSet": {
+        "include": ["us-fl.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Miami-Dade Public Library System",
+        "operator:type": "public",
+        "operator:wikidata": "Q6827243"
+      }
+    },
+    {
+      "displayName": "Mid-Columbia Libraries",
+      "id": "midcolumbialibraries-48ecdd",
+      "locationSet": {
+        "include": ["us-wa.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Mid-Columbia Libraries",
+        "operator:type": "public",
+        "operator:wikidata": "Q69494172"
       }
     },
     {
@@ -1913,6 +2251,19 @@
       }
     },
     {
+      "displayName": "Montgomery County Public Libraries",
+      "id": "montgomerycountypubliclibraries-1170f4",
+      "locationSet": {
+        "include": ["us-md.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Montgomery County Public Libraries",
+        "operator:type": "public",
+        "operator:wikidata": "Q23136604"
+      }
+    },
+    {
       "displayName": "Montpellier Méditerranée Métropole",
       "id": "montpelliermediterraneemetropole-668c92",
       "locationSet": {
@@ -1962,6 +2313,19 @@
         "operator": "Municipalidad de Neuquén",
         "operator:type": "government",
         "operator:wikidata": "Q118390946"
+      }
+    },
+    {
+      "displayName": "NCW Libraries",
+      "id": "ncwlibraries-48ecdd",
+      "locationSet": {
+        "include": ["us-wa.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "NCW Libraries",
+        "operator:type": "public",
+        "operator:wikidata": "Q7054759"
       }
     },
     {
@@ -2028,6 +2392,19 @@
         "operator": "Norfolk County Council",
         "operator:type": "government",
         "operator:wikidata": "Q6386227"
+      }
+    },
+    {
+      "displayName": "Norfolk Public Library",
+      "id": "norfolkpubliclibrary-1c5016",
+      "locationSet": {
+        "include": ["us-va.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Norfolk Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q30268146"
       }
     },
     {
@@ -2106,6 +2483,19 @@
         "operator": "NTNU Universitetsbiblioteket",
         "operator:type": "university",
         "operator:wikidata": "Q11990765"
+      }
+    },
+    {
+      "displayName": "Oakland Public Library",
+      "id": "oaklandpubliclibrary-b5320b",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Oakland Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q1090829"
       }
     },
     {
@@ -2222,6 +2612,19 @@
       }
     },
     {
+      "displayName": "Palm Beach County Library System",
+      "id": "palmbeachcountylibrarysystem-7fd740",
+      "locationSet": {
+        "include": ["us-fl.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Palm Beach County Library System",
+        "operator:type": "public",
+        "operator:wikidata": "Q7127985"
+      }
+    },
+    {
       "displayName": "Pestalozzi-Bibliothek Zürich",
       "id": "pestalozzibibliothekzurich-eb2614",
       "locationSet": {
@@ -2252,6 +2655,32 @@
       }
     },
     {
+      "displayName": "Phoenix Public Library",
+      "id": "phoenixpubliclibrary-3c0654",
+      "locationSet": {
+        "include": ["us-az.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Phoenix Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q7186963"
+      }
+    },
+    {
+      "displayName": "Pierce County Library System",
+      "id": "piercecountylibrarysystem-48ecdd",
+      "locationSet": {
+        "include": ["us-wa.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Pierce County Library System",
+        "operator:type": "public",
+        "operator:wikidata": "Q7191789"
+      }
+    },
+    {
       "displayName": "Pikes Peak Library District",
       "id": "pikespeaklibrarydistrict-0087cb",
       "locationSet": {
@@ -2263,6 +2692,19 @@
         "operator:short": "PPLD",
         "operator:type": "public",
         "operator:wikidata": "Q69470355"
+      }
+    },
+    {
+      "displayName": "Pioneerland Library System",
+      "id": "pioneerlandlibrarysystem-8eb121",
+      "locationSet": {
+        "include": ["us-mn.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Pioneerland Library System",
+        "operator:type": "public",
+        "operator:wikidata": "Q69480753"
       }
     },
     {
@@ -2343,6 +2785,32 @@
       }
     },
     {
+      "displayName": "Richland County Public Library",
+      "id": "richlandcountypubliclibrary-5407bf",
+      "locationSet": {
+        "include": ["us-sc.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Richland County Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q7330620"
+      }
+    },
+    {
+      "displayName": "Riverside County Library System",
+      "id": "riversidecountylibrarysystem-b5320b",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Riverside County Library System",
+        "operator:type": "public",
+        "operator:wikidata": "Q7338466"
+      }
+    },
+    {
       "displayName": "Rochester Public Library",
       "id": "rochesterpubliclibrary-4be4fd",
       "locationSet": {
@@ -2354,6 +2822,19 @@
         "operator:short": "RPL",
         "operator:type": "public",
         "operator:wikidata": "Q69486450"
+      }
+    },
+    {
+      "displayName": "Sacramento Public Library",
+      "id": "sacramentopubliclibrary-b5320b",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Sacramento Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q7397011"
       }
     },
     {
@@ -2371,6 +2852,19 @@
       }
     },
     {
+      "displayName": "Saint Paul Public Library",
+      "id": "saintpaulpubliclibrary-8eb121",
+      "locationSet": {
+        "include": ["us-mn.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Saint Paul Public Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q69480731"
+      }
+    },
+    {
       "displayName": "Salford City Council",
       "id": "salfordcitycouncil-e51a5f",
       "locationSet": {
@@ -2384,6 +2878,19 @@
         "operator": "Salford City Council",
         "operator:type": "government",
         "operator:wikidata": "Q17020402"
+      }
+    },
+    {
+      "displayName": "Salt Lake County Library Services",
+      "id": "saltlakecountylibraryservices-fa1838",
+      "locationSet": {
+        "include": ["us-ut.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Salt Lake County Library Services",
+        "operator:type": "public",
+        "operator:wikidata": "Q7405884"
       }
     },
     {
@@ -2493,6 +3000,19 @@
       }
     },
     {
+      "displayName": "Sno-Isle Libraries",
+      "id": "snoislelibraries-48ecdd",
+      "locationSet": {
+        "include": ["us-wa.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Sno-Isle Libraries",
+        "operator:type": "public",
+        "operator:wikidata": "Q7547864"
+      }
+    },
+    {
       "displayName": "Somerset Council",
       "id": "somersetcouncil-0ac97c",
       "locationSet": {
@@ -2510,6 +3030,19 @@
         "operator": "Somerset Council",
         "operator:type": "government",
         "operator:wikidata": "Q6386270"
+      }
+    },
+    {
+      "displayName": "Sonoma County Library",
+      "id": "sonomacountylibrary-b5320b",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Sonoma County Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q21625840"
       }
     },
     {
@@ -2600,6 +3133,32 @@
         "operator": "Theek 5",
         "operator:type": "public",
         "operator:wikidata": "Q59962203"
+      }
+    },
+    {
+      "displayName": "Three Rivers Regional Library System",
+      "id": "threeriversregionallibrarysystem-3f6d55",
+      "locationSet": {
+        "include": ["us-ga.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Three Rivers Regional Library System",
+        "operator:type": "public",
+        "operator:wikidata": "Q30634137"
+      }
+    },
+    {
+      "displayName": "Timberland Regional Library",
+      "id": "timberlandregionallibrary-48ecdd",
+      "locationSet": {
+        "include": ["us-wa.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Timberland Regional Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q7804695"
       }
     },
     {
@@ -2924,6 +3483,19 @@
       }
     },
     {
+      "displayName": "Ventura County Library",
+      "id": "venturacountylibrary-b5320b",
+      "locationSet": {
+        "include": ["us-ca.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Ventura County Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q7920376"
+      }
+    },
+    {
       "displayName": "Ville de Genève",
       "id": "villedegeneve-68bbbd",
       "locationSet": {
@@ -2988,6 +3560,32 @@
         "operator": "Westfriese Bibliotheken",
         "operator:type": "public",
         "operator:wikidata": "Q59961947"
+      }
+    },
+    {
+      "displayName": "Whatcom County Library System",
+      "id": "whatcomcountylibrarysystem-48ecdd",
+      "locationSet": {
+        "include": ["us-wa.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Whatcom County Library System",
+        "operator:type": "public",
+        "operator:wikidata": "Q69494158"
+      }
+    },
+    {
+      "displayName": "Whitman County Library",
+      "id": "whitmancountylibrary-48ecdd",
+      "locationSet": {
+        "include": ["us-wa.geojson"]
+      },
+      "tags": {
+        "amenity": "library",
+        "operator": "Whitman County Library",
+        "operator:type": "public",
+        "operator:wikidata": "Q69494133"
       }
     },
     {


### PR DESCRIPTION
This adds library operators for systems that have 10+ branches already in OSM. Many of these still have missing branches in OSM so it would be nice for folks to get offered the correct tagging when they get added.