### PR TITLE
Add BobBox parcel locker brand (South Africa)

### DIFF
--- a/data/brands/amenity/parcel_locker.json
+++ b/data/brands/amenity/parcel_locker.json
@@ -146,6 +146,17 @@
       }
     },
     {
+      "displayName": "BobBox",
+      "id": "bobbox-6115c3",
+      "locationSet": {"include": ["za"]},
+      "tags": {
+        "amenity": "parcel_locker",
+        "brand": "BobBox",
+        "brand:wikidata": "Q141276676",
+        "name": "BobBox"
+      }
+    },
+    {
       "displayName": "Box Now (Hrvatska)",
       "id": "boxnow-30ebd7",
       "locationSet": {"include": ["hr"]},


### PR DESCRIPTION
Adds BobBox, a South African smart parcel locker network operated by Bob Group, courier-agnostic and used across ~245-248 locations in 7 provinces.

- `amenity/parcel_locker`
- `brand:wikidata`: [Q141276676](https://www.wikidata.org/wiki/Q141276676)
- `locationSet`: `za`