### PR TITLE
Fix MN Metro Transit operator

### DIFF
--- a/data/transit/route/train.json
+++ b/data/transit/route/train.json
@@ -1539,8 +1539,8 @@
       "tags": {
         "network": "Metro Transit",
         "network:wikidata": "Q3307442",
-        "operator": "BNSF Railway",
-        "operator:wikidata": "Q267122",
+        "operator": "Metro Transit",
+        "operator:wikidata": "Q3307442",
         "route": "train"
       }
     },


### PR DESCRIPTION
The operator tag for metro transit is currently BNSF railroad. This is probably a holdover from the [Northstar Commuter Line](https://en.wikipedia.org/wiki/Northstar_Line), which has been closed since Jan 2026. The only currently operating rail routes in the Metro Transit network are light rail, which is operated by Metro Transit itself. 