### PR TITLE
fix city of gold coast name

### DIFF
--- a/data/operators/emergency/lifeguard.json
+++ b/data/operators/emergency/lifeguard.json
@@ -46,6 +46,22 @@
       }
     },
     {
+      "displayName": "City of Gold Coast",
+      "id": "cityofgoldcoast-4be82f",
+      "locationSet": {
+        "include": ["au-qld.geojson"]
+      },
+      "matchNames": [
+        "gccc",
+        "gold coast city council"
+      ],
+      "tags": {
+        "emergency": "lifeguard",
+        "operator": "City of Gold Coast",
+        "operator:wikidata": "Q30267253"
+      }
+    },
+    {
       "displayName": "Corpo de Bombeiros Militar de Santa Catarina",
       "id": "corpodebombeirosmilitardesantacatarina-30a857",
       "locationSet": {
@@ -96,19 +112,6 @@
         "operator": "Deutsche Lebens-Rettungs-Gesellschaft",
         "operator:short": "DLRG",
         "operator:wikidata": "Q871679"
-      }
-    },
-    {
-      "displayName": "Gold Coast City Council",
-      "id": "goldcoastcitycouncil-4be82f",
-      "locationSet": {
-        "include": ["au-qld.geojson"]
-      },
-      "tags": {
-        "emergency": "lifeguard",
-        "operator": "Gold Coast City Council",
-        "operator:short": "GCCC",
-        "operator:wikidata": "Q30267253"
       }
     },
     {

--- a/data/operators/leisure/park.json
+++ b/data/operators/leisure/park.json
@@ -2049,6 +2049,23 @@
       }
     },
     {
+      "displayName": "City of Gold Coast",
+      "id": "cityofgoldcoast-f88a26",
+      "locationSet": {
+        "include": ["au-qld.geojson"]
+      },
+      "matchNames": [
+        "gccc",
+        "gold coast city council"
+      ],
+      "tags": {
+        "leisure": "park",
+        "operator": "City of Gold Coast",
+        "operator:type": "government",
+        "operator:wikidata": "Q30267253"
+      }
+    },
+    {
       "displayName": "City of Goodyear",
       "id": "cityofgoodyear-1fe561",
       "locationSet": {
@@ -4746,20 +4763,6 @@
         "leisure": "park",
         "operator": "Gmina Oborniki Śląskie - Zarząd Zieleni",
         "operator:type": "government"
-      }
-    },
-    {
-      "displayName": "Gold Coast City Council",
-      "id": "goldcoastcitycouncil-f88a26",
-      "locationSet": {
-        "include": ["au-qld.geojson"]
-      },
-      "tags": {
-        "leisure": "park",
-        "operator": "Gold Coast City Council",
-        "operator:short": "GCCC",
-        "operator:type": "government",
-        "operator:wikidata": "Q30267253"
       }
     },
     {


### PR DESCRIPTION
"City of Gold Coast" is the more recent name.

Already in use for [charging stations](https://github.com/osmlab/name-suggestion-index/blob/44f3d1a395b63f1438ccc37687a9470720e4f42b/data/operators/amenity/charging_station.json#L1103), this PR fixes the inconsistency. 