### PR TITLE
Remove another batch of wind turbine manufacturers as operators

### DIFF
--- a/data/operators/power/generator.json
+++ b/data/operators/power/generator.json
@@ -13,6 +13,7 @@
         "^enercon$",
         "^entergy corporation and shell wind corporation$",
         "^gamesa$",
+        "^ge wind$",
         "^nordex$",
         "^private?$",
         "^siemens gamesa$",

--- a/data/operators/power/generator.json
+++ b/data/operators/power/generator.json
@@ -2016,16 +2016,6 @@
       }
     },
     {
-      "displayName": "DeWind",
-      "id": "dewind-19ecba",
-      "locationSet": {"include": ["us"]},
-      "tags": {
-        "operator": "DeWind",
-        "operator:wikidata": "Q5244167",
-        "power": "generator"
-      }
-    },
-    {
       "displayName": "Dezentrale Energie Anlagen Beteiligungs- und Verwaltungsgesellschaft mbH",
       "id": "dezentraleenergieanlagenbeteiligungsundverwaltungsgesellschaftmbh-b8ae25",
       "locationSet": {"include": ["de"]},
@@ -4064,17 +4054,6 @@
       }
     },
     {
-      "displayName": "GE Wind",
-      "id": "gewind-19ecba",
-      "locationSet": {"include": ["us"]},
-      "matchNames": ["ge wind energy"],
-      "tags": {
-        "operator": "GE Wind",
-        "operator:wikidata": "Q634056",
-        "power": "generator"
-      }
-    },
-    {
       "displayName": "Gecalsa",
       "id": "gecalsa-660d36",
       "locationSet": {
@@ -4284,17 +4263,6 @@
       "tags": {
         "operator": "Golden Spread Electric Cooperative",
         "operator:wikidata": "Q115691491",
-        "power": "generator"
-      }
-    },
-    {
-      "displayName": "Goldwind",
-      "id": "goldwind-19ecba",
-      "locationSet": {"include": ["us"]},
-      "matchNames": ["goldwind usa nwe"],
-      "tags": {
-        "operator": "Goldwind",
-        "operator:wikidata": "Q1090900",
         "power": "generator"
       }
     },


### PR DESCRIPTION
Following #12375  I found a few more manufacturers, that is GE Wind, Goldwind, DeWind.

As these are currently not even used (that is no object within OSM has the coresponding `operator:wikidata` value) these can safely be removed.