### PR TITLE
Remove GameStop from DE

### DIFF
--- a/data/brands/shop/video_games.json
+++ b/data/brands/shop/video_games.json
@@ -100,7 +100,7 @@
       "id": "gamestop-90cbab",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["au", "ca", "it", "nz"]
+        "exclude": ["au", "ca", "it", "nz", "de"]
       },
       "matchNames": [
         "eb games",


### PR DESCRIPTION
GameStop has terminated all operation in germany, including shops and websites.