### PR TITLE
Remove Supersol (ES) from supermarket.json: brand dissolved into Carr…

### DIFF
--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -8625,19 +8625,6 @@
       }
     },
     {
-      "displayName": "Supersol",
-      "id": "supersol-0a1807",
-      "locationSet": {
-        "include": ["ar", "es", "ma", "uy"]
-      },
-      "tags": {
-        "brand": "Supersol",
-        "brand:wikidata": "Q62073427",
-        "name": "Supersol",
-        "shop": "supermarket"
-      }
-    },
-    {
       "displayName": "Superspar",
       "id": "superspar-5f0ef1",
       "locationSet": {"include": ["es", "za"]},

--- a/data/brands/shop/supermarket.json
+++ b/data/brands/shop/supermarket.json
@@ -11,6 +11,7 @@
         "^duka la vyakula$",
         "^élelmiszer(bolt)?$",
         "^nafaka$",
+        "^supersol$",
         "^tienda( de (barrio|abarrotes))?$",
         "^гастроном$",
         "^дэлгүүр$",


### PR DESCRIPTION
Carrefour bought all 172 Supersol stores in 2020-21 and converted them to Carrefour Express, Carrefour Market and Supeco by end of 2021 (38 were sold on to Cash Lepe, Froiz, Maskom and Ecomor). The Supersol brand no longer trades anywhere.

Wikidata https://www.wikidata.org/wiki/Q62073427 has been amended to reflect the dissolution.
