### PR TITLE
Add Geile Warenautomaten (Q141404805) vending machines

### DIFF
--- a/data/operators/amenity/vending_machine.json
+++ b/data/operators/amenity/vending_machine.json
@@ -393,12 +393,12 @@
       "displayName": "Geile Warenautomaten",
       "id": "Geile Warenautomaten",
       "locationSet": {"include": ["de"]},
-      "matchNames": ["Geile Warenautomaten GmbH", "Geile Warenautomaten"]
+      "matchNames": ["Geile Warenautomaten GmbH", "Geile Warenautomaten"],
       "tags": {
         "amenity": "vending_machine",
         "operator": "Geile Warenautomaten",
         "operator:wikidata": "Q141404805"
       }
-    },
+    }
   ]
 }

--- a/data/operators/amenity/vending_machine.json
+++ b/data/operators/amenity/vending_machine.json
@@ -388,6 +388,17 @@
         "recycling:plastic_bottles": "yes",
         "vending": "bottle_return"
       }
-    }
+    },
+    {
+      "displayName": "Geile Warenautomaten",
+      "id": "Geile Warenautomaten",
+      "locationSet": {"include": ["de"]},
+      "matchNames": ["Geile Warenautomaten GmbH", "Geile Warenautomaten"]
+      "tags": {
+        "amenity": "vending_machine",
+        "operator": "Geile Warenautomaten",
+        "operator:wikidata": "Q141404805"
+      }
+    },
   ]
 }


### PR DESCRIPTION
Adds a new entry to vending machine operators:

_Geile Warenautomaten_ is a German operator of different kinds of vending machines with almost 14k locations according to their website.

Each vending machine has different content and different payment options, depending on what has been agreed upon with the location, therefore the only common tags are `amenity=vending_machine` as well as the `operator` and its wikidata attribute.