### PR TITLE
Update Záložňa Breva

### DIFF
--- a/data/brands/shop/pawnbroker.json
+++ b/data/brands/shop/pawnbroker.json
@@ -10,6 +10,17 @@
   },
   "items": [
     {
+      "displayName": "Záložňa Breva",
+      "locationSet": {"include": ["sk"]},
+      "matchNames": ["breva"],
+      "tags": {
+        "brand": "Záložňa Breva",
+        "brand:wikidata": "Q108371754",
+        "name": "Záložňa Breva",
+        "shop": "pawnbroker"
+      }
+    },
+    {
       "displayName": "Ablaza Pawnshop",
       "id": "ablazapawnshop-6d9487",
       "locationSet": {"include": ["ph"]},
@@ -351,20 +362,6 @@
         "brand": "Villarica",
         "brand:wikidata": "Q62391438",
         "name": "Villarica",
-        "shop": "pawnbroker"
-      }
-    },
-    {
-      "displayName": "Záložňa Breva",
-      "id": "zaloznabreva-504b45",
-      "locationSet": {"include": ["cz", "sk"]},
-      "matchNames": ["breva"],
-      "tags": {
-        "brand": "Záložňa Breva",
-        "brand:wikidata": "Q108371754",
-        "name": "Záložňa Breva",
-        "name:cs": "Zastavárna Index",
-        "name:sk": "Záložňa Breva",
         "shop": "pawnbroker"
       }
     },


### PR DESCRIPTION
The chain also operates in the Czech Republic, but under a different name and with only 6 branches.