### PR TITLE
Add Evolve E-Bike Share

### DIFF
--- a/data/brands/amenity/bicycle_rental.json
+++ b/data/brands/amenity/bicycle_rental.json
@@ -2501,6 +2501,22 @@
       }
     },
     {
+      "displayName": "Evolve E-Bike Share",
+      "locationSet": {
+        "include": [
+          "ca-bc.geojson"
+        ]
+      },
+      "tags": {
+        "amenity": "bicycle_rental",
+        "brand": "Evolve",
+        "brand:wikidata": "Q137825732",
+        "fee": "yes",
+        "operator": "Evo Car Share",
+        "operator:wikidata": "Q26553214"
+      }
+    },
+    {
       "displayName": "Lyft Bike",
       "id": "lyftbike-94cb92",
       "locationSet": {


### PR DESCRIPTION
Adds the Evolve E-Bike Share program rental stands. BCAA owns Evo Car Share which operates the Evolve E-Bike Share program.

"Evolve E-Bike Share" is the program name, but the shortened "Evolve" is the brand name.

This service only operates in British Columbia, Canada.